### PR TITLE
Cleans up broken links in docs

### DIFF
--- a/src/binary/int.rs
+++ b/src/binary/int.rs
@@ -138,7 +138,7 @@ impl DecodedInt {
     /// Encodes a negative zero as an `Int` and writes it to the privided `sink`.
     /// Returns the number of bytes written.
     ///
-    /// This method is similar to [write_i64]. However, because an i64 cannot represent a negative
+    /// This method is similar to [Self::write_i64]. However, because an i64 cannot represent a negative
     /// zero, a separate method is required.
     pub fn write_negative_zero<W: Write>(sink: &mut W) -> IonResult<usize> {
         sink.write_all(&[INT_NEGATIVE_ZERO])?;

--- a/src/binary/non_blocking/raw_binary_reader.rs
+++ b/src/binary/non_blocking/raw_binary_reader.rs
@@ -297,13 +297,14 @@ impl Container {
 /// A raw binary reader that pulls input bytes from a fixed buffer.
 ///
 /// If any read operation fails due to the buffer containing incomplete data, that method will
-/// return [IonError::Incomplete].
+/// return [`IonError::Incomplete`](crate::IonError::Incomplete).
 ///
-/// If the buffer (generic type `A`) is a [Vec<u8>], then data can be appended to it between read
+/// If the buffer (generic type `A`) is a [`Vec<u8>`], then data can be appended to it between read
 /// operations. This can be useful when reading from a data source that is growing over time, such
 /// as when tailing a growing file, reading over the network, or waiting for user input.
 /// Applications can read from the buffer until they encounter an `Incomplete`. Then, when more
-/// data is available, they can use [read_from] or [append_bytes] to add that data to the buffer.
+/// data is available, they can use [read_from](Self::read_from) or
+/// [append_bytes](Self::append_bytes) to add that data to the buffer.
 /// Finally, they can retry the read operation that had previously failed.
 ///
 /// Note that if the buffer runs out of data between top level values, this will be interpreted
@@ -503,7 +504,7 @@ impl<A: AsRef<[u8]>> RawBinaryBufferReader<A> {
     /// If the reader is currently positioned on a string, returns the slice of bytes that represents
     /// that string's *UNVALIDATED* utf-8 bytes. This method is available for performance optimization
     /// in scenarios where utf-8 validation may be unnecessary and/or a bottleneck. It is strongly
-    /// recommended that you use [read_str] unless absolutely necessary.
+    /// recommended that you use [read_str](Self::read_str) unless absolutely necessary.
     pub fn read_str_bytes(&mut self) -> IonResult<&[u8]> {
         let (_encoded_value, bytes) = self.value_and_bytes(IonType::String)?;
         Ok(bytes)

--- a/src/binary/raw_binary_reader.rs
+++ b/src/binary/raw_binary_reader.rs
@@ -774,7 +774,7 @@ const EMPTY_SLICE_U8: &[u8] = &[];
 const EMPTY_SLICE_RAW_SYMBOL_TOKEN: &[RawSymbolToken] = &[];
 
 /// Additional functionality that's only available if the data source is in-memory, such as a
-/// Vec<u8> or &[u8]).
+/// `Vec<u8>` or `&[u8]`).
 impl<T> RawBinaryReader<io::Cursor<T>>
 where
     T: AsRef<[u8]>,

--- a/src/binary/raw_binary_writer.rs
+++ b/src/binary/raw_binary_writer.rs
@@ -147,8 +147,8 @@ impl EncodingLevel {
 /// management; symbol-related operations (e.g. setting field IDs and annotations or writing symbol
 /// values) require a valid symbol ID to be provided by the caller.
 ///
-/// To produce a valid binary Ion stream, the writer MUST call [Writer::write_ion_version_marker] before
-/// writing any data.
+/// To produce a valid binary Ion stream, the writer MUST call
+/// [RawBinaryWriter::write_ion_version_marker] before writing any data.
 #[derive(Debug)]
 pub struct RawBinaryWriter<W: Write> {
     // A byte buffer to encode individual components of the stream.

--- a/src/binary/var_int.rs
+++ b/src/binary/var_int.rs
@@ -152,11 +152,11 @@ impl VarInt {
         Ok(encoded_bytes.len())
     }
 
-    /// Encodes a negative zero as an `VarInt` and writes it to the privided `sink`.
+    /// Encodes a negative zero as an `VarInt` and writes it to the provided `sink`.
     /// Returns the number of bytes written.
     ///
-    /// This method is similar to [write_i64]. However, because an i64 cannot represent a negative
-    /// zero, a separate method is required.
+    /// This method is similar to [write_i64](crate::binary::var_int::VarInt::write_i64).
+    /// However, because an i64 cannot represent a negative zero, a separate method is required.
     pub fn write_negative_zero<W: Write>(sink: &mut W) -> IonResult<usize> {
         sink.write_all(&[VARINT_NEGATIVE_ZERO])?;
         Ok(1)
@@ -171,7 +171,8 @@ impl VarInt {
     }
 
     /// Returns the value of the signed integer. If the [VarInt] is negative zero, this method
-    /// will return `0`. Use the [is_negative_zero] method to check for negative zero explicitly.
+    /// will return `0`. Use the [is_negative_zero](Self::is_negative_zero) method to check for
+    /// negative zero explicitly.
     #[inline(always)]
     pub fn value(&self) -> VarIntStorage {
         self.value

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -262,8 +262,8 @@ mod tests {
 }
 
 /// Types that implement this trait can be converted into an implementation of [io::BufRead],
-/// allowing users to build a [Reader] from a variety of types that might not define I/O operations
-/// on their own.
+/// allowing users to build a [Reader](crate::reader::Reader) from a variety of types that might not
+/// define I/O operations on their own.
 pub trait ToIonDataSource {
     type DataSource: IonDataSource;
     fn to_ion_data_source(self) -> Self::DataSource;

--- a/src/raw_reader.rs
+++ b/src/raw_reader.rs
@@ -18,11 +18,11 @@ where
     fn stream_complete(&mut self) {}
 }
 
-/// Allows a Box<dyn RawReader> to be used as a RawReader.
+/// Allows a `Box<dyn RawReader>` to be used as a RawReader.
 /// Note: this implementation contains some methods that are not object safe and so cannot be
 ///       invoked. For the moment, calling these methods via dynamic dispatch will result in a
 ///       panic. Longer-term, they will be replaced by object safe methods.
-///       See: https://github.com/amzn/ion-rust/issues/335
+///       See: <https://github.com/amzn/ion-rust/issues/335>
 impl<R: RawReader + ?Sized> IonReader for Box<R> {
     type Item = RawStreamItem;
     type Symbol = RawSymbolToken;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -442,7 +442,7 @@ impl<R: RawReader> IonReader for UserReader<R> {
 }
 
 /// Functionality that is only available if the data source we're reading from is in-memory, like
-/// a Vec<u8> or &[u8].
+/// a `Vec<u8>` or `&[u8]`.
 impl<T: AsRef<[u8]>> UserReader<RawBinaryReader<io::Cursor<T>>> {
     delegate! {
         to self.raw_reader {

--- a/src/stream_reader.rs
+++ b/src/stream_reader.rs
@@ -129,7 +129,7 @@ pub trait IonReader {
     /// current item is not a symbol or an IO error is encountered while reading, returns [crate::IonError].
     fn read_symbol(&mut self) -> IonResult<Self::Symbol>;
 
-    /// Attempts to read the current item as an Ion blob and return it as a [Vec<u8>]. If the
+    /// Attempts to read the current item as an Ion blob and return it as a `Vec<u8>`. If the
     /// current item is not a blob or an IO error is encountered while reading, returns [crate::IonError].
     fn read_blob(&mut self) -> IonResult<Vec<u8>>;
 
@@ -143,7 +143,7 @@ pub trait IonReader {
         Self: Sized,
         F: FnOnce(&[u8]) -> U;
 
-    /// Attempts to read the current item as an Ion clob and return it as a [Vec<u8>]. If the
+    /// Attempts to read the current item as an Ion clob and return it as a `Vec<u8>`. If the
     /// current item is not a clob or an IO error is encountered while reading, returns [crate::IonError].
     fn read_clob(&mut self) -> IonResult<Vec<u8>>;
 

--- a/src/system_reader.rs
+++ b/src/system_reader.rs
@@ -730,7 +730,7 @@ impl<R: RawReader> IonReader for SystemReader<R> {
 }
 
 /// Functionality that is only available if the data source we're reading from is in-memory, like
-/// a Vec<u8> or &[u8].
+/// a `Vec<u8>` or `&[u8]`.
 impl<T: AsRef<[u8]>> SystemReader<RawBinaryReader<io::Cursor<T>>> {
     delegate! {
         to self.raw_reader {

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -153,9 +153,9 @@ pub struct Timestamp {
 //       instantiated and tested for equality, but will not very useful as a general purpose
 //       datetime until these methods are added.
 impl Timestamp {
-    /// Converts a [NaiveDateTime] or [DateTime<FixedOffset>] to a Timestamp with the specified
-    /// precision. If the precision is [Precision::Second], nanosecond precision (the maximum
-    /// supported by a [Timelike]) is assumed.
+    /// Converts a [`NaiveDateTime`] or [`DateTime<FixedOffset>`] to a Timestamp with the specified
+    /// precision. If the precision is [`Precision::Second`], nanosecond precision (the maximum
+    /// supported by a [`Timelike`]) is assumed.
     pub fn from_datetime<D>(datetime: D, precision: Precision) -> Timestamp
     where
         D: Datelike + Timelike + Into<Timestamp>,

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates.
 
-//! Provides borrowed implementations of [`SymbolToken`], [`Element`] and its dependents.
+//! Provides borrowed implementations of [`IonSymbolToken`], [`IonElement`] and its dependents.
 //!
 //! Specifically, all implementations are tied to some particular lifetime, generally linked
 //! to a parser implementation of some sort or some context from which the borrow can occur.
@@ -137,7 +137,7 @@ impl<'val> Builder for ElementRef<'val> {
     }
 }
 
-/// A borrowed implementation of [`Sequence`].
+/// A borrowed implementation of [`IonSequence`].
 #[derive(Debug, Clone)]
 pub struct SequenceRef<'val> {
     // TODO: Since we've moved the elements Vec to the heap, we could consider replacing it with a
@@ -195,7 +195,7 @@ impl<'val> PartialEq for SequenceRef<'val> {
 
 impl<'val> Eq for SequenceRef<'val> {}
 
-/// A borrowed implementation of [`Struct`]
+/// A borrowed implementation of [`IonStruct`]
 #[derive(Debug, Clone)]
 pub struct StructRef<'val> {
     fields: Rc<FieldRefs<'val>>,
@@ -424,7 +424,7 @@ impl<'val> IonEq for Vec<ElementRef<'val>> {
     }
 }
 
-/// Variants for all borrowed version _values_ within an [`Element`].
+/// Variants for all borrowed version _values_ within an [`IonElement`].
 #[derive(Debug, Clone, PartialEq)]
 pub enum ValueRef<'val> {
     Null(IonType),
@@ -443,7 +443,7 @@ pub enum ValueRef<'val> {
     // TODO fill this in with the rest...
 }
 
-/// A borrowed implementation of [`Element`]
+/// A borrowed implementation of [`IonElement`]
 #[derive(Debug, Clone)]
 pub struct ElementRef<'val> {
     annotations: Vec<SymbolRef<'val>>,

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -10,9 +10,9 @@
 //! * The [`borrowed`] module provides an implementation of values that are tied to some
 //!   associated lifetime and borrow a reference to their underlying data in some way
 //!   (e.g. storing a `&str` in the value versus a fully owned `String`).
-//! * The [`reader`] module provides API and implementation to read Ion data into [`Element`]
+//! * The [`reader`] module provides API and implementation to read Ion data into [`IonElement`]
 //!   instances.
-//! * The [`writer`] module provides API and implementation to write Ion data from [`Element`]
+//! * The [`writer`] module provides API and implementation to write Ion data from [`IonElement`]
 //!   instances.
 //!
 //! ## Examples
@@ -39,7 +39,7 @@
 //! ```
 //!
 //! [`ElementReader::read_all`](reader::ElementReader::read_all) is a convenient way to put all of the
-//! parsed [`Element`] into a [`Vec`], with a single [`IonError`](crate::result::IonError) wrapper:
+//! parsed [`IonElement`] into a [`Vec`], with a single [`IonError`](crate::result::IonError) wrapper:
 //!
 //! ```
 //! # use ion_rs::IonType;
@@ -61,8 +61,8 @@
 //! ```
 //!
 //! [`ElementReader::read_one`](reader::ElementReader::read_one) is another convenient way to parse a single
-//! top-level element into a [`Element`].  This method will return an error if the data has
-//! a parsing error or if there is more than one [`Element`] in the stream:
+//! top-level element into a [`IonElement`].  This method will return an error if the data has
+//! a parsing error or if there is more than one [`IonElement`] in the stream:
 //!
 //! ```
 //! # use ion_rs::IonType;
@@ -95,7 +95,7 @@
 //! ```
 //!
 //! To serialize data, users can use the [`ElementWriter`](writer::ElementWriter) trait to serialize data
-//! from [`Element`] to binary or text Ion:
+//! from [`IonElement`] to binary or text Ion:
 //!
 //! ```ignore
 //! use ion_rs::result::IonResult;
@@ -126,7 +126,7 @@
 //! most easily by writing generic functions that can work with a reference of any type.
 //!
 //! For example, consider a fairly contrived, but generic `extract_text` function that unwraps
-//! and converts [`SymbolToken::text()`] into an owned `String`:
+//! and converts [`IonSymbolToken::text()`] into an owned `String`:
 //!
 //! ```
 //! use ion_rs::Symbol;
@@ -148,7 +148,7 @@
 //! assert_eq!(owned_text, borrowed_text);
 //! ```
 //!
-//! This extends to the [`Element`] trait as well which is the "top-level" API type for
+//! This extends to the [`IonElement`] trait as well which is the "top-level" API type for
 //! any Ion datum.  Consider a contrived function that extracts and returns the annotations
 //! of an underlying element as a `Vec<String>`.  Note that it filters out any annotation
 //! that may not have text (so data could be dropped):
@@ -392,7 +392,7 @@ where
     /// if the value is any `null`, or the text of the `symbol` is not defined.
     fn as_str(&self) -> Option<&str>;
 
-    /// Returns a reference to the [`SymbolToken`] of this element.
+    /// Returns a reference to the [`IonSymbolToken`] of this element.
     ///
     /// This will return `None` in the case that the type is not `symbol` or the value is
     /// any `null`.
@@ -410,13 +410,13 @@ where
     /// any `null`.
     fn as_bytes(&self) -> Option<&[u8]>;
 
-    /// Returns a reference to the [`Sequence`] of this element.
+    /// Returns a reference to the [`IonSequence`] of this element.
     ///
     /// This will return `None` in the case that the type is not `sexp`/`list` or
     /// if the value is any `null`.
     fn as_sequence(&self) -> Option<&Self::Sequence>;
 
-    /// Returns a reference to the [`Struct`] of this element.
+    /// Returns a reference to the [`IonStruct`] of this element.
     ///
     /// This will return `None` in the case that the type is not `struct` or the value is
     /// any `null`.

--- a/src/value/native_reader.rs
+++ b/src/value/native_reader.rs
@@ -106,7 +106,7 @@ impl<R: RawReader> NativeElementIterator<R> {
     }
 }
 
-/// Provides an implementation of [ElementReader] that is backed by a native Rust [Reader].
+/// Provides an implementation of [ElementReader] that is backed by a native Rust [Reader](crate::reader::Reader).
 pub struct NativeElementReader;
 
 impl ElementReader for NativeElementReader {

--- a/src/value/native_writer.rs
+++ b/src/value/native_writer.rs
@@ -2,7 +2,7 @@ use crate::value::writer::ElementWriter;
 use crate::value::{IonElement, IonSequence, IonStruct, IonSymbolToken};
 use crate::{IonResult, IonType, IonWriter, RawSymbolTokenRef};
 
-/// Writes [Element] instances to the underlying [Writer] implementation.
+/// Writes [`IonElement`] instances to the underlying [`IonWriter`] implementation.
 pub struct NativeElementWriter<W: IonWriter> {
     writer: W,
 }
@@ -21,7 +21,7 @@ impl<W: IonWriter> ElementWriter for NativeElementWriter<W> {
 }
 
 impl<W: IonWriter> NativeElementWriter<W> {
-    /// Constructs a new `NativeElementWriter` that wraps the provided [Writer] implementation.
+    /// Constructs a new `NativeElementWriter` that wraps the provided [`IonWriter`] implementation.
     pub fn new(writer: W) -> Self {
         NativeElementWriter { writer }
     }

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates.
 
-//! Provides owned implementations of [`SymbolToken`], [`Element`] and its dependents.
+//! Provides owned implementations of [`IonSymbolToken`], [`IonElement`] and its dependents.
 //!
 //! This API is simpler to manage with respect to borrowing lifetimes, but requires full
 //! ownership of data to do so.
@@ -139,7 +139,7 @@ impl Builder for Element {
     }
 }
 
-/// An owned implementation of [`Sequence`]
+/// An owned implementation of [`IonSequence`]
 #[derive(Debug, Clone)]
 pub struct Sequence {
     // TODO: Since we've moved the elements Vec to the heap, we could consider replacing it with a
@@ -422,7 +422,7 @@ impl IonEq for Vec<Element> {
     }
 }
 
-/// Variants for all owned version _values_ within an [`Element`].
+/// Variants for all owned version _values_ within an [`IonElement`].
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
     Null(IonType),

--- a/src/value/reader.rs
+++ b/src/value/reader.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates.
 
-//! Provides APIs to read Ion data into [`Element`](super::Element) from different sources such
+//! Provides APIs to read Ion data into [`IonElement`](super::IonElement) from different sources such
 //! as slices or files.
 
 use crate::result::{decoding_error, IonResult};
@@ -11,10 +11,10 @@ use crate::value::owned::Element;
 //      we could make it generic with generic associated types or just have a lifetime
 //      scoped implementation
 
-/// Reads Ion data into [`Element`](super::Element) instances.
+/// Reads Ion data into [`IonElement`](super::IonElement) instances.
 ///
 /// ## Notes
-/// Users of this trait should not assume any particular implementation of [`Element`](super::Element).
+/// Users of this trait should not assume any particular implementation of [`IonElement`](super::IonElement).
 /// In the future, [generic associated types (GAT)][gat] and [existential types in traits][et]
 /// should make it easier to model this more abstractly.
 ///
@@ -22,9 +22,9 @@ use crate::value::owned::Element;
 /// [et]:https://rust-lang.github.io/rfcs/2071-impl-trait-existential-types.html
 pub trait ElementReader {
     /// Parses Ion over a given slice of data and yields each top-level value as
-    /// an [`Element`](super::Element) instance.
+    /// an [`IonElement`](super::IonElement) instance.
     ///
-    /// The [`Iterator`] will generally return `Some(Ok([Element]))` but on a failure of
+    /// The [`Iterator`] will generally return `Some(Ok([`IonElement`]))` but on a failure of
     /// parsing it will return a `Some(Err([IonError]))` and then a `None` to signal no more
     /// elements.
     ///
@@ -42,9 +42,9 @@ pub trait ElementReader {
         self.iterate_over(data)?.collect()
     }
 
-    /// Parses Ion over a given slice into a single [`Element`](super::Element) instance.
+    /// Parses Ion over a given slice into a single [`IonElement`](super::IonElement) instance.
     /// Returns [`IonError`](crate::result::IonError) if any error occurs during the parse
-    /// or there is more than one top-level [`Element`](super::Element) in the data.
+    /// or there is more than one top-level [`IonElement`](super::IonElement) in the data.
     #[inline]
     fn read_one(&self, data: &[u8]) -> IonResult<Element> {
         let mut iter = self.iterate_over(data)?;

--- a/src/value/writer.rs
+++ b/src/value/writer.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates.
 
-//! Provides utility to serialize Ion data from [`Element`](super::Element) into common targets
+//! Provides utility to serialize Ion data from [`IonElement`](super::IonElement) into common targets
 //! such as byte buffers or files.
 
 use super::IonElement;
@@ -9,17 +9,17 @@ use crate::result::IonResult;
 pub use Format::*;
 pub use TextKind::*;
 
-/// Serializes [`Element`] instances into some kind of output sink.
+/// Serializes [`IonElement`] instances into some kind of output sink.
 pub trait ElementWriter {
     /// The output of the writer when finishing, it could be a managed buffer,
     /// some concept of a stream, metadata about a file, or something appropriate
     /// for the destination.
     type Output;
 
-    /// Serializes a single [`Element`] as a top-level value.
+    /// Serializes a single [`IonElement`] as a top-level value.
     fn write<E: IonElement>(&mut self, element: &E) -> IonResult<()>;
 
-    /// Serializes a collection of [`Element`] as a series of top-level values.
+    /// Serializes a collection of [`IonElement`] as a series of top-level values.
     ///
     /// This will return [`Err`] if writing any element causes a failure.
     fn write_all<'a, E: IonElement + 'a, I: IntoIterator<Item = &'a E>>(

--- a/tests/element_test_vectors.rs
+++ b/tests/element_test_vectors.rs
@@ -175,7 +175,7 @@ trait ElementApi {
     /// )
     /// ```
     ///
-    /// This will parse each string as a [`Vec`] of [`Element`] and apply the `group_assert` function
+    /// This will parse each string as a [`Vec`] of [`IonElement`] and apply the `group_assert` function
     /// for every pair of the parsed data including the identity case (a parsed document is
     /// compared against itself).
     fn read_group_embedded<R, S, F>(reader: &R, raw_group: &S, group_assert: &F) -> IonResult<()>


### PR DESCRIPTION
**Issue #, if available:**

None that I'm aware of.

**Description of changes:**

* Fixes broken intra-doc links, some formatting (e.g. Vec\<u8> -> `Vec<u8>` so that `cargo doc` doesn't complain about unclosed HTML tags), and some spelling mistakes.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
