### PR TITLE
Makes `List` and `SExp` thin wrappers around `Sequence`

### DIFF
--- a/src/element/builders.rs
+++ b/src/element/builders.rs
@@ -82,15 +82,17 @@ impl SequenceBuilder {
         self
     }
 
-    /// Builds a [`List`] with the previously specified elements.
+    /// Builds a [`Sequence`] with the previously specified elements.
     pub fn build(self) -> Sequence {
         self.values.into()
     }
 
+    /// Builds a [`List`] with the previously specified elements.
     pub fn build_list(self) -> List {
         List(self.build())
     }
 
+    /// Builds a [`SExp`] with the previously specified elements.
     pub fn build_sexp(self) -> SExp {
         SExp(self.build())
     }

--- a/src/element/list.rs
+++ b/src/element/list.rs
@@ -1,8 +1,10 @@
+use crate::element::builders::SequenceBuilder;
 use crate::element::iterators::ElementsIterator;
 use crate::element::{Element, Sequence};
+use crate::ion_eq::IonEq;
 use crate::text::text_formatter::IonValueFormatter;
+use delegate::delegate;
 use std::fmt::{Display, Formatter};
-use std::ops::Deref;
 
 /// An in-memory representation of an Ion list.
 /// ```
@@ -25,11 +27,34 @@ impl List {
     }
 }
 
-impl Deref for List {
-    type Target = Sequence;
+// impl Deref for List {
+//     type Target = Sequence;
+//
+//     fn deref(&self) -> &Self::Target {
+//         &self.0
+//     }
+// }
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
+impl List {
+    pub fn builder() -> SequenceBuilder {
+        Sequence::builder()
+    }
+
+    delegate! {
+        to self.0 {
+            pub fn clone_builder(&self) -> SequenceBuilder;
+            pub fn elements(&self) -> ElementsIterator<'_>;
+            pub fn get(&self, index: usize) -> Option<&Element>;
+            pub fn len(&self) -> usize;
+            pub fn is_empty(&self) -> bool;
+        }
+    }
+}
+
+impl IonEq for List {
+    fn ion_eq(&self, other: &Self) -> bool {
+        // The inner `Sequence` of both Lists are IonEq
+        self.0.ion_eq(&other.0)
     }
 }
 

--- a/src/element/list.rs
+++ b/src/element/list.rs
@@ -18,6 +18,7 @@ use std::fmt::{Display, Formatter};
 /// # Ok(())
 /// # }
 /// ```
+/// To build a `List` incrementally, see [SequenceBuilder].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct List(pub Sequence);
 

--- a/src/element/list.rs
+++ b/src/element/list.rs
@@ -27,19 +27,7 @@ impl List {
     }
 }
 
-// impl Deref for List {
-//     type Target = Sequence;
-//
-//     fn deref(&self) -> &Self::Target {
-//         &self.0
-//     }
-// }
-
 impl List {
-    pub fn builder() -> SequenceBuilder {
-        Sequence::builder()
-    }
-
     delegate! {
         to self.0 {
             pub fn clone_builder(&self) -> SequenceBuilder;

--- a/src/element/list.rs
+++ b/src/element/list.rs
@@ -1,14 +1,12 @@
-use crate::element::builders::ListBuilder;
 use crate::element::iterators::ElementsIterator;
-use crate::element::{Element, IonSequence};
+use crate::element::{Element, Sequence};
 use crate::text::text_formatter::IonValueFormatter;
 use std::fmt::{Display, Formatter};
+use std::ops::Deref;
 
 /// An in-memory representation of an Ion list.
-///
-/// [`List`] implements [`IonSequence`], which defines most of its functionality.
 /// ```
-/// use ion_rs::element::{Element, IonSequence, List};
+/// use ion_rs::element::{Element, List};
 /// use ion_rs::ion_list;
 /// # use ion_rs::IonResult;
 /// # fn main() -> IonResult<()> {
@@ -19,21 +17,25 @@ use std::fmt::{Display, Formatter};
 /// # }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct List {
-    pub(super) children: Vec<Element>,
-}
+pub struct List(pub Sequence);
 
 impl List {
-    pub(crate) fn new(children: Vec<Element>) -> Self {
-        Self { children }
+    pub(crate) fn new(elements: impl Into<Sequence>) -> Self {
+        List(elements.into())
     }
+}
 
-    pub fn builder() -> ListBuilder {
-        ListBuilder::new()
+impl Deref for List {
+    type Target = Sequence;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
+}
 
-    pub fn clone_builder(&self) -> ListBuilder {
-        ListBuilder::with_initial_elements(&self.children)
+impl AsRef<Sequence> for List {
+    fn as_ref(&self) -> &Sequence {
+        &self.0
     }
 }
 
@@ -52,6 +54,12 @@ impl Display for List {
         let mut ivf = IonValueFormatter { output: f };
         ivf.format_list(self).map_err(|_| std::fmt::Error)?;
         Ok(())
+    }
+}
+
+impl From<Sequence> for List {
+    fn from(sequence: Sequence) -> Self {
+        List(sequence)
     }
 }
 

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -12,7 +12,7 @@
 //! [simd-json-value]: https://docs.rs/simd-json/latest/simd_json/value/index.html
 //! [serde-json-value]: https://docs.serde.rs/serde_json/value/enum.Value.html
 
-use crate::element::builders::{ListBuilder, SExpBuilder, StructBuilder};
+use crate::element::builders::{SequenceBuilder, StructBuilder};
 use crate::element::iterators::SymbolsIterator;
 use crate::element::reader::ElementReader;
 use crate::ion_eq::IonEq;
@@ -34,7 +34,7 @@ pub mod writer;
 // Re-export the Value variant types and traits so they can be accessed directly from this module.
 pub use list::List;
 pub use r#struct::Struct;
-pub use sequence::IonSequence;
+pub use sequence::Sequence;
 pub use sexp::SExp;
 
 impl IonEq for Value {
@@ -306,12 +306,8 @@ impl Element {
         Value::Blob(bytes.into()).into()
     }
 
-    pub fn list_builder() -> ListBuilder {
-        ListBuilder::new()
-    }
-
-    pub fn sexp_builder() -> SExpBuilder {
-        SExpBuilder::new()
+    pub fn sequence_builder() -> SequenceBuilder {
+        Sequence::builder()
     }
 
     pub fn struct_builder() -> StructBuilder {
@@ -438,10 +434,9 @@ impl Element {
         }
     }
 
-    pub fn as_sequence(&self) -> Option<&dyn IonSequence> {
+    pub fn as_sequence(&self) -> Option<&Sequence> {
         match &self.value {
-            Value::SExp(sexp) => Some(sexp),
-            Value::List(list) => Some(list),
+            Value::SExp(SExp(s)) | Value::List(List(s)) => Some(s),
             _ => None,
         }
     }
@@ -793,7 +788,7 @@ mod tests {
         }
     }
 
-    use crate::element::{Element, IntoAnnotatedElement, IonSequence, Struct};
+    use crate::element::{Element, IntoAnnotatedElement, Struct};
     use crate::types::integer::IntAccess;
     use num_bigint::BigInt;
     use std::collections::HashSet;

--- a/src/element/sequence.rs
+++ b/src/element/sequence.rs
@@ -1,64 +1,55 @@
+use crate::element::builders::SequenceBuilder;
 use crate::element::iterators::ElementsIterator;
-use crate::element::{Element, List, SExp};
+use crate::element::Element;
 use crate::ion_eq::IonEq;
 
-/// Behavior that is common to both [SExp] and [Struct].
-pub trait IonSequence {
-    fn elements(&self) -> ElementsIterator<'_>;
-    fn get(&self, index: usize) -> Option<&Element>;
-    fn len(&self) -> usize;
-    fn is_empty(&self) -> bool {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Sequence {
+    elements: Vec<Element>,
+}
+
+impl Sequence {
+    pub fn new<E: Into<Element>, I: IntoIterator<Item = E>>(elements: I) -> Sequence {
+        let elements = elements.into_iter().map(|e| e.into()).collect();
+        Sequence { elements }
+    }
+
+    pub fn builder() -> SequenceBuilder {
+        SequenceBuilder::new()
+    }
+
+    pub fn clone_builder(&self) -> SequenceBuilder {
+        SequenceBuilder::with_initial_elements(&self.elements)
+    }
+
+    pub fn elements(&self) -> ElementsIterator<'_> {
+        ElementsIterator::new(&self.elements)
+    }
+
+    pub fn get(&self, index: usize) -> Option<&Element> {
+        self.elements.get(index)
+    }
+
+    pub fn len(&self) -> usize {
+        self.elements.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 }
 
-impl IonSequence for List {
-    fn elements(&self) -> ElementsIterator<'_> {
-        ElementsIterator::new(&self.children)
-    }
-
-    fn get(&self, index: usize) -> Option<&Element> {
-        self.children.get(index)
-    }
-
-    fn len(&self) -> usize {
-        self.children.len()
-    }
-
-    fn is_empty(&self) -> bool {
-        self.len() == 0
+// This is more efficient than Sequence::new(), which will iterate over and convert each value to
+// an Element for better ergonomics.
+impl From<Vec<Element>> for Sequence {
+    fn from(elements: Vec<Element>) -> Self {
+        Sequence { elements }
     }
 }
 
-impl<S: IonSequence> IonEq for S {
+impl IonEq for Sequence {
     fn ion_eq(&self, other: &Self) -> bool {
-        if self.len() != other.len() {
-            return false;
-        }
-        for (item1, item2) in self.elements().zip(other.elements()) {
-            if !item1.ion_eq(item2) {
-                return false;
-            }
-        }
-        true
-    }
-}
-
-impl IonSequence for SExp {
-    fn elements(&self) -> ElementsIterator<'_> {
-        ElementsIterator::new(&self.children)
-    }
-
-    fn get(&self, index: usize) -> Option<&Element> {
-        self.children.get(index)
-    }
-
-    fn len(&self) -> usize {
-        self.children.len()
-    }
-
-    fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.elements.ion_eq(&other.elements)
     }
 }
 

--- a/src/element/sexp.rs
+++ b/src/element/sexp.rs
@@ -18,6 +18,7 @@ use std::fmt::{Display, Formatter};
 /// # Ok(())
 /// # }
 /// ```
+/// To build a `SExp` incrementally, see [SequenceBuilder].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SExp(pub Sequence);
 

--- a/src/element/sexp.rs
+++ b/src/element/sexp.rs
@@ -1,14 +1,12 @@
-use crate::element::builders::SExpBuilder;
 use crate::element::iterators::ElementsIterator;
-use crate::element::{Element, IonSequence};
+use crate::element::{Element, Sequence};
 use crate::text::text_formatter::IonValueFormatter;
 use std::fmt::{Display, Formatter};
+use std::ops::Deref;
 
 /// An in-memory representation of an Ion s-expression
-///
-/// [`SExp`] implements [`IonSequence`], which defines most of its functionality.
 /// ```
-/// use ion_rs::element::{Element, IonSequence, List};
+/// use ion_rs::element::{Element, List};
 /// use ion_rs::ion_sexp;
 /// # use ion_rs::IonResult;
 /// # fn main() -> IonResult<()> {
@@ -19,21 +17,25 @@ use std::fmt::{Display, Formatter};
 /// # }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SExp {
-    pub(super) children: Vec<Element>,
-}
+pub struct SExp(pub Sequence);
 
 impl SExp {
-    pub(crate) fn new(children: Vec<Element>) -> Self {
-        Self { children }
+    pub(crate) fn new(elements: impl Into<Sequence>) -> Self {
+        SExp(elements.into())
     }
+}
 
-    pub fn builder() -> SExpBuilder {
-        SExpBuilder::new()
+impl Deref for SExp {
+    type Target = Sequence;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
+}
 
-    pub fn clone_builder(&self) -> SExpBuilder {
-        SExpBuilder::with_initial_elements(&self.children)
+impl AsRef<Sequence> for SExp {
+    fn as_ref(&self) -> &Sequence {
+        &self.0
     }
 }
 
@@ -52,6 +54,12 @@ impl Display for SExp {
         let mut ivf = IonValueFormatter { output: f };
         ivf.format_sexp(self).map_err(|_| std::fmt::Error)?;
         Ok(())
+    }
+}
+
+impl From<Sequence> for SExp {
+    fn from(sequence: Sequence) -> Self {
+        SExp(sequence)
     }
 }
 

--- a/src/element/sexp.rs
+++ b/src/element/sexp.rs
@@ -1,8 +1,10 @@
+use crate::element::builders::SequenceBuilder;
 use crate::element::iterators::ElementsIterator;
 use crate::element::{Element, Sequence};
+use crate::ion_eq::IonEq;
 use crate::text::text_formatter::IonValueFormatter;
+use delegate::delegate;
 use std::fmt::{Display, Formatter};
-use std::ops::Deref;
 
 /// An in-memory representation of an Ion s-expression
 /// ```
@@ -25,11 +27,26 @@ impl SExp {
     }
 }
 
-impl Deref for SExp {
-    type Target = Sequence;
+impl SExp {
+    pub fn builder() -> SequenceBuilder {
+        Sequence::builder()
+    }
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    delegate! {
+        to self.0 {
+            pub fn clone_builder(&self) -> SequenceBuilder;
+            pub fn elements(&self) -> ElementsIterator<'_>;
+            pub fn get(&self, index: usize) -> Option<&Element>;
+            pub fn len(&self) -> usize;
+            pub fn is_empty(&self) -> bool;
+        }
+    }
+}
+
+impl IonEq for SExp {
+    fn ion_eq(&self, other: &Self) -> bool {
+        // The inner `Sequence` of both Lists are IonEq
+        self.0.ion_eq(&other.0)
     }
 }
 

--- a/src/element/sexp.rs
+++ b/src/element/sexp.rs
@@ -28,10 +28,6 @@ impl SExp {
 }
 
 impl SExp {
-    pub fn builder() -> SequenceBuilder {
-        Sequence::builder()
-    }
-
     delegate! {
         to self.0 {
             pub fn clone_builder(&self) -> SequenceBuilder;

--- a/src/element/writer.rs
+++ b/src/element/writer.rs
@@ -5,7 +5,6 @@
 
 use crate::result::IonResult;
 
-use crate::element::sequence::IonSequence;
 use crate::element::{Element, Value};
 use crate::{IonType, IonWriter};
 pub use Format::*;

--- a/src/ion_hash/representation.rs
+++ b/src/ion_hash/representation.rs
@@ -7,7 +7,7 @@
 //! and not speed.
 
 use crate::binary::{self, decimal::DecimalBinaryEncoder, timestamp::TimestampBinaryEncoder};
-use crate::element::{Element, IonSequence, List, SExp, Struct};
+use crate::element::{Element, List, SExp, Struct};
 use crate::ion_hash::element_hasher::ElementHasher;
 use crate::ion_hash::type_qualifier::type_qualifier_symbol;
 use crate::types::decimal::Decimal;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@
 //! ```
 //! use ion_rs::IonResult;
 //! # fn main() -> IonResult<()> {
-//! use ion_rs::element::{Element, IonSequence, IntoAnnotatedElement,  Value};
+//! use ion_rs::element::{Element, IntoAnnotatedElement,  Value};
 //! use ion_rs::{ion_struct, ion_list};
 //! let element: Element = ion_struct! {
 //!   "foo": "hello",
@@ -137,7 +137,7 @@
 //! ```
 //! use ion_rs::IonResult;
 //! # fn main() -> IonResult<()> {
-//! use ion_rs::element::{Element, IonSequence, IntoAnnotatedElement,  Value};
+//! use ion_rs::element::{Element, IntoAnnotatedElement,  Value};
 //! use ion_rs::{ion_struct, ion_list, TextWriterBuilder, IonWriter};
 //! use ion_rs::element::writer::ElementWriter;
 //! let element: Element = ion_struct! {

--- a/src/text/text_formatter.rs
+++ b/src/text/text_formatter.rs
@@ -1,4 +1,4 @@
-use crate::element::{IonSequence, List, SExp, Struct};
+use crate::element::{List, SExp, Struct};
 use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
 use crate::{Decimal, Int, IonResult, IonType, RawSymbolTokenRef, Symbol, Timestamp};
 

--- a/tests/element_test_vectors.rs
+++ b/tests/element_test_vectors.rs
@@ -2,12 +2,11 @@
 
 use ion_rs::element::reader::ElementReader;
 use ion_rs::element::writer::{ElementWriter, Format, TextKind};
-use ion_rs::element::Element;
+use ion_rs::element::{Element, Sequence};
 use ion_rs::ion_eq::IonEq;
 use ion_rs::result::{decoding_error, IonError, IonResult};
 use ion_rs::{BinaryWriterBuilder, IonWriter, Reader, TextWriterBuilder};
 
-use ion_rs::element::IonSequence;
 use std::fs::read;
 use std::path::MAIN_SEPARATOR as PATH_SEPARATOR;
 use test_generator::test_resources;
@@ -156,7 +155,7 @@ trait ElementApi {
     /// This will parse each string as a [`Vec`] of [`Element`] and apply the `group_assert` function
     /// for every pair of the parsed data including the identity case (a parsed document is
     /// compared against itself).
-    fn read_group_embedded<F>(raw_group: &dyn IonSequence, group_assert: &F) -> IonResult<()>
+    fn read_group_embedded<F>(raw_group: &Sequence, group_assert: &F) -> IonResult<()>
     where
         F: Fn(&Vec<Element>, &Vec<Element>),
     {


### PR DESCRIPTION
See issue #500 for discussion.

This PR removes the `IonSequence` trait and reintroduces a concrete `Sequence` type. It also converts `List` and `SExp` into tuple structs that wrap `Sequence`.

`ListBuilder` and `SExpBuilder` have also been removed in favor of a single `SequenceBuilder` implementation with `build_list()` and `build_sexp()` methods.

`List` and `SExp` each implement `Deref<Target=Sequence>`, allowing them both to expose the functionality of their underlying `Sequence` of elements transparently.

This eliminates a fair amount of boilerplate code that was needed to provide functionality for both types. It also enables unified handling for `List` and `SExp` in match expressions in situations where the author does not care about the Ion type distinction. Finally, users no longer have to import `IonSequence` in order to access the basic functionality of `List` and `SExp`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
