### PR TITLE
Dependency updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,24 +29,23 @@ members = [
 
 [dependencies]
 base64 = "0.12"
-bigdecimal = "0.2"
+bigdecimal = "0.3.0"
 bytes = "0.4"
 chrono = "0.4"
-delegate = "0.5"
+delegate = "0.9.0"
 thiserror = "1.0"
 nom = "7.1.1"
-num-bigint = "0.3"
+num-bigint = "0.4.3"
 num-integer = "0.1.44"
 num-traits = "0.2"
 arrayvec = "0.7"
 smallvec = "1.9.0"
 
 [dev-dependencies]
-rstest = "0.9"
+rstest = "0.16.0"
 # Used by ion-tests integration
 walkdir = "2.3"
 test-generator = "0.3"
-pretty-hex = "0.2"
 memmap = "0.7.0"
 
 [profile.release]

--- a/ion-hash/Cargo.toml
+++ b/ion-hash/Cargo.toml
@@ -24,7 +24,7 @@ rust-version = "1.65"
 
 [dependencies]
 ion-rs = { path="..", version = "0.15" }
-num-bigint = "0.3"
+num-bigint = "0.4.3"
 digest = "0.9"
 sha2 = "0.9"
 thiserror = "1.0"


### PR DESCRIPTION
This patch updates out-of-date dependencies that could be upgraded without any additional logic or code changes.

* `bigdecimal`: 0.2 -> 0.3
* `delegate`: 0.5 -> 0.9
* `num-bigint`: 0.3. -> 0.4
* `rstest`: 0.9 -> 0.16

`pretty-hex` (which was not being used) is no longer a dev dependency.

`base64` and `bytes` remain outdated, but will require logic changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
