### PR TITLE
Make `Element` implement `Send`

### DIFF
--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -1385,6 +1385,22 @@ mod value_tests {
     use crate::{ion_list, ion_sexp, ion_struct, IonType};
     use rstest::*;
 
+    #[test]
+    fn demonstrate_element_implements_send() {
+        use std::thread;
+        // The Element type must implement `Send` in order for values to be
+        // moved between threads. If changes are made to the `Element` type
+        // or its nested field types (like the `Value` enum and its variants),
+        // then this test will fail to compile.
+        let list: Element = ion_list![1, 2, 3].into();
+        thread::scope(|_| {
+            // Move `list` into this scope, demonstrating `Send`
+            let elements = vec![list];
+            // Trivial assertion to use `elements`
+            assert_eq!(elements.len(), 1);
+        });
+    }
+
     #[rstest]
     #[case::strings(
         Element::from("hello"), // An explicitly constructed String Element

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -1390,7 +1390,7 @@ mod value_tests {
         use std::thread;
         // The Element type must implement `Send` in order for values to be
         // moved between threads. If changes are made to the `Element` type
-        // or its nested field types (like the `Value` enum and its variants),
+        // or its nested field types (like the `Value` enum and its variants)
         // which accidentally cause it not to implement `Send`, then this test
         // will fail to compile.
         let list: Element = ion_list![1, 2, 3].into();

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -1391,7 +1391,8 @@ mod value_tests {
         // The Element type must implement `Send` in order for values to be
         // moved between threads. If changes are made to the `Element` type
         // or its nested field types (like the `Value` enum and its variants),
-        // then this test will fail to compile.
+        // which accidentally cause it not to implement `Send`, then this test
+        // will fail to compile.
         let list: Element = ion_list![1, 2, 3].into();
         thread::scope(|_| {
             // Move `list` into this scope, demonstrating `Send`

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -4,13 +4,13 @@ use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
-use std::rc::Rc;
+use std::sync::Arc;
 
 /// Stores or points to the text of a given [Symbol].
 #[derive(Debug, Eq)]
 enum SymbolText {
     // This Symbol refers to a string in the symbol table
-    Shared(Rc<str>),
+    Shared(Arc<str>),
     // This Symbol owns its own text
     Owned(String),
     // This Symbol is equivalent to SID zero (`$0`)
@@ -42,7 +42,7 @@ impl Clone for SymbolText {
     fn clone(&self) -> Self {
         match self {
             SymbolText::Owned(text) => SymbolText::Owned(text.to_owned()),
-            SymbolText::Shared(text) => SymbolText::Shared(Rc::clone(text)),
+            SymbolText::Shared(text) => SymbolText::Shared(Arc::clone(text)),
             SymbolText::Unknown => SymbolText::Unknown,
         }
     }
@@ -88,7 +88,7 @@ impl Symbol {
         }
     }
 
-    pub fn shared(text: Rc<str>) -> Symbol {
+    pub fn shared(text: Arc<str>) -> Symbol {
         Symbol {
             text: SymbolText::Shared(text),
         }
@@ -178,8 +178,8 @@ mod symbol_tests {
     fn ordering_and_eq() {
         let mut symbols = vec![
             Symbol::owned("foo"),
-            Symbol::shared(Rc::from("bar")),
-            Symbol::shared(Rc::from("baz")),
+            Symbol::shared(Arc::from("bar")),
+            Symbol::shared(Arc::from("baz")),
             Symbol::owned("quux"),
         ];
         // Sort the list to demonstrate that our Ord implementation works.

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::constants::v1_0;
 use crate::symbol::Symbol;
@@ -54,8 +54,8 @@ impl SymbolTable {
 
         // Otherwise, intern it and return the new ID.
         let id = self.symbols_by_id.len();
-        let rc: Rc<str> = Rc::from(text);
-        let symbol = Symbol::shared(rc);
+        let arc: Arc<str> = Arc::from(text);
+        let symbol = Symbol::shared(arc);
         self.symbols_by_id.push(symbol.clone());
         self.ids_by_text.insert(symbol, id);
         id

--- a/src/system_reader.rs
+++ b/src/system_reader.rs
@@ -639,7 +639,7 @@ impl<R: RawReader> IonReader for SystemReader<R> {
             RawSymbolToken::SymbolId(sid) => sid,
         };
         if let Some(symbol) = self.symbol_table.symbol_for(sid) {
-            // Make a cheap clone of the Rc<str> in the symbol table
+            // Make a cheap clone of the Arc<str> in the symbol table
             Ok(symbol.clone())
         } else if !self.symbol_table.sid_is_valid(sid) {
             decoding_error(format!("Symbol ID ${sid} is out of range."))

--- a/src/text/raw_text_writer.rs
+++ b/src/text/raw_text_writer.rs
@@ -25,9 +25,7 @@ impl RawTextWriterBuilder {
     /// ```
     pub fn new() -> RawTextWriterBuilder {
         RawTextWriterBuilder {
-            whitespace_config: WhitespaceConfig {
-                ..COMPACT_WHITESPACE_CONFIG
-            },
+            whitespace_config: COMPACT_WHITESPACE_CONFIG.clone(),
         }
     }
 
@@ -45,9 +43,7 @@ impl RawTextWriterBuilder {
     //TODO: https://github.com/amazon-ion/ion-rust/issues/437
     pub fn lines() -> RawTextWriterBuilder {
         RawTextWriterBuilder {
-            whitespace_config: WhitespaceConfig {
-                ..LINES_WHITESPACE_CONFIG
-            },
+            whitespace_config: LINES_WHITESPACE_CONFIG.clone(),
         }
     }
 
@@ -70,9 +66,7 @@ impl RawTextWriterBuilder {
     /// ```
     pub fn pretty() -> RawTextWriterBuilder {
         RawTextWriterBuilder {
-            whitespace_config: WhitespaceConfig {
-                ..PRETTY_WHITESPACE_CONFIG
-            },
+            whitespace_config: PRETTY_WHITESPACE_CONFIG.clone(),
         }
     }
 
@@ -144,6 +138,7 @@ struct EncodingLevel {
     child_count: usize,
 }
 
+#[derive(Clone)]
 struct WhitespaceConfig {
     // Top-level values are independent of other values in the stream, we may separate differently
     space_between_top_level_values: &'static str,
@@ -400,7 +395,8 @@ impl<W: Write> RawTextWriter<W> {
     pub fn add_annotation<A: AsRawSymbolTokenRef>(&mut self, annotation: A) {
         // TODO: This function currently allocates a new string for each annotation.
         //       It will be common for this text to come from the symbol table; we should
-        //       make it possible to pass an Rc<str> or similar when applicable.
+        //       make it possible to pass an Arc<str> or similar when applicable.
+        //       See: https://github.com/amazon-ion/ion-rust/issues/496
         let text = match annotation.as_raw_symbol_token_ref() {
             RawSymbolTokenRef::SymbolId(sid) => format!("${sid}"),
             RawSymbolTokenRef::Text(text) => text.to_string(),


### PR DESCRIPTION
This PR modifies the `Symbol` type to use `Arc<str>` instead of `Rc<str>` when sharing references to text, eliminating the last remaining use of a non-`Send` type (`Rc`) in the `Element` API.

Following this change, `Element`s can be sent between threads or shared using native mechanisms like `Arc<Element>`.

Changes:
* Modifies the `Symbol::Shared` enum variant to use `Arc<str>` instead of `Rc<str>`.
* Adds a unit test demonstrating that `Element` implements `Send` and safeguarding against future changes that accidentally violate that property.
* Addresses a `clippy` warning added in Rust 1.70 nightly about using struct builder syntax unnecessarily.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
