### PR TITLE
Custom string type

### DIFF
--- a/src/binary/non_blocking/raw_binary_reader.rs
+++ b/src/binary/non_blocking/raw_binary_reader.rs
@@ -10,6 +10,7 @@ use crate::result::{
     incomplete_data_error,
 };
 use crate::types::integer::IntAccess;
+use crate::types::string::Str;
 use crate::types::SymbolId;
 use crate::{
     Decimal, Int, IonReader, IonResult, IonType, RawStreamItem, RawSymbolToken, Timestamp,
@@ -744,8 +745,8 @@ impl<A: AsRef<[u8]>> IonReader for RawBinaryBufferReader<A> {
         Ok(Decimal::new(coefficient, exponent))
     }
 
-    fn read_string(&mut self) -> IonResult<String> {
-        self.read_str().map(|s| s.to_string())
+    fn read_string(&mut self) -> IonResult<Str> {
+        self.read_str().map(|s| s.into())
     }
 
     fn map_string<F, U>(&mut self, f: F) -> IonResult<U>

--- a/src/binary/raw_binary_reader.rs
+++ b/src/binary/raw_binary_reader.rs
@@ -25,6 +25,7 @@ use crate::result::{decoding_error_raw, IonError};
 use crate::stream_reader::IonReader;
 use crate::types::decimal::Decimal;
 use crate::types::integer::{Int, IntAccess};
+use crate::types::string::Str;
 use crate::types::timestamp::Timestamp;
 use num_traits::Zero;
 use std::ops::Range;
@@ -534,8 +535,8 @@ impl<R: IonDataSource> IonReader for RawBinaryReader<R> {
         Ok(Decimal::new(coefficient, exponent))
     }
 
-    fn read_string(&mut self) -> IonResult<String> {
-        self.map_string(|s| s.to_owned())
+    fn read_string(&mut self) -> IonResult<Str> {
+        self.map_string(|s| s.into())
     }
 
     fn map_string<F, U>(&mut self, f: F) -> IonResult<U>

--- a/src/element/element_stream_reader.rs
+++ b/src/element/element_stream_reader.rs
@@ -3,7 +3,9 @@ use crate::text::parent_container::ParentContainer;
 
 use crate::element::iterators::SymbolsIterator;
 use crate::element::Element;
-use crate::{Decimal, Int, IonError, IonReader, IonResult, IonType, StreamItem, Symbol, Timestamp};
+use crate::{
+    Decimal, Int, IonError, IonReader, IonResult, IonType, Str, StreamItem, Symbol, Timestamp,
+};
 use std::fmt::Display;
 use std::mem;
 
@@ -236,8 +238,8 @@ impl IonReader for ElementStreamReader {
         self.current_value_as("decimal value", |v| v.as_decimal().map(|i| i.to_owned()))
     }
 
-    fn read_string(&mut self) -> IonResult<String> {
-        self.map_string(|s| s.to_owned())
+    fn read_string(&mut self) -> IonResult<Str> {
+        self.map_string(|s| s.into())
     }
 
     fn map_string<F, U>(&mut self, f: F) -> IonResult<U>

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -17,7 +17,7 @@ use crate::element::iterators::SymbolsIterator;
 use crate::element::reader::ElementReader;
 use crate::ion_eq::IonEq;
 use crate::text::text_formatter::IonValueFormatter;
-use crate::{Decimal, Int, IonResult, IonType, ReaderBuilder, Symbol, Timestamp};
+use crate::{Decimal, Int, IonResult, IonType, ReaderBuilder, Str, Symbol, Timestamp};
 use num_bigint::BigInt;
 use std::fmt::{Display, Formatter};
 
@@ -61,7 +61,7 @@ pub enum Value {
     Float(f64),
     Decimal(Decimal),
     Timestamp(Timestamp),
-    String(String),
+    String(Str),
     Symbol(Symbol),
     Bool(bool),
     Blob(Vec<u8>),
@@ -145,12 +145,19 @@ impl From<bool> for Value {
 
 impl From<&str> for Value {
     fn from(string_val: &str) -> Self {
-        Value::String(string_val.to_owned())
+        Value::String(string_val.into())
     }
 }
 
 impl From<String> for Value {
-    fn from(string_val: String) -> Self {
+    fn from(value: String) -> Self {
+        let s: Str = value.into();
+        Value::String(s)
+    }
+}
+
+impl From<Str> for Value {
+    fn from(string_val: Str) -> Self {
         Value::String(string_val)
     }
 }
@@ -262,8 +269,8 @@ impl Element {
         value.into()
     }
 
-    pub fn string<I: Into<String>>(str: I) -> Element {
-        let text: String = str.into();
+    pub fn string<I: Into<Str>>(str: I) -> Element {
+        let text: Str = str.into();
         text.into()
     }
 
@@ -383,7 +390,7 @@ impl Element {
 
     pub fn as_text(&self) -> Option<&str> {
         match &self.value {
-            Value::String(text) => Some(text),
+            Value::String(text) => Some(text.as_ref()),
             Value::Symbol(sym) => sym.text(),
             _ => None,
         }
@@ -391,7 +398,7 @@ impl Element {
 
     pub fn as_string(&self) -> Option<&str> {
         match &self.value {
-            Value::String(text) => Some(text),
+            Value::String(text) => Some(text.as_ref()),
             _ => None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,6 +204,7 @@ pub use symbol_table::SymbolTable;
 
 pub use types::decimal::Decimal;
 pub use types::integer::Int;
+pub use types::string::Str;
 pub use types::timestamp::Timestamp;
 pub use types::IonType;
 

--- a/src/raw_reader.rs
+++ b/src/raw_reader.rs
@@ -1,5 +1,6 @@
 use crate::raw_symbol_token::RawSymbolToken;
 use crate::stream_reader::IonReader;
+use crate::types::string::Str;
 use crate::types::IonType;
 use crate::{Decimal, Int, IonResult, Timestamp};
 use std::fmt::{Display, Formatter};
@@ -84,7 +85,7 @@ impl<R: RawReader + ?Sized> IonReader for Box<R> {
         (**self).read_decimal()
     }
 
-    fn read_string(&mut self) -> IonResult<String> {
+    fn read_string(&mut self) -> IonResult<Str> {
         (**self).read_string()
     }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -19,6 +19,7 @@ use crate::types::timestamp::Timestamp;
 use crate::{IonType, RawBinaryReader, RawTextReader};
 use std::fmt::{Display, Formatter};
 
+use crate::types::string::Str;
 /// Configures and constructs new instances of [Reader].
 pub struct ReaderBuilder {}
 
@@ -431,7 +432,7 @@ impl<R: RawReader> IonReader for UserReader<R> {
             fn read_f32(&mut self) -> IonResult<f32>;
             fn read_f64(&mut self) -> IonResult<f64>;
             fn read_decimal(&mut self) -> IonResult<Decimal>;
-            fn read_string(&mut self) -> IonResult<String>;
+            fn read_string(&mut self) -> IonResult<Str>;
             fn map_string<F, U>(&mut self, f: F) -> IonResult<U> where F: FnOnce(&str) -> U;
             fn map_string_bytes<F, U>(&mut self, f: F) -> IonResult<U> where F: FnOnce(&[u8]) -> U;
             fn read_blob(&mut self) -> IonResult<Vec<u8>>;

--- a/src/stream_reader.rs
+++ b/src/stream_reader.rs
@@ -1,6 +1,7 @@
 use crate::result::IonResult;
 use crate::types::decimal::Decimal;
 use crate::types::integer::Int;
+use crate::types::string::Str;
 use crate::types::timestamp::Timestamp;
 use crate::types::IonType;
 
@@ -102,7 +103,7 @@ pub trait IonReader {
 
     /// Attempts to read the current item as an Ion string and return it as a [String]. If the current
     /// item is not a string or an IO error is encountered while reading, returns [crate::IonError].
-    fn read_string(&mut self) -> IonResult<String>;
+    fn read_string(&mut self) -> IonResult<Str>;
 
     /// Takes a function that expects a string and, once the string's bytes are loaded, calls that
     /// function passing the string as a parameter. This allows users to avoid materializing the

--- a/src/system_reader.rs
+++ b/src/system_reader.rs
@@ -11,6 +11,7 @@ use crate::symbol::Symbol;
 use crate::system_reader::LstPosition::*;
 use crate::types::decimal::Decimal;
 use crate::types::integer::Int;
+use crate::types::string::Str;
 use crate::types::timestamp::Timestamp;
 use crate::{IonReader, IonType, RawBinaryReader, SymbolTable};
 
@@ -648,9 +649,9 @@ impl<R: RawReader> IonReader for SystemReader<R> {
         }
     }
 
-    fn read_string(&mut self) -> IonResult<String> {
+    fn read_string(&mut self) -> IonResult<Str> {
         if self.current_string_was_consumed() {
-            return Ok(self.lst.current_string.clone());
+            return Ok(self.lst.current_string.clone().into());
         }
         // Otherwise, delegate to the raw reader
         if self.raw_reader.current() == RawStreamItem::Nothing {

--- a/src/text/non_blocking/raw_text_reader.rs
+++ b/src/text/non_blocking/raw_text_reader.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 
+use crate::types::string::Str;
 use nom::Err::{Error, Failure, Incomplete};
 
 use crate::raw_reader::RawStreamItem;
@@ -815,8 +816,8 @@ impl<A: AsRef<[u8]>> IonReader for RawTextReader<A> {
         }
     }
 
-    fn read_string(&mut self) -> IonResult<String> {
-        self.map_string(|s| s.to_owned())
+    fn read_string(&mut self) -> IonResult<Str> {
+        self.map_string(|s| s.into())
     }
 
     fn map_string<F, U>(&mut self, f: F) -> IonResult<U>

--- a/src/text/raw_text_reader.rs
+++ b/src/text/raw_text_reader.rs
@@ -3,6 +3,7 @@ use crate::raw_reader::RawStreamItem;
 use crate::raw_symbol_token::RawSymbolToken;
 use crate::result::IonResult;
 use crate::stream_reader::IonReader;
+use crate::types::string::Str;
 use crate::types::timestamp::Timestamp;
 use crate::{Decimal, Int, IonError, IonType};
 
@@ -142,7 +143,7 @@ impl<T: ToIonDataSource> IonReader for RawTextReader<T> {
         self.reader.read_decimal()
     }
 
-    fn read_string(&mut self) -> IonResult<String> {
+    fn read_string(&mut self) -> IonResult<Str> {
         self.reader.read_string()
     }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -7,6 +7,7 @@ pub type SymbolId = usize;
 pub mod coefficient;
 pub mod decimal;
 pub mod integer;
+pub mod string;
 pub mod timestamp;
 
 use std::fmt;

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -10,7 +10,7 @@ use std::fmt::{Display, Formatter};
 /// ```
 #[derive(Eq, Ord, PartialOrd, Debug, Clone, Hash)]
 pub struct Str {
-    // For the time being, the `Text` type is an opaque wrapper around the standard Rust `String`
+    // For the time being, the `Str` type is an opaque wrapper around the standard Rust `String`
     // type. Having this opaque wrapper means that we can swap out its implementation without a
     // breaking change, allowing us to offer string interning, stack-allocated small strings, or
     // other optimizations as needed.
@@ -36,11 +36,10 @@ impl Str {
     ///
     /// ```
     /// use ion_rs::Str;
+    /// let s: Str = "".into();
+    /// assert!(s.is_empty());
     /// let s: Str = "hello!".into();
-    /// assert_eq!(s.len(), 6);
-    /// // Note that the length returned is a number of UTF-8 bytes, not codepoints or graphemes.
-    /// let s: Str = "🚀🚀🚀".into();
-    /// assert_eq!(s.len(), 12);
+    /// assert!(!s.is_empty());
     /// ```
     // This method is largely here because clippy complains if you provide a `len()` method but not
     // an accompanying `is_empty()` method.

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -31,6 +31,34 @@ impl Str {
     pub fn len(&self) -> usize {
         self.text.len()
     }
+
+    /// Returns `true` if this is the empty string (`""`); otherwise, returns `false`.
+    ///
+    /// ```
+    /// use ion_rs::Str;
+    /// let s: Str = "hello!".into();
+    /// assert_eq!(s.len(), 6);
+    /// // Note that the length returned is a number of UTF-8 bytes, not codepoints or graphemes.
+    /// let s: Str = "🚀🚀🚀".into();
+    /// assert_eq!(s.len(), 12);
+    /// ```
+    // This method is largely here because clippy complains if you provide a `len()` method but not
+    // an accompanying `is_empty()` method.
+    pub fn is_empty(&self) -> bool {
+        self.text.is_empty()
+    }
+
+    /// Returns a `&str` representation of this string's text.
+    ///
+    /// ```
+    /// use ion_rs::Str;
+    /// let s: Str = "hello, world!".into();
+    /// assert!(s.text().contains("world"));
+    /// assert!(s.text().is_ascii());
+    /// ```
+    pub fn text(&self) -> &str {
+        self.text.as_str()
+    }
 }
 
 impl Display for Str {
@@ -58,7 +86,7 @@ impl From<String> for Str {
 
 impl AsRef<str> for Str {
     fn as_ref(&self) -> &str {
-        self.text.as_ref()
+        self.text()
     }
 }
 
@@ -67,21 +95,20 @@ where
     S: AsRef<str>,
 {
     fn eq(&self, other: &S) -> bool {
-        let this_text: &str = self.as_ref();
         let other_text: &str = other.as_ref();
-        this_text == other_text
+        self.text() == other_text
     }
 }
 
 impl PartialEq<Str> for &str {
     fn eq(&self, other: &Str) -> bool {
-        self.eq(&other.as_ref())
+        self.eq(&other.text())
     }
 }
 
 impl PartialEq<Str> for String {
     fn eq(&self, other: &Str) -> bool {
         let self_text: &str = self.as_str();
-        self_text.eq(other.as_ref())
+        self_text.eq(other.text())
     }
 }

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -1,0 +1,87 @@
+use crate::text::text_formatter::IonValueFormatter;
+use std::fmt::{Display, Formatter};
+
+/// An owned, immutable in-memory representation of an Ion `string`.
+///
+/// ```
+/// use ion_rs::Str;
+/// let s: Str = "hello!".into();
+/// assert_eq!(s, "hello!");
+/// ```
+#[derive(Eq, Ord, PartialOrd, Debug, Clone, Hash)]
+pub struct Str {
+    // For the time being, the `Text` type is an opaque wrapper around the standard Rust `String`
+    // type. Having this opaque wrapper means that we can swap out its implementation without a
+    // breaking change, allowing us to offer string interning, stack-allocated small strings, or
+    // other optimizations as needed.
+    text: String,
+}
+
+impl Str {
+    /// Returns the number of UTF-8 encoded bytes in this string.
+    ///
+    /// ```
+    /// use ion_rs::Str;
+    /// let s: Str = "hello!".into();
+    /// assert_eq!(s.len(), 6);
+    /// // Note that the length returned is a number of UTF-8 bytes, not codepoints or graphemes.
+    /// let s: Str = "🚀🚀🚀".into();
+    /// assert_eq!(s.len(), 12);
+    /// ```
+    pub fn len(&self) -> usize {
+        self.text.len()
+    }
+}
+
+impl Display for Str {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut formatter = IonValueFormatter { output: f };
+        formatter
+            .format_string(self.as_ref())
+            .map_err(|_| std::fmt::Error)
+    }
+}
+
+impl From<&str> for Str {
+    fn from(value: &str) -> Self {
+        Str {
+            text: value.to_string(),
+        }
+    }
+}
+
+impl From<String> for Str {
+    fn from(value: String) -> Self {
+        Str { text: value }
+    }
+}
+
+impl AsRef<str> for Str {
+    fn as_ref(&self) -> &str {
+        self.text.as_ref()
+    }
+}
+
+impl<S> PartialEq<S> for Str
+where
+    S: AsRef<str>,
+{
+    fn eq(&self, other: &S) -> bool {
+        let this_text: &str = self.as_ref();
+        let other_text: &str = other.as_ref();
+        this_text == other_text
+    }
+}
+
+impl PartialEq<Str> for &str {
+    fn eq(&self, other: &Str) -> bool {
+        self.eq(&other.as_ref())
+    }
+}
+
+impl PartialEq<Str> for String {
+    fn eq(&self, other: &Str) -> bool {
+        let self_text: &str = self.as_str();
+        self_text.eq(other.as_ref())
+    }
+}


### PR DESCRIPTION
This PR introduces a new `Str` type that replaces all usages of
Rust's owned `String` type in the `Reader` and `Element` APIs.

For the time being, the `Str` type is a simple opaque wrapper
around `String` with trait implementations that allow it to be
used in much the same way. Having an opaque wrapper will allow
us to swap out the implementation later without a breaking
change, enabling us to provide stack-allocated small strings,
shared strings (interning), etc as desired.

The name `Str` was selected to:
1. Avoid collisions with `String` and `&str`.
2. Use (an abbreviation of) the same type name as Ion itself (vs, say, `Text`)

We can add more trait implementations and method pass-throughs
as needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
