### PR TITLE
Remove map_<type> APIs and replace them with read_<type>

### DIFF
--- a/examples/read_all_values.rs
+++ b/examples/read_all_values.rs
@@ -62,7 +62,7 @@ fn read_all_values<R: RawReader>(reader: &mut R) -> IonResult<usize> {
                 match ion_type {
                     Struct | List | SExp => reader.step_in()?,
                     String => {
-                        reader.map_string(|_s| ())?;
+                        let _string = reader.read_str()?;
                     }
                     Symbol => {
                         let _symbol_id = reader.read_symbol()?;
@@ -83,10 +83,10 @@ fn read_all_values<R: RawReader>(reader: &mut R) -> IonResult<usize> {
                         let _boolean = reader.read_bool()?;
                     }
                     Blob => {
-                        reader.map_blob(|_b| ())?;
+                        let _blob = reader.read_blob()?;
                     }
                     Clob => {
-                        reader.map_clob(|_c| ())?;
+                        let _clob = reader.read_clob()?;
                     }
                     Null => {}
                 }

--- a/src/blocking_reader.rs
+++ b/src/blocking_reader.rs
@@ -149,20 +149,8 @@ impl<R: BufferedRawReader, T: ToIonDataSource> IonReader for BlockingRawReader<R
         self.reader.read_string()
     }
 
-    fn map_string<F, U>(&mut self, f: F) -> IonResult<U>
-    where
-        Self: Sized,
-        F: FnOnce(&str) -> U,
-    {
-        self.reader.map_string(f)
-    }
-
-    fn map_string_bytes<F, U>(&mut self, f: F) -> IonResult<U>
-    where
-        Self: Sized,
-        F: FnOnce(&[u8]) -> U,
-    {
-        self.reader.map_string_bytes(f)
+    fn read_str(&mut self) -> IonResult<&str> {
+        self.reader.read_str()
     }
 
     fn read_symbol(&mut self) -> IonResult<Self::Symbol> {
@@ -170,27 +158,11 @@ impl<R: BufferedRawReader, T: ToIonDataSource> IonReader for BlockingRawReader<R
     }
 
     fn read_blob(&mut self) -> IonResult<Blob> {
-        self.map_blob(|b| Vec::from(b)).map(Blob::from)
-    }
-
-    fn map_blob<F, U>(&mut self, f: F) -> IonResult<U>
-    where
-        Self: Sized,
-        F: FnOnce(&[u8]) -> U,
-    {
-        self.reader.map_blob(f)
+        self.reader.read_blob()
     }
 
     fn read_clob(&mut self) -> IonResult<Clob> {
-        self.map_clob(|c| Vec::from(c)).map(Clob::from)
-    }
-
-    fn map_clob<F, U>(&mut self, f: F) -> IonResult<U>
-    where
-        Self: Sized,
-        F: FnOnce(&[u8]) -> U,
-    {
-        self.reader.map_clob(f)
+        self.reader.read_clob()
     }
 
     fn read_timestamp(&mut self) -> IonResult<Timestamp> {

--- a/src/element/element_stream_reader.rs
+++ b/src/element/element_stream_reader.rs
@@ -239,26 +239,17 @@ impl IonReader for ElementStreamReader {
     }
 
     fn read_string(&mut self) -> IonResult<Str> {
-        self.map_string(|s| s.into())
-    }
-
-    fn map_string<F, U>(&mut self, f: F) -> IonResult<U>
-    where
-        Self: Sized,
-        F: FnOnce(&str) -> U,
-    {
         match self.current_value.as_ref() {
-            Some(element) if element.as_text().is_some() => Ok(f(element.as_text().unwrap())),
+            Some(element) if element.as_text().is_some() => Ok(element.as_text().unwrap().into()),
             _ => Err(self.expected("string value")),
         }
     }
 
-    fn map_string_bytes<F, U>(&mut self, f: F) -> IonResult<U>
-    where
-        Self: Sized,
-        F: FnOnce(&[u8]) -> U,
-    {
-        self.map_string(|s| f(s.as_bytes()))
+    fn read_str(&mut self) -> IonResult<&str> {
+        match self.current_value.as_ref() {
+            Some(element) if element.as_text().is_some() => Ok(element.as_text().unwrap()),
+            _ => Err(self.expected("string value")),
+        }
     }
 
     fn read_symbol(&mut self) -> IonResult<Self::Symbol> {
@@ -266,31 +257,19 @@ impl IonReader for ElementStreamReader {
     }
 
     fn read_blob(&mut self) -> IonResult<Blob> {
-        self.map_blob(|b| Vec::from(b)).map(Blob::from)
-    }
-
-    fn map_blob<F, U>(&mut self, f: F) -> IonResult<U>
-    where
-        Self: Sized,
-        F: FnOnce(&[u8]) -> U,
-    {
         match self.current_value.as_ref() {
-            Some(element) if element.as_lob().is_some() => Ok(f(element.as_lob().unwrap())),
-            _ => Err(self.expected("blob value")),
+            Some(element) if element.as_blob().is_some() => {
+                Ok(Blob::from(element.as_blob().unwrap()))
+            }
+            _ => Err(self.expected("blog value")),
         }
     }
 
     fn read_clob(&mut self) -> IonResult<Clob> {
-        self.map_clob(|c| Vec::from(c)).map(Clob::from)
-    }
-
-    fn map_clob<F, U>(&mut self, f: F) -> IonResult<U>
-    where
-        Self: Sized,
-        F: FnOnce(&[u8]) -> U,
-    {
         match self.current_value.as_ref() {
-            Some(element) if element.as_lob().is_some() => Ok(f(element.as_lob().unwrap())),
+            Some(element) if element.as_clob().is_some() => {
+                Ok(Clob::from(element.as_clob().unwrap()))
+            }
             _ => Err(self.expected("clob value")),
         }
     }

--- a/src/raw_reader.rs
+++ b/src/raw_reader.rs
@@ -83,20 +83,8 @@ impl<R: RawReader + ?Sized> IonReader for Box<R> {
         (**self).read_string()
     }
 
-    fn map_string<F, U>(&mut self, _f: F) -> IonResult<U>
-    where
-        Self: Sized,
-        F: FnOnce(&str) -> U,
-    {
-        todo!("Cannot use `map_string` via dynamic dispatch. Use `read_string` instead. See: https://github.com/amazon-ion/ion-rust/issues/335")
-    }
-
-    fn map_string_bytes<F, U>(&mut self, _f: F) -> IonResult<U>
-    where
-        Self: Sized,
-        F: FnOnce(&[u8]) -> U,
-    {
-        todo!("Cannot use `map_string_bytes` via dynamic dispatch. Use `read_string` instead. See: https://github.com/amazon-ion/ion-rust/issues/335")
+    fn read_str(&mut self) -> IonResult<&str> {
+        (**self).read_str()
     }
 
     fn read_symbol(&mut self) -> IonResult<Self::Symbol> {
@@ -107,24 +95,8 @@ impl<R: RawReader + ?Sized> IonReader for Box<R> {
         (**self).read_blob()
     }
 
-    fn map_blob<F, U>(&mut self, _f: F) -> IonResult<U>
-    where
-        Self: Sized,
-        F: FnOnce(&[u8]) -> U,
-    {
-        todo!("Cannot use `map_blob` via dynamic dispatch. Use `read_blob` instead. See: https://github.com/amazon-ion/ion-rust/issues/335")
-    }
-
     fn read_clob(&mut self) -> IonResult<Clob> {
         (**self).read_clob()
-    }
-
-    fn map_clob<F, U>(&mut self, _f: F) -> IonResult<U>
-    where
-        Self: Sized,
-        F: FnOnce(&[u8]) -> U,
-    {
-        todo!("Cannot use `map_clob` via dynamic dispatch. Use `read_clob` instead. See: https://github.com/amazon-ion/ion-rust/issues/335")
     }
 
     fn read_timestamp(&mut self) -> IonResult<Timestamp> {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -434,12 +434,9 @@ impl<R: RawReader> IonReader for UserReader<R> {
             fn read_f64(&mut self) -> IonResult<f64>;
             fn read_decimal(&mut self) -> IonResult<Decimal>;
             fn read_string(&mut self) -> IonResult<Str>;
-            fn map_string<F, U>(&mut self, f: F) -> IonResult<U> where F: FnOnce(&str) -> U;
-            fn map_string_bytes<F, U>(&mut self, f: F) -> IonResult<U> where F: FnOnce(&[u8]) -> U;
+            fn read_str(&mut self) -> IonResult<&str>;
             fn read_blob(&mut self) -> IonResult<Blob>;
-            fn map_blob<F, U>(&mut self, f: F) -> IonResult<U> where F: FnOnce(&[u8]) -> U;
             fn read_clob(&mut self) -> IonResult<Clob>;
-            fn map_clob<F, U>(&mut self, f: F) -> IonResult<U> where F: FnOnce(&[u8]) -> U;
             fn read_timestamp(&mut self) -> IonResult<Timestamp>;
             fn step_in(&mut self) -> IonResult<()>;
             fn step_out(&mut self) -> IonResult<()>;

--- a/src/stream_reader.rs
+++ b/src/stream_reader.rs
@@ -106,26 +106,10 @@ pub trait IonReader {
     /// item is not a string or an IO error is encountered while reading, returns [crate::IonError].
     fn read_string(&mut self) -> IonResult<Str>;
 
-    /// Takes a function that expects a string and, once the string's bytes are loaded, calls that
-    /// function passing the string as a parameter. This allows users to avoid materializing the
-    /// string if they only intend to inspect it for length, pattern matches, etc.
-    // TODO: Replace with a `read_str(&self) -> IonResult<&str>`
-    //       See: https://github.com/amazon-ion/ion-rust/issues/335
-    fn map_string<F, U>(&mut self, f: F) -> IonResult<U>
-    where
-        Self: Sized,
-        F: FnOnce(&str) -> U;
-
-    /// Takes a function that expects a string and, once the string's bytes are loaded, calls that
-    /// function passing the string's raw bytes as a parameter. Some implementations may be able
-    /// to optimize this by calling the function without first validating that the bytes are utf8.
-    /// As such, callers MUST NOT depend on the string contents being valid utf8.
-    // TODO: Replace with a `read_string_bytes(&self) -> IonResult<&[u8]>`
-    //       See: https://github.com/amazon-ion/ion-rust/issues/335
-    fn map_string_bytes<F, U>(&mut self, f: F) -> IonResult<U>
-    where
-        Self: Sized,
-        F: FnOnce(&[u8]) -> U;
+    /// Attempts to read the current item as an Ion string and return it as a [&str]. If the
+    /// current item is not a string or an IO error is encountered while reading, returns
+    /// [crate::IonError].
+    fn read_str(&mut self) -> IonResult<&str>;
 
     /// Attempts to read the current item as an Ion symbol and return it as a [Self::Symbol]. If the
     /// current item is not a symbol or an IO error is encountered while reading, returns [crate::IonError].
@@ -135,29 +119,9 @@ pub trait IonReader {
     /// current item is not a blob or an IO error is encountered while reading, returns [crate::IonError].
     fn read_blob(&mut self) -> IonResult<Blob>;
 
-    /// Takes a function that expects a byte slice and, once the blob's bytes are loaded, calls that
-    /// function passing the blob's bytes as a parameter. This allows users to avoid materializing the
-    /// clob if they only intend to inspect it for length, pattern matches, etc.
-    // TODO: Replace with a `read_blob_bytes(&self) -> IonResult<&[u8]>`
-    //       See: https://github.com/amazon-ion/ion-rust/issues/335
-    fn map_blob<F, U>(&mut self, f: F) -> IonResult<U>
-    where
-        Self: Sized,
-        F: FnOnce(&[u8]) -> U;
-
     /// Attempts to read the current item as an Ion clob and return it as a `Vec<u8>`. If the
     /// current item is not a clob or an IO error is encountered while reading, returns [crate::IonError].
     fn read_clob(&mut self) -> IonResult<Clob>;
-
-    /// Takes a function that expects a byte slice and, once the clob's bytes are loaded, calls that
-    /// function passing the clob's bytes as a parameter. This allows users to avoid materializing the
-    /// clob if they only intend to inspect it for length, pattern matches, etc.
-    // TODO: Replace with a `read_clob_bytes(&self) -> IonResult<&[u8]]>`
-    //       See: https://github.com/amazon-ion/ion-rust/issues/335
-    fn map_clob<F, U>(&mut self, f: F) -> IonResult<U>
-    where
-        Self: Sized,
-        F: FnOnce(&[u8]) -> U;
 
     /// Attempts to read the current item as an Ion timestamp and return [crate::Timestamp]. If the current
     /// item is not a timestamp or an IO error is encountered while reading, returns [crate::IonError].

--- a/src/text/non_blocking/raw_text_reader.rs
+++ b/src/text/non_blocking/raw_text_reader.rs
@@ -844,30 +844,17 @@ impl<A: AsRef<[u8]> + Expandable> IonReader for RawTextReader<A> {
     }
 
     fn read_string(&mut self) -> IonResult<Str> {
-        self.map_string(|s| s.into())
-    }
-
-    fn map_string<F, U>(&mut self, f: F) -> IonResult<U>
-    where
-        Self: Sized,
-        F: FnOnce(&str) -> U,
-    {
         match self.current_value.as_ref().map(|current| current.value()) {
-            Some(TextValue::String(ref value)) => Ok(f(value.as_str())),
+            Some(TextValue::String(ref value)) => Ok(Str::from(value.as_str())),
             _ => Err(self.expected("string value")),
         }
     }
 
-    fn map_string_bytes<F, U>(&mut self, f: F) -> IonResult<U>
-    where
-        Self: Sized,
-        F: FnOnce(&[u8]) -> U,
-    {
-        // In the binary reader, this method can bypass utf-8 validation and return a view of the
-        // raw bytes in the input buffer. In the text reader, this optimization isn't available;
-        // some of the input bytes may be encoded as text unicode escapes and require processing
-        // to turn into &[u8].
-        self.map_string(|s| f(s.as_bytes()))
+    fn read_str(&mut self) -> IonResult<&str> {
+        match self.current_value.as_ref().map(|current| current.value()) {
+            Some(TextValue::String(ref value)) => Ok(value.as_str()),
+            _ => Err(self.expected("string value")),
+        }
     }
 
     fn read_symbol(&mut self) -> IonResult<Self::Symbol> {
@@ -878,31 +865,15 @@ impl<A: AsRef<[u8]> + Expandable> IonReader for RawTextReader<A> {
     }
 
     fn read_blob(&mut self) -> IonResult<Blob> {
-        self.map_blob(|b| Vec::from(b)).map(Blob::from)
-    }
-
-    fn map_blob<F, U>(&mut self, f: F) -> IonResult<U>
-    where
-        Self: Sized,
-        F: FnOnce(&[u8]) -> U,
-    {
         match self.current_value.as_ref().map(|current| current.value()) {
-            Some(TextValue::Blob(ref value)) => Ok(f(value.as_slice())),
+            Some(TextValue::Blob(ref value)) => Ok(Blob::from(value.as_slice())),
             _ => Err(self.expected("blob value")),
         }
     }
 
     fn read_clob(&mut self) -> IonResult<Clob> {
-        self.map_clob(|c| Vec::from(c)).map(Clob::from)
-    }
-
-    fn map_clob<F, U>(&mut self, f: F) -> IonResult<U>
-    where
-        Self: Sized,
-        F: FnOnce(&[u8]) -> U,
-    {
         match self.current_value.as_ref().map(|current| current.value()) {
-            Some(TextValue::Clob(ref value)) => Ok(f(value.as_slice())),
+            Some(TextValue::Clob(ref value)) => Ok(Clob::from(value.as_slice())),
             _ => Err(self.expected("clob value")),
         }
     }


### PR DESCRIPTION
*Issue #, if available:* #335

*Description of changes:*
This PR removes the `map_`-style functions from the reader trait and replaces their use with `read_`-style functions.

`read_str` was added to the IonReader trait. The function already existed in the binary reader, so it was moved into the trait impl and the implemented for the other readers.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
