### PR TITLE
Updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ $ git submodule update --init --recursive
 Building the project:
 
 ```bash
-$ cargo build --workspace --all-targets
+$ cargo build --workspace --all-features
 ```
 
 Running all tests for `ion-rust`:
 
 ```bash
-$ cargo test --workspace
+$ cargo test --workspace --all-features
 ```
 
 [spec]: https://amazon-ion.github.io/ion-docs/docs/spec.html

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ Running all tests for `ion-rust`:
 $ cargo test --workspace --all-features
 ```
 
+Our continuous integration builds/tests, checks formatting, builds all API docs including private,
+and clippy linting, you will likely want to check most of these to avoid having to wait until the
+CI finds it:
+
+```bash
+$ ./clean-rebuild.sh
+```
+
 [spec]: https://amazon-ion.github.io/ion-docs/docs/spec.html
 [ion-tests]: https://github.com/amazon-ion/ion-tests
 [bindgen-req]: https://rust-lang.github.io/rust-bindgen/requirements.html

--- a/clean-rebuild.sh
+++ b/clean-rebuild.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+# update the index
+cargo update
+
+# default build
+cargo clean
+cargo test --workspace
+
+# all features
+cargo clean
+cargo test --workspace --all-features
+
+# make sure formatting is good
+cargo fmt -- --check
+
+# make sure we deal with lints
+cargo clippy --workspace --all-features --tests -- -Dwarnings
+
+# general **all** rustdoc
+cargo doc --document-private-items --all-features


### PR DESCRIPTION
The original text suggested using `--all-targets` for building.  This replaces that with `--all-features` as the suggestion for both building and testing.  Removing `--all-targets`, especially for tests, is good because doc tests don't get built/run with that parameter.

Also adds a `clean-rebuild.sh` script to do a bunch of things that one might want to do before a PR (or just sanity check for all the things we care about in CI).  Does not cover all the permutations of features for building, but default and `--all-features`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
