### PR TITLE
Fix permissions for clippy-check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,8 @@ jobs:
         # meantime, the build only tests Windows Server 2019.
         # See https://github.com/amzn/ion-rust/issues/353
         os: [ubuntu-latest, windows-2019, macos-latest]
+    permissions:
+      checks: write
 
     steps:
       - name: Remove MSys64 MingW64 Binaries


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
The clippy-check github action has been failing with the move to the amazon-ion org. This seems to be due to default permissions that changed between the amzn org, and our new org. Documentation seems to say that we should be able to allow write permissions via the workflow config, so this PR is an attempt at doing that.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
