### PR TITLE
Adds Copy/Clone derivation to StreamItem

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -146,7 +146,7 @@ pub mod integration_testing {
 }
 
 /// Stream components that an application-level [Reader] implementation may encounter.
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum StreamItem {
     /// A non-null Ion value and its corresponding Ion data type.
     Value(IonType),


### PR DESCRIPTION
This makes it consistent with `RawStreamItem` and `SystemStreamItem`.

When writing #512, I noticed that `StreamItem` did not derive these traits.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
