### PR TITLE
Format Agnostic RawReader Pass

### DIFF
--- a/src/result.rs
+++ b/src/result.rs
@@ -4,8 +4,8 @@ use std::{fmt, io};
 
 use thiserror::Error;
 
-/// Position represents the location within an ion document where an error has been
-/// identified. For all formats `byte_offset` will contain the number of bytes into the document
+/// Position represents the location within an Ion stream where an error has been
+/// identified. For all formats `byte_offset` will contain the number of bytes into the stream
 /// that have been processed prior to encountering the error. When working with the text format,
 /// `line_column` will be updated to contain the line and column as well.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -32,7 +32,7 @@ impl Position {
         }
     }
 
-    /// Returns the offset from the start of the ion document in bytes.
+    /// Returns the offset from the start of the Ion stream in bytes.
     pub fn byte_offset(&self) -> usize {
         self.byte_offset
     }
@@ -44,12 +44,12 @@ impl Position {
 
     /// If available returns the line component of the text position.
     pub fn line(&self) -> Option<usize> {
-        self.line_column.and_then(|(line, _column)| Some(line))
+        self.line_column.map(|(line, _column)| line)
     }
 
     /// If available returns the column component of the text position.
     pub fn column(&self) -> Option<usize> {
-        self.line_column.and_then(|(_line, column)| Some(column))
+        self.line_column.map(|(_line, column)| column)
     }
 
     /// Returns true if the current Position contains line and column offsets.

--- a/src/text/non_blocking/raw_text_reader.rs
+++ b/src/text/non_blocking/raw_text_reader.rs
@@ -972,7 +972,7 @@ mod reader_tests {
     use super::*;
     use crate::raw_reader::RawStreamItem;
     use crate::raw_symbol_token::{local_sid_token, text_token, RawSymbolToken};
-    use crate::result::{IonResult, Position, TextPosition};
+    use crate::result::{IonResult, Position};
     use crate::stream_reader::IonReader;
     use crate::text::non_blocking::raw_text_reader::RawTextReader;
     use crate::text::text_value::{IntoAnnotations, TextValue};
@@ -1014,7 +1014,7 @@ mod reader_tests {
             Err(IonError::Incomplete {
                 position:
                     Position {
-                        line_column: TextPosition::LineAndColumn(line, column),
+                        line_column: Some((line, column)),
                         ..
                     },
                 ..
@@ -1048,7 +1048,7 @@ mod reader_tests {
             Err(IonError::Incomplete {
                 position:
                     Position {
-                        line_column: TextPosition::LineAndColumn(line, column),
+                        line_column: Some((line, column)),
                         ..
                     },
                 ..

--- a/src/text/non_blocking/raw_text_reader.rs
+++ b/src/text/non_blocking/raw_text_reader.rs
@@ -326,7 +326,7 @@ impl<A: AsRef<[u8]>> RawTextReader<A> {
                 Ok(())
             }
             RootParseResult::Incomplete(line, column) => {
-                incomplete_text_error("text", self.buffer.bytes_consumed(), line, column)
+                incomplete_text_error("text", self.buffer.get_position())
             }
             RootParseResult::Eof => {
                 // We are only concerned with EOF behaviors when we are at the end of the stream,
@@ -345,12 +345,7 @@ impl<A: AsRef<[u8]>> RawTextReader<A> {
                     self.process_stream_item(item)
                 } else {
                     // If we are not at the end of the stream, we need to get more data.
-                    incomplete_text_error(
-                        "text",
-                        self.buffer.bytes_consumed(),
-                        self.buffer.lines_loaded(),
-                        self.buffer.line_offset(),
-                    )
+                    incomplete_text_error("text", self.buffer.get_position())
                 }
             }
             RootParseResult::NoMatch => {
@@ -412,12 +407,7 @@ impl<A: AsRef<[u8]>> RawTextReader<A> {
             Ok(Some(value)) => Ok(value),
             Ok(None) => {
                 if !self.is_eos {
-                    incomplete_text_error(
-                        "text",
-                        self.buffer.bytes_consumed(),
-                        self.buffer.lines_loaded(),
-                        self.buffer.line_offset(),
-                    )
+                    incomplete_text_error("text", self.buffer.get_position())
                 } else {
                     decoding_error(format!(
                         "unexpected end of input while reading {} on line {}: '{}'",
@@ -445,7 +435,7 @@ impl<A: AsRef<[u8]>> RawTextReader<A> {
         match self.parse_next_nom(parser) {
             RootParseResult::Ok(item) => Ok(Some(item)),
             RootParseResult::Incomplete(line, column) => {
-                incomplete_text_error("text", self.buffer.bytes_consumed(), line, column)
+                incomplete_text_error("text", self.buffer.get_position())
             }
             RootParseResult::Eof => Ok(None),
             RootParseResult::NoMatch => {
@@ -461,12 +451,7 @@ impl<A: AsRef<[u8]>> RawTextReader<A> {
                     );
                     decoding_error(error_message)
                 } else {
-                    incomplete_text_error(
-                        "text",
-                        self.buffer.bytes_consumed(),
-                        self.buffer.lines_loaded(),
-                        self.buffer.line_offset(),
-                    )
+                    incomplete_text_error("text", self.buffer.get_position())
                 }
             }
             RootParseResult::Failure(error_message) => decoding_error(error_message),
@@ -1025,7 +1010,7 @@ mod reader_tests {
             Err(IonError::Incomplete {
                 position:
                     Position {
-                        line_column: TextPosition::LineColumn(line, column),
+                        line_column: TextPosition::LineAndColumn(line, column),
                         ..
                     },
                 ..
@@ -1059,7 +1044,7 @@ mod reader_tests {
             Err(IonError::Incomplete {
                 position:
                     Position {
-                        line_column: TextPosition::LineColumn(line, column),
+                        line_column: TextPosition::LineAndColumn(line, column),
                         ..
                     },
                 ..

--- a/src/text/non_blocking/text_buffer.rs
+++ b/src/text/non_blocking/text_buffer.rs
@@ -1,3 +1,4 @@
+use crate::result::Position;
 use crate::{IonError, IonResult};
 
 use std::io::Read;
@@ -109,6 +110,11 @@ impl<A: AsRef<[u8]>> TextBuffer<A> {
     /// Returns the total number of bytes that have been consumed.
     pub fn bytes_consumed(&self) -> usize {
         self.bytes_consumed
+    }
+
+    pub fn get_position(&self) -> Position {
+        Position::with_offset(self.bytes_consumed)
+            .with_text_position(self.line_number, self.line_offset)
     }
 
     /// Save a checkpoint that can be rolled back to.

--- a/src/text/non_blocking/text_buffer.rs
+++ b/src/text/non_blocking/text_buffer.rs
@@ -25,6 +25,7 @@ struct Checkpoint {
     pub line: ValidUtf8Span,
     pub line_number: usize,
     pub offset: usize,
+    pub bytes_consumed: usize,
 }
 
 /// Calculates the offset into a slice, where a given subslice is located.
@@ -72,6 +73,8 @@ pub(crate) struct TextBuffer<A: AsRef<[u8]>> {
     data_exhausted: bool,
     /// The span of our `data` that has been validated as UTF-8.
     data_utf8: ValidUtf8Span,
+    /// The total number of bytes that have been consumed.
+    bytes_consumed: usize,
 
     /// The current validated line data (can contain multiple lines).
     line: ValidUtf8Span,
@@ -94,12 +97,18 @@ impl<A: AsRef<[u8]>> TextBuffer<A> {
             data_end: data_len,
             data_exhausted: false,
             data_utf8: ValidUtf8Span(0, 0),
+            bytes_consumed: 0,
             line: ValidUtf8Span(0, 0),
             line_offset: 0,
             line_number: 0,
             line_end_column: 0,
             checkpoint: None,
         }
+    }
+
+    /// Returns the total number of bytes that have been consumed.
+    pub fn bytes_consumed(&self) -> usize {
+        self.bytes_consumed
     }
 
     /// Save a checkpoint that can be rolled back to.
@@ -111,6 +120,7 @@ impl<A: AsRef<[u8]>> TextBuffer<A> {
             line: self.line,
             line_number: self.line_number,
             offset: self.line_offset,
+            bytes_consumed: self.bytes_consumed,
         })
     }
 
@@ -119,6 +129,7 @@ impl<A: AsRef<[u8]>> TextBuffer<A> {
             self.line_offset = checkpoint.offset;
             self.line = checkpoint.line;
             self.line_number = checkpoint.line_number;
+            self.bytes_consumed = checkpoint.bytes_consumed;
         }
     }
 
@@ -179,6 +190,7 @@ impl<A: AsRef<[u8]>> TextBuffer<A> {
             "Cannot consume() a number of bytes that will leave invalid UTF-8 in the current line."
         );
         self.line_offset += number_of_bytes;
+        self.bytes_consumed += number_of_bytes;
     }
 
     /// Loads a single line from the underlying data source into the buffer.

--- a/src/text/raw_text_reader.rs
+++ b/src/text/raw_text_reader.rs
@@ -63,7 +63,7 @@ impl<T: ToIonDataSource> IonReader for RawTextReader<T> {
 
         loop {
             let result = self.reader.next();
-            if let Err(IonError::IncompleteText { .. }) = result {
+            if let Err(IonError::Incomplete { .. }) = result {
                 let bytes_read = self.read_source(read_size)?;
                 // if we have no bytes, and our stream has been marked as fully loaded, then we
                 // need to bubble up the error. Otherwise, if our stream has not been marked as
@@ -202,7 +202,7 @@ impl<T: ToIonDataSource> IonReader for RawTextReader<T> {
         let mut read_size = self.expected_read_size;
         loop {
             let result = self.reader.step_out();
-            if let Err(IonError::IncompleteText { .. }) = result {
+            if let Err(IonError::Incomplete { .. }) = result {
                 if 0 == self.read_source(read_size)? {
                     return result;
                 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
This PR adds a format agnostic Position for error reporting of locations within an Ion document. For both text and binary formats the Position holds a byte offset. Positions within text documents can also add an optional Line and Column to the Position for better error reporting in the text format.

The addition of Position allowed the text only error `IncompleteText` to be removed and the RawTextReader can now use the `Incomplete` error like RawBinaryReader.

This PR also adjusts the handling of incomplete data in the RawBinaryReader's `step_out`. Prior to this PR if `step_out` was called without enough data in the buffer, the function would return `Ok(())` and set the reader's state to `Skipping` with the remaining bytes that could not be skipped. This PR continues to consume, and set the `Skipping` state, but returns an `Incomplete` error rather than `Ok(())` in order to match the behavior of the RawTextReader.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
