### PR TITLE
Handle incomplete errors when parsing escaped string sequences

### DIFF
--- a/src/text/non_blocking/raw_text_reader.rs
+++ b/src/text/non_blocking/raw_text_reader.rs
@@ -1795,4 +1795,32 @@ mod reader_tests {
 
         Ok(())
     }
+
+    #[test]
+    fn generate_incomplete_on_truncated_escape() -> IonResult<()> {
+        let source = "\"123456\\u269b\"";
+        //                       ^-- First read stops here. (offset 9)
+        let mut reader = RawTextReader::new(source.as_bytes()[..10].to_owned());
+
+        match reader.next() {
+            Err(IonError::Incomplete {
+                position:
+                    Position {
+                        line_column: Some((line, column)),
+                        ..
+                    },
+                ..
+            }) => {
+                assert_eq!(line, 0); // Line is still 0 since we haven't actually seen a '\n' yet.
+                assert_eq!(column, 0); // start of the string; the value being parsed.
+            }
+            Err(e) => panic!("unexpected error after partial escaped sequence: {e}"),
+            Ok(item) => {
+                panic!("unexpected successful parsing of partial escaped sequence data: {item:?}")
+            }
+        }
+        reader.append_bytes(source[10..].as_bytes())?;
+        next_type(&mut reader, IonType::String, false);
+        Ok(())
+    }
 }

--- a/src/text/non_blocking/text_buffer.rs
+++ b/src/text/non_blocking/text_buffer.rs
@@ -345,7 +345,7 @@ impl TextBuffer<Vec<u8>> {
         self.restack();
         self.reserve_capacity(length);
 
-        let read_buffer = &mut self.data.as_mut_slice()[self.data_end..];
+        let read_buffer = &mut self.data.as_mut_slice()[self.data_end..(self.data_end + length)];
         let bytes_read = source.read(read_buffer)?;
         self.data_end += bytes_read;
 

--- a/src/text/parsers/text_support.rs
+++ b/src/text/parsers/text_support.rs
@@ -41,6 +41,7 @@ where
     // Return a fatal error.
     match parser.parse(remaining) {
         Ok((remaining, string_fragment)) => Ok((remaining, string_fragment)),
+        Err(e @ nom::Err::Incomplete(_)) => Err(e),
         Err(e) => fatal_parse_error(remaining, format!("could not parse {label}: {e}")),
     }
 }


### PR DESCRIPTION
*Issue #, if available:* #494

*Description of changes:*
This PR adds two changes:
1) Updates error handling while parsing escaped string sequences in order to bubble up nom's Incomplete errors to the reader, so that they can be communicated further.
2) Updates `read_from` to ensure that the amount of data read is limited to the length provided by the caller. Prior to this PR the entire rest of the buffer would be used for reading data. While this could be beneficial (the memory is allocated, using it makes sense) the caller expects to read no more than `length`, so as a matter of correctness we shouldn't read more than `length`.

A regression test was also added to mimic the behavior seen in #494.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
