### PR TITLE
Version bump to ion-rs v0.15.0; ion-hash v0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
   "**/ion-tests/iontestdata/**",
   "*.pdf"
 ]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 # We need at least 1.65 for GATs
 # https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html

--- a/ion-hash/Cargo.toml
+++ b/ion-hash/Cargo.toml
@@ -16,14 +16,14 @@ exclude = [
     "**/ion-tests/iontestdata/**",
     "*.pdf"
 ]
-version = "0.0.9"
+version = "0.1.0"
 edition = "2021"
 # We need at least 1.65 for GATs
 # https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html
 rust-version = "1.65"
 
 [dependencies]
-ion-rs = { path="..", version = "0.14" }
+ion-rs = { path="..", version = "0.15" }
 num-bigint = "0.3"
 digest = "0.9"
 sha2 = "0.9"


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

* Version bump to ion-rs v0.15.0; ion-hash v0.1.0
* Update `ion-tests` submodule to the latest commit. "After all the tests pass, why not? Why shouldn't I keep it?", thought I. 

This should be reviewed and merged after #455

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
