### PR TITLE
Fixes a warning for ion-hash

### DIFF
--- a/src/ion_hash/mod.rs
+++ b/src/ion_hash/mod.rs
@@ -20,7 +20,7 @@
 //! # fn main() {}
 //! ```
 
-use digest::{self, FixedOutput, Output, Reset, Update};
+use digest::{self, FixedOutput, Reset, Update};
 
 use crate::element::Element;
 use crate::IonResult;
@@ -30,6 +30,8 @@ mod element_hasher;
 mod representation;
 mod type_qualifier;
 
+#[cfg(feature = "sha2")]
+use digest::Output;
 #[cfg(feature = "sha2")]
 use sha2::Sha256;
 /// Utility to hash an [`Element`] using SHA-256 as the hash function.


### PR DESCRIPTION
When compiling only ion-hash with no `sha2` feature, we get a warning that we import an unused `digest::Output`, this gates that import on the feature being enabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
