### PR TITLE
Added IonResult type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/target
+**/*.rs.bk
+Cargo.lock
+callgrind.out.*
+*.callgrind
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ion-rust"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+failure = "~0.1"
+failure_derive = "~0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+#[macro_use]
+extern crate failure_derive;
+
+pub mod result;

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,0 +1,41 @@
+use std::convert::From;
+use std::io;
+
+/// A unified Result type representing the outcome of method calls that may fail.
+pub type IonResult<T> = Result<T, IonError>;
+
+/// Represents the different types of high-level failures that might occur when reading Ion data.
+#[derive(Debug, Fail, Clone)]
+pub enum IonError {
+    /// Indicates that an IO error was encountered while reading or writing.
+    #[fail(display = "An IO error occurred: {}", description)]
+    IoError { description: String },
+
+    /// Indicates that the data stream being read contained illegal or otherwise unreadable data.
+    #[fail(display = "A decoding error occurred: {}", description)]
+    DecodingError { description: String },
+}
+
+/// A convenience method for creating an IonError::IoError with the provided description text.
+pub fn io_error<T>(description: &str) -> IonResult<T> {
+    Err(IonError::IoError {
+        description: description.to_string(),
+    })
+}
+
+/// A convenience method for creating an IonError::DecodingError with the provided description text.
+pub fn decoding_error<T, S: AsRef<str>>(description: S) -> IonResult<T> {
+    Err(IonError::DecodingError {
+        description: description.as_ref().to_string(),
+    })
+}
+
+/// Allows [`io::Error`]s to be converted to an IonError and propagated using the `?` operator.
+impl From<io::Error> for IonError {
+    fn from(error: io::Error) -> Self {
+        use std::error::Error;
+        IonError::IoError {
+            description: format!("Encountered an IO error: {:?}", error.description()),
+        }
+    }
+}


### PR DESCRIPTION
#### Changes

* Adds basic `.gitignore` and `Cargo.toml` files.
* Declares a dependency on the `failure` crate, which provides various ergonomic improvements to Rust's error handling.
* Adds the `IonResult` data type.

#### Details
`IonResult` is a stack-allocated enum (tagged union) that represents the outcome of any `ion-rust` operation that might fail. When returned, it will contain either the requested value or an `IonError` enum describing the reason that value could not be obtained.

#### Further resources
* The Rust Book's [chapter on `enum`s](https://doc.rust-lang.org/book/ch06-01-defining-an-enum.html)
* The Rust Book's [chapter on `Result`s](https://doc.rust-lang.org/book/ch09-02-recoverable-errors-with-result.html)
* The `failure` crate's [documentation](https://docs.rs/failure/0.1.5/failure/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
