### PR TITLE
Suppresses invalid clippy warning

### DIFF
--- a/src/value/element_stream_reader.rs
+++ b/src/value/element_stream_reader.rs
@@ -172,6 +172,9 @@ impl IonReader for ElementStreamReader {
         false
     }
 
+    // Clippy reports a redundant closure, but fixing it causes the code to break.
+    // See: https://github.com/amazon-ion/ion-rust/issues/472
+    #[allow(clippy::redundant_closure)]
     fn annotations<'a>(&'a self) -> Box<dyn Iterator<Item = IonResult<Self::Symbol>> + 'a> {
         let iterator = self
             .current_value


### PR DESCRIPTION
This PR suppresses an invalid `clippy` warning.

See issue #472 for details.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
