### PR TITLE
Adds IonType, IonTypeCode

### DIFF
--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -1,0 +1,5 @@
+//! This modules provides the necessary structures and logic to read values from a binary Ion
+//! data stream.
+mod type_code;
+
+pub(crate) use type_code::IonTypeCode;

--- a/src/binary/type_code.rs
+++ b/src/binary/type_code.rs
@@ -1,0 +1,93 @@
+use crate::result::{
+    IonResult,
+    decoding_error
+};
+use crate::types::IonType;
+
+/// Represents the type information found in the header byte of each binary Ion value.
+/// While this value can be readily mapped to a user-level [`IonType`], it is a distinct concept.
+/// The IonTypeCode enum captures system-level information that is not exposed to end users of the
+/// library, including:
+/// * Whether the cursor is positioned over whitespace that needs to be skipped.
+/// * Whether the integer value being read is positive or negative.
+/// * Whether the next type code is reserved.
+///
+/// See the
+/// [Typed Value Formats](http://amzn.github.io/ion-docs/docs/binary.html#typed-value-formats)
+/// section of the spec for more information.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub(crate) enum IonTypeCode {
+    NullOrWhitespace, // 0
+    Boolean,          // 1
+    PositiveInteger,  // 2
+    NegativeInteger,  // 3
+    Float,            // 4
+    Decimal,          // 5
+    Timestamp,        // 6
+    Symbol,           // 7
+    String,           // 8
+    Clob,             // 9
+    Blob,             // 10
+    List,             // 11
+    SExpression,      // 12
+    Struct,           // 13
+    Annotation,       // 14
+    Reserved,         // 15
+}
+
+impl IonTypeCode {
+    /// Attempts to convert the system-level IonTypeCode into the corresponding user-level IonType.
+    pub fn into_ion_type(self) -> IonResult<IonType> {
+        use self::IonTypeCode::*;
+        let ion_type = match self {
+            NullOrWhitespace => IonType::Null,
+            Boolean => IonType::Boolean,
+            PositiveInteger | NegativeInteger => IonType::Integer,
+            Float => IonType::Float,
+            Decimal => IonType::Decimal,
+            Timestamp => IonType::Timestamp,
+            Symbol => IonType::Symbol,
+            String => IonType::String,
+            Clob => IonType::Clob,
+            Blob => IonType::Blob,
+            List => IonType::List,
+            SExpression => IonType::SExpression,
+            Struct => IonType::Struct,
+            _ => {
+                return decoding_error(format!(
+                    "Attempted to make an IonType from an invalid type code: {:?}",
+                    self
+                ));
+            }
+        };
+        Ok(ion_type)
+    }
+
+    /// Attempts to convert the provided byte into an IonTypeCode. Any value greater than 15
+    /// will result in an Error.
+    pub fn from(type_code: u8) -> IonResult<IonTypeCode> {
+        use self::IonTypeCode::*;
+        let ion_type_code = match type_code {
+            0 => NullOrWhitespace,
+            1 => Boolean,
+            2 => PositiveInteger,
+            3 => NegativeInteger,
+            4 => Float,
+            5 => Decimal,
+            6 => Timestamp,
+            7 => Symbol,
+            8 => String,
+            9 => Clob,
+            10 => Blob,
+            11 => List,
+            12 => SExpression,
+            13 => Struct,
+            14 => Annotation,
+            15 => Reserved,
+            _ => {
+                return decoding_error(format!("{:?} is not a valid header type code.", type_code));
+            }
+        };
+        Ok(ion_type_code)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,9 @@
+#![allow(dead_code)]
+
 #[macro_use]
 extern crate failure_derive;
 
 pub mod result;
+
+mod types;
+mod binary;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,0 +1,7 @@
+//! This module provides an implementation of the data types described by the
+//! [Ion Data Model](http://amzn.github.io/ion-docs/docs/spec.html#the-ion-data-model)
+//! section of the Ion 1.0 spec.
+
+mod r#type;
+
+pub use r#type::IonType;

--- a/src/types/type.rs
+++ b/src/types/type.rs
@@ -1,0 +1,19 @@
+/// Represents the Ion data type of a given value. To learn more about each data type,
+/// read [the Ion Data Model](http://amzn.github.io/ion-docs/docs/spec.html#the-ion-data-model)
+/// section of the spec.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Copy, Clone)]
+pub enum IonType {
+    Null,
+    Boolean,
+    Integer,
+    Float,
+    Decimal,
+    Timestamp,
+    Symbol,
+    String,
+    Clob,
+    Blob,
+    List,
+    SExpression,
+    Struct,
+}


### PR DESCRIPTION
#### Changes

* Builds on PR #1, which set up the repo as well as basic error handling.
* Creates two submodules:
  * The `types` module will eventually be home to data types like `IonString`, `IonInteger`, etc.
  * The `binary` module will be home to the data structures needed to read and write binary Ion, e.g. `BinaryIonReader`, `BinaryIonWriter`, etc.
* Creates `types::IonType`, an enum which is analogous to Java's IonType enum.
* Creates `binary::IonTypeCode`, an enum which represents the system-level information obtained from the type code half of a binary value's header byte.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
