### PR TITLE
Makes `Value::List` and `Value::SExp` wrap `Sequence`

### DIFF
--- a/src/element/list.rs
+++ b/src/element/list.rs
@@ -77,6 +77,12 @@ impl From<Sequence> for List {
     }
 }
 
+impl From<List> for Sequence {
+    fn from(value: List) -> Self {
+        value.0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::ion_list;

--- a/src/element/reader.rs
+++ b/src/element/reader.rs
@@ -3,9 +3,9 @@
 //! Provides APIs to read Ion data into [Element] from different sources such
 //! as slices or files.
 
-use crate::element::{Element, Struct, Value};
+use crate::element::{Element, Sequence, Struct, Value};
 use crate::result::{decoding_error, IonResult};
-use crate::{element, IonReader, StreamItem, Symbol};
+use crate::{IonReader, StreamItem, Symbol};
 
 /// Reads Ion data into [`Element`] instances.
 ///
@@ -150,8 +150,8 @@ impl<'a, R: IonReader<Item = StreamItem, Symbol = Symbol>> ElementLoader<'a, R> 
                     Clob => Value::Clob(self.reader.read_clob()?),
                     Blob => Value::Blob(self.reader.read_blob()?),
                     // It's a collection; recursively materialize all of this value's children
-                    List => Value::List(element::List::new(self.materialize_sequence()?)),
-                    SExp => Value::SExp(element::SExp::new(self.materialize_sequence()?)),
+                    List => Value::List(self.materialize_sequence()?),
+                    SExp => Value::SExp(self.materialize_sequence()?),
                     Struct => Value::Struct(self.materialize_struct()?),
                 }
             }
@@ -162,14 +162,14 @@ impl<'a, R: IonReader<Item = StreamItem, Symbol = Symbol>> ElementLoader<'a, R> 
     /// Steps into the current sequence and materializes each of its children to construct
     /// an [Vec<Element>]. When all of the the children have been materialized, steps out.
     /// The reader MUST be positioned over a list or s-expression when this is called.
-    fn materialize_sequence(&mut self) -> IonResult<Vec<Element>> {
+    fn materialize_sequence(&mut self) -> IonResult<Sequence> {
         let mut child_elements = Vec::new();
         self.reader.step_in()?;
         while let Some(element) = self.materialize_next()? {
             child_elements.push(element);
         }
         self.reader.step_out()?;
-        Ok(child_elements)
+        Ok(child_elements.into())
     }
 
     /// Steps into the current struct and materializes each of its fields to construct

--- a/src/element/sequence.rs
+++ b/src/element/sequence.rs
@@ -39,6 +39,12 @@ impl Sequence {
     }
 }
 
+impl AsRef<Sequence> for Sequence {
+    fn as_ref(&self) -> &Sequence {
+        self
+    }
+}
+
 // This is more efficient than Sequence::new(), which will iterate over and convert each value to
 // an Element for better ergonomics.
 impl From<Vec<Element>> for Sequence {

--- a/src/element/sexp.rs
+++ b/src/element/sexp.rs
@@ -77,6 +77,12 @@ impl From<Sequence> for SExp {
     }
 }
 
+impl From<SExp> for Sequence {
+    fn from(value: SExp) -> Self {
+        value.0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::ion_sexp;

--- a/src/ion_hash/representation.rs
+++ b/src/ion_hash/representation.rs
@@ -7,7 +7,7 @@
 //! and not speed.
 
 use crate::binary::{self, decimal::DecimalBinaryEncoder, timestamp::TimestampBinaryEncoder};
-use crate::element::{Element, List, SExp, Struct};
+use crate::element::{Element, Sequence, Struct};
 use crate::ion_hash::element_hasher::ElementHasher;
 use crate::ion_hash::type_qualifier::type_qualifier_symbol;
 use crate::types::decimal::Decimal;
@@ -26,8 +26,8 @@ pub(crate) trait RepresentationEncoder {
             IonType::Symbol => self.write_repr_symbol(elem.as_symbol())?,
             IonType::String => self.write_repr_string(elem.as_string())?,
             IonType::Clob | IonType::Blob => self.write_repr_blob(elem.as_lob())?,
-            IonType::List => self.write_repr_list(elem.as_list())?,
-            IonType::SExp => self.write_repr_sexp(elem.as_sexp())?,
+            IonType::List => self.write_repr_list(elem.as_sequence())?,
+            IonType::SExp => self.write_repr_sexp(elem.as_sequence())?,
             IonType::Struct => self.write_repr_struct(elem.as_struct())?,
         }
 
@@ -41,8 +41,8 @@ pub(crate) trait RepresentationEncoder {
     fn write_repr_symbol(&mut self, value: Option<&Symbol>) -> IonResult<()>;
     fn write_repr_string(&mut self, value: Option<&str>) -> IonResult<()>;
     fn write_repr_blob(&mut self, value: Option<&[u8]>) -> IonResult<()>;
-    fn write_repr_list(&mut self, value: Option<&List>) -> IonResult<()>;
-    fn write_repr_sexp(&mut self, value: Option<&SExp>) -> IonResult<()>;
+    fn write_repr_list(&mut self, value: Option<&Sequence>) -> IonResult<()>;
+    fn write_repr_sexp(&mut self, value: Option<&Sequence>) -> IonResult<()>;
     fn write_repr_struct(&mut self, value: Option<&Struct>) -> IonResult<()>;
 }
 
@@ -154,7 +154,7 @@ where
         Ok(())
     }
 
-    fn write_repr_list(&mut self, value: Option<&List>) -> IonResult<()> {
+    fn write_repr_list(&mut self, value: Option<&Sequence>) -> IonResult<()> {
         if let Some(seq) = value {
             for elem in seq.elements() {
                 self.update_serialized_bytes(elem)?;
@@ -164,7 +164,7 @@ where
         Ok(())
     }
 
-    fn write_repr_sexp(&mut self, value: Option<&SExp>) -> IonResult<()> {
+    fn write_repr_sexp(&mut self, value: Option<&Sequence>) -> IonResult<()> {
         if let Some(seq) = value {
             for elem in seq.elements() {
                 self.update_serialized_bytes(elem)?;

--- a/src/ion_hash/type_qualifier.rs
+++ b/src/ion_hash/type_qualifier.rs
@@ -6,7 +6,7 @@ use std::slice;
 ///!
 ///! [spec]: https://amazon-ion.github.io/ion-hash/docs/spec.html.
 use crate::binary::IonTypeCode;
-use crate::element::{Element, List, SExp, Struct};
+use crate::element::{Element, Sequence, Struct};
 use crate::{Decimal, Int, IonType, Symbol, Timestamp};
 use num_bigint::Sign;
 
@@ -47,8 +47,8 @@ impl TypeQualifier {
             IonType::String => type_qualifier_string(elem.as_string()),
             IonType::Clob => type_qualifier_clob(elem.as_lob()),
             IonType::Blob => type_qualifier_blob(elem.as_lob()),
-            IonType::List => type_qualifier_list(elem.as_list()),
-            IonType::SExp => type_qualifier_sexp(elem.as_sexp()),
+            IonType::List => type_qualifier_list(elem.as_sequence()),
+            IonType::SExp => type_qualifier_sexp(elem.as_sequence()),
             IonType::Struct => type_qualifier_struct(elem.as_struct()),
         }
     }
@@ -125,11 +125,11 @@ pub(crate) fn type_qualifier_blob(value: Option<&[u8]>) -> TypeQualifier {
     combine(IonTypeCode::Blob, qualify_nullness(value))
 }
 
-pub(crate) fn type_qualifier_list(value: Option<&List>) -> TypeQualifier {
+pub(crate) fn type_qualifier_list(value: Option<&Sequence>) -> TypeQualifier {
     combine(IonTypeCode::List, qualify_nullness(value))
 }
 
-pub(crate) fn type_qualifier_sexp(value: Option<&SExp>) -> TypeQualifier {
+pub(crate) fn type_qualifier_sexp(value: Option<&Sequence>) -> TypeQualifier {
     combine(IonTypeCode::SExpression, qualify_nullness(value))
 }
 


### PR DESCRIPTION
This PR partially addresses issue #500.

It modifies the `Value` enum's `List` and `SExp` variants from:

```rust
enum Value {
  // ...
  List(List),
  SExp(SExp),
  // ...
}
```

to

```rust
enum Value {
  // ...
  List(Sequence),
  SExp(Sequence),
}
```

while also preserving the standalone `element::List(Sequence)` and `element::SExp(Sequence)` types, which are used primarily by the SequenceBuilder, `ion_list!`, and `ion_sexp!`.

Following this change, matching sequence types is flattened/simplified:
```rust
if let List(seq) | SExp(seq) = value {
  // iterate over `seq`
}
```
but we retain the ability to construct strongly typed standalone values when necessary, such as in the `ion_list!`
and `ion_sexp!` macros.

```rust
// Constructs an element::List(Sequence)
let list: List = ion_list![1, 2, 3];
// Discards the outer wrapper element::List, moving the Sequence into a `Value::List(...)`.
let value: Value = list.into(); // Discards the outer `List`
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
