### PR TITLE
Fixes clippy warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,7 +83,9 @@ jobs:
         with:
           # Adding comments to the PR requires the GITHUB_TOKEN secret.
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --tests
+          # We are opinionated here and fail the build if anything is complained about.
+          # We can always explicitly allow clippy things we disagree with or if this gets too annoying, get rid of it.
+          args: --workspace --all-features --tests -- -Dwarnings
       - name: Rustdoc on Everything
         # We really only need to run this once--ubuntu/all features mode is as good as any
         if: matrix.os == 'ubuntu-latest' && matrix.features == 'all'

--- a/src/ion_data/ion_ord.rs
+++ b/src/ion_data/ion_ord.rs
@@ -254,7 +254,7 @@ mod ord_tests {
 
         let mut original_iter = original.iter();
         let mut previous_element = original_iter.next().unwrap();
-        while let Some(element) = original_iter.next() {
+        for element in original_iter {
             if element == previous_element {
                 assert_eq!(Ordering::Equal, element.cmp(previous_element));
             } else {

--- a/src/thunk.rs
+++ b/src/thunk.rs
@@ -49,7 +49,7 @@ where
 #[derive(Debug)]
 pub struct Thunk<'a, T>(IonResult<ThunkVal<'a, T>>);
 
-const EMPTY_THUNK_ERROR_TEXT: &'static str = "Empty thunk";
+const EMPTY_THUNK_ERROR_TEXT: &str = "Empty thunk";
 
 impl<'a, T> Thunk<'a, T> {
     #[inline]
@@ -220,7 +220,7 @@ mod tests {
             illegal_operation("Oops!!!")
         }
 
-        let mut thunk: Thunk<i32> = Thunk::defer(|| expected());
+        let mut thunk: Thunk<i32> = Thunk::defer(expected);
         assert_eq!(ThunkState::Deferred, thunk.thunk_state());
         assert_eq!(expected(), thunk.memoize());
         assert_eq!(ThunkState::Error, thunk.thunk_state());


### PR DESCRIPTION
Made clippy required for CI--we tend to keep the source tree clean, but the clippy warnings are easy to miss and cannot be seen on PRs from user forks.  by adding `-Dwarnings` to the clippy CI step, we make sure this breaks the build--we can always add annotations to ignore suggestions explicitly and/or we can back this out if clippy is too annoying.

Also adds `--workspace` to the clippy, as it doesn't seem to check `ion-hash` by default without it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
