### PR TITLE
Make Display for Decimal more human-friendly

### DIFF
--- a/src/types/decimal.rs
+++ b/src/types/decimal.rs
@@ -298,7 +298,7 @@ impl Display for Decimal {
     #[rustfmt::skip] // https://github.com/rust-lang/rustfmt/issues/3255
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         // Inspired by the formatting conventions of Java's BigDecimal.toString()
-        const WIDE_NUMBER: i64 = 6; // if you think about it, six is a lot 🙃
+        const WIDE_NUMBER: usize = 6; // if you think about it, six is a lot 🙃
 
         let digits = &*self.coefficient.magnitude.to_string();
         let len = digits.len();
@@ -311,7 +311,7 @@ impl Display for Decimal {
             write!(f, "-").unwrap();
         };
 
-        if self.exponent == 0 && len > WIDE_NUMBER as usize { // e.g. A.BCDEFGd6
+        if self.exponent == 0 && len > WIDE_NUMBER { // e.g. A.BCDEFGd6
             write!(f, "{}.{}d{}", &digits[0..1], &digits[1..len], (dot_index - 1))
         } else if self.exponent == 0 { // e.g. ABC.
             write!(f, "{}.", &digits)
@@ -321,7 +321,7 @@ impl Display for Decimal {
             if dot_index > 0 { // e.g. A.BC or AB.C
                 let dot_index = dot_index as usize;
                 write!(f, "{}.{}", &digits[0..dot_index], &digits[dot_index..len])
-            } else if dot_index > -WIDE_NUMBER { // e.g. 0.ABC or 0.000ABC
+            } else if dot_index > -(WIDE_NUMBER as i64) { // e.g. 0.ABC or 0.000ABC
                 let width = dot_index.unsigned_abs() as usize + len;
                 write!(f, "0.{digits:0>width$}", width = width, digits = digits)
             } else { // e.g. A.BCd-12

--- a/src/types/decimal.rs
+++ b/src/types/decimal.rs
@@ -298,7 +298,7 @@ impl Display for Decimal {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let digits = &*self.coefficient.magnitude.to_string();
         let len = digits.len();
-        // The index of the decimal, relative to the magnitude representation
+        // The index of the decimal point, relative to the magnitude representation
         //       0123
         // Given ABCDd-2, the decimal gets inserted at position 2.
         let i_d = len as i64 + self.exponent;

--- a/src/types/decimal.rs
+++ b/src/types/decimal.rs
@@ -315,7 +315,6 @@ impl Display for Decimal {
             write!(f, "{}.", &digits)
         } else if self.exponent >= 0 {
             // e.g. ABCd1
-            // let zeroes = "0".repeat(self.exponent as usize);
             write!(f, "{}d{}", &digits, self.exponent)
         } else {
             // exponent < 0, there is a fractional component


### PR DESCRIPTION
*Description of changes:*

Before this all Decimals would be displayed as e.g. 37d-2 instead of 0.37. After this decimals are displayed as `ABC.DEF`, `ABCd3` or `0.000ABC` unless the number of padding zeroes grows large, in which case it will fall back to `A.BCd-E` for some exponent.

This also prefers to quantify the scale of larger numbers, e.g. `ABCDEFGd0` will be written as A.BCDEFGd6 instead of `ABCDEFG.`

"large" is henceforth "six" until someone changes it ;)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
