### PR TITLE
Fix silent test failures caused by unimplemented features

### DIFF
--- a/tests/element_test_vectors.rs
+++ b/tests/element_test_vectors.rs
@@ -393,7 +393,7 @@ mod impl_display_for_element_tests {
     use ion_rs::TextWriterBuilder;
     use std::fs::read;
 
-    const TO_STRING_SKIP_LIST: [&'static str; 12] = [
+    const TO_STRING_SKIP_LIST: &[&'static str] = &[
         // These tests have shared symbol table imports in them, which the Reader does not
         // yet support.
         "ion-tests/iontestdata/good/subfieldInt.ion",


### PR DESCRIPTION
**Issue #, if available:**

Fixes #468 

**Description of changes:**

Updates `impl_display_for_element_tests::test_to_string` so that it doesn't return a `Result`. All intermediate results must now be dealt with in this function.

Adds a skip list for failing test cases. All currently skipped tests cases are due to unimplemented functionality.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
