### PR TITLE
Refactors Annotations conversion trait implementations

### DIFF
--- a/src/element/element_stream_reader.rs
+++ b/src/element/element_stream_reader.rs
@@ -179,7 +179,7 @@ impl IonReader for ElementStreamReader {
         let iterator = self
             .current_value
             .as_ref()
-            .map(|value| value.annotations().into_iter())
+            .map(|value| value.annotations().iter())
             .unwrap_or_else(|| SymbolsIterator::empty())
             .cloned()
             // The annotations are already in memory and are already resolved to text, so

--- a/src/element/iterators.rs
+++ b/src/element/iterators.rs
@@ -45,6 +45,26 @@ create_new_slice_iterator_type!(
     ElementsIterator => Element
 );
 
+/// Consuming iterator for [`Annotations`].
+#[derive(Debug, Clone)]
+pub struct AnnotationsIntoIter {
+    into_iter: std::vec::IntoIter<Symbol>,
+}
+
+impl AnnotationsIntoIter {
+    pub(crate) fn new(into_iter: std::vec::IntoIter<Symbol>) -> Self {
+        Self { into_iter }
+    }
+}
+
+impl Iterator for AnnotationsIntoIter {
+    type Item = Symbol;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.into_iter.next()
+    }
+}
+
 // A convenient type alias for a vector capable of storing a single `usize` inline
 // without heap allocation. This type should not be used in public interfaces directly.
 pub(crate) type IndexVec = SmallVec<[usize; 1]>;

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -19,6 +19,7 @@ use crate::ion_data::IonEq;
 use crate::ion_data::IonOrd;
 use crate::text::text_formatter::IonValueFormatter;
 use crate::{Decimal, Int, IonResult, IonType, ReaderBuilder, Str, Symbol, Timestamp};
+use annotations::IntoAnnotations;
 use num_bigint::BigInt;
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
@@ -312,11 +313,8 @@ impl From<Struct> for Value {
 /// ```
 pub trait IntoAnnotatedElement: Into<Value> {
     /// Converts the value into an [Element] with the specified annotations.
-    fn with_annotations<S: Into<Symbol>, I: IntoIterator<Item = S>>(
-        self,
-        annotations: I,
-    ) -> Element {
-        Element::new(annotations.into(), self.into())
+    fn with_annotations<I: IntoAnnotations>(self, annotations: I) -> Element {
+        Element::new(annotations.into_annotations(), self.into())
     }
 }
 
@@ -444,11 +442,8 @@ impl Element {
         &self.annotations
     }
 
-    pub fn with_annotations<S: Into<Symbol>, I: IntoIterator<Item = S>>(
-        self,
-        annotations: I,
-    ) -> Self {
-        Element::new(annotations.into(), self.value)
+    pub fn with_annotations<I: IntoAnnotations>(self, annotations: I) -> Self {
+        Element::new(annotations.into_annotations(), self.value)
     }
 
     pub fn is_null(&self) -> bool {
@@ -619,6 +614,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::element::annotations::IntoAnnotations;
     use crate::types::timestamp::Timestamp;
     use crate::{ion_list, ion_sexp, ion_struct, Decimal, Int, IonType, Symbol};
     use chrono::*;
@@ -638,7 +634,7 @@ mod tests {
     fn annotations_text_case() -> CaseAnnotations {
         CaseAnnotations {
             elem: 10i64.with_annotations(["foo", "bar", "baz"]),
-            annotations: ["foo", "bar", "baz"].into(),
+            annotations: ["foo", "bar", "baz"].into_annotations(),
         }
     }
 


### PR DESCRIPTION
Adds `IntoAnnotations` trait for generic conversions.  Moves blanked implementation of `From<...>` for `Annotations` to this trait because it conflicts with `Annotations` implementing `IntoIter`.

Adds `IntoIter` for Annotations as a consuming iterator.

Adds `From<Vec<Symbol>>` as a special case conversion for avoiding generic conversion traits.  Adds `FromIterator` to support `collect()` on any iterator transform.

fixes #526, fixes #527 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
