### PR TITLE
Fix validated span calculation bug which could result in invalid UTF-8 sequences.

### DIFF
--- a/src/text/non_blocking/text_buffer.rs
+++ b/src/text/non_blocking/text_buffer.rs
@@ -287,7 +287,6 @@ impl<A: AsRef<[u8]>> TextBuffer<A> {
                     // There is an incomplete multi-byte sequence at the end of the data.
                     // We'll assume the remaining bytes for that sequence will be appended later
                     // and mark everything up to the start of that sequence as valid.
-                    // last_valid_offset + valid_end
                     last_valid_offset + valid_end
                 } else {
                     // The input contained an invalid UTF-8 sequence.

--- a/src/text/non_blocking/text_buffer.rs
+++ b/src/text/non_blocking/text_buffer.rs
@@ -287,7 +287,7 @@ impl<A: AsRef<[u8]>> TextBuffer<A> {
                     // There is an incomplete multi-byte sequence at the end of the data.
                     // We'll assume the remaining bytes for that sequence will be appended later
                     // and mark everything up to the start of that sequence as valid.
-                    last_valid_offset + valid_start
+                    last_valid_offset + valid_end
                 } else {
                     // The input contained an invalid UTF-8 sequence.
                     Err(TextError::utf8_error(last_valid_offset))?


### PR DESCRIPTION
*Issue #, if available:* 461

*Description of changes:*
An issue was identified in #461 where a partial unicode sequence was being included in the text returned by the non-blocking text buffer. This turned out to be due to a typo when generating the range of UTF-8 validated characters within the buffer.

In order for `validate_data` to incrementally validate data we keep track of the previously validated end and validate from that point to the current end of the buffer each time more data is added. When the data is passed to `from_utf8` it is sliced from the full data, re-indexing it. In order to account for the re-indexing, we need to add the true offset from the previously validated end, to the new validated end offset returned by `from_utf8`.

Unfortunately prior to this PR a typo/bug was made where rather than adding the previously validated end, the prevously validated **start** was added. This resulted in invalid ranges being tracked for validated data. The issue would present when data was added to the text buffer resulting in a partial UTF-8 sequence.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
