### PR TITLE
Implements `IntoIterator` for container Elements

### DIFF
--- a/src/element/builders.rs
+++ b/src/element/builders.rs
@@ -1,4 +1,4 @@
-use crate::element::{Element, List, SExp, Struct};
+use crate::element::{Element, Struct};
 use crate::Symbol;
 
 /// Constructs [List] values incrementally.
@@ -381,6 +381,8 @@ macro_rules! ion_struct {
     }};
 }
 
+use crate::element::list::List;
+use crate::element::sexp::SExp;
 pub use ion_list;
 pub use ion_sexp;
 pub use ion_struct;

--- a/src/element/builders.rs
+++ b/src/element/builders.rs
@@ -123,7 +123,7 @@ impl SExpBuilder {
 ///
 /// ```
 /// use ion_rs::ion_struct;
-/// use ion_rs::element::{Element, Struct};
+/// use ion_rs::element::{Struct, Element};
 /// let base_struct: Struct = ion_struct! {
 ///     "foo": 1,
 ///     "bar": 2,

--- a/src/element/list.rs
+++ b/src/element/list.rs
@@ -3,7 +3,20 @@ use crate::element::Element;
 use crate::text::text_formatter::IonValueFormatter;
 use std::fmt::{Display, Formatter};
 
-/// An in-memory representation of an Ion list
+/// An in-memory representation of an Ion list.
+///
+/// [`List`] implements [`IonSequence`], which defines most of its functionality.
+/// ```
+/// use ion_rs::element::{Element, IonSequence, List};
+/// use ion_rs::ion_list;
+/// # use ion_rs::IonResult;
+/// # fn main() -> IonResult<()> {
+/// let list = ion_list![1, 2, 3];
+/// assert_eq!(list.len(), 3);
+/// assert_eq!(list.get(1), Some(&Element::integer(2)));
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct List {
     pub(super) children: Vec<Element>,

--- a/src/element/list.rs
+++ b/src/element/list.rs
@@ -1,0 +1,32 @@
+use crate::element::builders::ListBuilder;
+use crate::element::Element;
+use crate::text::text_formatter::IonValueFormatter;
+use std::fmt::{Display, Formatter};
+
+/// An in-memory representation of an Ion list
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct List {
+    pub(super) children: Vec<Element>,
+}
+
+impl List {
+    pub(crate) fn new(children: Vec<Element>) -> Self {
+        Self { children }
+    }
+
+    pub fn builder() -> ListBuilder {
+        ListBuilder::new()
+    }
+
+    pub fn clone_builder(&self) -> ListBuilder {
+        ListBuilder::with_initial_elements(&self.children)
+    }
+}
+
+impl Display for List {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut ivf = IonValueFormatter { output: f };
+        ivf.format_list(self).map_err(|_| std::fmt::Error)?;
+        Ok(())
+    }
+}

--- a/src/element/list.rs
+++ b/src/element/list.rs
@@ -1,5 +1,6 @@
 use crate::element::builders::ListBuilder;
-use crate::element::Element;
+use crate::element::iterators::ElementsIterator;
+use crate::element::{Element, IonSequence};
 use crate::text::text_formatter::IonValueFormatter;
 use std::fmt::{Display, Formatter};
 
@@ -36,10 +37,37 @@ impl List {
     }
 }
 
+// Allows `for element in &list {...}` syntax
+impl<'a> IntoIterator for &'a List {
+    type Item = &'a Element;
+    type IntoIter = ElementsIterator<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.elements()
+    }
+}
+
 impl Display for List {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut ivf = IonValueFormatter { output: f };
         ivf.format_list(self).map_err(|_| std::fmt::Error)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ion_list;
+    use crate::types::integer::IntAccess;
+
+    #[test]
+    fn for_element_in_list() {
+        // Simple example to exercise List's implementation of IntoIterator
+        let list = ion_list![1, 2, 3];
+        let mut sum = 0;
+        for element in &list {
+            sum += element.as_i64().unwrap();
+        }
+        assert_eq!(sum, 6i64);
     }
 }

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -25,7 +25,6 @@ pub mod builders;
 mod element_stream_reader;
 mod iterators;
 mod list;
-pub mod owned;
 pub mod reader;
 mod sequence;
 mod sexp;

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -13,16 +13,12 @@
 //! [serde-json-value]: https://docs.serde.rs/serde_json/value/enum.Value.html
 
 use crate::element::builders::{ListBuilder, SExpBuilder, StructBuilder};
-use crate::element::iterators::{
-    ElementsIterator, FieldIterator, FieldValuesIterator, IndexVec, SymbolsIterator,
-};
+use crate::element::iterators::{ElementsIterator, SymbolsIterator};
 use crate::element::reader::ElementReader;
 use crate::ion_eq::IonEq;
-use crate::symbol_ref::AsSymbolRef;
 use crate::text::text_formatter::IonValueFormatter;
 use crate::{Decimal, Int, IonResult, IonType, ReaderBuilder, Symbol, Timestamp};
 use num_bigint::BigInt;
-use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 
 pub mod builders;
@@ -30,7 +26,10 @@ mod element_stream_reader;
 mod iterators;
 pub mod owned;
 pub mod reader;
+mod r#struct;
 pub mod writer;
+
+pub use r#struct::Struct;
 
 /// Behavior that is common to both [SExp] and [Struct].
 pub trait IonSequence {
@@ -147,200 +146,6 @@ impl IonSequence for SExp {
         self.len() == 0
     }
 }
-
-// This collection is broken out into its own type to allow instances of it to be shared with Arc/Rc.
-#[derive(Debug, Clone)]
-struct Fields {
-    // Key/value pairs in the order they were inserted
-    by_index: Vec<(Symbol, Element)>,
-    // Maps symbols to a list of indexes where values may be found in `by_index` above
-    by_name: HashMap<Symbol, IndexVec>,
-}
-
-impl Fields {
-    /// Gets all of the indexes that contain a value associated with the given field name.
-    fn get_indexes<A: AsSymbolRef>(&self, field_name: A) -> Option<&IndexVec> {
-        field_name
-            .as_symbol_ref()
-            .text()
-            .map(|text| {
-                // If the symbol has defined text, look it up by &str
-                self.by_name.get(text)
-            })
-            .unwrap_or_else(|| {
-                // Otherwise, construct a (cheap, stack-allocated) Symbol with unknown text...
-                let symbol = Symbol::unknown_text();
-                // ...and use the unknown text symbol to look up matching field values
-                self.by_name.get(&symbol)
-            })
-    }
-
-    /// Iterates over the values found at the specified indexes.
-    fn get_values_at_indexes<'a>(&'a self, indexes: &'a IndexVec) -> FieldValuesIterator<'a> {
-        FieldValuesIterator {
-            current: 0,
-            indexes: Some(indexes),
-            by_index: &self.by_index,
-        }
-    }
-
-    /// Gets the last value in the Struct that is associated with the specified field name.
-    ///
-    /// Note that the Ion data model views a struct as a bag of (name, value) pairs and does not
-    /// have a notion of field ordering. In most use cases, field names are distinct and the last
-    /// appearance of a field in the struct's serialized form will have been the _only_ appearance.
-    /// If a field name appears more than once, this method makes the arbitrary decision to return
-    /// the value associated with the last appearance. If your application uses structs that repeat
-    /// field names, you are encouraged to use [get_all] instead.
-    fn get_last<A: AsSymbolRef>(&self, field_name: A) -> Option<&Element> {
-        self.get_indexes(field_name)
-            .and_then(|indexes| indexes.last())
-            .and_then(|index| self.by_index.get(*index))
-            .map(|(_name, value)| value)
-    }
-
-    /// Iterates over all of the values associated with the given field name.
-    fn get_all<A: AsSymbolRef>(&self, field_name: A) -> FieldValuesIterator {
-        let indexes = self.get_indexes(field_name);
-        FieldValuesIterator {
-            current: 0,
-            indexes,
-            by_index: &self.by_index,
-        }
-    }
-
-    /// Iterates over all of the (field name, field value) pairs in the struct.
-    fn iter(&self) -> impl Iterator<Item = &(Symbol, Element)> {
-        self.by_index.iter()
-    }
-}
-
-/// An in-memory representation of an Ion Struct
-#[derive(Debug, Clone)]
-pub struct Struct {
-    fields: Fields,
-}
-
-impl Display for Struct {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ivf = IonValueFormatter { output: f };
-        ivf.format_struct(self).map_err(|_| std::fmt::Error)?;
-        Ok(())
-    }
-}
-
-impl Struct {
-    pub fn builder() -> StructBuilder {
-        StructBuilder::new()
-    }
-
-    pub fn clone_builder(&self) -> StructBuilder {
-        StructBuilder::with_initial_fields(&self.fields.by_index)
-    }
-
-    /// Returns an iterator over the field name/value pairs in this Struct.
-    pub fn fields(&self) -> impl Iterator<Item = (&Symbol, &Element)> {
-        self.fields
-            .iter()
-            // Here we convert from &(name, value) to (&name, &value).
-            // The former makes a stronger assertion about how the data is being stored. We don't
-            // want that to be a mandatory part of the public API.
-            .map(|(name, element)| (name, element))
-    }
-
-    fn fields_eq(&self, other: &Self) -> bool {
-        // For each field name in `self`, get the list of indexes that contain a value with that name.
-        for (field_name, field_value_indexes) in &self.fields.by_name {
-            let other_value_indexes = match other.fields.get_indexes(field_name) {
-                Some(indexes) => indexes,
-                // The other struct doesn't have a field with this name so they're not equal.
-                None => return false,
-            };
-
-            if field_value_indexes.len() != other_value_indexes.len() {
-                // The other struct has fields with the same name, but a different number of them.
-                return false;
-            }
-
-            for field_value in self.fields.get_values_at_indexes(field_value_indexes) {
-                if other
-                    .fields
-                    .get_values_at_indexes(other_value_indexes)
-                    .all(|other_value| !field_value.ion_eq(other_value))
-                {
-                    // Couldn't find an equivalent field in the other struct
-                    return false;
-                }
-            }
-        }
-
-        // If all of the above conditions hold, the two structs are equal.
-        true
-    }
-
-    /// Returns the number of fields in this Struct.
-    pub fn len(&self) -> usize {
-        self.fields.by_index.len()
-    }
-
-    /// Returns `true` if this struct has zero fields.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-}
-
-impl<K, V> FromIterator<(K, V)> for Struct
-where
-    K: Into<Symbol>,
-    V: Into<Element>,
-{
-    /// Returns an owned struct from the given iterator of field names/values.
-    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
-        let mut by_index: Vec<(Symbol, Element)> = Vec::new();
-        let mut by_name: HashMap<Symbol, IndexVec> = HashMap::new();
-        for (field_name, field_value) in iter {
-            let field_name = field_name.into();
-            let field_value = field_value.into();
-
-            by_name
-                .entry(field_name.clone())
-                .or_insert_with(IndexVec::new)
-                .push(by_index.len());
-            by_index.push((field_name, field_value));
-        }
-
-        let fields = Fields { by_index, by_name };
-        Self { fields }
-    }
-}
-
-impl Struct {
-    pub fn iter(&self) -> FieldIterator<'_> {
-        FieldIterator::new(&self.fields.by_index)
-    }
-
-    pub fn get<A: AsSymbolRef>(&self, field_name: A) -> Option<&Element> {
-        self.fields.get_last(field_name)
-    }
-
-    pub fn get_all<A: AsSymbolRef>(&self, field_name: A) -> FieldValuesIterator<'_> {
-        self.fields.get_all(field_name)
-    }
-}
-
-impl PartialEq for Struct {
-    fn eq(&self, other: &Self) -> bool {
-        // check if both fields have same length
-        self.len() == other.len()
-            // we need to test equality in both directions for both fields
-            // A good example for this is annotated vs not annotated values in struct
-            //  { a:4, a:4 } vs. { a:4, a:a::4 } // returns true
-            //  { a:4, a:a::4 } vs. { a:4, a:4 } // returns false
-            && self.fields_eq(other) && other.fields_eq(self)
-    }
-}
-
-impl Eq for Struct {}
 
 impl IonEq for Value {
     fn ion_eq(&self, other: &Self) -> bool {

--- a/src/element/owned.rs
+++ b/src/element/owned.rs
@@ -1,1 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates.

--- a/src/element/sequence.rs
+++ b/src/element/sequence.rs
@@ -1,0 +1,77 @@
+use crate::element::iterators::ElementsIterator;
+use crate::element::{Element, List, SExp};
+use crate::ion_eq::IonEq;
+
+/// Behavior that is common to both [SExp] and [Struct].
+pub trait IonSequence {
+    fn elements(&self) -> ElementsIterator<'_>;
+    fn get(&self, index: usize) -> Option<&Element>;
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl IonSequence for List {
+    fn elements(&self) -> ElementsIterator<'_> {
+        ElementsIterator::new(&self.children)
+    }
+
+    fn get(&self, index: usize) -> Option<&Element> {
+        self.children.get(index)
+    }
+
+    fn len(&self) -> usize {
+        self.children.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<S: IonSequence> IonEq for S {
+    fn ion_eq(&self, other: &Self) -> bool {
+        if self.len() != other.len() {
+            return false;
+        }
+        for (item1, item2) in self.elements().zip(other.elements()) {
+            if !item1.ion_eq(item2) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl IonSequence for SExp {
+    fn elements(&self) -> ElementsIterator<'_> {
+        ElementsIterator::new(&self.children)
+    }
+
+    fn get(&self, index: usize) -> Option<&Element> {
+        self.children.get(index)
+    }
+
+    fn len(&self) -> usize {
+        self.children.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl IonEq for Vec<Element> {
+    fn ion_eq(&self, other: &Self) -> bool {
+        if self.len() != other.len() {
+            return false;
+        }
+        for (v1, v2) in self.iter().zip(other.iter()) {
+            if !v1.ion_eq(v2) {
+                return false;
+            }
+        }
+        true
+    }
+}

--- a/src/element/sexp.rs
+++ b/src/element/sexp.rs
@@ -1,0 +1,32 @@
+use crate::element::builders::SExpBuilder;
+use crate::element::Element;
+use crate::text::text_formatter::IonValueFormatter;
+use std::fmt::{Display, Formatter};
+
+/// An in-memory representation of an Ion s-expression
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SExp {
+    pub(super) children: Vec<Element>,
+}
+
+impl SExp {
+    pub(crate) fn new(children: Vec<Element>) -> Self {
+        Self { children }
+    }
+
+    pub fn builder() -> SExpBuilder {
+        SExpBuilder::new()
+    }
+
+    pub fn clone_builder(&self) -> SExpBuilder {
+        SExpBuilder::with_initial_elements(&self.children)
+    }
+}
+
+impl Display for SExp {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut ivf = IonValueFormatter { output: f };
+        ivf.format_sexp(self).map_err(|_| std::fmt::Error)?;
+        Ok(())
+    }
+}

--- a/src/element/sexp.rs
+++ b/src/element/sexp.rs
@@ -4,6 +4,19 @@ use crate::text::text_formatter::IonValueFormatter;
 use std::fmt::{Display, Formatter};
 
 /// An in-memory representation of an Ion s-expression
+///
+/// [`SExp`] implements [`IonSequence`], which defines most of its functionality.
+/// ```
+/// use ion_rs::element::{Element, IonSequence, List};
+/// use ion_rs::ion_sexp;
+/// # use ion_rs::IonResult;
+/// # fn main() -> IonResult<()> {
+/// let sexp = ion_sexp!(1 2 3);
+/// assert_eq!(sexp.len(), 3);
+/// assert_eq!(sexp.get(1), Some(&Element::integer(2)));
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SExp {
     pub(super) children: Vec<Element>,

--- a/src/element/sexp.rs
+++ b/src/element/sexp.rs
@@ -1,5 +1,6 @@
 use crate::element::builders::SExpBuilder;
-use crate::element::Element;
+use crate::element::iterators::ElementsIterator;
+use crate::element::{Element, IonSequence};
 use crate::text::text_formatter::IonValueFormatter;
 use std::fmt::{Display, Formatter};
 
@@ -36,10 +37,37 @@ impl SExp {
     }
 }
 
+// Allows `for element in &sexp {...}` syntax
+impl<'a> IntoIterator for &'a SExp {
+    type Item = &'a Element;
+    type IntoIter = ElementsIterator<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.elements()
+    }
+}
+
 impl Display for SExp {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut ivf = IonValueFormatter { output: f };
         ivf.format_sexp(self).map_err(|_| std::fmt::Error)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ion_sexp;
+    use crate::types::integer::IntAccess;
+
+    #[test]
+    fn for_element_in_sexp() {
+        // Simple example to exercise SExp's implementation of IntoIterator
+        let sexp = ion_sexp!(1 2 3);
+        let mut sum = 0;
+        for element in &sexp {
+            sum += element.as_i64().unwrap();
+        }
+        assert_eq!(sum, 6i64);
     }
 }

--- a/src/element/struct.rs
+++ b/src/element/struct.rs
@@ -1,0 +1,203 @@
+use crate::element::builders::StructBuilder;
+use crate::element::iterators::{FieldIterator, FieldValuesIterator, IndexVec};
+use crate::element::Element;
+use crate::ion_eq::IonEq;
+use crate::symbol_ref::AsSymbolRef;
+use crate::text::text_formatter::IonValueFormatter;
+use crate::Symbol;
+use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
+
+// This collection is broken out into its own type to allow instances of it to be shared with Arc/Rc.
+#[derive(Debug, Clone)]
+struct Fields {
+    // Key/value pairs in the order they were inserted
+    by_index: Vec<(Symbol, Element)>,
+    // Maps symbols to a list of indexes where values may be found in `by_index` above
+    by_name: HashMap<Symbol, IndexVec>,
+}
+
+impl Fields {
+    /// Gets all of the indexes that contain a value associated with the given field name.
+    fn get_indexes<A: AsSymbolRef>(&self, field_name: A) -> Option<&IndexVec> {
+        field_name
+            .as_symbol_ref()
+            .text()
+            .map(|text| {
+                // If the symbol has defined text, look it up by &str
+                self.by_name.get(text)
+            })
+            .unwrap_or_else(|| {
+                // Otherwise, construct a (cheap, stack-allocated) Symbol with unknown text...
+                let symbol = Symbol::unknown_text();
+                // ...and use the unknown text symbol to look up matching field values
+                self.by_name.get(&symbol)
+            })
+    }
+
+    /// Iterates over the values found at the specified indexes.
+    fn get_values_at_indexes<'a>(&'a self, indexes: &'a IndexVec) -> FieldValuesIterator<'a> {
+        FieldValuesIterator {
+            current: 0,
+            indexes: Some(indexes),
+            by_index: &self.by_index,
+        }
+    }
+
+    /// Gets the last value in the Struct that is associated with the specified field name.
+    ///
+    /// Note that the Ion data model views a struct as a bag of (name, value) pairs and does not
+    /// have a notion of field ordering. In most use cases, field names are distinct and the last
+    /// appearance of a field in the struct's serialized form will have been the _only_ appearance.
+    /// If a field name appears more than once, this method makes the arbitrary decision to return
+    /// the value associated with the last appearance. If your application uses structs that repeat
+    /// field names, you are encouraged to use [get_all] instead.
+    fn get_last<A: AsSymbolRef>(&self, field_name: A) -> Option<&Element> {
+        self.get_indexes(field_name)
+            .and_then(|indexes| indexes.last())
+            .and_then(|index| self.by_index.get(*index))
+            .map(|(_name, value)| value)
+    }
+
+    /// Iterates over all of the values associated with the given field name.
+    fn get_all<A: AsSymbolRef>(&self, field_name: A) -> FieldValuesIterator {
+        let indexes = self.get_indexes(field_name);
+        FieldValuesIterator {
+            current: 0,
+            indexes,
+            by_index: &self.by_index,
+        }
+    }
+
+    /// Iterates over all of the (field name, field value) pairs in the struct.
+    fn iter(&self) -> impl Iterator<Item = &(Symbol, Element)> {
+        self.by_index.iter()
+    }
+}
+
+/// An in-memory representation of an Ion Struct
+#[derive(Debug, Clone)]
+pub struct Struct {
+    fields: Fields,
+}
+
+impl Display for Struct {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut ivf = IonValueFormatter { output: f };
+        ivf.format_struct(self).map_err(|_| std::fmt::Error)?;
+        Ok(())
+    }
+}
+
+impl Struct {
+    pub fn builder() -> StructBuilder {
+        StructBuilder::new()
+    }
+
+    pub fn clone_builder(&self) -> StructBuilder {
+        StructBuilder::with_initial_fields(&self.fields.by_index)
+    }
+
+    /// Returns an iterator over the field name/value pairs in this Struct.
+    pub fn fields(&self) -> impl Iterator<Item = (&Symbol, &Element)> {
+        self.fields
+            .iter()
+            // Here we convert from &(name, value) to (&name, &value).
+            // The former makes a stronger assertion about how the data is being stored. We don't
+            // want that to be a mandatory part of the public API.
+            .map(|(name, element)| (name, element))
+    }
+
+    fn fields_eq(&self, other: &Self) -> bool {
+        // For each field name in `self`, get the list of indexes that contain a value with that name.
+        for (field_name, field_value_indexes) in &self.fields.by_name {
+            let other_value_indexes = match other.fields.get_indexes(field_name) {
+                Some(indexes) => indexes,
+                // The other struct doesn't have a field with this name so they're not equal.
+                None => return false,
+            };
+
+            if field_value_indexes.len() != other_value_indexes.len() {
+                // The other struct has fields with the same name, but a different number of them.
+                return false;
+            }
+
+            for field_value in self.fields.get_values_at_indexes(field_value_indexes) {
+                if other
+                    .fields
+                    .get_values_at_indexes(other_value_indexes)
+                    .all(|other_value| !field_value.ion_eq(other_value))
+                {
+                    // Couldn't find an equivalent field in the other struct
+                    return false;
+                }
+            }
+        }
+
+        // If all of the above conditions hold, the two structs are equal.
+        true
+    }
+
+    /// Returns the number of fields in this Struct.
+    pub fn len(&self) -> usize {
+        self.fields.by_index.len()
+    }
+
+    /// Returns `true` if this struct has zero fields.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<K, V> FromIterator<(K, V)> for Struct
+where
+    K: Into<Symbol>,
+    V: Into<Element>,
+{
+    /// Returns an owned struct from the given iterator of field names/values.
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+        let mut by_index: Vec<(Symbol, Element)> = Vec::new();
+        let mut by_name: HashMap<Symbol, IndexVec> = HashMap::new();
+        for (field_name, field_value) in iter {
+            let field_name = field_name.into();
+            let field_value = field_value.into();
+
+            by_name
+                .entry(field_name.clone())
+                .or_insert_with(IndexVec::new)
+                .push(by_index.len());
+            by_index.push((field_name, field_value));
+        }
+
+        let fields = Fields { by_index, by_name };
+        Self { fields }
+    }
+}
+
+impl Struct {
+    pub fn iter(&self) -> FieldIterator<'_> {
+        FieldIterator::new(&self.fields.by_index)
+    }
+
+    pub fn get<A: AsSymbolRef>(&self, field_name: A) -> Option<&Element> {
+        self.fields.get_last(field_name)
+    }
+
+    pub fn get_all<A: AsSymbolRef>(&self, field_name: A) -> FieldValuesIterator<'_> {
+        self.fields.get_all(field_name)
+    }
+}
+
+impl PartialEq for Struct {
+    fn eq(&self, other: &Self) -> bool {
+        // check if both fields have same length
+        self.len() == other.len()
+            // we need to test equality in both directions for both fields
+            // A good example for this is annotated vs not annotated values in struct
+            //  { a:4, a:4 } vs. { a:4, a:a::4 } // returns true
+            //  { a:4, a:a::4 } vs. { a:4, a:4 } // returns false
+            && self.fields_eq(other) && other.fields_eq(self)
+    }
+}
+
+impl Eq for Struct {}

--- a/src/element/struct.rs
+++ b/src/element/struct.rs
@@ -77,17 +77,17 @@ impl Fields {
 
 /// An in-memory representation of an Ion Struct
 /// ```
-/// use ion_rs::element::{Element, IonSequence, List};
+/// use ion_rs::element::Element;
 /// use ion_rs::ion_struct;
 /// # use ion_rs::IonResult;
 /// # fn main() -> IonResult<()> {
-/// let list = ion_struct! {
+/// let struct_ = ion_struct! {
 ///   "foo": 1,
 ///   "bar": true,
 ///   "baz": "hello"
 /// };
-/// assert_eq!(list.len(), 3);
-/// assert_eq!(list.get("baz"), Some(&Element::string("hello")));
+/// assert_eq!(struct_.len(), 3);
+/// assert_eq!(struct_.get("baz"), Some(&Element::string("hello")));
 /// # Ok(())
 /// # }
 /// ```

--- a/src/element/struct.rs
+++ b/src/element/struct.rs
@@ -76,6 +76,21 @@ impl Fields {
 }
 
 /// An in-memory representation of an Ion Struct
+/// ```
+/// use ion_rs::element::{Element, IonSequence, List};
+/// use ion_rs::ion_struct;
+/// # use ion_rs::IonResult;
+/// # fn main() -> IonResult<()> {
+/// let list = ion_struct! {
+///   "foo": 1,
+///   "bar": true,
+///   "baz": "hello"
+/// };
+/// assert_eq!(list.len(), 3);
+/// assert_eq!(list.get("baz"), Some(&Element::string("hello")));
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug, Clone)]
 pub struct Struct {
     fields: Fields,

--- a/src/element/writer.rs
+++ b/src/element/writer.rs
@@ -5,7 +5,8 @@
 
 use crate::result::IonResult;
 
-use crate::element::{Element, IonSequence, Value};
+use crate::element::sequence::IonSequence;
+use crate::element::{Element, Value};
 use crate::{IonType, IonWriter};
 pub use Format::*;
 pub use TextKind::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,9 +108,9 @@
 //! ## Traversing an `Element`
 //!
 //! ```
-//! # use ion_rs::IonResult;
+//! use ion_rs::IonResult;
 //! # fn main() -> IonResult<()> {
-//! use ion_rs::element::{Element, IntoAnnotatedElement, IonSequence, Value};
+//! use ion_rs::element::{Element, IonSequence, IntoAnnotatedElement,  Value};
 //! use ion_rs::{ion_struct, ion_list};
 //! let element: Element = ion_struct! {
 //!   "foo": "hello",
@@ -135,9 +135,9 @@
 //! ## Writing an `Element` to an `io::Write`
 //!
 //! ```
-//! # use ion_rs::IonResult;
+//! use ion_rs::IonResult;
 //! # fn main() -> IonResult<()> {
-//! use ion_rs::element::{Element, IntoAnnotatedElement, IonSequence, Value};
+//! use ion_rs::element::{Element, IonSequence, IntoAnnotatedElement,  Value};
 //! use ion_rs::{ion_struct, ion_list, TextWriterBuilder, IonWriter};
 //! use ion_rs::element::writer::ElementWriter;
 //! let element: Element = ion_struct! {

--- a/tests/element_test_vectors.rs
+++ b/tests/element_test_vectors.rs
@@ -2,11 +2,12 @@
 
 use ion_rs::element::reader::ElementReader;
 use ion_rs::element::writer::{ElementWriter, Format, TextKind};
-use ion_rs::element::{Element, IonSequence};
+use ion_rs::element::Element;
 use ion_rs::ion_eq::IonEq;
 use ion_rs::result::{decoding_error, IonError, IonResult};
 use ion_rs::{BinaryWriterBuilder, IonWriter, Reader, TextWriterBuilder};
 
+use ion_rs::element::IonSequence;
 use std::fs::read;
 use std::path::MAIN_SEPARATOR as PATH_SEPARATOR;
 use test_generator::test_resources;


### PR DESCRIPTION
This PR adds implementations of `IntoIterator` for each of the container `Element` types, allowing the expected looping syntax:

```rust
for element in &list {
    // ...
}

for element in &sexp {
    // ...
}

for (field_name, value) in &struct_ {
    // ...
}
```

It also moves the container types to their own modules for easier navigation.

Each commit is self-contained. Only the final commit (`Implements IntoIterator...`) contains any new logic. The rest are mechanical refactorings. I recommend reviewing them in order.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
