### PR TITLE
Fix rustdoc

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,8 +37,7 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          # explicitly add rustc to get rustdoc
-          components: rustc, rustfmt, clippy
+          components: rustfmt, clippy
           override: true
       - name: Cargo Build
         uses: actions-rs/cargo@v1
@@ -81,5 +80,5 @@ jobs:
       - name: Rustdoc on Everything
         uses: actions-rs/cargo@v1
         with:
-          command: doc --document-private-items --all-features
-          args: --verbose -- --check
+          command: doc
+          args: --document-private-items --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,4 +77,8 @@ jobs:
           # Adding comments to the PR requires the GITHUB_TOKEN secret.
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --tests
-
+      - name: Rustdoc on Everything
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc --document-private-items --all-features
+          args: --verbose -- --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,8 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          components: rustfmt, clippy
+          # explicitly add rustc to get rustdoc
+          components: rustc, rustfmt, clippy
           override: true
       - name: Cargo Build
         uses: actions-rs/cargo@v1

--- a/src/binary/header.rs
+++ b/src/binary/header.rs
@@ -43,7 +43,7 @@ impl Header {
 /// It is expected that the jump table will be referenced when a reader attempts to begin reading
 /// the next value from its input data. This calling code must handle the end-of-file case,
 /// IO errors, and decoding errors. Each value in the table is stored as an
-/// IonResult<Option<IonValueHeader>> so that in the even that another value is available and
+/// [`IonResult<Option<IonValueHeader>>`] so that in the even that another value is available and
 /// no IO errors occur, the value from the jump table can be returned as-is with no transformations
 /// required.
 /// All values stored in the table are either an `Err(IonError::DecodingError)` or an

--- a/src/binary/non_blocking/binary_buffer.rs
+++ b/src/binary/non_blocking/binary_buffer.rs
@@ -80,8 +80,8 @@ impl<A: AsRef<[u8]>> BinaryBuffer<A> {
         &self.data.as_ref()[from..to]
     }
 
-    /// Returns the number of bytes that have been marked as read either via the [consume] method
-    /// or one of the `read_*` methods.
+    /// Returns the number of bytes that have been marked as read either via the
+    /// [`consume`](Self::consume) method or one of the `read_*` methods.
     pub fn total_consumed(&self) -> usize {
         self.total_consumed
     }
@@ -137,7 +137,7 @@ impl<A: AsRef<[u8]>> BinaryBuffer<A> {
     /// returns an `Ok(_)` containing a `(major, minor)` version tuple and consumes the
     /// source bytes.
     ///
-    /// See: https://amazon-ion.github.io/ion-docs/docs/binary.html#value-streams
+    /// See: <https://amazon-ion.github.io/ion-docs/docs/binary.html#value-streams>
     pub fn read_ivm(&mut self) -> IonResult<(u8, u8)> {
         let bytes = self
             .peek_n_bytes(IVM.len())
@@ -156,7 +156,7 @@ impl<A: AsRef<[u8]>> BinaryBuffer<A> {
     /// Reads a `VarUInt` encoding primitive from the beginning of the buffer. If it is successful,
     /// returns an `Ok(_)` containing its [VarUInt] representation and consumes the source bytes.
     ///
-    /// See: https://amazon-ion.github.io/ion-docs/docs/binary.html#varuint-and-varint-fields
+    /// See: <https://amazon-ion.github.io/ion-docs/docs/binary.html#varuint-and-varint-fields>
     pub fn read_var_uint(&mut self) -> IonResult<VarUInt> {
         const BITS_PER_ENCODED_BYTE: usize = 7;
         const STORAGE_SIZE_IN_BITS: usize = mem::size_of::<usize>() * 8;
@@ -194,7 +194,7 @@ impl<A: AsRef<[u8]>> BinaryBuffer<A> {
     /// Reads a `VarInt` encoding primitive from the beginning of the buffer. If it is successful,
     /// returns an `Ok(_)` containing its [VarInt] representation and consumes the source bytes.
     ///
-    /// See: https://amazon-ion.github.io/ion-docs/docs/binary.html#varuint-and-varint-fields
+    /// See: <https://amazon-ion.github.io/ion-docs/docs/binary.html#varuint-and-varint-fields>
     pub fn read_var_int(&mut self) -> IonResult<VarInt> {
         const BITS_PER_ENCODED_BYTE: usize = 7;
         const STORAGE_SIZE_IN_BITS: usize = mem::size_of::<i64>() * 8;
@@ -265,7 +265,7 @@ impl<A: AsRef<[u8]>> BinaryBuffer<A> {
     /// successful, returns an `Ok(_)` containing its [DecodedUInt] representation and consumes the
     /// source bytes.
     ///
-    /// See: https://amazon-ion.github.io/ion-docs/docs/binary.html#uint-and-int-fields
+    /// See: <https://amazon-ion.github.io/ion-docs/docs/binary.html#uint-and-int-fields>
     pub fn read_uint(&mut self, length: usize) -> IonResult<DecodedUInt> {
         if length <= mem::size_of::<u64>() {
             return self.read_small_uint(length);
@@ -321,7 +321,7 @@ impl<A: AsRef<[u8]>> BinaryBuffer<A> {
     /// successful, returns an `Ok(_)` containing its [DecodedInt] representation and consumes the
     /// source bytes.
     ///
-    /// See: https://amazon-ion.github.io/ion-docs/docs/binary.html#uint-and-int-fields
+    /// See: <https://amazon-ion.github.io/ion-docs/docs/binary.html#uint-and-int-fields>
     pub fn read_int(&mut self, length: usize) -> IonResult<DecodedInt> {
         if length == 0 {
             return Ok(DecodedInt::new(Int::I64(0), false, 0));
@@ -376,7 +376,7 @@ impl<A: AsRef<[u8]>> BinaryBuffer<A> {
     /// Reads a `NOP` encoding primitive from the buffer. If it is successful, returns an `Ok(_)`
     /// containing the number of bytes that were consumed.
     ///
-    /// See: https://amazon-ion.github.io/ion-docs/docs/binary.html#nop-pad
+    /// See: <https://amazon-ion.github.io/ion-docs/docs/binary.html#nop-pad>
     #[inline(never)]
     // NOP padding is not widely used in Ion 1.0, in part because many writer implementations do not
     // expose the ability to write them. As such, this method has been marked `inline(never)` to
@@ -479,9 +479,9 @@ impl BinaryBuffer<Vec<u8>> {
         self.end += bytes.len();
     }
 
-    /// Tries to read `length` bytes from `source`. Unlike [append_bytes], this method does not do
-    /// any copying. A slice of the reader's buffer is handed to `source` so it can be populated
-    /// directly.
+    /// Tries to read `length` bytes from `source`. Unlike [`append_bytes`](Self::append_bytes),
+    /// this method does not do any copying. A slice of the reader's buffer is handed to `source`
+    /// so it can be populated directly.
     ///
     /// If successful, returns an `Ok(_)` containing the number of bytes that were actually read.
     pub fn read_from<R: Read>(&mut self, mut source: R, length: usize) -> IonResult<usize> {

--- a/src/binary/non_blocking/raw_binary_reader.rs
+++ b/src/binary/non_blocking/raw_binary_reader.rs
@@ -334,9 +334,9 @@ impl BufferedRawReader for RawBinaryReader<Vec<u8>> {
         Ok(())
     }
 
-    /// Tries to read `length` bytes from `source`. Unlike [append_bytes], this method does not do
-    /// any copying. A slice of the reader's buffer is handed to `source` so it can be populated
-    /// directly.
+    /// Tries to read `length` bytes from `source`. Unlike [append_bytes](Self::append_bytes),
+    /// this method does not do any copying. A slice of the reader's buffer is handed to `source`
+    /// so it can be populated directly.
     fn read_from<R: Read>(&mut self, source: R, length: usize) -> IonResult<usize> {
         self.buffer.read_from(source, length)
     }

--- a/src/binary/non_blocking/raw_binary_reader.rs
+++ b/src/binary/non_blocking/raw_binary_reader.rs
@@ -173,7 +173,7 @@ impl EncodedValue {
     /// Returns the number of bytes used to encode the series of VarUInt annotation symbol IDs, if
     /// any.
     ///
-    /// See: https://amazon-ion.github.io/ion-docs/docs/binary.html#annotations
+    /// See: <https://amazon-ion.github.io/ion-docs/docs/binary.html#annotations>
     fn annotations_sequence_length(&self) -> Option<usize> {
         if self.annotations_header_length == 0 {
             return None;
@@ -473,7 +473,7 @@ impl<A: AsRef<[u8]>> RawBinaryReader<A> {
     /// Verifies that the reader is currently positioned over an Ion value of the expected type.
     /// If it is, returns a reference to the corresponding `&EncodedValue` and the slice of input
     /// bytes that represents the body of the value.
-    /// If it is not, returns [IonError::IllegalOperation].
+    /// If it is not, returns [`IllegalOperation`](crate::result::IonError::IllegalOperation).
     #[inline]
     fn value_and_bytes(&self, expected_ion_type: IonType) -> IonResult<(&EncodedValue, &[u8])> {
         // Get a reference to the EncodedValue. This is only possible if the reader is parked
@@ -505,8 +505,8 @@ impl<A: AsRef<[u8]>> RawBinaryReader<A> {
         Ok((encoded_value, bytes))
     }
 
-    /// Like [value_and_bytes], but wraps the byte slice in a `BinaryBuffer` to make it easy
-    /// to read a series of encoding primitives from the slice.
+    /// Like [`value_and_bytes`](Self::value_and_bytes), but wraps the byte slice in a
+    /// `BinaryBuffer` to make it easy to read a series of encoding primitives from the slice.
     #[inline]
     fn value_and_buffer(
         &mut self,

--- a/src/element/annotations.rs
+++ b/src/element/annotations.rs
@@ -30,8 +30,8 @@ impl Annotations {
         }
     }
 
-    /// Returns a [SymbolsIterator] that yields each of the [Symbol]s in this annotations sequence
-    /// in order.
+    /// Returns an [`Iterator`] that yields each of the [`Symbol`]s in this annotations
+    /// sequence in order.
     pub fn iter(&self) -> SymbolsIterator {
         self.into_iter()
     }

--- a/src/element/reader.rs
+++ b/src/element/reader.rs
@@ -160,7 +160,7 @@ impl<'a, R: IonReader<Item = StreamItem, Symbol = Symbol>> ElementLoader<'a, R> 
     }
 
     /// Steps into the current sequence and materializes each of its children to construct
-    /// an [Vec<Element>]. When all of the the children have been materialized, steps out.
+    /// an [`Vec<Element>`]. When all of the the children have been materialized, steps out.
     /// The reader MUST be positioned over a list or s-expression when this is called.
     fn materialize_sequence(&mut self) -> IonResult<Sequence> {
         let mut child_elements = Vec::new();
@@ -173,7 +173,7 @@ impl<'a, R: IonReader<Item = StreamItem, Symbol = Symbol>> ElementLoader<'a, R> 
     }
 
     /// Steps into the current struct and materializes each of its fields to construct
-    /// an [OwnedStruct]. When all of the the fields have been materialized, steps out.
+    /// an [`Struct`]. When all of the the fields have been materialized, steps out.
     /// The reader MUST be positioned over a struct when this is called.
     fn materialize_struct(&mut self) -> IonResult<Struct> {
         let mut child_elements = Vec::new();

--- a/src/element/struct.rs
+++ b/src/element/struct.rs
@@ -51,7 +51,7 @@ impl Fields {
     /// appearance of a field in the struct's serialized form will have been the _only_ appearance.
     /// If a field name appears more than once, this method makes the arbitrary decision to return
     /// the value associated with the last appearance. If your application uses structs that repeat
-    /// field names, you are encouraged to use [get_all] instead.
+    /// field names, you are encouraged to use [`get_all`](Self::get_all) instead.
     fn get_last<A: AsSymbolRef>(&self, field_name: A) -> Option<&Element> {
         self.get_indexes(field_name)
             .and_then(|indexes| indexes.last())

--- a/src/ion_hash/element_hasher.rs
+++ b/src/ion_hash/element_hasher.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates.
 
 //! Provides [`ElementHasher`], a single-use IonHash implementation for an
-//! [`IonElement`].
+//! [`Element`].
 
 use std::io;
 

--- a/src/ion_hash/mod.rs
+++ b/src/ion_hash/mod.rs
@@ -45,8 +45,8 @@ impl Markers {
     const ESC: u8 = 0x0C;
 }
 
-/// This trait mostly exists to extend the [`Digest`] trait to support Ion Hash.
-/// See [`hash_element`].
+/// This trait mostly exists to extend the [`Digest`](digest::Digest) trait to support Ion Hash.
+/// See [`hash_element`](Self::hash_element).
 pub trait IonHasher {
     type Output;
 
@@ -54,7 +54,7 @@ pub trait IonHasher {
     fn hash_element(elem: &Element) -> IonResult<Self::Output>;
 }
 
-/// Implements [`IonHasher`] for any type that implements [Digest].
+/// Implements [`IonHasher`] for any type that implements [`Digest`](digest::Digest).
 ///
 /// Note: the `Digest` trait is implemented for types that implement a set of
 /// traits. You should read the `D` generic as `Digest`. The reason we list the
@@ -67,8 +67,8 @@ where
 {
     type Output = digest::Output<D>;
 
-    /// Provides Ion hash over arbitrary [`IonElement`] instances with a given
-    /// [`Digest`] algorithm.
+    /// Provides Ion hash over arbitrary [`Element`] instances with a given
+    /// [`Digest`](digest::Digest) algorithm.
     fn hash_element(elem: &Element) -> IonResult<Self::Output> {
         ElementHasher::new(D::default()).hash_element(elem)
     }

--- a/src/ion_hash/representation.rs
+++ b/src/ion_hash/representation.rs
@@ -2,7 +2,7 @@
 
 //! This module provides an extension trait [`RepresentationEncoder`] that is implemented
 //! for Ion types found in the [`Element`] API. In the fullness of time, this
-//! file should not exist as we should be using the Ion "raw" binary writer
+//! module should not exist as we should be using the Ion "raw" binary writer
 //! instead. This implementation fills in that gap, and is focused on coverage
 //! and not speed.
 

--- a/src/ion_hash/representation.rs
+++ b/src/ion_hash/representation.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates.
 
-//! This file provides an extension trait [`Representation`] that is implemented
-//! for Ion types found in the [`IonElement`] API. In the fullness of time, this
+//! This module provides an extension trait [`RepresentationEncoder`] that is implemented
+//! for Ion types found in the [`Element`] API. In the fullness of time, this
 //! file should not exist as we should be using the Ion "raw" binary writer
 //! instead. This implementation fills in that gap, and is focused on coverage
 //! and not speed.

--- a/src/ion_hash/type_qualifier.rs
+++ b/src/ion_hash/type_qualifier.rs
@@ -29,7 +29,7 @@ const fn combine(ion_type_code: IonTypeCode, q: u8) -> TypeQualifier {
 }
 
 impl TypeQualifier {
-    /// Computes a [`TypeQualifier`] from an [`IonElement`] according to the rules
+    /// Computes a [`TypeQualifier`] from an [`Element`] according to the rules
     /// laid out in the spec. In many cases, the `T` is determined by the Ion
     /// binary type code.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 #![deny(rustdoc::broken_intra_doc_links)]
+#![deny(rustdoc::bare_urls)]
 //! # Reading and writing `Element`s
 //!
 //! The [Element] API offers a convenient way to read and write Ion data when its exact shape is

--- a/src/raw_reader.rs
+++ b/src/raw_reader.rs
@@ -164,7 +164,7 @@ impl Display for RawStreamItem {
     }
 }
 
-/// BufferedRawReader is a RawReader which can be created from a Vec<u8> and implements the needed
+/// BufferedRawReader is a RawReader which can be created from a [`Vec<u8>`] and implements the needed
 /// functionality to provide non-blocking reader support. This includes the ability to add more
 /// data as needed, as well as marking when the stream is complete.
 pub trait BufferedRawReader: RawReader + From<Vec<u8>> {

--- a/src/raw_symbol_token.rs
+++ b/src/raw_symbol_token.rs
@@ -34,14 +34,14 @@ impl RawSymbolToken {
     }
 }
 
-/// Constructs an [`OwnedSymbolToken`] with unknown text and a local ID.
+/// Constructs a [`RawSymbolToken`] with unknown text and a local ID.
 /// A common case for binary parsing (though technically relevant in text).
 #[inline]
 pub fn local_sid_token(local_sid: SymbolId) -> RawSymbolToken {
     RawSymbolToken::SymbolId(local_sid)
 }
 
-/// Constructs an [`OwnedSymbolToken`] with just text.
+/// Constructs an [`RawSymbolToken`] with just text.
 /// A common case for text and synthesizing tokens.
 #[inline]
 pub fn text_token<T: Into<String>>(text: T) -> RawSymbolToken {

--- a/src/shared_symbol_table.rs
+++ b/src/shared_symbol_table.rs
@@ -2,8 +2,9 @@ use crate::result::illegal_operation;
 use crate::IonResult;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-/// Stores [SharedSymbolTable] with the table name, version and imports
-/// For more information on [SharedSymbolTable]: https://amazon-ion.github.io/ion-docs/docs/symbols.html#shared-symbol-tables
+/// Stores [`SharedSymbolTable`] with the table name, version and imports
+/// For more information on [`SharedSymbolTable`], see:
+/// <https://amazon-ion.github.io/ion-docs/docs/symbols.html#shared-symbol-tables>
 pub struct SharedSymbolTable {
     name: String,
     version: usize,
@@ -25,12 +26,12 @@ impl SharedSymbolTable {
         })
     }
 
-    /// Returns the version of this [SharedSymbolTable]
+    /// Returns the version of this [`SharedSymbolTable`]
     pub fn version(&self) -> usize {
         self.version
     }
 
-    /// Returns the name of this [SharedSymbolTable]
+    /// Returns the name of this [`SharedSymbolTable`]
     pub fn name(&self) -> &str {
         &self.name
     }

--- a/src/text/non_blocking/raw_text_reader.rs
+++ b/src/text/non_blocking/raw_text_reader.rs
@@ -404,11 +404,10 @@ impl<A: AsRef<[u8]> + Expandable> RawTextReader<A> {
     }
 
     /// Assumes that the reader is inside a struct AND that a field has already been successfully
-    /// parsed from input using [`next_struct_field_name`][1] and attempts to parse the next value.
+    /// parsed from input using [`next_struct_field_name`](Self::next_struct_field_name) and
+    /// attempts to parse the next value.
     /// In this input position, only a value (or whitespace/comments) are legal. Anything else
     /// (including EOF) will result in a decoding error.
-    ///
-    /// [1]: Self::next_struct_field_name
     fn next_struct_field_value(&mut self) -> IonResult<AnnotatedTextValue> {
         // Only called after a call to [next_struct_field_name] that returns Some(field_name).
         // It is not legal for a field name to be followed by a '}' or EOF.

--- a/src/text/non_blocking/raw_text_reader.rs
+++ b/src/text/non_blocking/raw_text_reader.rs
@@ -404,9 +404,11 @@ impl<A: AsRef<[u8]> + Expandable> RawTextReader<A> {
     }
 
     /// Assumes that the reader is inside a struct AND that a field has already been successfully
-    /// parsed from input using [next_struct_field_name] and attempts to parse the next value.
+    /// parsed from input using [`next_struct_field_name`][1] and attempts to parse the next value.
     /// In this input position, only a value (or whitespace/comments) are legal. Anything else
     /// (including EOF) will result in a decoding error.
+    ///
+    /// [1]: Self::next_struct_field_name
     fn next_struct_field_value(&mut self) -> IonResult<AnnotatedTextValue> {
         // Only called after a call to [next_struct_field_name] that returns Some(field_name).
         // It is not legal for a field name to be followed by a '}' or EOF.

--- a/src/text/non_blocking/text_buffer.rs
+++ b/src/text/non_blocking/text_buffer.rs
@@ -33,7 +33,7 @@ struct Checkpoint {
 /// This is used primarily for identifying where a &str comes from within our
 /// TextBuffer's data.
 ///
-/// Taken from https://stackoverflow.com/a/50781657
+/// Taken from <https://stackoverflow.com/a/50781657>
 trait SubsliceOffset {
     fn subslice_offset(&self, inner: &Self) -> Option<usize>;
 }
@@ -140,7 +140,7 @@ impl<A: AsRef<[u8]>> TextBuffer<A> {
     }
 
     /// Returns the trailing portion of the current line that has not yet been marked as read via
-    /// the [consume] method.
+    /// the [`consume`](Self::consume) method.
     pub fn remaining_text(&self) -> &str {
         self.string_view(self.line.increment_start(self.line_offset))
     }
@@ -153,7 +153,8 @@ impl<A: AsRef<[u8]>> TextBuffer<A> {
     }
 
     /// Returns the amount of data currently available in the buffer that has not been marked as
-    /// read via the [consume] method. This includes data that has not been split into lines yet.
+    /// read via the [`consume`](Self::consume) method. This includes data that has not been
+    /// split into lines yet.
     pub fn bytes_remaining(&self) -> usize {
         self.data_end - (self.line.0 + self.line_offset)
     }
@@ -161,9 +162,11 @@ impl<A: AsRef<[u8]>> TextBuffer<A> {
     /// Returns the number of lines that have been loaded from input.
     ///
     /// The number returned may be:
-    ///   * Greater than the number of lines that have been marked read via [consume].
-    ///   * Less than the number of lines that have been requested via [load_next_line] and
-    ///     [load_next_n_lines] if the input stream was exhausted.
+    ///   * Greater than the number of lines that have been marked read via
+    ///     [`consume`](Self::consume).
+    ///   * Less than the number of lines that have been requested via
+    ///     [`load_next_line`](Self::load_next_line) and
+    ///     [`load_next_n_lines`](Self::load_next_n_lines) if the input stream was exhausted.
     pub fn lines_loaded(&self) -> usize {
         self.line_number
     }
@@ -177,12 +180,12 @@ impl<A: AsRef<[u8]>> TextBuffer<A> {
         self.bytes_remaining() == 0 && self.data_exhausted
     }
 
-    /// Discards [number_of_bytes] bytes from the remaining line.
+    /// Discards `number_of_bytes` bytes from the remaining line.
     ///
-    /// If [number_of_bytes] would cause the remaining bytes to be invalid UTF-8,
+    /// If `number_of_bytes` would cause the remaining bytes to be invalid UTF-8,
     /// this method will panic.
     ///
-    /// If [number_of_bytes] is greater than the number of bytes remaining in the current line,
+    /// If `number_of_bytes` is greater than the number of bytes remaining in the current line,
     /// this method will panic.
     pub fn consume(&mut self, number_of_bytes: usize) {
         let remaining_line = self.remaining_text();
@@ -337,9 +340,9 @@ impl TextBuffer<Vec<u8>> {
         self.validate_data()
     }
 
-    /// Tries to read `length` bytes from `source`. Unlike [append_bytes], this method does not do
-    /// any copying. A slice of the reader's buffer is handed to `source` so it can be populated
-    /// directly.
+    /// Tries to read `length` bytes from `source`. Unlike [`append_bytes`](Self::append_bytes),
+    /// this method does not do any copying. A slice of the reader's buffer is handed to `source`
+    /// so it can be populated directly.
     pub fn read_from<R: Read>(&mut self, mut source: R, length: usize) -> IonResult<usize> {
         self.checkpoint = None;
         self.restack();

--- a/src/text/parse_result.rs
+++ b/src/text/parse_result.rs
@@ -1,29 +1,30 @@
 //! The [`nom` parser combinator crate](https://docs.rs/nom/latest/nom/) intentionally provides
 //! bare-bones error reporting by default. Each error contains only a `&str` representing the input
-//! that could not be matched and an [ErrorKind] enum variant indicating which `nom` parser produced
+//! that could not be matched and an [`ErrorKind`] enum variant indicating which `nom` parser produced
 //! the error. This stack-allocated type is very cheap to create, which is important because a
 //! typical parse will require creating large numbers of short-lived error values.
 //!
-//! This module defines [IonParseError], a custom error type that can capture more information than is
-//! supported by [nom::error::Error], as well as traits and functions for upgrading an `Error` into
-//! an [IonParseError]. The module also defines [IonParseResult], a type alias for a [nom::IResult]
-//! that parses `&str`s and produces [IonParseError]s if something goes wrong.
+//! This module defines [`IonParseError`], a custom error type that can capture more information than is
+//! supported by [`nom::error::Error`], as well as traits and functions for upgrading an `Error` into
+//! an [`IonParseError`]. The module also defines [`IonParseResult`], a type alias for a [`IResult`]
+//! that parses `&str`s and produces [`IonParseError`]s if something goes wrong.
 //!
 //! Two new extension traits are also provided to facilitate combining core `nom` parsers that
 //! return an `IResult` (for example: `one_of`, `opt`, or `alt`) with higher-level parsers that
 //! return an `IonParseResult` (for example: `parse_timestamp` or `parse_decimal`).
 //!
-//! 1. [UpgradeIResult] adds an `.upgrade()` method to every `IResult` that cheaply converts it into
+//! 1. [`UpgradeIResult`] adds an `.upgrade()` method to every `IResult` that cheaply converts it into
 //! an `IonParseResult`.
-//! 2. [UpgradeParser] adds an `.upgrade()` method to every implementation of [nom::Parser] that
+//! 2. [`UpgradeParser`] adds an `.upgrade()` method to every implementation of [`Parser`] that
 //! causes it to return an `IonParseResult` instead of an `IResult`.
 
 use nom::error::{Error as NomError, ErrorKind, ParseError};
 use nom::{Err, IResult, Parser};
 use std::fmt::Debug;
 
-/// A type alias for a [nom::IResult] whose input is a `&str` and whose error type is an
-/// [IonParseError]. All of the Ion parsers in the [text::parsers] crate return an `IonParseResult`.
+/// A type alias for a [`IResult`] whose input is a `&str` and whose error type is an
+/// [`IonParseError`]. All of the Ion parsers in the `text::parsers` module return an
+/// [`IonParseResult`].
 ///
 /// If the parser is successful, it will return `Ok(output_value)`. If it encounters a problem,
 /// it will return a `nom::Err<IonParseError>`. [nom::Err] is a generic enum with three possible
@@ -250,10 +251,10 @@ where
 ///     )(input)                // <- OK!
 /// }
 /// ```
-/// This conversion is essentially free; `upgrade()` produces a stack-allocated [Upgraded] whose only field is
-/// the wrapped parser; this means that its size and layout are identical to the original parser.
-/// The only cost is the trivial expense of converting the parser's output from an `IResult` to an
-/// `IonParseResult`.
+/// This conversion is essentially free; `upgrade()` produces a stack-allocated [`UpgradedParser`]
+/// whose only field is the wrapped parser; this means that its size and layout are identical
+/// to the original parser. The only cost is the trivial expense of converting the parser's
+/// output from an `IResult` to an [`IonParseResult`].
 pub(crate) trait UpgradeParser<O> {
     fn upgrade(self) -> UpgradedParser<Self>;
 }

--- a/src/text/parsers/clob.rs
+++ b/src/text/parsers/clob.rs
@@ -14,8 +14,8 @@ use nom::Err::Incomplete;
 use nom::Needed;
 use std::str;
 
-/// Matches the text representation of a clob value and returns the resulting [Clob]
-/// as a [TextValue::Clob].
+/// Matches the text representation of a clob value and returns the resulting `clob`
+/// as a [`TextValue::Clob`].
 pub(crate) fn parse_clob(input: &str) -> IonParseResult<TextValue> {
     map(
         delimited(
@@ -32,16 +32,16 @@ fn parse_clob_body(input: &str) -> IonParseResult<TextValue> {
     alt((short_clob, long_clob))(input)
 }
 
-/// Matches a short clob (e.g. `"Hello"`) and returns the resulting [Clob]
-/// as a [TextValue::Clob].
+/// Matches a short clob (e.g. `"Hello"`) and returns the resulting `clob`
+/// as a [`TextValue::Clob`].
 fn short_clob(input: &str) -> IonParseResult<TextValue> {
     map(delimited(char('"'), short_clob_body, char('"')), |text| {
         TextValue::Clob(text)
     })(input)
 }
 
-/// Matches a long clob (e.g. `'''Hello, '''\n'''World!'''`) and returns the resulting [Clob]
-/// as a [TextValue::Clob].
+/// Matches a long clob (e.g. `'''Hello, '''\n'''World!'''`) and returns the resulting `clob`
+/// as a [`TextValue::Clob`].
 fn long_clob(input: &str) -> IonParseResult<TextValue> {
     // TODO: This parser allocates a Vec to hold each intermediate '''...''' string
     //       and then again to merge them into a finished product. These allocations

--- a/src/text/parsers/containers.rs
+++ b/src/text/parsers/containers.rs
@@ -140,7 +140,8 @@ pub(crate) fn s_expression_scalar(input: &str) -> IonParseResult<AnnotatedTextVa
 }
 
 /// Returns [None] if the next token in input is an end-of-s-expression delimiter (`)`).
-/// Otherwise, matches and returns the next value in the s-expression using [s_expression_stream_value].
+/// Otherwise, matches and returns the next value in the s-expression using
+/// [`s_expression_value`].
 pub(crate) fn s_expression_value_or_end(input: &str) -> IonParseResult<Option<AnnotatedTextValue>> {
     map(s_expression_end, |_end_marker| None)
         .or(map(s_expression_value, Some))
@@ -162,7 +163,7 @@ pub(crate) fn s_expression_delimiter(input: &str) -> IonParseResult<()> {
 }
 
 /// Matches a struct field name and returns it as a [RawSymbolToken].
-/// This function should be called before [struct_stream_value].
+/// This function should be called before [`struct_field_value`].
 pub(crate) fn struct_field_name(input: &str) -> IonParseResult<RawSymbolToken> {
     delimited(
         whitespace_or_comments,

--- a/src/text/parsers/text_support.rs
+++ b/src/text/parsers/text_support.rs
@@ -177,12 +177,11 @@ pub(crate) fn escaped_char_unicode(input: &str) -> IonParseResult<char> {
     Ok((remaining_input, character))
 }
 
-/// Rust's [`char`][1] type represents any Unicode code point EXCEPT a surrogate. If we encounter a high
-/// surrogate in the stream, we cannot convert it to a `char` yet. We must find the (mandatory)
-/// low surrogate that follows it in the stream; then we can combine the high and low surrogates
-/// into a complete code point. This code point can then be returned as a Rust [`char`][1].
-///
-/// [1]: prim@char
+/// Rust's [`char`](prim@char) type represents any Unicode code point EXCEPT a surrogate. If we
+/// encounter a high surrogate in the stream, we cannot convert it to a `char` yet. We must find the
+/// (mandatory) low surrogate that follows it in the stream; then we can combine the high and low
+/// surrogates into a complete code point. This code point can then be returned as a Rust
+/// [`char`](prim@char).
 fn complete_surrogate_pair<'a>(
     input: &'a str,
     input_after_high_surrogate: &'a str,

--- a/src/text/parsers/text_support.rs
+++ b/src/text/parsers/text_support.rs
@@ -83,7 +83,7 @@ pub(crate) fn escaped_char_no_unicode(input: &str) -> IonParseResult<StringFragm
 }
 
 /// Matches an escaped literal and returns the appropriate substitute character.
-/// See: https://amazon-ion.github.io/ion-docs/docs/spec.html#escapes
+/// See: <https://amazon-ion.github.io/ion-docs/docs/spec.html#escapes>
 pub(crate) fn escaped_char_literal(input: &str) -> IonParseResult<char> {
     alt((
         value('\n', char('n')),
@@ -177,10 +177,12 @@ pub(crate) fn escaped_char_unicode(input: &str) -> IonParseResult<char> {
     Ok((remaining_input, character))
 }
 
-/// Rust's [char] type represents any Unicode code point EXCEPT a surrogate. If we encounter a high
+/// Rust's [`char`][1] type represents any Unicode code point EXCEPT a surrogate. If we encounter a high
 /// surrogate in the stream, we cannot convert it to a `char` yet. We must find the (mandatory)
 /// low surrogate that follows it in the stream; then we can combine the high and low surrogates
-/// into a complete code point. This code point can then be returned as a Rust [char].
+/// into a complete code point. This code point can then be returned as a Rust [`char`][1].
+///
+/// [1]: prim@char
 fn complete_surrogate_pair<'a>(
     input: &'a str,
     input_after_high_surrogate: &'a str,

--- a/src/text/parsers/top_level.rs
+++ b/src/text/parsers/top_level.rs
@@ -60,7 +60,7 @@ pub(crate) fn version_int(input: &str) -> IonParseResult<&str> {
 /// the major and minor version of the Ion stream to follow, respectively. See [version_int].
 /// Note that this MUST be an identifier (i.e. an unquoted symbol) and not any other encoding of the
 /// same symbol value. For more information see:
-/// https://amazon-ion.github.io/ion-docs/docs/symbols.html#ion-version-markers
+/// <https://amazon-ion.github.io/ion-docs/docs/symbols.html#ion-version-markers>
 pub(crate) fn ion_version_marker(input: &str) -> IonParseResult<(u32, u32)> {
     // See if the input text matches an IVM. If not, return a non-fatal error.
     let (remaining_input, (_, major_text, _, minor_text)) = delimited(

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -142,8 +142,8 @@ fn offset_east(seconds_east: i32) -> FixedOffset {
         .expect("seconds_east was outside the supported range")
 }
 
-/// Constructs a DateTime<FixedOffset> at the specified offset using the fields of [NaiveDateTime]
-/// representing the desired UTC datetime.
+/// Constructs a [`DateTime<FixedOffset>`] at the specified offset using the fields of
+/// [`NaiveDateTime`] representing the desired UTC datetime.
 fn datetime_at_offset(utc_datetime: &NaiveDateTime, seconds_east: i32) -> DateTime<FixedOffset> {
     offset_east(seconds_east).from_utc_datetime(utc_datetime)
 }
@@ -812,9 +812,9 @@ struct TimestampBuilder {
 }
 
 impl TimestampBuilder {
-    /// Sets all of the fields on the given [NaiveDateTime] or [DateTime<FixedOffset>] using the
+    /// Sets all of the fields on the given [`NaiveDateTime`] or [`DateTime<FixedOffset>`] using the
     /// values from the TimestampBuilder. Only those fields required by the TimestampBuilder's
-    /// configured [Precision] will be set.
+    /// configured [`Precision`] will be set.
     fn configure_datetime<D>(&mut self, mut datetime: D) -> IonResult<D>
     where
         D: Datelike + Timelike + Debug,


### PR DESCRIPTION
Cleans up doc comments such that `cargo doc --document-private-items --all-features` works and is in CI.

Fixes #516

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
