### PR TITLE
Address boundary handling issues in non-blocking raw text reader, and its blocking wrapper

### DIFF
--- a/src/text/non_blocking/raw_text_reader.rs
+++ b/src/text/non_blocking/raw_text_reader.rs
@@ -291,7 +291,7 @@ impl<A: AsRef<[u8]>> RawTextReader<A> {
 
     /// Continues any previously incomplete parsing attempt.
     fn continue_state(&mut self) -> IonResult<()> {
-        if self.need_continue {
+        if self.need_continue && self.step_out_nest == 0 {
             self.need_continue = false;
 
             match self.state {

--- a/src/text/raw_text_reader.rs
+++ b/src/text/raw_text_reader.rs
@@ -229,6 +229,7 @@ impl<T: ToIonDataSource> IonReader for RawTextReader<T> {
 
 #[cfg(test)]
 mod reader_tests {
+    use crate::data_source::ToIonDataSource;
     use crate::raw_reader::RawStreamItem;
     use crate::raw_symbol_token::{local_sid_token, text_token, RawSymbolToken};
     use crate::result::IonResult;
@@ -239,9 +240,12 @@ mod reader_tests {
     use crate::types::timestamp::Timestamp;
     use crate::IonType;
     use crate::RawStreamItem::Nothing;
-    use crate::data_source::ToIonDataSource;
 
-    fn next_type<T: ToIonDataSource>(reader: &mut RawTextReader<T>, ion_type: IonType, is_null: bool) {
+    fn next_type<T: ToIonDataSource>(
+        reader: &mut RawTextReader<T>,
+        ion_type: IonType,
+        is_null: bool,
+    ) {
         assert_eq!(
             reader.next().unwrap(),
             RawStreamItem::nullable_value(ion_type, is_null)
@@ -783,7 +787,6 @@ mod reader_tests {
         }
     }
 
-
     #[test]
     // This test validates that the last value in the text buffer is not consumed unless the user
     // has flagged the stream as being completely loaded.
@@ -851,7 +854,8 @@ mod reader_tests {
 
     #[test]
     fn nested_struct() -> IonResult<()> {
-        let (source, _metrics) = TestIonSource::new(r#"
+        let (source, _metrics) = TestIonSource::new(
+            r#"
                 $ion_1_0
                 {}
                 {
@@ -866,7 +870,7 @@ mod reader_tests {
                     }
                 }
                 11
-            "#
+            "#,
         );
         let reader = &mut RawTextReader::new_with_size(source, 24)?;
 

--- a/src/text/raw_text_reader.rs
+++ b/src/text/raw_text_reader.rs
@@ -876,7 +876,7 @@ mod reader_tests {
 
         assert_eq!(reader.next().unwrap(), RawStreamItem::VersionMarker(1, 0));
 
-        next_type(reader, IonType::Struct, false); // Version Table
+        next_type(reader, IonType::Struct, false);
 
         next_type(reader, IonType::Struct, false);
         reader.step_in()?;
@@ -912,7 +912,7 @@ mod reader_tests {
         // The reader is now at the second 'true' in the s-expression nested in 'bar'/'b'
         reader.step_out()?; // Step out of .[1].bar.b
         reader.step_out()?; // Step out of .[1].bar
-        reader.step_out()?; // Step out of secont .[1]
+        reader.step_out()?; // Step out of .[1]
 
         next_type(reader, IonType::Int, false);
         assert_eq!(reader.read_i64()?, 11);

--- a/src/text/raw_text_reader.rs
+++ b/src/text/raw_text_reader.rs
@@ -904,11 +904,11 @@ mod reader_tests {
         next_type(reader, IonType::SExp, false);
         reader.step_in()?;
         next_type(reader, IonType::Bool, false);
-        assert_eq!(reader.read_bool()?, true);
+        assert!(reader.read_bool()?);
         next_type(reader, IonType::Bool, false);
-        assert_eq!(reader.read_bool()?, true);
+        assert!(reader.read_bool()?);
         next_type(reader, IonType::Bool, false);
-        assert_eq!(reader.read_bool()?, true);
+        assert!(reader.read_bool()?);
         // The reader is now at the second 'true' in the s-expression nested in 'bar'/'b'
         reader.step_out()?; // Step out of .[1].bar.b
         reader.step_out()?; // Step out of .[1].bar


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Previous implementation of the non-blocking reader, and its blocking wrapper, had two bugs when handling incomplete errors, and continuing after an incomplete error.

The non-blocking reader did not take into account the `step_out` nesting when unsetting the `need_continue`. When stepping out of a container that contained a container that had not yet been read, this would result in the reader stepping out beyond the target depth.

The blocking reader did not properly mark the stream as complete when stepping out of a container. If a `step_out` caused the last remaining data from the stream to be read (completing the stream) root level values at the end of the stream could be ambiguous and continue to cause incomplete data errors, until the stream had been marked complete.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
