### PR TITLE
Fix transposed string formats for RawStreamItem

### DIFF
--- a/src/raw_reader.rs
+++ b/src/raw_reader.rs
@@ -190,8 +190,8 @@ impl Display for RawStreamItem {
         use RawStreamItem::*;
         match self {
             VersionMarker(major, minor) => write!(f, "ion version marker (v{}.{})", major, minor),
-            Value(ion_type) => write!(f, "null.{}", ion_type),
-            Null(ion_type) => write!(f, "{}", ion_type),
+            Value(ion_type) => write!(f, "{}", ion_type),
+            Null(ion_type) => write!(f, "null.{}", ion_type),
             Nothing => write!(f, "nothing/end-of-sequence"),
         }
     }


### PR DESCRIPTION
*Issue #, if available:*

None

*Description of changes:*

Looks like two of the format strings for RawStreamItem got transposed at some point. This change swaps them back the way they should be.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
