### PR TITLE
Introduces a lazy binary reader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
 [features]
 default = []
 ion-hash = ["digest"]
+experimental-lazy-reader = []
 
 # Feature for indicating particularly bleeding edge APIs or functionality in the library.
 # These are not guaranteed any sort of API stability and may also have non-standard

--- a/examples/lazy_read_all_values.rs
+++ b/examples/lazy_read_all_values.rs
@@ -1,0 +1,78 @@
+#[cfg(not(feature = "experimental-lazy-reader"))]
+fn main() {
+    println!("This example requires the 'experimental-lazy-reader' feature to work.");
+}
+
+#[cfg(feature = "experimental-lazy-reader")]
+use ion_rs::IonResult;
+
+#[cfg(feature = "experimental-lazy-reader")]
+fn main() -> IonResult<()> {
+    lazy_reader_example::read_all_values()
+}
+
+#[cfg(feature = "experimental-lazy-reader")]
+mod lazy_reader_example {
+
+    use ion_rs::lazy::binary::lazy_reader::LazyReader;
+    use ion_rs::lazy::binary::system::lazy_sequence::LazySequence;
+    use ion_rs::lazy::binary::system::lazy_struct::LazyStruct;
+    use ion_rs::lazy::binary::system::lazy_value::LazyValue;
+    use ion_rs::lazy::value_ref::ValueRef;
+    use ion_rs::IonResult;
+    use memmap::MmapOptions;
+    use std::fs::File;
+    use std::process::exit;
+
+    pub fn read_all_values() -> IonResult<()> {
+        let args: Vec<String> = std::env::args().collect();
+        let path = args.get(1).unwrap_or_else(|| {
+            eprintln!("USAGE:\n\n    {} [Binary Ion file]\n", args.get(0).unwrap());
+            eprintln!("No mode was specified.");
+            exit(1);
+        });
+
+        let file = File::open(path).unwrap();
+
+        // This example uses `mmap` so we can view the entire input file as a `&[u8]`.
+        let mmap = unsafe { MmapOptions::new().map(&file).unwrap() };
+        let ion_data: &[u8] = &mmap[..];
+
+        // We're going to recursively visit and read every value in the input stream, counting
+        // them as we go.
+        let mut count = 0;
+        let mut reader = LazyReader::new(ion_data)?;
+        while let Some(lazy_value) = reader.next()? {
+            count += count_value_and_children(&lazy_value)?;
+        }
+        println!("Read {} values.", count);
+        Ok(())
+    }
+
+    // Counts scalar values as 1 and container values as (the number of children) + 1.
+    fn count_value_and_children(lazy_value: &LazyValue) -> IonResult<usize> {
+        use ValueRef::*;
+        let child_count = match lazy_value.read()? {
+            List(s) | SExp(s) => count_sequence_children(&s)?,
+            Struct(s) => count_struct_children(&s)?,
+            _ => 0,
+        };
+        Ok(1 + child_count)
+    }
+
+    fn count_sequence_children(lazy_sequence: &LazySequence) -> IonResult<usize> {
+        let mut count = 0;
+        for value in lazy_sequence {
+            count += count_value_and_children(&value?)?;
+        }
+        Ok(count)
+    }
+
+    fn count_struct_children(lazy_struct: &LazyStruct) -> IonResult<usize> {
+        let mut count = 0;
+        for field in lazy_struct {
+            count += count_value_and_children(field?.value())?;
+        }
+        Ok(count)
+    }
+}

--- a/examples/read_all_values.rs
+++ b/examples/read_all_values.rs
@@ -1,7 +1,7 @@
 use ion_rs::binary::non_blocking::raw_binary_reader::RawBinaryReader;
 use ion_rs::raw_reader::RawStreamItem;
 use ion_rs::result::IonResult;
-use ion_rs::{BlockingRawBinaryReader, IonType, RawReader};
+use ion_rs::{BlockingRawBinaryReader, IonReader, IonType, RawReader, StreamItem, UserReader};
 use memmap::MmapOptions;
 use std::fs::File;
 use std::process::exit;
@@ -9,12 +9,18 @@ use std::process::exit;
 fn main() -> IonResult<()> {
     let args: Vec<String> = std::env::args().collect();
     let mode = args.get(1).unwrap_or_else(|| {
-        eprintln!("USAGE:\n\n    {} [Binary Ion file]\n", args.get(0).unwrap());
+        eprintln!(
+            "USAGE:\n\n    {} [raw-blocking|raw-nonblocking|user] [Binary Ion file]\n",
+            args.get(0).unwrap()
+        );
         eprintln!("No mode was specified.");
         exit(1);
     });
     let path = args.get(2).unwrap_or_else(|| {
-        eprintln!("USAGE:\n\n    {} [Binary Ion file]\n", args.get(0).unwrap());
+        eprintln!(
+            "USAGE:\n\n    {} [raw-blocking|raw-nonblocking|user] [Binary Ion file]\n",
+            args.get(0).unwrap()
+        );
         eprintln!("No input file was specified.");
         exit(2);
     });
@@ -27,12 +33,17 @@ fn main() -> IonResult<()> {
     // Treat the mmap as a byte array.
     let ion_data: &[u8] = &mmap[..];
 
-    if mode == "blocking" {
+    if mode == "raw-blocking" {
         let mut reader = BlockingRawBinaryReader::new(ion_data)?;
-        let number_of_values = read_all_values(&mut reader)?;
+        let number_of_values = read_all_values_raw(&mut reader)?;
         println!("Blocking: read {} values", number_of_values);
-    } else if mode == "nonblocking" {
+    } else if mode == "raw-nonblocking" {
         let mut reader = RawBinaryReader::new(ion_data);
+        let number_of_values = read_all_values_raw(&mut reader)?;
+        println!("Non-blocking: read {} values", number_of_values);
+    } else if mode == "user" {
+        let raw_reader = RawBinaryReader::new(ion_data);
+        let mut reader = UserReader::new(raw_reader);
         let number_of_values = read_all_values(&mut reader)?;
         println!("Non-blocking: read {} values", number_of_values);
     } else {
@@ -45,13 +56,68 @@ fn main() -> IonResult<()> {
 
 // Visits each value in the stream recursively, reading each scalar into a native Rust type.
 // Prints the total number of values read upon completion.
-fn read_all_values<R: RawReader>(reader: &mut R) -> IonResult<usize> {
+fn read_all_values_raw<R: RawReader>(reader: &mut R) -> IonResult<usize> {
     use IonType::*;
     use RawStreamItem::{Nothing, Null as NullValue, Value, VersionMarker};
     let mut count: usize = 0;
     loop {
         match reader.next()? {
             VersionMarker(_major, _minor) => {}
+            NullValue(_ion_type) => {
+                count += 1;
+                continue;
+            }
+            Value(ion_type) => {
+                count += 1;
+                match ion_type {
+                    Struct | List | SExp => reader.step_in()?,
+                    String => {
+                        let _string = reader.read_str()?;
+                    }
+                    Symbol => {
+                        let _symbol_id = reader.read_symbol()?;
+                    }
+                    Int => {
+                        let _int = reader.read_i64()?;
+                    }
+                    Float => {
+                        let _float = reader.read_f64()?;
+                    }
+                    Decimal => {
+                        let _decimal = reader.read_decimal()?;
+                    }
+                    Timestamp => {
+                        let _timestamp = reader.read_timestamp()?;
+                    }
+                    Bool => {
+                        let _boolean = reader.read_bool()?;
+                    }
+                    Blob => {
+                        let _blob = reader.read_blob()?;
+                    }
+                    Clob => {
+                        let _clob = reader.read_clob()?;
+                    }
+                    Null => {}
+                }
+            }
+            Nothing if reader.depth() > 0 => {
+                reader.step_out()?;
+            }
+            _ => break,
+        }
+    }
+    Ok(count)
+}
+
+// Visits each value in the stream recursively, reading each scalar into a native Rust type.
+// Prints the total number of values read upon completion.
+fn read_all_values<R: IonReader<Item = StreamItem>>(reader: &mut R) -> IonResult<usize> {
+    use IonType::*;
+    use StreamItem::{Nothing, Null as NullValue, Value};
+    let mut count: usize = 0;
+    loop {
+        match reader.next()? {
             NullValue(_ion_type) => {
                 count += 1;
                 continue;

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -14,7 +14,7 @@ mod nibbles;
 pub mod non_blocking;
 pub mod raw_binary_writer;
 pub mod timestamp;
-mod type_code;
+pub(crate) mod type_code;
 pub mod uint;
 pub mod var_int;
 pub mod var_uint;

--- a/src/binary/non_blocking/type_descriptor.rs
+++ b/src/binary/non_blocking/type_descriptor.rs
@@ -17,7 +17,7 @@ pub(crate) struct TypeDescriptor {
 
 /// A statically defined array of TypeDescriptor that allows a binary reader to map a given
 /// byte (`u8`) to a `TypeDescriptor` without having to perform any masking or bitshift operations.
-pub(crate) const ION_1_0_TYPE_DESCRIPTORS: &[TypeDescriptor; 256] = &init_type_descriptor_cache();
+pub(crate) static ION_1_0_TYPE_DESCRIPTORS: &[TypeDescriptor; 256] = &init_type_descriptor_cache();
 
 const DEFAULT_HEADER: TypeDescriptor = TypeDescriptor {
     ion_type_code: IonTypeCode::NullOrNop,

--- a/src/element/writer.rs
+++ b/src/element/writer.rs
@@ -106,7 +106,7 @@ mod tests {
     #[test]
     fn element_roundtrip() -> IonResult<()> {
         let mut buffer = Vec::new();
-        let mut writer = TextWriterBuilder::new().build(&mut buffer)?;
+        let mut writer = TextWriterBuilder::default().build(&mut buffer)?;
 
         let ion = r#"
             null true 0 1e0 2.0 2022T foo "bar" (foo bar baz) [foo, bar, baz] {foo: true, bar: false}

--- a/src/lazy/binary/encoded_value.rs
+++ b/src/lazy/binary/encoded_value.rs
@@ -1,0 +1,268 @@
+use crate::binary::non_blocking::type_descriptor::Header;
+use crate::types::SymbolId;
+use crate::IonType;
+use std::ops::Range;
+
+/// Type, offset, and length information about the serialized value over which the
+/// NonBlockingRawBinaryReader is currently positioned.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct EncodedValue {
+    // If the compiler decides that a value is too large to be moved/copied with inline code,
+    // it will relocate the value using memcpy instead. This can be quite slow by comparison.
+    //
+    // Be cautious when adding new member fields or modifying the data types of existing member
+    // fields, as this may cause the in-memory size of `EncodedValue` instances to grow.
+    //
+    // See the Rust Performance Book section on measuring type sizes[1] for more information.
+    // [1] https://nnethercote.github.io/perf-book/type-sizes.html#measuring-type-sizes
+
+    // The type descriptor byte that identified this value; includes the type code, length code,
+    // and IonType.
+    pub header: Header,
+
+    // Each encoded value has up to five components, appearing in the following order:
+    //
+    // [ field_id? | annotations? | header (type descriptor) | header_length? | value ]
+    //
+    // Components shown with a `?` are optional.
+    //
+    // EncodedValue stores the offset of the type descriptor byte from the beginning of the
+    // data source (`header_offset`). The lengths of the other fields can be used to calculate
+    // their positions relative to the type descriptor byte. For example, to find the offset of the
+    // field ID (if present), we can do:
+    //     header_offset - annotations_header_length - field_id_length
+    //
+    // This allows us to store a single `usize` for the header offset, while other lengths can be
+    // packed into a `u8`. Values are not permitted to have a field ID or annotations that take
+    // more than 255 bytes to represent.
+    //
+    // We store the offset for the header byte because it is guaranteed to be present for all values.
+    // Field IDs and annotations appear earlier in the stream but are optional.
+
+    // The number of bytes used to encode the field ID (if present) preceding the Ion value. If
+    // `field_id` is undefined, `field_id_length` will be zero.
+    pub field_id_length: u8,
+    // If this value is inside a struct, `field_id` will contain the SymbolId that represents
+    // its field name.
+    pub field_id: Option<SymbolId>,
+    // The number of bytes used to encode the annotations wrapper (if present) preceding the Ion
+    // value. If `annotations` is empty, `annotations_header_length` will be zero.
+    pub annotations_header_length: u8,
+    // The number of bytes used to encode the series of symbol IDs inside the annotations wrapper.
+    pub annotations_sequence_length: u8,
+    // Type descriptor byte location.
+    pub header_offset: usize,
+    // The number of bytes used to encode the optional length VarUInt following the header byte.
+    pub length_length: u8,
+    // The number of bytes used to encode the value itself, not including the header byte
+    // or length fields.
+    pub value_length: usize,
+    // The sum total of:
+    //     field_id_length + annotations_header_length + header_length + value_length
+    // While this can be derived from the above fields, storing it for reuse offers a modest
+    // optimization. `total_length` is needed when stepping into a value, skipping a value,
+    // and reading a value's data.
+    pub total_length: usize,
+}
+
+impl EncodedValue {
+    pub fn header(&self) -> Header {
+        self.header
+    }
+
+    /// Returns the offset of the current value's type descriptor byte.
+    pub fn header_offset(&self) -> usize {
+        self.header_offset
+    }
+
+    /// Returns the length of this value's header, including the type descriptor byte and any
+    /// additional bytes used to encode the value's length.
+    pub fn header_length(&self) -> usize {
+        // The `length_length` field does not include the type descriptor byte, so add 1.
+        self.length_length as usize + 1
+    }
+
+    /// Returns an offset Range that contains this value's type descriptor byte and any additional
+    /// bytes used to encode the `length`.
+    pub fn header_range(&self) -> Range<usize> {
+        let start = self.header_offset;
+        let end = start + self.header_length();
+        start..end
+    }
+
+    /// Returns the number of bytes used to encode this value's data.
+    /// If the value can fit in the type descriptor byte (e.g. `true`, `false`, `null`, `0`),
+    /// this function will return 0.
+    #[inline(always)]
+    pub fn value_length(&self) -> usize {
+        self.value_length
+    }
+
+    /// The offset of the first byte following the header (including length bytes, if present).
+    /// If `value_length()` returns zero, this offset is actually the first byte of
+    /// the next encoded value and should not be read.
+    pub fn value_offset(&self) -> usize {
+        self.header_offset + self.header_length()
+    }
+
+    /// Returns an offset Range containing any bytes following the header.
+    pub fn value_range(&self) -> Range<usize> {
+        let start = self.value_offset();
+        let end = start + self.value_length;
+        start..end
+    }
+
+    /// Returns the index of the first byte that is beyond the end of the current value's encoding.
+    pub fn value_end_exclusive(&self) -> usize {
+        self.value_offset() + self.value_length
+    }
+
+    /// Returns the number of bytes used to encode this value's field ID, if present.
+    pub fn field_id_length(&self) -> Option<usize> {
+        self.field_id.as_ref()?;
+        Some(self.field_id_length as usize)
+    }
+
+    /// Returns the offset of the first byte used to encode this value's field ID, if present.
+    pub fn field_id_offset(&self) -> Option<usize> {
+        self.field_id.as_ref()?;
+        Some(
+            self.header_offset
+                - self.annotations_header_length as usize
+                - self.field_id_length as usize,
+        )
+    }
+
+    /// Returns an offset Range that contains the bytes used to encode this value's field ID,
+    /// if present.
+    pub fn field_id_range(&self) -> Option<Range<usize>> {
+        if let Some(start) = self.field_id_offset() {
+            let end = start + self.field_id_length as usize;
+            return Some(start..end);
+        }
+        None
+    }
+
+    /// Returns true if this encoded value has an annotations wrapper.
+    pub fn has_annotations(&self) -> bool {
+        self.annotations_header_length > 0
+    }
+
+    /// Returns the number of bytes used to encode this value's annotations, if any.
+    /// While annotations envelope the value that they decorate, this function does not include
+    /// the length of the value itself.
+    pub fn annotations_header_length(&self) -> Option<usize> {
+        if self.annotations_header_length == 0 {
+            return None;
+        }
+        Some(self.annotations_header_length as usize)
+    }
+
+    /// Returns the number of bytes used to encode the series of VarUInt annotation symbol IDs, if
+    /// any.
+    ///
+    /// See: <https://amazon-ion.github.io/ion-docs/docs/binary.html#annotations>
+    pub fn annotations_sequence_length(&self) -> Option<usize> {
+        if self.annotations_header_length == 0 {
+            return None;
+        }
+        Some(self.annotations_sequence_length as usize)
+    }
+
+    pub fn annotations_sequence_range(&self) -> Option<Range<usize>> {
+        let wrapper_offset = self.annotations_offset()?;
+        let wrapper_exclusive_end = wrapper_offset + self.annotations_header_length as usize;
+        let sequence_length = self.annotations_sequence_length as usize;
+        let sequence_offset = wrapper_exclusive_end - sequence_length;
+        Some(sequence_offset..wrapper_exclusive_end)
+    }
+
+    pub fn annotations_sequence_offset(&self) -> Option<usize> {
+        Some(self.annotations_sequence_range()?.start)
+    }
+
+    /// Returns the offset of the beginning of the annotations wrapper, if present.
+    pub fn annotations_offset(&self) -> Option<usize> {
+        if self.annotations_header_length == 0 {
+            return None;
+        }
+        Some(self.header_offset - self.annotations_header_length as usize)
+    }
+
+    /// Returns an offset Range that includes the bytes used to encode this value's annotations,
+    /// if any. While annotations envelope the value that they modify, this function does not
+    /// include the bytes of the encoded value itself.
+    pub fn annotations_range(&self) -> Option<Range<usize>> {
+        if let Some(start) = self.annotations_offset() {
+            let end = start + self.annotations_header_length as usize;
+            return Some(start..end);
+        }
+        None
+    }
+
+    /// Returns the total number of bytes used to represent the current value, including the
+    /// field ID (if any), its annotations (if any), its header (type descriptor + length bytes),
+    /// and its value.
+    pub fn total_length(&self) -> usize {
+        self.total_length
+    }
+
+    pub fn ion_type(&self) -> IonType {
+        self.header.ion_type
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::binary::non_blocking::type_descriptor::Header;
+    use crate::binary::IonTypeCode;
+    use crate::lazy::binary::encoded_value::EncodedValue;
+    use crate::{IonResult, IonType};
+
+    #[test]
+    fn accessors() -> IonResult<()> {
+        // 3-byte String with 1-byte annotation and field ID $10
+        let value = EncodedValue {
+            header: Header {
+                ion_type: IonType::String,
+                ion_type_code: IonTypeCode::String,
+                length_code: 3,
+            },
+            field_id_length: 1,
+            field_id: Some(10),
+            annotations_header_length: 3,
+            annotations_sequence_length: 1,
+            header_offset: 200,
+            length_length: 0,
+            value_length: 3,
+            total_length: 7,
+        };
+        assert_eq!(value.ion_type(), IonType::String);
+        assert_eq!(
+            value.header(),
+            Header {
+                ion_type: IonType::String,
+                ion_type_code: IonTypeCode::String,
+                length_code: 3,
+            }
+        );
+        assert_eq!(value.header_offset(), 200);
+        assert_eq!(value.header_length(), 1);
+        assert_eq!(value.header_range(), 200..201);
+        assert_eq!(value.field_id_length(), Some(1));
+        assert_eq!(value.field_id_offset(), Some(196));
+        assert_eq!(value.field_id_range(), Some(196..197));
+        assert!(value.has_annotations());
+        assert_eq!(value.annotations_range(), Some(197..200));
+        assert_eq!(value.annotations_header_length(), Some(3));
+        assert_eq!(value.annotations_sequence_offset(), Some(199));
+        assert_eq!(value.annotations_sequence_length(), Some(1));
+        assert_eq!(value.annotations_sequence_range(), Some(199..200));
+        assert_eq!(value.value_length(), 3);
+        assert_eq!(value.value_offset(), 201);
+        assert_eq!(value.value_range(), 201..204);
+        assert_eq!(value.value_end_exclusive(), 204);
+        assert_eq!(value.total_length(), 7);
+        Ok(())
+    }
+}

--- a/src/lazy/binary/immutable_buffer.rs
+++ b/src/lazy/binary/immutable_buffer.rs
@@ -1,0 +1,939 @@
+use crate::binary::constants::v1_0::{length_codes, IVM};
+use crate::binary::int::DecodedInt;
+use crate::binary::non_blocking::type_descriptor::{
+    Header, TypeDescriptor, ION_1_0_TYPE_DESCRIPTORS,
+};
+use crate::binary::uint::DecodedUInt;
+use crate::binary::var_int::VarInt;
+use crate::binary::var_uint::VarUInt;
+use crate::lazy::binary::encoded_value::EncodedValue;
+use crate::lazy::binary::raw::lazy_raw_value::LazyRawValue;
+use crate::result::{
+    decoding_error, decoding_error_raw, incomplete_data_error, incomplete_data_error_raw,
+};
+use crate::types::UInt;
+use crate::{Int, IonResult, IonType};
+use num_bigint::{BigInt, BigUint, Sign};
+use std::fmt::{Debug, Formatter};
+use std::mem;
+
+// This limit is used for stack-allocating buffer space to encode/decode UInts.
+const UINT_STACK_BUFFER_SIZE: usize = 16;
+// This number was chosen somewhat arbitrarily and could be lifted if a use case demands it.
+const MAX_UINT_SIZE_IN_BYTES: usize = 2048;
+
+// This limit is used for stack-allocating buffer space to encode/decode Ints.
+const INT_STACK_BUFFER_SIZE: usize = 16;
+// This number was chosen somewhat arbitrarily and could be lifted if a use case demands it.
+const MAX_INT_SIZE_IN_BYTES: usize = 2048;
+
+/// A buffer of unsigned bytes that can be cheaply copied and which defines methods for parsing
+/// the various encoding elements of a binary Ion stream.
+///
+/// Upon success, each parsing method on the `ImmutableBuffer` will return the value that was read
+/// and a copy of the `ImmutableBuffer` that starts _after_ the bytes that were parsed.
+///
+/// Methods that `peek` at the input stream do not return a copy of the buffer.
+#[derive(PartialEq, Clone, Copy)]
+pub(crate) struct ImmutableBuffer<'a> {
+    data: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Debug for ImmutableBuffer<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ImmutableBuffer {{")?;
+        for byte in self.bytes().iter().take(16) {
+            write!(f, "{:x?} ", *byte)?;
+        }
+        write!(f, "}}")
+    }
+}
+
+pub(crate) type ParseResult<'a, T> = IonResult<(T, ImmutableBuffer<'a>)>;
+
+impl<'a> ImmutableBuffer<'a> {
+    /// Constructs a new `ImmutableBuffer` that wraps `data`.
+    #[inline]
+    pub fn new(data: &[u8]) -> ImmutableBuffer {
+        Self::new_with_offset(data, 0)
+    }
+
+    pub fn new_with_offset(data: &[u8], offset: usize) -> ImmutableBuffer {
+        ImmutableBuffer { data, offset }
+    }
+
+    /// Returns a slice containing all of the buffer's bytes.
+    pub fn bytes(&self) -> &[u8] {
+        self.data
+    }
+
+    /// Gets a slice from the buffer starting at `offset` and ending at `offset + length`.
+    /// The caller must check that the buffer contains `length + offset` bytes prior
+    /// to calling this method.
+    pub fn bytes_range(&self, offset: usize, length: usize) -> &'a [u8] {
+        &self.data[offset..offset + length]
+    }
+
+    /// Like [`Self::bytes_range`] above, but returns an updated copy of the [`ImmutableBuffer`]
+    /// instead of a `&[u8]`.
+    pub fn slice(&self, offset: usize, length: usize) -> ImmutableBuffer<'a> {
+        ImmutableBuffer {
+            data: self.bytes_range(offset, length),
+            offset: self.offset + offset,
+        }
+    }
+
+    /// Returns the number of bytes between the start of the original input byte array and the
+    /// subslice of that byte array that this `ImmutableBuffer` represents.
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Returns the number of bytes in the buffer.
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Returns `true` if there are no bytes in the buffer. Otherwise, returns `false`.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// If the buffer is not empty, returns `Some(_)` containing the next byte in the buffer.
+    /// Otherwise, returns `None`.
+    pub fn peek_next_byte(&self) -> Option<u8> {
+        self.data.first().copied()
+    }
+
+    /// If there are at least `n` bytes left in the buffer, returns `Some(_)` containing a slice
+    /// with the first `n` bytes. Otherwise, returns `None`.
+    pub fn peek_n_bytes(&self, n: usize) -> Option<&'a [u8]> {
+        self.data.get(..n)
+    }
+
+    /// Creates a copy of this `ImmutableBuffer` that begins `num_bytes_to_consume` further into the
+    /// slice.
+    #[inline]
+    pub fn consume(&self, num_bytes_to_consume: usize) -> Self {
+        // This assertion is always run during testing but is removed in the release build.
+        debug_assert!(num_bytes_to_consume <= self.len());
+        Self {
+            data: &self.data[num_bytes_to_consume..],
+            offset: self.offset + num_bytes_to_consume,
+        }
+    }
+
+    /// Reads the first byte in the buffer and returns it as a [TypeDescriptor].
+    #[inline]
+    pub fn peek_type_descriptor(&self) -> IonResult<TypeDescriptor> {
+        if self.is_empty() {
+            return incomplete_data_error("a type descriptor", self.offset());
+        }
+        let next_byte = self.data[0];
+        Ok(ION_1_0_TYPE_DESCRIPTORS[next_byte as usize])
+    }
+
+    /// Reads the first four bytes in the buffer as an Ion version marker. If it is successful,
+    /// returns an `Ok(_)` containing a `(major, minor)` version tuple.
+    ///
+    /// See: <https://amazon-ion.github.io/ion-docs/docs/binary.html#value-streams>
+    pub fn read_ivm(self) -> ParseResult<'a, (u8, u8)> {
+        let bytes = self
+            .peek_n_bytes(IVM.len())
+            .ok_or_else(|| incomplete_data_error_raw("an IVM", self.offset()))?;
+
+        match bytes {
+            [0xE0, major, minor, 0xEA] => {
+                let version = (*major, *minor);
+                Ok((version, self.consume(IVM.len())))
+            }
+            invalid_ivm => decoding_error(format!("invalid IVM: {invalid_ivm:?}")),
+        }
+    }
+
+    /// Reads a `VarUInt` encoding primitive from the beginning of the buffer. If it is successful,
+    /// returns an `Ok(_)` containing its [VarUInt] representation.
+    ///
+    /// See: <https://amazon-ion.github.io/ion-docs/docs/binary.html#varuint-and-varint-fields>
+    pub fn read_var_uint(self) -> ParseResult<'a, VarUInt> {
+        const BITS_PER_ENCODED_BYTE: usize = 7;
+        const STORAGE_SIZE_IN_BITS: usize = mem::size_of::<usize>() * 8;
+        const MAX_ENCODED_SIZE_IN_BYTES: usize = STORAGE_SIZE_IN_BITS / BITS_PER_ENCODED_BYTE;
+
+        const LOWER_7_BITMASK: u8 = 0b0111_1111;
+        const HIGHEST_BIT_VALUE: u8 = 0b1000_0000;
+
+        let mut magnitude: usize = 0;
+        let mut encoded_size_in_bytes = 0;
+
+        for byte in self.bytes().iter().copied() {
+            encoded_size_in_bytes += 1;
+            magnitude <<= 7; // Shifts 0 to 0 in the first iteration
+            let lower_seven = (LOWER_7_BITMASK & byte) as usize;
+            magnitude |= lower_seven;
+            if byte >= HIGHEST_BIT_VALUE {
+                // This is the final byte.
+                // Make sure we haven't exceeded the configured maximum size
+                if encoded_size_in_bytes > MAX_ENCODED_SIZE_IN_BYTES {
+                    return Self::value_too_large(
+                        "a VarUInt",
+                        encoded_size_in_bytes,
+                        MAX_ENCODED_SIZE_IN_BYTES,
+                    );
+                }
+                return Ok((
+                    VarUInt::new(magnitude, encoded_size_in_bytes),
+                    self.consume(encoded_size_in_bytes),
+                ));
+            }
+        }
+
+        incomplete_data_error("a VarUInt", self.offset() + encoded_size_in_bytes)
+    }
+
+    /// Reads a `VarInt` encoding primitive from the beginning of the buffer. If it is successful,
+    /// returns an `Ok(_)` containing its [VarInt] representation.
+    ///
+    /// See: <https://amazon-ion.github.io/ion-docs/docs/binary.html#varuint-and-varint-fields>
+    pub fn read_var_int(self) -> ParseResult<'a, VarInt> {
+        const BITS_PER_ENCODED_BYTE: usize = 7;
+        const STORAGE_SIZE_IN_BITS: usize = mem::size_of::<i64>() * 8;
+        const MAX_ENCODED_SIZE_IN_BYTES: usize = STORAGE_SIZE_IN_BITS / BITS_PER_ENCODED_BYTE;
+
+        const LOWER_6_BITMASK: u8 = 0b0011_1111;
+        const LOWER_7_BITMASK: u8 = 0b0111_1111;
+        const HIGHEST_BIT_VALUE: u8 = 0b1000_0000;
+
+        const BITS_PER_BYTE: usize = 8;
+        const BITS_PER_U64: usize = mem::size_of::<u64>() * BITS_PER_BYTE;
+
+        // Unlike VarUInt's encoding, the first byte in a VarInt is a special case because
+        // bit #6 (0-indexed, from the right) indicates whether the value is positive (0) or
+        // negative (1).
+
+        if self.is_empty() {
+            return incomplete_data_error("a VarInt", self.offset());
+        }
+        let first_byte: u8 = self.peek_next_byte().unwrap();
+        let no_more_bytes: bool = first_byte >= 0b1000_0000; // If the first bit is 1, we're done.
+        let is_negative: bool = (first_byte & 0b0100_0000) == 0b0100_0000;
+        let sign: i64 = if is_negative { -1 } else { 1 };
+        let mut magnitude = (first_byte & 0b0011_1111) as i64;
+
+        if no_more_bytes {
+            return Ok((
+                VarInt::new(magnitude * sign, is_negative, 1),
+                self.consume(1),
+            ));
+        }
+
+        let mut encoded_size_in_bytes = 1;
+        // Whether we found the terminating byte in this buffer.
+        let mut terminated = false;
+
+        for byte in self.bytes()[1..].iter().copied() {
+            let lower_seven = (0b0111_1111 & byte) as i64;
+            magnitude <<= 7;
+            magnitude |= lower_seven;
+            encoded_size_in_bytes += 1;
+            if byte >= 0b1000_0000 {
+                terminated = true;
+                break;
+            }
+        }
+
+        if !terminated {
+            return incomplete_data_error("a VarInt", self.offset() + encoded_size_in_bytes);
+        }
+
+        if encoded_size_in_bytes > MAX_ENCODED_SIZE_IN_BYTES {
+            return decoding_error(format!(
+                "Found a {encoded_size_in_bytes}-byte VarInt. Max supported size is {MAX_ENCODED_SIZE_IN_BYTES} bytes."
+            ));
+        }
+
+        Ok((
+            VarInt::new(magnitude * sign, is_negative, encoded_size_in_bytes),
+            self.consume(encoded_size_in_bytes),
+        ))
+    }
+
+    /// Reads the first `length` bytes from the buffer as a `UInt` encoding primitive. If it is
+    /// successful, returns an `Ok(_)` containing its [DecodedUInt] representation.
+    ///
+    /// See: <https://amazon-ion.github.io/ion-docs/docs/binary.html#uint-and-int-fields>
+    pub fn read_uint(self, length: usize) -> ParseResult<'a, DecodedUInt> {
+        if length <= mem::size_of::<u64>() {
+            return self.read_small_uint(length);
+        }
+
+        // The UInt is too large to fit in a u64; read it as a BigUInt instead.
+        self.read_big_uint(length)
+    }
+
+    /// Reads the first `length` bytes from the buffer as a `UInt`. The caller must confirm that
+    /// `length` is small enough to fit in a `u64`.
+    #[inline]
+    fn read_small_uint(self, length: usize) -> ParseResult<'a, DecodedUInt> {
+        let uint_bytes = self
+            .peek_n_bytes(length)
+            .ok_or_else(|| incomplete_data_error_raw("a UInt", self.offset()))?;
+        let magnitude = DecodedUInt::small_uint_from_slice(uint_bytes);
+        Ok((
+            DecodedUInt::new(UInt::U64(magnitude), length),
+            self.consume(length),
+        ))
+    }
+
+    /// Reads the first `length` bytes from the buffer as a `UInt`. If `length` is small enough
+    /// that the value can fit in a `usize`, it is strongly recommended that you use
+    /// `read_small_uint` instead as it will be much faster.
+    #[inline(never)]
+    // This method performs allocations and its generated assembly is rather large. Isolating its
+    // logic in a separate method that is never inlined keeps `read_uint` (its caller) small enough
+    // to inline. This is important as `read_uint` is on the hot path for most Ion streams.
+    fn read_big_uint(self, length: usize) -> ParseResult<'a, DecodedUInt> {
+        if length > MAX_UINT_SIZE_IN_BYTES {
+            return Self::value_too_large("a Uint", length, MAX_UINT_SIZE_IN_BYTES);
+        }
+
+        let uint_bytes = self
+            .peek_n_bytes(length)
+            .ok_or_else(|| incomplete_data_error_raw("a UInt", self.offset()))?;
+
+        let magnitude = BigUint::from_bytes_be(uint_bytes);
+        Ok((
+            DecodedUInt::new(UInt::BigUInt(magnitude), length),
+            self.consume(length),
+        ))
+    }
+
+    #[inline(never)]
+    // This method is inline(never) because it is rarely invoked and its allocations/formatting
+    // compile to a non-trivial number of instructions.
+    fn value_too_large<T>(label: &str, length: usize, max_length: usize) -> IonResult<T> {
+        decoding_error(format!(
+            "found {label} that was too large; size = {length}, max size = {max_length}"
+        ))
+    }
+
+    /// Reads the first `length` bytes from the buffer as an `Int` encoding primitive. If it is
+    /// successful, returns an `Ok(_)` containing its [DecodedInt] representation and consumes the
+    /// source bytes.
+    ///
+    /// See: <https://amazon-ion.github.io/ion-docs/docs/binary.html#uint-and-int-fields>
+    pub fn read_int(self, length: usize) -> ParseResult<'a, DecodedInt> {
+        if length == 0 {
+            return Ok((DecodedInt::new(Int::I64(0), false, 0), self.consume(0)));
+        } else if length > MAX_INT_SIZE_IN_BYTES {
+            return decoding_error(format!(
+                "Found a {length}-byte Int. Max supported size is {MAX_INT_SIZE_IN_BYTES} bytes."
+            ));
+        }
+
+        let int_bytes = self
+            .peek_n_bytes(length)
+            .ok_or_else(|| incomplete_data_error_raw("an Int encoding primitive", self.offset()))?;
+
+        let mut is_negative: bool = false;
+
+        let value = if length <= mem::size_of::<i64>() {
+            // This Int will fit in an i64.
+            let first_byte: i64 = i64::from(int_bytes[0]);
+            let sign: i64 = if first_byte & 0b1000_0000 == 0 {
+                1
+            } else {
+                is_negative = true;
+                -1
+            };
+            let mut magnitude: i64 = first_byte & 0b0111_1111;
+            for &byte in &int_bytes[1..] {
+                let byte = i64::from(byte);
+                magnitude <<= 8;
+                magnitude |= byte;
+            }
+            Int::I64(sign * magnitude)
+        } else {
+            // This Int is too big for an i64, we'll need to use a BigInt
+            let value = if int_bytes[0] & 0b1000_0000 == 0 {
+                BigInt::from_bytes_be(Sign::Plus, int_bytes)
+            } else {
+                is_negative = true;
+                // The leading sign bit is the only part of the input that can't be considered
+                // unsigned, big-endian integer bytes. We need to make our own copy of the input
+                // so we can flip that bit back to a zero before calling `from_bytes_be`.
+                let mut owned_int_bytes = Vec::from(int_bytes);
+                owned_int_bytes[0] &= 0b0111_1111;
+                BigInt::from_bytes_be(Sign::Minus, owned_int_bytes.as_slice())
+            };
+
+            Int::BigInt(value)
+        };
+        Ok((
+            DecodedInt::new(value, is_negative, length),
+            self.consume(length),
+        ))
+    }
+
+    /// Attempts to decode an annotations wrapper at the beginning of the buffer and returning
+    /// its subfields in an [`AnnotationsWrapper`].
+    pub fn read_annotations_wrapper(
+        &self,
+        type_descriptor: TypeDescriptor,
+    ) -> ParseResult<'a, AnnotationsWrapper> {
+        // Consume the first byte; its contents are already in the `type_descriptor` parameter.
+        let input_after_type_descriptor = self.consume(1);
+
+        // Read the combined length of the annotations sequence and the value that follows it
+        let (annotations_and_value_length, input_after_combined_length) =
+            match type_descriptor.length_code {
+                length_codes::NULL => (0, input_after_type_descriptor),
+                length_codes::VAR_UINT => {
+                    let (var_uint, input) = input_after_type_descriptor.read_var_uint()?;
+                    (var_uint.value(), input)
+                }
+                length => (length as usize, input_after_type_descriptor),
+            };
+
+        // Read the length of the annotations sequence
+        let (annotations_length, input_after_annotations_length) =
+            input_after_combined_length.read_var_uint()?;
+
+        // Validate that the annotations sequence is not empty.
+        if annotations_length.value() == 0 {
+            return decoding_error("found an annotations wrapper with no annotations");
+        }
+
+        // Validate that the annotated value is not missing.
+        let expected_value_length = annotations_and_value_length
+            - annotations_length.size_in_bytes()
+            - annotations_length.value();
+
+        if expected_value_length == 0 {
+            return decoding_error("found an annotation wrapper with no value");
+        }
+
+        // Skip over the annotations sequence itself; the reader will return to it if/when the
+        // reader asks to iterate over those symbol IDs.
+        let final_input = input_after_annotations_length.consume(annotations_length.value());
+
+        // Here, `self` is the (immutable) buffer we started with. Comparing it with `input`
+        // gets us the before-and-after we need to calculate the size of the header.
+        let annotations_header_length = final_input.offset() - self.offset();
+        let annotations_header_length = u8::try_from(annotations_header_length).map_err(|_e| {
+            decoding_error_raw("found an annotations header greater than 255 bytes long")
+        })?;
+
+        let annotations_sequence_length =
+            u8::try_from(annotations_length.value()).map_err(|_e| {
+                decoding_error_raw("found an annotations sequence greater than 255 bytes long")
+            })?;
+
+        let wrapper = AnnotationsWrapper {
+            header_length: annotations_header_length,
+            sequence_length: annotations_sequence_length,
+            expected_value_length,
+        };
+
+        Ok((wrapper, final_input))
+    }
+
+    /// Reads a `NOP` encoding primitive from the buffer. If it is successful, returns an `Ok(_)`
+    /// containing the number of bytes that were consumed.
+    ///
+    /// See: <https://amazon-ion.github.io/ion-docs/docs/binary.html#nop-pad>
+    #[inline(never)]
+    // NOP padding is not widely used in Ion 1.0, in part because many writer implementations do not
+    // expose the ability to write them. As such, this method has been marked `inline(never)` to
+    // allow the hot path to be better optimized.
+    pub fn read_nop_pad(self) -> ParseResult<'a, usize> {
+        let type_descriptor = self.peek_type_descriptor()?;
+        // Advance beyond the type descriptor
+        let remaining = self.consume(1);
+        // If the type descriptor says we should skip more bytes, skip them.
+        let (length, remaining) = remaining.read_length(type_descriptor.length_code)?;
+        if remaining.len() < length.value() {
+            return incomplete_data_error("a NOP", remaining.offset());
+        }
+        let remaining = remaining.consume(length.value());
+        let total_nop_pad_size = 1 + length.size_in_bytes() + length.value();
+        Ok((total_nop_pad_size, remaining))
+    }
+
+    /// Calls [`Self::read_nop_pad`] in a loop until the buffer is empty or a type descriptor
+    /// is encountered that is not a NOP.
+    #[inline(never)]
+    // NOP padding is not widely used in Ion 1.0. This method is annotated with `inline(never)`
+    // to avoid the compiler bloating other methods on the hot path with its rarely used
+    // instructions.
+    pub fn consume_nop_padding(self, mut type_descriptor: TypeDescriptor) -> ParseResult<'a, ()> {
+        let mut buffer = self;
+        // Skip over any number of NOP regions
+        while type_descriptor.is_nop() {
+            let (_, buffer_after_nop) = buffer.read_nop_pad()?;
+            buffer = buffer_after_nop;
+            if buffer.is_empty() {
+                break;
+            }
+            type_descriptor = buffer.peek_type_descriptor()?
+        }
+        Ok(((), buffer))
+    }
+
+    /// Interprets the length code in the provided [Header]; if necessary, will read more bytes
+    /// from the buffer to interpret as the value's length. If it is successful, returns an `Ok(_)`
+    /// containing a [VarUInt] representation of the value's length. If no additional bytes were
+    /// read, the returned `VarUInt`'s `size_in_bytes()` method will return `0`.
+    pub fn read_value_length(self, header: Header) -> ParseResult<'a, VarUInt> {
+        use IonType::*;
+        // Some type-specific `length` field overrides
+        let length_code = match header.ion_type {
+            // Null (0x0F) and Boolean (0x10, 0x11) are the only types that don't have/use a `length`
+            // field; the header contains the complete value.
+            Null | Bool => 0,
+            // If a struct has length = 1, its fields are ordered and the actual length follows.
+            // For the time being, this reader does not have any special handling for this case.
+            // Use `0xE` (14) as the length code instead so the call to `read_length` below
+            // consumes a VarUInt.
+            Struct if header.length_code == 1 => length_codes::VAR_UINT,
+            // For any other type, use the header's declared length code.
+            _ => header.length_code,
+        };
+
+        // Read the length, potentially consuming a VarUInt in the process.
+        let (length, remaining) = self.read_length(length_code)?;
+
+        // After we get the length, perform some type-specific validation.
+        match header.ion_type {
+            Float => match header.length_code {
+                0 | 4 | 8 | 15 => {}
+                _ => return decoding_error("found a float with an illegal length code"),
+            },
+            Timestamp if !header.is_null() && length.value() <= 1 => {
+                return decoding_error("found a timestamp with length <= 1")
+            }
+            Struct if header.length_code == 1 && length.value() == 0 => {
+                return decoding_error("found an empty ordered struct")
+            }
+            _ => {}
+        };
+
+        Ok((length, remaining))
+    }
+
+    /// Interprets a type descriptor's `L` nibble (length) in the way used by most Ion types.
+    ///
+    /// If `L` is...
+    ///   * `f`: the value is a typed `null` and its length is `0`.
+    ///   * `e`: the length is encoded as a `VarUInt` that follows the type descriptor.
+    ///   * anything else: the `L` represents the actual length.
+    ///
+    /// If successful, returns an `Ok(_)` that contains the [VarUInt] representation
+    /// of the value's length.
+    pub fn read_length(self, length_code: u8) -> ParseResult<'a, VarUInt> {
+        let length = match length_code {
+            length_codes::NULL => VarUInt::new(0, 0),
+            length_codes::VAR_UINT => return self.read_var_uint(),
+            magnitude => VarUInt::new(magnitude as usize, 0),
+        };
+
+        // If we reach this point, the length was in the header byte and no additional bytes were
+        // consumed
+        Ok((length, self))
+    }
+
+    /// Reads a field ID and a value from the buffer.
+    pub(crate) fn peek_field(self) -> IonResult<Option<LazyRawValue<'a>>> {
+        self.peek_value(true)
+    }
+
+    /// Reads a value from the buffer.
+    pub(crate) fn peek_value_without_field_id(self) -> IonResult<Option<LazyRawValue<'a>>> {
+        self.peek_value(false)
+    }
+
+    /// Reads a value from the buffer. If `has_field` is true, it will read a field ID first.
+    // This method consumes leading NOP bytes, but leaves the header representation in the buffer.
+    // The resulting LazyRawValue's buffer slice always starts with the first non-NOP byte in the
+    // header, which can be either a field ID, an annotations wrapper, or a type descriptor.
+    fn peek_value(self, has_field: bool) -> IonResult<Option<LazyRawValue<'a>>> {
+        let initial_input = self;
+        if initial_input.is_empty() {
+            return Ok(None);
+        }
+        let (field_id, field_id_length, mut input) = if has_field {
+            let (field_id_var_uint, input_after_field_id) = initial_input.read_var_uint()?;
+            if input_after_field_id.is_empty() {
+                return incomplete_data_error(
+                    "found field name but no value",
+                    input_after_field_id.offset(),
+                );
+            }
+            let field_id_length = u8::try_from(field_id_var_uint.size_in_bytes())
+                .map_err(|_| decoding_error_raw("found a field id with length over 255 bytes"))?;
+            (
+                Some(field_id_var_uint.value()),
+                field_id_length,
+                input_after_field_id,
+            )
+        } else {
+            (None, 0, initial_input)
+        };
+
+        let mut annotations_header_length = 0u8;
+        let mut annotations_sequence_length = 0u8;
+        let mut expected_value_length = None;
+
+        let mut type_descriptor = input.peek_type_descriptor()?;
+        if type_descriptor.is_annotation_wrapper() {
+            let (wrapper, input_after_annotations) =
+                input.read_annotations_wrapper(type_descriptor)?;
+            annotations_header_length = wrapper.header_length;
+            annotations_sequence_length = wrapper.sequence_length;
+            expected_value_length = Some(wrapper.expected_value_length);
+            input = input_after_annotations;
+            type_descriptor = input.peek_type_descriptor()?;
+            if type_descriptor.is_annotation_wrapper() {
+                return decoding_error("found an annotations wrapper ");
+            }
+        } else if type_descriptor.is_nop() {
+            (_, input) = input.consume_nop_padding(type_descriptor)?;
+        }
+
+        let header = type_descriptor
+            .to_header()
+            .ok_or_else(|| decoding_error_raw("found a non-value in value position"))?;
+
+        let header_offset = input.offset();
+        let (length, _) = input.consume(1).read_value_length(header)?;
+        let length_length = u8::try_from(length.size_in_bytes()).map_err(|_e| {
+            decoding_error_raw("found a value with a header length field over 255 bytes long")
+        })?;
+        let value_length = length.value(); // ha
+        let total_length = field_id_length as usize
+            + annotations_header_length as usize
+            + 1 // Header byte
+            + length_length as usize
+            + value_length;
+
+        if let Some(expected_value_length) = expected_value_length {
+            let actual_value_length = 1 + length_length as usize + value_length;
+            if expected_value_length != actual_value_length {
+                println!("{} != {}", expected_value_length, actual_value_length);
+                return decoding_error(
+                    "value length did not match length declared by annotations wrapper",
+                );
+            }
+        }
+
+        let encoded_value = EncodedValue {
+            header,
+            field_id_length,
+            field_id,
+            annotations_header_length,
+            annotations_sequence_length,
+            header_offset,
+            length_length,
+            value_length,
+            total_length,
+        };
+        let lazy_value = LazyRawValue {
+            encoded_value,
+            input: initial_input,
+        };
+        Ok(Some(lazy_value))
+    }
+}
+
+/// Represents the data found in an Ion 1.0 annotations wrapper.
+pub struct AnnotationsWrapper {
+    pub header_length: u8,
+    pub sequence_length: u8,
+    pub expected_value_length: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::IonError;
+    use num_traits::Num;
+
+    fn input_test<A: AsRef<[u8]>>(input: A) {
+        let input = ImmutableBuffer::new(input.as_ref());
+        // We can peek at the first byte...
+        assert_eq!(input.peek_next_byte(), Some(b'f'));
+        // ...without modifying the input. Looking at the next 3 bytes still includes 'f'.
+        assert_eq!(input.peek_n_bytes(3), Some("foo".as_bytes()));
+        // Advancing the cursor by 1...
+        let input = input.consume(1);
+        // ...causes next_byte() to return 'o'.
+        assert_eq!(input.peek_next_byte(), Some(b'o'));
+        let input = input.consume(1);
+        assert_eq!(input.peek_next_byte(), Some(b'o'));
+        let input = input.consume(1);
+        assert_eq!(input.peek_n_bytes(2), Some(" b".as_bytes()));
+        assert_eq!(input.peek_n_bytes(6), Some(" bar b".as_bytes()));
+    }
+
+    #[test]
+    fn string_test() {
+        input_test(String::from("foo bar baz"));
+    }
+
+    #[test]
+    fn slice_test() {
+        input_test("foo bar baz".as_bytes());
+    }
+
+    #[test]
+    fn vec_test() {
+        input_test(Vec::from("foo bar baz".as_bytes()));
+    }
+
+    #[test]
+    fn read_var_uint() -> IonResult<()> {
+        let buffer = ImmutableBuffer::new(&[0b0111_1001, 0b0000_1111, 0b1000_0001]);
+        let var_uint = buffer.read_var_uint()?.0;
+        assert_eq!(3, var_uint.size_in_bytes());
+        assert_eq!(1_984_385, var_uint.value());
+        Ok(())
+    }
+
+    #[test]
+    fn read_var_uint_zero() -> IonResult<()> {
+        let buffer = ImmutableBuffer::new(&[0b1000_0000]);
+        let var_uint = buffer.read_var_uint()?.0;
+        assert_eq!(var_uint.size_in_bytes(), 1);
+        assert_eq!(var_uint.value(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn read_var_uint_two_bytes_max_value() -> IonResult<()> {
+        let buffer = ImmutableBuffer::new(&[0b0111_1111, 0b1111_1111]);
+        let var_uint = buffer.read_var_uint()?.0;
+        assert_eq!(var_uint.size_in_bytes(), 2);
+        assert_eq!(var_uint.value(), 16_383);
+        Ok(())
+    }
+
+    #[test]
+    fn read_incomplete_var_uint() -> IonResult<()> {
+        let buffer = ImmutableBuffer::new(&[0b0111_1001, 0b0000_1111]);
+        match buffer.read_var_uint() {
+            Err(IonError::Incomplete { .. }) => Ok(()),
+            other => panic!("expected IonError::Incomplete, but found: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_var_uint_overflow_detection() {
+        let buffer = ImmutableBuffer::new(&[
+            0b0111_1111,
+            0b0111_1111,
+            0b0111_1111,
+            0b0111_1111,
+            0b0111_1111,
+            0b0111_1111,
+            0b0111_1111,
+            0b0111_1111,
+            0b0111_1111,
+            0b1111_1111,
+        ]);
+        buffer
+            .read_var_uint()
+            .expect_err("This should have failed due to overflow.");
+    }
+
+    #[test]
+    fn read_var_int_zero() -> IonResult<()> {
+        let buffer = ImmutableBuffer::new(&[0b1000_0000]);
+        let var_int = buffer.read_var_int()?.0;
+        assert_eq!(var_int.size_in_bytes(), 1);
+        assert_eq!(var_int.value(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn read_negative_var_int() -> IonResult<()> {
+        let buffer = ImmutableBuffer::new(&[0b0111_1001, 0b0000_1111, 0b1000_0001]);
+        let var_int = buffer.read_var_int()?.0;
+        assert_eq!(var_int.size_in_bytes(), 3);
+        assert_eq!(var_int.value(), -935_809);
+        Ok(())
+    }
+
+    #[test]
+    fn read_positive_var_int() -> IonResult<()> {
+        let buffer = ImmutableBuffer::new(&[0b0011_1001, 0b0000_1111, 0b1000_0001]);
+        let var_int = buffer.read_var_int()?.0;
+        assert_eq!(var_int.size_in_bytes(), 3);
+        assert_eq!(var_int.value(), 935_809);
+        Ok(())
+    }
+
+    #[test]
+    fn read_var_int_two_byte_min() -> IonResult<()> {
+        let buffer = ImmutableBuffer::new(&[0b0111_1111, 0b1111_1111]);
+        let var_int = buffer.read_var_int()?.0;
+        assert_eq!(var_int.size_in_bytes(), 2);
+        assert_eq!(var_int.value(), -8_191);
+        Ok(())
+    }
+
+    #[test]
+    fn read_var_int_two_byte_max() -> IonResult<()> {
+        let buffer = ImmutableBuffer::new(&[0b0011_1111, 0b1111_1111]);
+        let var_int = buffer.read_var_int()?.0;
+        assert_eq!(var_int.size_in_bytes(), 2);
+        assert_eq!(var_int.value(), 8_191);
+        Ok(())
+    }
+
+    #[test]
+    fn read_var_int_overflow_detection() -> IonResult<()> {
+        let buffer = ImmutableBuffer::new(&[
+            0b0111_1111,
+            0b0111_1111,
+            0b0111_1111,
+            0b0111_1111,
+            0b0111_1111,
+            0b0111_1111,
+            0b0111_1111,
+            0b0111_1111,
+            0b0111_1111,
+            0b1111_1111,
+        ]);
+        buffer
+            .read_var_int()
+            .expect_err("This should have failed due to overflow.");
+        Ok(())
+    }
+
+    #[test]
+    fn read_one_byte_uint() -> IonResult<()> {
+        let buffer = ImmutableBuffer::new(&[0b1000_0000]);
+        let var_int = buffer.read_uint(buffer.len())?.0;
+        assert_eq!(var_int.size_in_bytes(), 1);
+        assert_eq!(var_int.value(), &UInt::U64(128));
+        Ok(())
+    }
+
+    #[test]
+    fn read_two_byte_uint() -> IonResult<()> {
+        let buffer = ImmutableBuffer::new(&[0b0111_1111, 0b1111_1111]);
+        let var_int = buffer.read_uint(buffer.len())?.0;
+        assert_eq!(var_int.size_in_bytes(), 2);
+        assert_eq!(var_int.value(), &UInt::U64(32_767));
+        Ok(())
+    }
+
+    #[test]
+    fn read_three_byte_uint() -> IonResult<()> {
+        let buffer = ImmutableBuffer::new(&[0b0011_1100, 0b1000_0111, 0b1000_0001]);
+        let var_int = buffer.read_uint(buffer.len())?.0;
+        assert_eq!(var_int.size_in_bytes(), 3);
+        assert_eq!(var_int.value(), &UInt::U64(3_966_849));
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_ten_byte_uint() -> IonResult<()> {
+        let data = vec![0xFFu8; 10];
+        let buffer = ImmutableBuffer::new(&data);
+        let uint = buffer.read_uint(buffer.len())?.0;
+        assert_eq!(uint.size_in_bytes(), 10);
+        assert_eq!(
+            uint.value(),
+            &UInt::BigUInt(BigUint::from_str_radix("ffffffffffffffffffff", 16).unwrap())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_uint_too_large() {
+        let mut buffer = Vec::with_capacity(MAX_UINT_SIZE_IN_BYTES + 1);
+        buffer.resize(MAX_UINT_SIZE_IN_BYTES + 1, 1);
+        let buffer = ImmutableBuffer::new(&buffer);
+        let _uint = buffer
+            .read_uint(buffer.len())
+            .expect_err("This exceeded the configured max UInt size.");
+    }
+
+    #[test]
+    fn read_int_negative_zero() -> IonResult<()> {
+        let buffer = ImmutableBuffer::new(&[0b1000_0000]); // Negative zero
+        let int = buffer.read_int(buffer.len())?.0;
+        assert_eq!(int.size_in_bytes(), 1);
+        assert_eq!(int.value(), &Int::I64(0));
+        assert!(int.is_negative_zero());
+        Ok(())
+    }
+
+    #[test]
+    fn read_int_positive_zero() -> IonResult<()> {
+        let buffer = ImmutableBuffer::new(&[0b0000_0000]); // Negative zero
+        let int = buffer.read_int(buffer.len())?.0;
+        assert_eq!(int.size_in_bytes(), 1);
+        assert_eq!(int.value(), &Int::I64(0));
+        assert!(!int.is_negative_zero());
+        Ok(())
+    }
+
+    #[test]
+    fn read_int_length_zero() -> IonResult<()> {
+        let buffer = ImmutableBuffer::new(&[]); // Negative zero
+        let int = buffer.read_int(buffer.len())?.0;
+        assert_eq!(int.size_in_bytes(), 0);
+        assert_eq!(int.value(), &Int::I64(0));
+        assert!(!int.is_negative_zero());
+        Ok(())
+    }
+
+    #[test]
+    fn read_two_byte_negative_int() -> IonResult<()> {
+        let buffer = ImmutableBuffer::new(&[0b1111_1111, 0b1111_1111]);
+        let int = buffer.read_int(buffer.len())?.0;
+        assert_eq!(int.size_in_bytes(), 2);
+        assert_eq!(int.value(), &Int::I64(-32_767));
+        Ok(())
+    }
+
+    #[test]
+    fn read_two_byte_positive_int() -> IonResult<()> {
+        let buffer = ImmutableBuffer::new(&[0b0111_1111, 0b1111_1111]);
+        let int = buffer.read_int(buffer.len())?.0;
+        assert_eq!(int.size_in_bytes(), 2);
+        assert_eq!(int.value(), &Int::I64(32_767));
+        Ok(())
+    }
+
+    #[test]
+    fn read_three_byte_negative_int() -> IonResult<()> {
+        let buffer = ImmutableBuffer::new(&[0b1011_1100, 0b1000_0111, 0b1000_0001]);
+        let int = buffer.read_int(buffer.len())?.0;
+        assert_eq!(int.size_in_bytes(), 3);
+        assert_eq!(int.value(), &Int::I64(-3_966_849));
+        Ok(())
+    }
+
+    #[test]
+    fn read_three_byte_positive_int() -> IonResult<()> {
+        let buffer = ImmutableBuffer::new(&[0b0011_1100, 0b1000_0111, 0b1000_0001]);
+        let int = buffer.read_int(buffer.len())?.0;
+        assert_eq!(int.size_in_bytes(), 3);
+        assert_eq!(int.value(), &Int::I64(3_966_849));
+        Ok(())
+    }
+
+    #[test]
+    fn read_int_overflow() -> IonResult<()> {
+        let data = vec![1; MAX_INT_SIZE_IN_BYTES + 1];
+        let buffer = ImmutableBuffer::new(&data); // Negative zero
+        buffer
+            .read_int(buffer.len())
+            .expect_err("This exceeded the configured max Int size.");
+        Ok(())
+    }
+}

--- a/src/lazy/binary/lazy_reader.rs
+++ b/src/lazy/binary/lazy_reader.rs
@@ -1,0 +1,222 @@
+use crate::binary::constants::v1_0::IVM;
+use crate::element::reader::ElementReader;
+use crate::element::Element;
+use crate::lazy::binary::system::lazy_system_reader::LazySystemReader;
+use crate::lazy::binary::system::lazy_value::LazyValue;
+use crate::result::{decoding_error, decoding_error_raw};
+use crate::IonResult;
+
+/// A binary reader that only reads each value that it visits upon request (that is: lazily).
+///
+/// Each time [`LazyReader::next`] is called, the reader will advance to the next top-level value
+/// in the input stream. Once positioned on a top-level value, users may visit nested values by
+/// calling [`LazyValue::read`] and working with the resulting [`crate::lazy::value_ref::ValueRef`],
+/// which may contain either a scalar value or a lazy container that may itself be traversed.
+///
+/// The values that the reader yields ([`LazyValue`],
+/// [`crate::lazy::binary::system::lazy_sequence::LazySequence`], and
+/// [`crate::lazy::binary::system::lazy_struct::LazyStruct`]) are
+/// immutable references to the data stream, and remain valid until [`LazyReader::next`] is called
+/// again to advance the reader to the next top level value. This means that these references can
+/// be stored, read, and re-read as long as the reader remains on the same top-level value.
+/// ```
+///# use ion_rs::IonResult;
+///# fn main() -> IonResult<()> {
+///
+/// // Construct an Element and serialize it as binary Ion.
+/// use ion_rs::element::Element;
+/// use ion_rs::ion_list;
+/// use ion_rs::lazy::binary::lazy_reader::LazyReader;
+///
+/// let element: Element = ion_list! [10, 20, 30].into();
+/// let binary_ion = element.to_binary()?;
+///
+/// let mut lazy_reader = LazyReader::new(&binary_ion)?;
+///
+/// // Get the first value from the stream and confirm that it's a list.
+/// let lazy_list = lazy_reader.expect_next()?.read()?.expect_list()?;
+///
+/// // Visit the values in the list
+/// let mut sum = 0;
+/// for lazy_value in &lazy_list {
+///     // Read each lazy value in the lazy list as an int (i64) and
+///     // add it to the running total
+///     sum += lazy_value?.read()?.expect_i64()?;
+/// }
+///
+/// assert_eq!(sum, 60);
+///
+/// // Note that we can re-read any of the lazy values. Here we'll step into the list again and
+/// // read the first child value.
+/// let first_int = lazy_list.iter().next().unwrap()?.read()?.expect_i64()?;
+/// assert_eq!(first_int, 10);
+///
+///# Ok(())
+///# }
+/// ```
+pub struct LazyReader<'data> {
+    system_reader: LazySystemReader<'data>,
+}
+
+impl<'data> LazyReader<'data> {
+    pub fn new(ion_data: &'data [u8]) -> IonResult<LazyReader<'data>> {
+        if ion_data.len() < IVM.len() {
+            return decoding_error("input is too short to be recognized as Ion");
+        } else if ion_data[..IVM.len()] != IVM {
+            return decoding_error("input does not begin with an Ion version marker");
+        }
+
+        let system_reader = LazySystemReader::new(ion_data);
+        Ok(LazyReader { system_reader })
+    }
+
+    /// Returns the next top-level value in the input stream as `Ok(Some(lazy_value))`.
+    /// If there are no more top-level values in the stream, returns `Ok(None)`.
+    /// If the next value is incomplete (that is: only part of it is in the input buffer) or if the
+    /// input buffer contains invalid data, returns `Err(ion_error)`.
+    pub fn next<'top>(&'top mut self) -> IonResult<Option<LazyValue<'top, 'data>>> {
+        self.system_reader.next_value()
+    }
+
+    /// Like [`Self::next`], but returns an `IonError` if there are no more values in the stream.
+    pub fn expect_next<'top>(&'top mut self) -> IonResult<LazyValue<'top, 'data>> {
+        self.next()?
+            .ok_or_else(|| decoding_error_raw("expected another top-level value"))
+    }
+}
+
+pub struct LazyElementIterator<'iter, 'data> {
+    lazy_reader: &'iter mut LazyReader<'data>,
+}
+
+impl<'iter, 'data> Iterator for LazyElementIterator<'iter, 'data> {
+    type Item = IonResult<Element>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.lazy_reader.next() {
+            Ok(None) => None,
+            Ok(Some(lazy_value)) => Some(lazy_value.try_into()),
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+impl<'data> ElementReader for LazyReader<'data> {
+    type ElementIterator<'a> = LazyElementIterator<'a, 'data> where Self: 'a,;
+
+    fn read_next_element(&mut self) -> IonResult<Option<Element>> {
+        let lazy_value = match self.next()? {
+            None => return Ok(None),
+            Some(lazy_value) => lazy_value,
+        };
+        let element: Element = lazy_value.try_into()?;
+        Ok(Some(element))
+    }
+
+    fn elements(&mut self) -> Self::ElementIterator<'_> {
+        LazyElementIterator { lazy_reader: self }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::element::writer::ElementWriter;
+    use crate::element::Element;
+    use crate::lazy::value_ref::ValueRef;
+    use crate::{
+        ion_list, ion_sexp, ion_struct, BinaryWriterBuilder, Int, IonResult, IonType, IonWriter,
+    };
+
+    fn to_binary_ion(text_ion: &str) -> IonResult<Vec<u8>> {
+        let mut buffer = Vec::new();
+        let mut writer = BinaryWriterBuilder::default().build(&mut buffer)?;
+        let elements = Element::read_all(text_ion)?;
+        writer.write_elements(&elements)?;
+        writer.flush()?;
+        drop(writer);
+        Ok(buffer)
+    }
+
+    #[test]
+    fn sequence_iter() -> IonResult<()> {
+        let ion_data = to_binary_ion(
+            r#"
+                (foo baz baz)
+                (1 2 3)
+                (a b c)
+        "#,
+        )?;
+        let mut reader = LazyReader::new(&ion_data)?;
+        // For each top-level value...
+        while let Some(top_level_value) = reader.next()? {
+            // ...see if it's an S-expression...
+            if let ValueRef::SExp(sexp) = top_level_value.read()? {
+                //...and if it is, print its child values.
+                for lazy_value in &sexp {
+                    println!("{:?}", lazy_value?.read()?)
+                }
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_rewind() -> IonResult<()> {
+        let data = &to_binary_ion(
+            r#"
+            [
+                "yo",
+                77,
+                true,
+                {name:"hi", name: "hello"},
+            ]
+        "#,
+        )?;
+        let mut reader = LazyReader::new(data)?;
+
+        let first_value = reader.expect_next()?;
+        let list = first_value.read()?.expect_list()?;
+        let lazy_values = list.iter().collect::<IonResult<Vec<_>>>()?;
+
+        assert_eq!(lazy_values[1].read()?.expect_int()?, Int::from(77));
+        assert!(lazy_values[2].read()?.expect_bool()?);
+        Ok(())
+    }
+
+    #[test]
+    fn materialize() -> IonResult<()> {
+        let data = &to_binary_ion(
+            r#"
+            [
+                "yo",
+                77,
+                true,
+                {name:"hi", name: "hello"},
+            ]
+            null.int
+            (null null.string)
+        "#,
+        )?;
+        let mut reader = LazyReader::new(data)?;
+        let list: Element = ion_list![
+            "yo",
+            77,
+            true,
+            ion_struct! {
+                "name": "hi",
+                "name": "hello"
+            }
+        ]
+        .into();
+        assert_eq!(reader.read_next_element()?, Some(list));
+        assert_eq!(
+            reader.read_next_element()?,
+            Some(Element::null(IonType::Int))
+        );
+        let sexp: Element = ion_sexp!(IonType::Null IonType::String).into();
+        assert_eq!(reader.read_next_element()?, Some(sexp));
+        assert_eq!(reader.read_next_element()?, None);
+        Ok(())
+    }
+}

--- a/src/lazy/binary/mod.rs
+++ b/src/lazy/binary/mod.rs
@@ -1,0 +1,8 @@
+mod encoded_value;
+pub mod immutable_buffer;
+pub mod lazy_reader;
+pub mod raw;
+pub mod system;
+
+#[cfg(test)]
+pub(crate) mod test_utilities;

--- a/src/lazy/binary/raw/lazy_raw_reader.rs
+++ b/src/lazy/binary/raw/lazy_raw_reader.rs
@@ -1,0 +1,248 @@
+use crate::lazy::binary::immutable_buffer::ImmutableBuffer;
+use crate::lazy::binary::raw::lazy_raw_value::LazyRawValue;
+use crate::lazy::raw_stream_item::RawStreamItem;
+use crate::result::{decoding_error, incomplete_data_error};
+use crate::IonResult;
+
+pub struct LazyRawReader<'data> {
+    data: DataSource<'data>,
+}
+
+impl<'data> LazyRawReader<'data> {
+    pub fn new(data: &'data [u8]) -> LazyRawReader<'data> {
+        Self::new_with_offset(data, 0)
+    }
+
+    fn new_with_offset(data: &'data [u8], offset: usize) -> LazyRawReader<'data> {
+        let data = DataSource::new(ImmutableBuffer::new_with_offset(data, offset));
+        LazyRawReader { data }
+    }
+
+    fn read_ivm(&mut self, buffer: ImmutableBuffer<'data>) -> IonResult<RawStreamItem<'data>> {
+        let ((major, minor), _buffer_after_ivm) = buffer.read_ivm()?;
+        if (major, minor) != (1, 0) {
+            return decoding_error(format!(
+                "unsupported version of Ion: v{}.{}; only 1.0 is supported",
+                major, minor,
+            ));
+        }
+        self.data.buffer = buffer;
+        self.data.bytes_to_skip = 4; // IVM length
+        return Ok(RawStreamItem::VersionMarker(1, 0));
+    }
+
+    fn read_value(&mut self, buffer: ImmutableBuffer<'data>) -> IonResult<RawStreamItem<'data>> {
+        let lazy_value = match ImmutableBuffer::peek_value_without_field_id(buffer)? {
+            Some(lazy_value) => lazy_value,
+            None => return Ok(RawStreamItem::Nothing),
+        };
+        self.data.buffer = buffer;
+        self.data.bytes_to_skip = lazy_value.encoded_value.total_length();
+        Ok(RawStreamItem::Value(lazy_value))
+    }
+
+    // Elided 'top lifetime
+    pub fn next<'top>(&'top mut self) -> IonResult<RawStreamItem<'data>>
+    where
+        'data: 'top,
+    {
+        let mut buffer = self.data.advance_to_next_item()?;
+        if buffer.is_empty() {
+            return Ok(RawStreamItem::Nothing);
+        }
+        let type_descriptor = buffer.peek_type_descriptor()?;
+        if type_descriptor.is_nop() {
+            (_, buffer) = buffer.consume_nop_padding(type_descriptor)?;
+        } else if type_descriptor.is_ivm_start() {
+            return self.read_ivm(buffer);
+        }
+
+        self.read_value(buffer)
+    }
+}
+
+/// Wraps an [`ImmutableBuffer`], allowing the reader to advance each time an item is successfully
+/// parsed from it.
+pub(crate) struct DataSource<'data> {
+    // The buffer we're reading from
+    buffer: ImmutableBuffer<'data>,
+    // Each time something is parsed from the buffer successfully, the caller will mark the number
+    // of bytes that may be skipped the next time `advance_to_next_item` is called.
+    bytes_to_skip: usize,
+}
+
+impl<'data> DataSource<'data> {
+    pub(crate) fn new(buffer: ImmutableBuffer<'data>) -> DataSource<'data> {
+        DataSource {
+            buffer,
+            bytes_to_skip: 0,
+        }
+    }
+
+    pub(crate) fn buffer(&self) -> ImmutableBuffer<'data> {
+        self.buffer
+    }
+
+    fn advance_to_next_item(&mut self) -> IonResult<ImmutableBuffer<'data>> {
+        if self.buffer.len() < self.bytes_to_skip {
+            return incomplete_data_error(
+                "cannot advance to next item, insufficient data in buffer",
+                self.buffer.offset(),
+            );
+        }
+
+        if self.bytes_to_skip > 0 {
+            Ok(self.buffer.consume(self.bytes_to_skip))
+        } else {
+            Ok(self.buffer)
+        }
+    }
+
+    pub(crate) fn try_parse_next<
+        F: Fn(ImmutableBuffer<'data>) -> IonResult<Option<LazyRawValue<'data>>>,
+    >(
+        &mut self,
+        parser: F,
+    ) -> IonResult<Option<LazyRawValue<'data>>> {
+        let buffer = self.advance_to_next_item()?;
+
+        let lazy_value = match parser(buffer) {
+            Ok(Some(output)) => output,
+            Ok(None) => return Ok(None),
+            Err(e) => return Err(e),
+        };
+
+        self.buffer = buffer;
+        self.bytes_to_skip = lazy_value.encoded_value.total_length();
+        Ok(Some(lazy_value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::lazy::binary::raw::lazy_raw_reader::LazyRawReader;
+    use crate::lazy::binary::test_utilities::to_binary_ion;
+    use crate::lazy::raw_stream_item::RawStreamItem;
+    use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
+    use crate::{IonResult, IonType, RawSymbolTokenRef};
+
+    #[test]
+    fn test_struct() -> IonResult<()> {
+        // This test only uses symbols in the system symbol table to avoid LST processing
+        let data = &to_binary_ion(
+            r#"
+            {name:"hi", name: "hello"}
+        "#,
+        )?;
+        let mut reader = LazyRawReader::new(data);
+        let _ivm = reader.next()?.expect_ivm()?;
+        let value = reader.next()?.expect_value()?;
+        let lazy_struct = value.read()?.expect_struct()?;
+        let mut fields = lazy_struct.iter();
+        let field1 = fields.next().expect("field 1")?;
+        assert_eq!(field1.name(), 4.as_raw_symbol_token_ref()); // 'name'
+        Ok(())
+    }
+
+    #[test]
+    fn test_sequence() -> IonResult<()> {
+        // This test only uses symbols in the system symbol table to avoid LST processing
+        let data = &to_binary_ion(
+            r#"
+            [1, true, foo]
+        "#,
+        )?;
+        let mut reader = LazyRawReader::new(data);
+        let _ivm = reader.next()?.expect_ivm()?;
+        let _symbol_table = reader.next()?.expect_value()?;
+        let lazy_list = reader.next()?.expect_value()?.read()?.expect_list()?;
+        // Exercise the `Debug` impl
+        println!("Lazy Raw Sequence: {:?}", lazy_list);
+        let mut list_values = lazy_list.iter();
+        assert_eq!(list_values.next().expect("first")?.ion_type(), IonType::Int);
+        assert_eq!(
+            list_values.next().expect("second")?.ion_type(),
+            IonType::Bool
+        );
+        assert_eq!(
+            list_values.next().expect("third")?.ion_type(),
+            IonType::Symbol
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_top_level() -> IonResult<()> {
+        let data = &to_binary_ion(
+            r#"
+            "yo"
+            77
+            true
+            {name:"hi", name: "hello"}
+        "#,
+        )?;
+        let mut reader = LazyRawReader::new(data);
+        loop {
+            match reader.next()? {
+                RawStreamItem::VersionMarker(major, minor) => println!("IVM: v{}.{}", major, minor),
+                RawStreamItem::Value(value) => println!("{:?}", value.read()?),
+                RawStreamItem::Nothing => break,
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn annotations() -> IonResult<()> {
+        let data = &to_binary_ion(
+            r#"
+            $ion_symbol_table::{symbols: ["foo", "bar", "baz"]}
+            foo::bar::baz::7             
+        "#,
+        )?;
+        let mut reader = LazyRawReader::new(data);
+        let _ivm = reader.next()?.expect_ivm()?;
+
+        // Read annotations from $ion_symbol_table::{...}
+        let symbol_table = reader.next()?.expect_value()?;
+        assert_eq!(symbol_table.ion_type(), IonType::Struct);
+        let annotations = symbol_table
+            .annotations()
+            .collect::<IonResult<Vec<RawSymbolTokenRef<'_>>>>()?;
+        assert_eq!(annotations.len(), 1);
+        assert_eq!(annotations[0], 3.as_raw_symbol_token_ref());
+
+        // Read annotations from foo::bar::baz::7
+        let int = reader.next()?.expect_value()?;
+        assert_eq!(int.ion_type(), IonType::Int);
+        let annotations = int
+            .annotations()
+            .collect::<IonResult<Vec<RawSymbolTokenRef<'_>>>>()?;
+        assert_eq!(annotations.len(), 3);
+        assert_eq!(annotations[0], 10.as_raw_symbol_token_ref());
+        assert_eq!(annotations[1], 11.as_raw_symbol_token_ref());
+        assert_eq!(annotations[2], 12.as_raw_symbol_token_ref());
+        Ok(())
+    }
+
+    #[test]
+    fn nop() -> IonResult<()> {
+        let data: Vec<u8> = vec![
+            0xe0, 0x01, 0x00, 0xea, // IVM
+            0x00, // 1-byte NOP
+            0x01, 0xff, // 2-byte NOP
+            0x02, 0xff, 0xff, // 3-byte NOP
+            0x0f, // null
+        ];
+
+        let mut reader = LazyRawReader::new(&data);
+        let _ivm = reader.next()?.expect_ivm()?;
+
+        assert_eq!(
+            reader.next()?.expect_value()?.read()?.expect_null()?,
+            IonType::Null
+        );
+
+        Ok(())
+    }
+}

--- a/src/lazy/binary/raw/lazy_raw_sequence.rs
+++ b/src/lazy/binary/raw/lazy_raw_sequence.rs
@@ -1,0 +1,92 @@
+use crate::lazy::binary::immutable_buffer::ImmutableBuffer;
+use crate::lazy::binary::raw::lazy_raw_reader::DataSource;
+use crate::lazy::binary::raw::lazy_raw_value::LazyRawValue;
+use crate::{IonResult, IonType};
+use std::fmt;
+use std::fmt::{Debug, Formatter};
+
+pub struct LazyRawSequence<'data> {
+    pub(crate) value: LazyRawValue<'data>,
+}
+
+impl<'data> LazyRawSequence<'data> {
+    pub fn ion_type(&self) -> IonType {
+        self.value.ion_type()
+    }
+
+    pub fn iter(&self) -> RawSequenceIterator<'data> {
+        // Get as much of the sequence's body as is available in the input buffer.
+        // Reading a child value may fail as `Incomplete`
+        let buffer_slice = self.value.available_body();
+        RawSequenceIterator::new(buffer_slice)
+    }
+}
+
+impl<'a, 'data> IntoIterator for &'a LazyRawSequence<'data> {
+    type Item = IonResult<LazyRawValue<'data>>;
+    type IntoIter = RawSequenceIterator<'data>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a> Debug for LazyRawSequence<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self.value.encoded_value.ion_type() {
+            IonType::SExp => {
+                write!(f, "(")?;
+                for value in self {
+                    write!(
+                        f,
+                        "{:?} ",
+                        value
+                            .map_err(|_| fmt::Error)?
+                            .read()
+                            .map_err(|_| fmt::Error)?
+                    )?;
+                }
+                write!(f, ")").unwrap();
+            }
+            IonType::List => {
+                write!(f, "[")?;
+                for value in self {
+                    write!(
+                        f,
+                        "{:?},",
+                        value
+                            .map_err(|_| fmt::Error)?
+                            .read()
+                            .map_err(|_| fmt::Error)?
+                    )?;
+                }
+                write!(f, "]").unwrap();
+            }
+            _ => unreachable!("LazyRawSequence is only created for list and sexp"),
+        }
+
+        Ok(())
+    }
+}
+
+pub struct RawSequenceIterator<'data> {
+    source: DataSource<'data>,
+}
+
+impl<'data> RawSequenceIterator<'data> {
+    pub(crate) fn new(input: ImmutableBuffer<'data>) -> RawSequenceIterator<'data> {
+        RawSequenceIterator {
+            source: DataSource::new(input),
+        }
+    }
+}
+
+impl<'data> Iterator for RawSequenceIterator<'data> {
+    type Item = IonResult<LazyRawValue<'data>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.source
+            .try_parse_next(ImmutableBuffer::peek_value_without_field_id)
+            .transpose()
+    }
+}

--- a/src/lazy/binary/raw/lazy_raw_struct.rs
+++ b/src/lazy/binary/raw/lazy_raw_struct.rs
@@ -1,0 +1,102 @@
+use crate::lazy::binary::immutable_buffer::ImmutableBuffer;
+use crate::lazy::binary::raw::lazy_raw_reader::DataSource;
+use crate::lazy::binary::raw::lazy_raw_value::LazyRawValue;
+use crate::{IonResult, RawSymbolTokenRef};
+use std::fmt;
+use std::fmt::{Debug, Formatter};
+
+pub struct LazyRawStruct<'data> {
+    pub(crate) value: LazyRawValue<'data>,
+}
+
+impl<'a, 'data> IntoIterator for &'a LazyRawStruct<'data> {
+    type Item = IonResult<LazyRawField<'data>>;
+    type IntoIter = RawStructIterator<'data>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a> Debug for LazyRawStruct<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{{")?;
+        for field in self {
+            let field = field.map_err(|_| fmt::Error)?;
+            let name = field.name();
+            let lazy_value = field.value();
+            let value = lazy_value.read().map_err(|_| fmt::Error)?;
+            write!(f, "{:?}:{:?},", name, value).unwrap();
+        }
+        write!(f, "}}")?;
+        Ok(())
+    }
+}
+
+impl<'data> LazyRawStruct<'data> {
+    pub fn iter(&self) -> RawStructIterator<'data> {
+        // Get as much of the struct's body as is available in the input buffer.
+        // Reading a child value may fail as `Incomplete`
+        let buffer_slice = self.value.available_body();
+        RawStructIterator::new(buffer_slice)
+    }
+}
+
+pub struct RawStructIterator<'data> {
+    source: DataSource<'data>,
+}
+
+impl<'data> RawStructIterator<'data> {
+    pub(crate) fn new(input: ImmutableBuffer<'data>) -> RawStructIterator<'data> {
+        RawStructIterator {
+            source: DataSource::new(input),
+        }
+    }
+}
+
+impl<'data> Iterator for RawStructIterator<'data> {
+    type Item = IonResult<LazyRawField<'data>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.source.try_parse_next(ImmutableBuffer::peek_field) {
+            Ok(Some(lazy_raw_value)) => Some(Ok(LazyRawField::new(lazy_raw_value))),
+            Ok(None) => None,
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+pub struct LazyRawField<'data> {
+    pub(crate) value: LazyRawValue<'data>,
+}
+
+impl<'data> LazyRawField<'data> {
+    pub(crate) fn new(value: LazyRawValue<'data>) -> Self {
+        LazyRawField { value }
+    }
+
+    pub fn name(&self) -> RawSymbolTokenRef<'data> {
+        // We're in a struct field, the field ID must be populated.
+        let field_id = self.value.encoded_value.field_id.unwrap();
+        RawSymbolTokenRef::SymbolId(field_id)
+    }
+
+    pub fn value(&self) -> &LazyRawValue<'data> {
+        &self.value
+    }
+
+    pub(crate) fn into_value(self) -> LazyRawValue<'data> {
+        self.value
+    }
+}
+
+impl<'a> Debug for LazyRawField<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "${}: {:?}",
+            self.value.encoded_value.field_id.unwrap(),
+            self.value()
+        )
+    }
+}

--- a/src/lazy/binary/raw/lazy_raw_value.rs
+++ b/src/lazy/binary/raw/lazy_raw_value.rs
@@ -1,0 +1,386 @@
+use crate::binary::int::DecodedInt;
+use crate::binary::uint::DecodedUInt;
+use crate::lazy::binary::encoded_value::EncodedValue;
+use crate::lazy::binary::immutable_buffer::ImmutableBuffer;
+use crate::lazy::binary::raw::lazy_raw_sequence::LazyRawSequence;
+use crate::lazy::binary::raw::lazy_raw_struct::LazyRawStruct;
+use crate::lazy::binary::raw::raw_annotations_iterator::RawAnnotationsIterator;
+use crate::lazy::raw_value_ref::RawValueRef;
+use crate::result::{decoding_error, decoding_error_raw, incomplete_data_error};
+use crate::types::SymbolId;
+use crate::{Decimal, IonResult, IonType, RawSymbolTokenRef, Timestamp};
+use bytes::{BigEndian, ByteOrder};
+use std::fmt::{Debug, Formatter};
+use std::{fmt, mem};
+
+#[derive(Clone)]
+pub struct LazyRawValue<'data> {
+    pub(crate) encoded_value: EncodedValue,
+    pub(crate) input: ImmutableBuffer<'data>,
+}
+
+impl<'a> Debug for LazyRawValue<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "LazyRawValue {{\n  val={:?},\n  buf={:?}\n}}\n",
+            self.encoded_value, self.input
+        )
+    }
+}
+
+type ValueParseResult<'a> = IonResult<RawValueRef<'a>>;
+
+impl<'data> LazyRawValue<'data> {
+    pub fn ion_type(&self) -> IonType {
+        self.encoded_value.ion_type()
+    }
+
+    fn has_annotations(&self) -> bool {
+        self.encoded_value.has_annotations()
+    }
+
+    fn annotations_sequence(&self) -> ImmutableBuffer<'data> {
+        let offset_and_length = self
+            .encoded_value
+            .annotations_sequence_offset()
+            .map(|offset| {
+                (
+                    offset,
+                    self.encoded_value.annotations_sequence_length().unwrap(),
+                )
+            });
+        let (sequence_offset, sequence_length) = match offset_and_length {
+            None => return self.input.slice(0, 0),
+            Some(offset_and_length) => offset_and_length,
+        };
+        let local_sequence_offset = sequence_offset - self.input.offset();
+
+        self.input.slice(local_sequence_offset, sequence_length)
+    }
+
+    pub fn annotations(&self) -> RawAnnotationsIterator<'data> {
+        RawAnnotationsIterator::new(self.annotations_sequence())
+    }
+
+    pub fn read(&self) -> ValueParseResult<'data> {
+        if self.encoded_value.header().is_null() {
+            let raw_value_ref = RawValueRef::Null(self.ion_type());
+            return Ok(raw_value_ref);
+        }
+
+        match self.ion_type() {
+            IonType::Null => unreachable!("all null types handled above"),
+            IonType::Bool => self.read_bool(),
+            IonType::Int => self.read_int(),
+            IonType::Float => self.read_float(),
+            IonType::Decimal => self.read_decimal(),
+            IonType::Timestamp => self.read_timestamp(),
+            IonType::Symbol => self.read_symbol(),
+            IonType::String => self.read_string(),
+            IonType::Clob => self.read_clob(),
+            IonType::Blob => self.read_blob(),
+            IonType::List => self.read_list(),
+            IonType::SExp => self.read_sexp(),
+            IonType::Struct => self.read_struct(),
+        }
+    }
+
+    // Can return Err if there aren't enough bytes available
+    fn value_body(&self) -> IonResult<&'data [u8]> {
+        let value_total_length = self.encoded_value.total_length();
+        if self.input.len() < value_total_length {
+            eprintln!("[value_body] Incomplete {:?}", self);
+            return incomplete_data_error(
+                "only part of the requested value is available in the buffer",
+                self.input.offset(),
+            );
+        }
+        let value_body_length = self.encoded_value.value_length();
+        let value_offset = value_total_length - value_body_length;
+        Ok(self.input.bytes_range(value_offset, value_body_length))
+    }
+
+    pub(crate) fn available_body(&self) -> ImmutableBuffer<'data> {
+        let value_total_length = self.encoded_value.total_length();
+        let value_body_length = self.encoded_value.value_length();
+        let value_offset = value_total_length - value_body_length;
+
+        let bytes_needed = std::cmp::min(self.input.len() - value_offset, value_body_length);
+        let buffer_slice = self.input.slice(value_offset, bytes_needed);
+        buffer_slice
+    }
+
+    pub(crate) fn field_name(&self) -> Option<SymbolId> {
+        self.encoded_value.field_id
+    }
+
+    fn read_bool(&self) -> ValueParseResult<'data> {
+        debug_assert!(self.encoded_value.ion_type() == IonType::Bool);
+        let representation = self.encoded_value.header().length_code;
+        let value = match representation {
+            0 => false,
+            1 => true,
+            invalid => {
+                return decoding_error(format!(
+                    "found a boolean value with an illegal representation (must be 0 or 1): {}",
+                    invalid
+                ))
+            }
+        };
+        Ok(RawValueRef::Bool(value))
+    }
+
+    fn read_int(&self) -> ValueParseResult<'data> {
+        debug_assert!(self.encoded_value.ion_type() == IonType::Int);
+        // `value_body()` returns a buffer starting at the body of the value.
+        // It also confirms that the entire value is in the buffer.
+        let uint_bytes = self.value_body()?;
+        let magnitude: Int = if uint_bytes.len() <= mem::size_of::<u64>() {
+            DecodedUInt::small_uint_from_slice(uint_bytes).into()
+        } else {
+            DecodedUInt::big_uint_from_slice(uint_bytes).into()
+        };
+
+        use crate::binary::type_code::IonTypeCode::*;
+        use crate::Int;
+        use num_traits::Zero;
+        let value = match (self.encoded_value.header.ion_type_code, magnitude) {
+            (PositiveInteger, integer) => integer,
+            (NegativeInteger, integer) if integer.is_zero() => {
+                return decoding_error("found a negative integer (typecode=3) with a value of 0");
+            }
+            (NegativeInteger, integer) => -integer,
+            _itc => return decoding_error("unexpected ion type code"),
+        };
+        Ok(RawValueRef::Int(value))
+    }
+
+    fn read_float(&self) -> ValueParseResult<'data> {
+        debug_assert!(self.encoded_value.ion_type() == IonType::Float);
+        let ieee_bytes = self.value_body()?;
+        let number_of_bytes = self.encoded_value.value_length();
+        let value = match number_of_bytes {
+            0 => 0f64,
+            4 => f64::from(BigEndian::read_f32(ieee_bytes)),
+            8 => BigEndian::read_f64(ieee_bytes),
+            _ => return decoding_error("encountered a float with an illegal length"),
+        };
+        Ok(RawValueRef::Float(value))
+    }
+
+    fn read_decimal(&self) -> ValueParseResult<'data> {
+        debug_assert!(self.encoded_value.ion_type() == IonType::Decimal);
+
+        if self.encoded_value.value_length() == 0 {
+            return Ok(RawValueRef::Decimal(Decimal::new(0i32, 0i64)));
+        }
+
+        // Skip the type descriptor
+        let input = self.input.consume(1);
+
+        let (exponent_var_int, remaining) = input.read_var_int()?;
+        let coefficient_size_in_bytes =
+            self.encoded_value.value_length() - exponent_var_int.size_in_bytes();
+
+        let exponent = exponent_var_int.value();
+        let (coefficient, _remaining) = remaining.read_int(coefficient_size_in_bytes)?;
+
+        if coefficient.is_negative_zero() {
+            return Ok(RawValueRef::Decimal(Decimal::negative_zero_with_exponent(
+                exponent,
+            )));
+        }
+
+        Ok(RawValueRef::Decimal(Decimal::new(coefficient, exponent)))
+    }
+
+    fn read_timestamp(&self) -> ValueParseResult<'data> {
+        debug_assert!(self.encoded_value.ion_type() == IonType::Timestamp);
+
+        let input = ImmutableBuffer::new(self.value_body()?);
+
+        let (offset, input) = input.read_var_int()?;
+        let is_known_offset = !offset.is_negative_zero();
+        let offset_minutes = offset.value() as i32;
+        let (year_var_uint, input) = input.read_var_uint()?;
+        let year = year_var_uint.value() as u32;
+
+        // Year precision
+
+        let builder = Timestamp::with_year(year);
+        if input.is_empty() {
+            let timestamp = builder.build()?;
+            return Ok(RawValueRef::Timestamp(timestamp));
+        }
+
+        // Month precision
+
+        let (month_var_uint, input) = input.read_var_uint()?;
+        let month = month_var_uint.value() as u32;
+        let builder = builder.with_month(month);
+        if input.is_empty() {
+            let timestamp = builder.build()?;
+            return Ok(RawValueRef::Timestamp(timestamp));
+        }
+
+        // Day precision
+
+        let (day_var_uint, input) = input.read_var_uint()?;
+        let day = day_var_uint.value() as u32;
+        let builder = builder.with_day(day);
+        if input.is_empty() {
+            let timestamp = builder.build()?;
+            return Ok(RawValueRef::Timestamp(timestamp));
+        }
+
+        // Hour-and-minute precision
+
+        let (hour_var_uint, input) = input.read_var_uint()?;
+        let hour = hour_var_uint.value() as u32;
+        if input.is_empty() {
+            return decoding_error("timestamps with an hour must also specify a minute");
+        }
+        let (minute_var_uint, input) = input.read_var_uint()?;
+        let minute = minute_var_uint.value() as u32;
+        let builder = builder.with_hour_and_minute(hour, minute);
+        if input.is_empty() {
+            let timestamp = if is_known_offset {
+                builder.build_utc_fields_at_offset(offset_minutes)
+            } else {
+                builder.build_at_unknown_offset()
+            }?;
+            return Ok(RawValueRef::Timestamp(timestamp));
+        }
+
+        // Second precision
+
+        let (second_var_uint, input) = input.read_var_uint()?;
+        let second = second_var_uint.value() as u32;
+        let builder = builder.with_second(second);
+        if input.is_empty() {
+            let timestamp = if is_known_offset {
+                builder.build_utc_fields_at_offset(offset_minutes)
+            } else {
+                builder.build_at_unknown_offset()
+            }?;
+            return Ok(RawValueRef::Timestamp(timestamp));
+        }
+
+        // Fractional second precision
+
+        let (subsecond_exponent_var_uint, input) = input.read_var_int()?;
+        let subsecond_exponent = subsecond_exponent_var_uint.value();
+        // The remaining bytes represent the coefficient.
+        let coefficient_size_in_bytes = self.encoded_value.value_length() - input.offset();
+        let (subsecond_coefficient, _input) = if coefficient_size_in_bytes == 0 {
+            (DecodedInt::zero(), input)
+        } else {
+            input.read_int(coefficient_size_in_bytes)?
+        };
+
+        let builder = builder
+            .with_fractional_seconds(Decimal::new(subsecond_coefficient, subsecond_exponent));
+        let timestamp = if is_known_offset {
+            builder.build_utc_fields_at_offset(offset_minutes)
+        } else {
+            builder.build_at_unknown_offset()
+        }?;
+
+        Ok(RawValueRef::Timestamp(timestamp))
+    }
+
+    /// If the reader is currently positioned on a symbol value, parses that value into a `SymbolId`.
+    pub fn read_symbol_id(&self) -> IonResult<SymbolId> {
+        debug_assert!(self.encoded_value.ion_type() == IonType::Symbol);
+        let uint_bytes = self.value_body()?;
+        if uint_bytes.len() > mem::size_of::<usize>() {
+            return decoding_error("found a symbol ID that was too large to fit in a usize");
+        }
+        let magnitude = DecodedUInt::small_uint_from_slice(uint_bytes);
+        // This cast is safe because we've confirmed the value was small enough to fit in a usize.
+        Ok(magnitude as usize)
+    }
+
+    pub fn read_symbol(&self) -> ValueParseResult<'data> {
+        debug_assert!(self.encoded_value.ion_type() == IonType::Symbol);
+        self.read_symbol_id()
+            .map(|sid| RawValueRef::Symbol(RawSymbolTokenRef::SymbolId(sid)))
+    }
+
+    /// If the reader is currently positioned on a string, returns a [&str] containing its text.
+    fn read_string(&self) -> ValueParseResult<'data> {
+        debug_assert!(self.encoded_value.ion_type() == IonType::String);
+        let raw_bytes = self.value_body()?;
+        let text = std::str::from_utf8(raw_bytes)
+            .map_err(|_| decoding_error_raw("found a string with invalid utf-8 data"))?;
+        Ok(RawValueRef::String(text))
+    }
+
+    fn read_blob(&self) -> ValueParseResult<'data> {
+        debug_assert!(self.encoded_value.ion_type() == IonType::Blob);
+        let bytes = self.value_body()?;
+        Ok(RawValueRef::Blob(bytes))
+    }
+
+    fn read_clob(&self) -> ValueParseResult<'data> {
+        debug_assert!(self.encoded_value.ion_type() == IonType::Clob);
+        let bytes = self.value_body()?;
+        Ok(RawValueRef::Clob(bytes))
+    }
+
+    fn read_sexp(&self) -> ValueParseResult<'data> {
+        debug_assert!(self.encoded_value.ion_type() == IonType::SExp);
+        let lazy_value = LazyRawValue {
+            encoded_value: self.encoded_value,
+            input: self.input,
+        };
+        let lazy_sequence = LazyRawSequence { value: lazy_value };
+        Ok(RawValueRef::SExp(lazy_sequence))
+    }
+
+    fn read_list(&self) -> ValueParseResult<'data> {
+        debug_assert!(self.encoded_value.ion_type() == IonType::List);
+        let lazy_value = LazyRawValue {
+            encoded_value: self.encoded_value,
+            input: self.input,
+        };
+        let lazy_sequence = LazyRawSequence { value: lazy_value };
+        Ok(RawValueRef::List(lazy_sequence))
+    }
+
+    fn read_struct(&self) -> ValueParseResult<'data> {
+        debug_assert!(self.encoded_value.ion_type() == IonType::Struct);
+        let lazy_value = LazyRawValue {
+            encoded_value: self.encoded_value,
+            input: self.input,
+        };
+        let lazy_struct = LazyRawStruct { value: lazy_value };
+        Ok(RawValueRef::Struct(lazy_struct))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::lazy::binary::raw::lazy_raw_reader::LazyRawReader;
+    use crate::lazy::binary::test_utilities::to_binary_ion;
+    use crate::IonResult;
+
+    #[test]
+    fn annotations_sequence() -> IonResult<()> {
+        let data = &to_binary_ion(
+            r#"
+            $ion_symbol_table::{symbols: ["foo"]}
+            foo // binary writer will omit the symtab if we don't use a symbol 
+        "#,
+        )?;
+        let mut reader = LazyRawReader::new(data);
+        let _ivm = reader.next()?.expect_ivm()?;
+        let value = reader.next()?.expect_value()?;
+        let annotations_sequence = value.annotations_sequence();
+        assert_eq!(annotations_sequence.len(), 1);
+        assert_eq!(annotations_sequence.offset(), 6);
+        assert_eq!(annotations_sequence.bytes()[0], 0x83u8); // 0x83 == $3 == $ion_symbol_table
+        Ok(())
+    }
+}

--- a/src/lazy/binary/raw/mod.rs
+++ b/src/lazy/binary/raw/mod.rs
@@ -1,0 +1,5 @@
+pub mod lazy_raw_reader;
+pub mod lazy_raw_sequence;
+pub mod lazy_raw_struct;
+pub mod lazy_raw_value;
+pub mod raw_annotations_iterator;

--- a/src/lazy/binary/raw/raw_annotations_iterator.rs
+++ b/src/lazy/binary/raw/raw_annotations_iterator.rs
@@ -1,0 +1,31 @@
+use crate::lazy::binary::immutable_buffer::ImmutableBuffer;
+use crate::{IonResult, RawSymbolTokenRef};
+
+/// Iterates over a slice of bytes, lazily reading them as a sequence of VarUInt symbol IDs.
+pub struct RawAnnotationsIterator<'a> {
+    buffer: ImmutableBuffer<'a>,
+}
+
+impl<'a> RawAnnotationsIterator<'a> {
+    pub(crate) fn new(buffer: ImmutableBuffer<'a>) -> RawAnnotationsIterator<'a> {
+        RawAnnotationsIterator { buffer }
+    }
+}
+
+impl<'a> Iterator for RawAnnotationsIterator<'a> {
+    type Item = IonResult<RawSymbolTokenRef<'a>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.buffer.is_empty() {
+            return None;
+        }
+        let (var_uint, buffer_after_var_uint) = match self.buffer.read_var_uint() {
+            Ok(output) => output,
+            Err(error) => return Some(Err(error)),
+        };
+        // If this var_uint was longer than the declared annotations wrapper length, return an error.
+        let symbol_id = RawSymbolTokenRef::SymbolId(var_uint.value());
+        self.buffer = buffer_after_var_uint;
+        Some(Ok(symbol_id))
+    }
+}

--- a/src/lazy/binary/system/lazy_sequence.rs
+++ b/src/lazy/binary/system/lazy_sequence.rs
@@ -1,0 +1,252 @@
+use crate::element::{Annotations, Element, IntoAnnotatedElement, Sequence, Value};
+use crate::lazy::binary::raw::lazy_raw_sequence::{LazyRawSequence, RawSequenceIterator};
+use crate::lazy::binary::system::lazy_value::AnnotationsIterator;
+use crate::lazy::binary::system::lazy_value::LazyValue;
+use crate::{IonError, IonResult, IonType, SymbolTable};
+use std::fmt;
+use std::fmt::{Debug, Formatter};
+
+/// A list or S-expression in a binary Ion stream whose header has been parsed but whose body
+/// (i.e. its child values) have not. A `LazySequence` is immutable; its data can be read any
+/// number of times.
+///
+/// ```
+///# use ion_rs::IonResult;
+///# fn main() -> IonResult<()> {
+///
+/// // Construct an Element and serialize it as binary Ion.
+/// use ion_rs::element::Element;
+/// use ion_rs::ion_list;
+/// use ion_rs::lazy::binary::lazy_reader::LazyReader;
+///
+/// let element: Element = ion_list! [10, 20, 30].into();
+/// let binary_ion = element.to_binary()?;
+///
+/// let mut lazy_reader = LazyReader::new(&binary_ion)?;
+///
+/// // Get the first value from the stream and confirm that it's a list.
+/// let lazy_list = lazy_reader.expect_next()?.read()?.expect_list()?;
+///
+/// // Visit the values in the list
+/// let mut sum = 0;
+/// for lazy_value in &lazy_list {
+///     // Read each lazy value in the lazy list as an int (i64) and
+///     // add it to the running total
+///     sum += lazy_value?.read()?.expect_i64()?;
+/// }
+///
+/// assert_eq!(sum, 60);
+///
+/// // Note that we can re-read any of the lazy values. Here we'll step into the list again and
+/// // read the first child value.
+/// let first_int = lazy_list.iter().next().unwrap()?.read()?.expect_i64()?;
+/// assert_eq!(first_int, 10);
+///
+///# Ok(())
+///# }
+/// ```
+pub struct LazySequence<'top, 'data> {
+    pub(crate) raw_sequence: LazyRawSequence<'data>,
+    pub(crate) symbol_table: &'top SymbolTable,
+}
+
+impl<'top, 'data> LazySequence<'top, 'data> {
+    /// Returns the [`IonType`] of this sequence.
+    ///
+    /// This will always be either [`IonType::List`] or [`IonType::SExp`].
+    // TODO: We should have a `SequenceType` enum with only those options.
+    pub fn ion_type(&self) -> IonType {
+        self.raw_sequence.ion_type()
+    }
+
+    /// Returns an iterator over the values in this sequence. See: [`LazyValue`].
+    pub fn iter(&self) -> SequenceIterator<'top, 'data> {
+        SequenceIterator {
+            raw_sequence_iter: self.raw_sequence.iter(),
+            symbol_table: self.symbol_table,
+        }
+    }
+
+    /// Returns an iterator over the annotations on this value. If this value has no annotations,
+    /// the resulting iterator will be empty.
+    ///
+    /// ```
+    ///# use ion_rs::IonResult;
+    ///# fn main() -> IonResult<()> {
+    ///
+    /// // Construct an Element and serialize it as binary Ion.
+    /// use ion_rs::element::{Element, IntoAnnotatedElement};
+    /// use ion_rs::{ion_sexp, IonType};
+    /// use ion_rs::lazy::binary::lazy_reader::LazyReader;
+    ///
+    /// let element: Element = ion_sexp!(true false).with_annotations(["foo", "bar", "baz"]);
+    /// let binary_ion = element.to_binary()?;
+    ///
+    /// let mut lazy_reader = LazyReader::new(&binary_ion)?;
+    ///
+    /// // Get the first lazy value from the stream.
+    /// let lazy_sexp = lazy_reader.expect_next()?.read()?.expect_sexp()?;
+    ///
+    /// // Inspect its annotations.
+    /// let mut annotations = lazy_sexp.annotations();
+    /// assert_eq!(annotations.next().unwrap()?, "foo");
+    /// assert_eq!(annotations.next().unwrap()?, "bar");
+    /// assert_eq!(annotations.next().unwrap()?, "baz");
+    ///
+    ///# Ok(())
+    ///# }
+    /// ```
+    pub fn annotations(&self) -> AnnotationsIterator<'top, 'data> {
+        AnnotationsIterator {
+            raw_annotations: self.raw_sequence.value.annotations(),
+            symbol_table: self.symbol_table,
+            initial_offset: self
+                .raw_sequence
+                .value
+                .encoded_value
+                .annotations_offset()
+                .unwrap_or(self.raw_sequence.value.encoded_value.header_offset),
+        }
+    }
+}
+
+impl<'top, 'data> TryFrom<LazySequence<'top, 'data>> for Sequence {
+    type Error = IonError;
+
+    fn try_from(lazy_sequence: LazySequence<'top, 'data>) -> Result<Self, Self::Error> {
+        let sequence: Sequence = lazy_sequence
+            .iter()
+            .map(|v| Element::try_from(v?))
+            .collect::<IonResult<Vec<_>>>()?
+            .into();
+        Ok(sequence)
+    }
+}
+
+impl<'top, 'data> TryFrom<LazySequence<'top, 'data>> for Element {
+    type Error = IonError;
+
+    fn try_from(lazy_sequence: LazySequence<'top, 'data>) -> Result<Self, Self::Error> {
+        let ion_type = lazy_sequence.ion_type();
+        let annotations: Annotations = lazy_sequence.annotations().try_into()?;
+        let sequence: Sequence = lazy_sequence.try_into()?;
+        let value = match ion_type {
+            IonType::SExp => Value::SExp(sequence),
+            IonType::List => Value::List(sequence),
+            _ => unreachable!("no other IonTypes are sequences"),
+        };
+        Ok(value.with_annotations(annotations))
+    }
+}
+
+impl<'a, 'top, 'data> IntoIterator for &'a LazySequence<'top, 'data> {
+    type Item = IonResult<LazyValue<'top, 'data>>;
+    type IntoIter = SequenceIterator<'top, 'data>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+pub struct SequenceIterator<'top, 'data> {
+    raw_sequence_iter: RawSequenceIterator<'data>,
+    symbol_table: &'top SymbolTable,
+}
+
+impl<'top, 'data> Iterator for SequenceIterator<'top, 'data> {
+    type Item = IonResult<LazyValue<'top, 'data>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let raw_value = match self.raw_sequence_iter.next() {
+            Some(Ok(raw_value)) => raw_value,
+            Some(Err(e)) => return Some(Err(e)),
+            None => return None,
+        };
+
+        let lazy_value = LazyValue {
+            raw_value,
+            symbol_table: self.symbol_table,
+        };
+        Some(Ok(lazy_value))
+    }
+}
+
+impl<'top, 'data> Debug for LazySequence<'top, 'data> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self.ion_type() {
+            IonType::SExp => {
+                write!(f, "(")?;
+                for value in self {
+                    write!(
+                        f,
+                        "{:?} ",
+                        value
+                            .map_err(|_| fmt::Error)?
+                            .read()
+                            .map_err(|_| fmt::Error)?
+                    )?;
+                }
+                write!(f, ")")?;
+            }
+            IonType::List => {
+                write!(f, "[")?;
+                for value in self {
+                    write!(
+                        f,
+                        "{:?},",
+                        value
+                            .map_err(|_| fmt::Error)?
+                            .read()
+                            .map_err(|_| fmt::Error)?
+                    )?;
+                }
+                write!(f, "]")?;
+            }
+            _ => unreachable!("LazySequence is only created for list and sexp"),
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::element::Element;
+    use crate::lazy::binary::lazy_reader::LazyReader;
+    use crate::lazy::binary::test_utilities::to_binary_ion;
+    use crate::IonResult;
+
+    #[test]
+    fn annotations() -> IonResult<()> {
+        let binary_ion = to_binary_ion("foo::bar::baz::[1, 2, 3]")?;
+        let mut reader = LazyReader::new(&binary_ion)?;
+        let list = reader.expect_next()?.read()?.expect_list()?;
+        assert!(list.annotations().are(["foo", "bar", "baz"])?);
+        list.annotations().expect(["foo", "bar", "baz"])?;
+        Ok(())
+    }
+
+    #[test]
+    fn try_into_element() -> IonResult<()> {
+        let ion_text = "foo::baz::baz::[1, 2, 3]";
+        let binary_ion = to_binary_ion(ion_text)?;
+        let mut reader = LazyReader::new(&binary_ion)?;
+        let list = reader.expect_next()?.read()?.expect_list()?;
+        let result: IonResult<Element> = list.try_into();
+        assert!(result.is_ok());
+        assert_eq!(result?, Element::read_one(ion_text)?);
+        Ok(())
+    }
+
+    #[test]
+    fn try_into_element_error() -> IonResult<()> {
+        let mut binary_ion = to_binary_ion("foo::baz::baz::[1, 2, 3]")?;
+        let _oops_i_lost_a_byte = binary_ion.pop().unwrap();
+        let mut reader = LazyReader::new(&binary_ion)?;
+        let list = reader.expect_next()?.read()?.expect_list()?;
+        // Conversion will fail because the reader will encounter an unexpected end of input
+        let result: IonResult<Element> = list.try_into();
+        assert!(result.is_err());
+        Ok(())
+    }
+}

--- a/src/lazy/binary/system/lazy_struct.rs
+++ b/src/lazy/binary/system/lazy_struct.rs
@@ -1,0 +1,430 @@
+use crate::element::builders::StructBuilder;
+use crate::element::{Annotations, Element, IntoAnnotatedElement, Struct};
+use crate::lazy::binary::raw::lazy_raw_struct::{LazyRawStruct, RawStructIterator};
+use crate::lazy::binary::system::lazy_value::AnnotationsIterator;
+use crate::lazy::binary::system::lazy_value::LazyValue;
+use crate::lazy::value_ref::ValueRef;
+use crate::result::decoding_error_raw;
+use crate::{IonError, IonResult, SymbolRef, SymbolTable};
+use std::fmt;
+use std::fmt::{Debug, Formatter};
+
+/// An as-of-yet unread binary Ion struct. `LazyStruct` is immutable; its fields and annotations
+/// can be read any number of times.
+///
+/// ```
+///# use ion_rs::IonResult;
+///# fn main() -> IonResult<()> {
+/// use nom::AsBytes;
+/// use ion_rs::{BinaryWriterBuilder, ion_struct, IonType};
+/// use ion_rs::element::Element;
+/// use ion_rs::lazy::binary::lazy_reader::LazyReader;
+/// use ion_rs::lazy::value_ref::ValueRef;
+///
+/// let ion_data = r#"{foo: 1, bar: 2, foo: 3, bar: 4}"#;
+/// let ion_bytes: Vec<u8> = Element::read_one(ion_data)?.to_binary()?;
+/// let mut reader = LazyReader::new(&ion_bytes)?;
+///
+/// // Advance the reader to the first value and confirm it's a struct
+/// let lazy_struct = reader.expect_next()?.read()?.expect_struct()?;
+///
+/// // Add up the integer values of all the fields named 'foo'
+/// let mut foo_sum = 0i64;
+/// for field in &lazy_struct {
+///     let field = field?;
+///     if field.name()? == "foo" {
+///         foo_sum += field.value().read()?.expect_i64()?;
+///     }
+/// }
+///
+/// assert_eq!(foo_sum, 4);
+///# Ok(())
+///# }
+/// ```
+pub struct LazyStruct<'top, 'data> {
+    pub(crate) raw_struct: LazyRawStruct<'data>,
+    pub(crate) symbol_table: &'top SymbolTable,
+}
+
+// Best-effort debug formatting for LazyStruct. Any failures that occur during reading will result
+// in the output being silently truncated.
+impl<'top, 'data> Debug for LazyStruct<'top, 'data> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{{")?;
+        for field in self {
+            let field = field.map_err(|_| fmt::Error)?;
+            let name = field.name().map_err(|_| fmt::Error)?;
+            let lazy_value = field.value();
+            let value = lazy_value.read().map_err(|_| fmt::Error)?;
+            write!(f, "{}:{:?},", name.text().unwrap_or("$0"), value)?;
+        }
+        write!(f, "}}")?;
+        Ok(())
+    }
+}
+
+impl<'top, 'data> LazyStruct<'top, 'data> {
+    /// Returns an iterator over this struct's fields. See [`LazyField`].
+    pub fn iter(&self) -> StructIterator<'top, 'data> {
+        StructIterator {
+            raw_struct_iter: self.raw_struct.iter(),
+            symbol_table: self.symbol_table,
+        }
+    }
+
+    /// Returns the value of the first field with the specified name, if any. The returned value is
+    /// a [`LazyValue`]. Its type and annotations can be inspected without calling [LazyValue::read].
+    ///
+    /// Because the `LazyStruct` does not store materialized values, it must seek over its fields
+    /// to find one with the requested name, giving this method linear time complexity.
+    /// ```
+    ///# use ion_rs::IonResult;
+    ///# fn main() -> IonResult<()> {
+    /// use ion_rs::element::Element;
+    /// use ion_rs::IonType;
+    /// use ion_rs::lazy::binary::lazy_reader::LazyReader;
+    /// use ion_rs::lazy::value_ref::ValueRef;
+    ///
+    /// let ion_data = r#"{foo: "hello", bar: quux::5, baz: null, bar: false}"#;
+    /// let ion_bytes: Vec<u8> = Element::read_one(ion_data)?.to_binary()?;
+    /// let mut reader = LazyReader::new(&ion_bytes)?;
+    ///
+    /// let lazy_struct = reader.expect_next()?.read()?.expect_struct()?;
+    ///
+    /// assert!(lazy_struct.find("foo")?.is_some());
+    /// assert!(lazy_struct.find("Ontario")?.is_none());
+    ///
+    /// // There are two 'bar' fields; `find` will return the value of the first.
+    /// let value = lazy_struct.find("bar")?.unwrap();
+    ///
+    /// assert!(value.annotations().next().unwrap()? == "quux");
+    /// assert_eq!(value.read()?, ValueRef::Int(5.into()));
+    ///
+    ///# Ok(())
+    ///# }
+    /// ```
+    pub fn find(&self, name: &str) -> IonResult<Option<LazyValue<'top, 'data>>> {
+        for field in self {
+            let field = field?;
+            if field.name()? == name {
+                let value = field.value;
+                return Ok(Some(value));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Like [`LazyStruct::find`], but returns an [`IonError::DecodingError`] if no field with the
+    /// specified name is found.
+    /// ```
+    ///# use ion_rs::IonResult;
+    ///# fn main() -> IonResult<()> {
+    /// use ion_rs::element::Element;
+    /// use ion_rs::IonType;
+    /// use ion_rs::lazy::binary::lazy_reader::LazyReader;
+    /// use ion_rs::lazy::value_ref::ValueRef;
+    ///
+    /// let ion_data = r#"{foo: "hello", bar: quux::5, baz: null, bar: false}"#;
+    /// let ion_bytes: Vec<u8> = Element::read_one(ion_data)?.to_binary()?;
+    /// let mut reader = LazyReader::new(&ion_bytes)?;
+    ///
+    /// let lazy_struct = reader.expect_next()?.read()?.expect_struct()?;
+    ///
+    /// assert!(lazy_struct.find_expected("foo").is_ok());
+    /// assert!(lazy_struct.find_expected("Ontario").is_err());
+    ///
+    ///# Ok(())
+    ///# }
+    /// ```
+    pub fn find_expected(&self, name: &str) -> IonResult<LazyValue<'top, 'data>> {
+        self.find(name)?
+            .ok_or_else(|| decoding_error_raw(format!("missing required field {}", name)))
+    }
+
+    /// Like [`LazyStruct::find`], but eagerly calls [`LazyValue::read`] on the first field with a
+    /// matching name.
+    /// ```
+    ///# use ion_rs::IonResult;
+    ///# fn main() -> IonResult<()> {
+    /// use ion_rs::element::Element;
+    /// use ion_rs::IonType;
+    /// use ion_rs::lazy::binary::lazy_reader::LazyReader;
+    /// use ion_rs::lazy::value_ref::ValueRef;
+    ///
+    /// let ion_data = r#"{foo: "hello", bar: null.list, baz: 3, bar: 4}"#;
+    /// let ion_bytes = Element::read_one(ion_data)?.to_binary()?;
+    /// let mut reader = LazyReader::new(&ion_bytes)?;
+    ///
+    /// let lazy_struct = reader.expect_next()?.read()?.expect_struct()?;
+    ///
+    /// assert_eq!(lazy_struct.get("foo")?, Some(ValueRef::String("hello")));
+    /// assert_eq!(lazy_struct.get("baz")?, Some(ValueRef::Int(3.into())));
+    /// assert_eq!(lazy_struct.get("bar")?, Some(ValueRef::Null(IonType::List)));
+    ///# Ok(())
+    ///# }
+    /// ```
+    pub fn get(&self, name: &str) -> IonResult<Option<ValueRef<'top, 'data>>>
+    where
+        'data: 'top,
+    {
+        self.find(name)?.map(|f| f.read()).transpose()
+    }
+
+    /// Like [`LazyStruct::get`], but returns an [`IonError::DecodingError`] if no field with the
+    /// specified name is found.
+    /// ```
+    ///# use ion_rs::IonResult;
+    ///# fn main() -> IonResult<()> {
+    /// use ion_rs::element::Element;
+    /// use ion_rs::IonType;
+    /// use ion_rs::lazy::binary::lazy_reader::LazyReader;
+    /// use ion_rs::lazy::value_ref::ValueRef;
+    ///
+    /// let ion_data = r#"{foo: "hello", bar: null.list, baz: 3, bar: 4}"#;
+    /// let ion_bytes = Element::read_one(ion_data)?.to_binary()?;
+    /// let mut reader = LazyReader::new(&ion_bytes)?;
+    ///
+    /// let lazy_struct = reader.expect_next()?.read()?.expect_struct()?;
+    ///
+    /// assert_eq!(lazy_struct.get_expected("foo")?, ValueRef::String("hello"));
+    /// assert!(dbg!(lazy_struct.get_expected("Ontario")).is_err());
+    ///# Ok(())
+    ///# }
+    /// ```
+    pub fn get_expected(&self, name: &str) -> IonResult<ValueRef<'top, 'data>>
+    where
+        'data: 'top,
+    {
+        self.get(name)?
+            .ok_or_else(move || decoding_error_raw(format!("missing required field {}", name)))
+    }
+
+    /// Returns an iterator over the annotations on this value. If this value has no annotations,
+    /// the resulting iterator will be empty.
+    ///
+    /// ```
+    ///# use ion_rs::IonResult;
+    ///# fn main() -> IonResult<()> {
+    ///
+    /// // Construct an Element and serialize it as binary Ion.
+    /// use ion_rs::element::{Element, IntoAnnotatedElement};
+    /// use ion_rs::{ion_struct, IonType};
+    /// use ion_rs::lazy::binary::lazy_reader::LazyReader;
+    ///
+    /// let element: Element = ion_struct! {"foo": 1, "bar": 2}.with_annotations(["foo", "bar", "baz"]);
+    /// let binary_ion = element.to_binary()?;
+    ///
+    /// let mut lazy_reader = LazyReader::new(&binary_ion)?;
+    ///
+    /// // Get the first lazy value from the stream.
+    /// let lazy_struct = lazy_reader.expect_next()?.read()?.expect_struct()?;
+    ///
+    /// // Inspect its annotations.
+    /// let mut annotations = lazy_struct.annotations();
+    /// assert_eq!(annotations.next().unwrap()?, "foo");
+    /// assert_eq!(annotations.next().unwrap()?, "bar");
+    /// assert_eq!(annotations.next().unwrap()?, "baz");
+    ///
+    ///# Ok(())
+    ///# }
+    /// ```
+    pub fn annotations(&self) -> AnnotationsIterator<'top, 'data> {
+        AnnotationsIterator {
+            raw_annotations: self.raw_struct.value.annotations(),
+            symbol_table: self.symbol_table,
+            initial_offset: self
+                .raw_struct
+                .value
+                .encoded_value
+                .annotations_offset()
+                .unwrap_or(self.raw_struct.value.encoded_value.header_offset),
+        }
+    }
+}
+
+/// A single field within a [`LazyStruct`].
+pub struct LazyField<'top, 'data> {
+    pub(crate) value: LazyValue<'top, 'data>,
+}
+
+impl<'top, 'data> Debug for LazyField<'top, 'data> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}: {:?}",
+            self.name().map_err(|_| fmt::Error)?.text().unwrap_or("$0"),
+            self.value().read().map_err(|_| fmt::Error)?,
+        )
+    }
+}
+
+impl<'top, 'data> LazyField<'top, 'data> {
+    /// Returns a symbol representing the name of this field.
+    pub fn name(&self) -> IonResult<SymbolRef<'top>> {
+        let field_sid = self.value.raw_value.field_name().unwrap();
+        self.value
+            .symbol_table
+            .symbol_for(field_sid)
+            .map(|symbol| symbol.into())
+            .ok_or_else(|| decoding_error_raw("found a symbol ID that was not in the symbol table"))
+    }
+
+    /// Returns a lazy value representing the value of this field. To access the value's data,
+    /// see [`LazyValue::read`].
+    pub fn value(&self) -> &LazyValue<'top, 'data> {
+        &self.value
+    }
+}
+
+pub struct StructIterator<'top, 'data> {
+    pub(crate) raw_struct_iter: RawStructIterator<'data>,
+    pub(crate) symbol_table: &'top SymbolTable,
+}
+
+impl<'top, 'data> Iterator for StructIterator<'top, 'data> {
+    type Item = IonResult<LazyField<'top, 'data>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        StructIterator::next_field(self).transpose()
+    }
+}
+
+impl<'top, 'data> StructIterator<'top, 'data> {
+    pub fn next_field(&mut self) -> IonResult<Option<LazyField<'top, 'data>>> {
+        let raw_field = match self.raw_struct_iter.next() {
+            Some(raw_field) => raw_field?,
+            None => return Ok(None),
+        };
+
+        let lazy_value = LazyValue {
+            raw_value: raw_field.into_value(),
+            symbol_table: self.symbol_table,
+        };
+        let lazy_field = LazyField { value: lazy_value };
+        Ok(Some(lazy_field))
+    }
+}
+
+impl<'top, 'data> TryFrom<LazyStruct<'top, 'data>> for Struct {
+    type Error = IonError;
+
+    fn try_from(lazy_struct: LazyStruct<'top, 'data>) -> Result<Self, Self::Error> {
+        let mut builder = StructBuilder::new();
+        for field in &lazy_struct {
+            let field = field?;
+            builder = builder.with_field(field.name()?, Element::try_from(field.value().clone())?);
+        }
+        Ok(builder.build())
+    }
+}
+
+impl<'top, 'data> TryFrom<LazyStruct<'top, 'data>> for Element {
+    type Error = IonError;
+
+    fn try_from(lazy_struct: LazyStruct<'top, 'data>) -> Result<Self, Self::Error> {
+        let annotations: Annotations = lazy_struct.annotations().try_into()?;
+        let struct_: Struct = lazy_struct.try_into()?;
+        Ok(struct_.with_annotations(annotations))
+    }
+}
+
+impl<'a, 'top, 'data> IntoIterator for &'a LazyStruct<'top, 'data> {
+    type Item = IonResult<LazyField<'top, 'data>>;
+    type IntoIter = StructIterator<'top, 'data>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lazy::binary::lazy_reader::LazyReader;
+    use crate::lazy::binary::test_utilities::to_binary_ion;
+
+    #[test]
+    fn find() -> IonResult<()> {
+        let ion_data = to_binary_ion("{foo: 1, bar: 2, baz: 3}")?;
+        let mut reader = LazyReader::new(&ion_data)?;
+        let struct_ = reader.expect_next()?.read()?.expect_struct()?;
+        let baz = struct_.find("baz")?;
+        assert!(baz.is_some());
+        assert_eq!(baz.unwrap().read()?, ValueRef::Int(3.into()));
+        let quux = struct_.get("quux")?;
+        assert_eq!(quux, None);
+        Ok(())
+    }
+
+    #[test]
+    fn find_expected() -> IonResult<()> {
+        let ion_data = to_binary_ion("{foo: 1, bar: 2, baz: 3}")?;
+        let mut reader = LazyReader::new(&ion_data)?;
+        let struct_ = reader.expect_next()?.read()?.expect_struct()?;
+        let baz = struct_.find_expected("baz");
+        assert!(baz.is_ok());
+        assert_eq!(baz.unwrap().read()?, ValueRef::Int(3.into()));
+        let quux = struct_.find_expected("quux");
+        assert!(quux.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn get() -> IonResult<()> {
+        let ion_data = to_binary_ion("{foo: 1, bar: 2, baz: 3}")?;
+        let mut reader = LazyReader::new(&ion_data)?;
+        let struct_ = reader.expect_next()?.read()?.expect_struct()?;
+        let baz = struct_.get("baz")?;
+        assert_eq!(baz, Some(ValueRef::Int(3.into())));
+        let quux = struct_.get("quux")?;
+        assert_eq!(quux, None);
+        Ok(())
+    }
+
+    #[test]
+    fn get_expected() -> IonResult<()> {
+        let ion_data = to_binary_ion("{foo: 1, bar: 2, baz: 3}")?;
+        let mut reader = LazyReader::new(&ion_data)?;
+        let struct_ = reader.expect_next()?.read()?.expect_struct()?;
+        let baz = struct_.get_expected("baz");
+        assert_eq!(baz, Ok(ValueRef::Int(3.into())));
+        let quux = struct_.get_expected("quux");
+        assert!(quux.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn annotations() -> IonResult<()> {
+        let ion_data = to_binary_ion("a::b::c::{foo: 1, bar: 2, baz: quux::quuz::3}")?;
+        let mut reader = LazyReader::new(&ion_data)?;
+        let struct_ = reader.expect_next()?.read()?.expect_struct()?;
+        assert!(struct_.annotations().are(["a", "b", "c"])?);
+        let baz = struct_.find_expected("baz")?;
+        assert!(baz.annotations().are(["quux", "quuz"])?);
+        Ok(())
+    }
+
+    #[test]
+    fn try_into_element() -> IonResult<()> {
+        let ion_text = "foo::baz::baz::{a: 1, b: 2, c: 3}";
+        let binary_ion = to_binary_ion(ion_text)?;
+        let mut reader = LazyReader::new(&binary_ion)?;
+        let struct_ = reader.expect_next()?.read()?.expect_struct()?;
+        let result: IonResult<Element> = struct_.try_into();
+        assert!(result.is_ok());
+        assert_eq!(result?, Element::read_one(ion_text)?);
+        Ok(())
+    }
+
+    #[test]
+    fn try_into_element_error() -> IonResult<()> {
+        let mut binary_ion = to_binary_ion("foo::baz::baz::{a: 1, b: 2, c: 3}")?;
+        let _oops_i_lost_a_byte = binary_ion.pop().unwrap();
+        let mut reader = LazyReader::new(&binary_ion)?;
+        let struct_ = reader.expect_next()?.read()?.expect_struct()?;
+        // Conversion will fail because the reader will encounter an unexpected end of input
+        let result: IonResult<Element> = struct_.try_into();
+        assert!(result.is_err());
+        Ok(())
+    }
+}

--- a/src/lazy/binary/system/lazy_system_reader.rs
+++ b/src/lazy/binary/system/lazy_system_reader.rs
@@ -1,0 +1,353 @@
+use crate::result::decoding_error;
+use crate::{IonResult, IonType, RawSymbolTokenRef, SymbolTable};
+
+use crate::lazy::binary::raw::lazy_raw_reader::LazyRawReader;
+use crate::lazy::binary::raw::lazy_raw_struct::LazyRawStruct;
+use crate::lazy::binary::raw::lazy_raw_value::LazyRawValue;
+
+use crate::lazy::binary::system::lazy_struct::LazyStruct;
+use crate::lazy::binary::system::lazy_value::LazyValue;
+use crate::lazy::raw_stream_item::RawStreamItem;
+use crate::lazy::raw_value_ref::RawValueRef;
+use crate::lazy::system_stream_item::SystemStreamItem;
+
+// Symbol IDs used for processing symbol table structs
+const ION_SYMBOL_TABLE: RawSymbolTokenRef = RawSymbolTokenRef::SymbolId(3);
+const IMPORTS: RawSymbolTokenRef = RawSymbolTokenRef::SymbolId(6);
+const SYMBOLS: RawSymbolTokenRef = RawSymbolTokenRef::SymbolId(7);
+
+/// A binary reader that only reads each value that it visits upon request (that is: lazily).
+///
+/// Unlike [`crate::lazy::binary::lazy_reader::LazyReader`], which only exposes values that are part
+/// of the application data model, [`LazySystemReader`] also yields Ion version markers
+/// (as [`SystemStreamItem::VersionMarker`]) and structs representing a symbol table (as
+/// [`SystemStreamItem::SymbolTable`]).
+///
+/// Each time [`LazySystemReader::next_item`] is called, the reader will advance to the next top-level
+/// value in the input stream. Once positioned on a top-level value, users may visit nested values by
+/// calling [`LazyValue::read`] and working with the resulting [`crate::lazy::value_ref::ValueRef`],
+/// which may contain either a scalar value or a lazy container that may itself be traversed.
+///
+/// The values that the reader yields ([`LazyValue`],
+/// [`crate::lazy::binary::system::lazy_sequence::LazySequence`], and [`LazyStruct`]) are immutable
+/// references to the data stream, and remain valid until [`LazySystemReader::next_item`] is
+/// called again to advance the reader to the next top level value. This means that these references
+/// can be stored, read, and re-read as long as the reader remains on the same top-level value.
+/// ```
+///# use ion_rs::IonResult;
+///# fn main() -> IonResult<()> {
+///
+/// // Construct an Element and serialize it as binary Ion.
+/// use ion_rs::element::Element;
+/// use ion_rs::ion_list;
+/// use ion_rs::lazy::binary::lazy_reader::LazyReader;
+///
+/// let element: Element = ion_list! [10, 20, 30].into();
+/// let binary_ion = element.to_binary()?;
+///
+/// let mut lazy_reader = LazyReader::new(&binary_ion)?;
+///
+/// // Get the first value from the stream and confirm that it's a list.
+/// let lazy_list = lazy_reader.expect_next()?.read()?.expect_list()?;
+///
+/// // Visit the values in the list
+/// let mut sum = 0;
+/// for lazy_value in &lazy_list {
+///     // Read each lazy value in the lazy list as an int (i64) and
+///     // add it to the running total
+///     sum += lazy_value?.read()?.expect_i64()?;
+/// }
+///
+/// assert_eq!(sum, 60);
+///
+/// // Note that we can re-read any of the lazy values. Here we'll step into the list again and
+/// // read the first child value.
+/// let first_int = lazy_list.iter().next().unwrap()?.read()?.expect_i64()?;
+/// assert_eq!(first_int, 10);
+///
+///# Ok(())
+///# }
+/// ```
+pub struct LazySystemReader<'data> {
+    raw_reader: LazyRawReader<'data>,
+    symbol_table: SymbolTable,
+    pending_lst: PendingLst,
+}
+
+// If the reader encounters a symbol table in the stream, it will store all of the symbols that
+// the table defines in this structure so that they may be applied when the reader next advances.
+struct PendingLst {
+    is_lst_append: bool,
+    symbols: Vec<Option<String>>,
+}
+
+impl<'data> LazySystemReader<'data> {
+    pub(crate) fn new(ion_data: &'data [u8]) -> LazySystemReader<'data> {
+        let raw_reader = LazyRawReader::new(ion_data);
+        LazySystemReader {
+            raw_reader,
+            symbol_table: SymbolTable::new(),
+            pending_lst: PendingLst {
+                is_lst_append: false,
+                symbols: Vec::new(),
+            },
+        }
+    }
+
+    // Returns `true` if the provided [`LazyRawValue`] is a struct whose first annotation is
+    // `$ion_symbol_table`.
+    fn is_symbol_table_struct(lazy_value: &LazyRawValue) -> IonResult<bool> {
+        if lazy_value.ion_type() != IonType::Struct {
+            return Ok(false);
+        }
+        if let Some(symbol_ref) = lazy_value.annotations().next() {
+            return Ok(symbol_ref? == ION_SYMBOL_TABLE);
+        };
+        Ok(false)
+    }
+
+    /// Returns the next top-level stream item (IVM, Symbol Table, Value, or Nothing) as a
+    /// [`SystemStreamItem`].
+    pub fn next_item<'top>(&'top mut self) -> IonResult<SystemStreamItem<'top, 'data>> {
+        let LazySystemReader {
+            raw_reader,
+            symbol_table,
+            pending_lst,
+        } = self;
+        Self::apply_pending_lst(symbol_table, pending_lst);
+        let lazy_raw_value = match raw_reader.next()? {
+            RawStreamItem::VersionMarker(major, minor) => {
+                return Ok(SystemStreamItem::VersionMarker(major, minor));
+            }
+            RawStreamItem::Value(lazy_raw_value) => lazy_raw_value,
+            RawStreamItem::Nothing => return Ok(SystemStreamItem::Nothing),
+        };
+        if Self::is_symbol_table_struct(&lazy_raw_value)? {
+            Self::process_symbol_table(pending_lst, &lazy_raw_value)?;
+            let lazy_struct = LazyStruct {
+                raw_struct: LazyRawStruct {
+                    value: lazy_raw_value,
+                },
+                symbol_table,
+            };
+            return Ok(SystemStreamItem::SymbolTable(lazy_struct));
+        }
+        let lazy_value = LazyValue::new(symbol_table, lazy_raw_value);
+        Ok(SystemStreamItem::Value(lazy_value))
+    }
+
+    /// Returns the next value that is part of the application data model, bypassing all encoding
+    /// artifacts (IVMs, symbol tables).
+    // It would make more sense for this logic to live in the user-level `LazyReader` as a simple
+    // loop over LazySystemReader::next. However, due to a limitation in the borrow checker[1], it's
+    // not able to determine that calling LazySystemReader::next() multiple times in the same lexical
+    // scope is safe. Rust's experimental borrow checker, Polonius, is able to understand it.
+    // Until Polonius is available, the method will live here instead.
+    // [1]: https://github.com/rust-lang/rust/issues/70255
+    pub fn next_value<'top>(&'top mut self) -> IonResult<Option<LazyValue<'top, 'data>>> {
+        let LazySystemReader {
+            raw_reader,
+            symbol_table,
+            pending_lst,
+        } = self;
+        loop {
+            Self::apply_pending_lst(symbol_table, pending_lst);
+            let lazy_raw_value = match raw_reader.next()? {
+                RawStreamItem::VersionMarker(_, _) => continue,
+                RawStreamItem::Value(lazy_raw_value) => lazy_raw_value,
+                RawStreamItem::Nothing => return Ok(None),
+            };
+            if Self::is_symbol_table_struct(&lazy_raw_value)? {
+                // process the symbol table, but do not surface it
+                Self::process_symbol_table(pending_lst, &lazy_raw_value)?;
+            } else {
+                return Ok(Some(LazyValue::new(symbol_table, lazy_raw_value)));
+            }
+        }
+    }
+
+    // If the last stream item the reader visited was a symbol table, its `PendingLst` will
+    // contain new symbols that need to be added to the local symbol table.
+    fn apply_pending_lst(symbol_table: &mut SymbolTable, pending_lst: &mut PendingLst) {
+        // `is_empty()` will be true if the last item was not a symbol table OR if it was a symbol
+        // table but did not define new symbols. In either case, there's nothing for us to do.
+        if pending_lst.symbols.is_empty() {
+            return;
+        }
+        // If the symbol table's `imports` field had a value of `$ion_symbol_table`, then we're
+        // appending the symbols it defined to the end of our existing local symbol table.
+        // Otherwise, we need to clear the existing table before appending the new symbols.
+        if !pending_lst.is_lst_append {
+            // We're setting the symbols list, not appending to it.
+            symbol_table.reset();
+        }
+        // `drain()` empties the pending symbols list
+        for symbol in pending_lst.symbols.drain(..) {
+            symbol_table.intern_or_add_placeholder(symbol);
+        }
+        pending_lst.is_lst_append = false;
+    }
+
+    // Traverses a symbol table, processing the `symbols` and `imports` fields as needed to
+    // populate the `PendingLst`.
+    fn process_symbol_table(
+        pending_lst: &mut PendingLst,
+        symbol_table: &LazyRawValue,
+    ) -> IonResult<()> {
+        // We've already confirmed this is an annotated struct
+        let symbol_table = symbol_table.read()?.expect_struct()?;
+        // Assume it's not an LST append unless we found `imports: $ion_symbol_table`
+        pending_lst.is_lst_append = false;
+        // let mut fields = symbol_table.iter();
+        let mut found_symbols_field = false;
+        let mut found_imports_field = false;
+
+        for field in &symbol_table {
+            let field = field?;
+            if field.name() == SYMBOLS {
+                if found_symbols_field {
+                    return decoding_error("found symbol table with multiple 'symbols' fields");
+                }
+                found_symbols_field = true;
+                Self::process_symbols(pending_lst, field.value())?;
+            }
+            if field.name() == IMPORTS {
+                if found_imports_field {
+                    return decoding_error("found symbol table with multiple 'imports' fields");
+                }
+                found_imports_field = true;
+                Self::process_imports(pending_lst, field.value())?;
+            }
+            // Ignore other fields
+        }
+        Ok(())
+    }
+
+    // Store any strings defined in the `symbols` field in the `PendingLst` for future application.
+    fn process_symbols(pending_lst: &mut PendingLst, symbols: &LazyRawValue) -> IonResult<()> {
+        if let RawValueRef::List(list) = symbols.read()? {
+            for symbol_text in &list {
+                if let RawValueRef::String(text) = symbol_text?.read()? {
+                    pending_lst.symbols.push(Some(text.to_owned()))
+                } else {
+                    pending_lst.symbols.push(None)
+                }
+            }
+        }
+        // Nulls and non-list values are ignored.
+        Ok(())
+    }
+
+    // Check for `imports: $ion_symbol_table`.
+    fn process_imports(pending_lst: &mut PendingLst, imports: &LazyRawValue) -> IonResult<()> {
+        match imports.read()? {
+            RawValueRef::Symbol(symbol_ref) => {
+                if symbol_ref == RawSymbolTokenRef::SymbolId(3) {
+                    pending_lst.is_lst_append = true;
+                }
+                // Any other symbol is ignored
+            }
+            // TODO: Implement shared symbol table imports
+            RawValueRef::List(_) => {
+                return decoding_error(
+                    "This implementation does not yet support shared symbol table imports",
+                );
+            }
+            _ => {
+                // Nulls and other types are ignored
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lazy::binary::test_utilities::to_binary_ion;
+    use crate::lazy::system_stream_item::SystemStreamItem;
+    use crate::IonResult;
+
+    #[test]
+    fn try_it() -> IonResult<()> {
+        let ion_data = to_binary_ion(
+            r#"
+        foo
+        bar
+        $ion_symbol_table
+        baz
+        name
+        gary
+        imports
+        hello
+        "#,
+        )?;
+        let mut system_reader = LazySystemReader::new(&ion_data);
+        loop {
+            match system_reader.next_item()? {
+                SystemStreamItem::VersionMarker(major, minor) => {
+                    println!("ivm => v{}.{}", major, minor)
+                }
+                SystemStreamItem::SymbolTable(ref s) => println!("symtab => {:?}", s),
+                SystemStreamItem::Value(ref v) => println!("value => {:?}", v.read()?),
+                SystemStreamItem::Nothing => break,
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn sequence_iter() -> IonResult<()> {
+        let ion_data = to_binary_ion(
+            r#"
+        (
+          (foo baz baz)
+          (1 2 3)
+          (a b c)
+        )
+        "#,
+        )?;
+        let mut system_reader = LazySystemReader::new(&ion_data);
+        loop {
+            match system_reader.next_item()? {
+                SystemStreamItem::Value(value) => {
+                    for value in &value.read()?.expect_sexp()? {
+                        println!("{:?}", value?.read()?);
+                    }
+                }
+                SystemStreamItem::Nothing => break,
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn struct_iter() -> IonResult<()> {
+        let ion_data = to_binary_ion(
+            r#"
+        {
+          foo: 1,
+          bar: true,
+          baz: null.symbol,
+          quux: "hello"
+        }
+        "#,
+        )?;
+        let mut system_reader = LazySystemReader::new(&ion_data);
+        loop {
+            match system_reader.next_item()? {
+                SystemStreamItem::Value(value) => {
+                    for field in &value.read()?.expect_struct()? {
+                        let field = field?;
+                        println!("{:?}: {:?},", field.name()?, field.value().read()?);
+                    }
+                }
+                SystemStreamItem::Nothing => break,
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/lazy/binary/system/lazy_value.rs
+++ b/src/lazy/binary/system/lazy_value.rs
@@ -1,0 +1,447 @@
+use crate::element::{Annotations, Element, IntoAnnotatedElement, Value};
+use crate::lazy::binary::raw::lazy_raw_value::LazyRawValue;
+use crate::lazy::binary::raw::raw_annotations_iterator::RawAnnotationsIterator;
+use crate::lazy::value_ref::ValueRef;
+use crate::result::decoding_error;
+use crate::symbol_ref::AsSymbolRef;
+use crate::{IonError, IonResult, IonType, RawSymbolTokenRef, SymbolRef, SymbolTable};
+
+/// A value in a binary Ion stream whose header has been parsed but whose body (i.e. its data) has
+/// not. A `LazyValue` is immutable; its data can be read any number of times.
+///
+/// ```
+///# use ion_rs::IonResult;
+///# fn main() -> IonResult<()> {
+///
+/// // Construct an Element and serialize it as binary Ion.
+/// use ion_rs::element::Element;
+/// use ion_rs::ion_list;
+/// use ion_rs::lazy::binary::lazy_reader::LazyReader;
+///
+/// let element: Element = ion_list! [10, 20, 30].into();
+/// let binary_ion = element.to_binary()?;
+///
+/// let mut lazy_reader = LazyReader::new(&binary_ion)?;
+///
+/// // Get the first value from the stream and confirm that it's a list.
+/// let lazy_list = lazy_reader.expect_next()?.read()?.expect_list()?;
+///
+/// // Visit the values in the list
+/// let mut sum = 0;
+/// for lazy_value in &lazy_list {
+///     // Read each lazy value in the lazy list as an int (i64) and
+///     // add it to the running total
+///     sum += lazy_value?.read()?.expect_i64()?;
+/// }
+///
+/// assert_eq!(sum, 60);
+///
+/// // Note that we can re-read any of the lazy values. Here we'll step into the list again and
+/// // read the first child value.
+/// let first_int = lazy_list.iter().next().unwrap()?.read()?.expect_i64()?;
+/// assert_eq!(first_int, 10);
+///
+///# Ok(())
+///# }
+/// ```
+#[derive(Clone)]
+pub struct LazyValue<'top, 'data> {
+    pub(crate) raw_value: LazyRawValue<'data>,
+    pub(crate) symbol_table: &'top SymbolTable,
+}
+
+impl<'top, 'data> LazyValue<'top, 'data> {
+    pub(crate) fn new(
+        symbol_table: &'top SymbolTable,
+        raw_value: LazyRawValue<'data>,
+    ) -> LazyValue<'top, 'data> {
+        LazyValue {
+            raw_value,
+            symbol_table,
+        }
+    }
+
+    /// Returns the [`IonType`] of this value.
+    /// ```
+    ///# use ion_rs::IonResult;
+    ///# fn main() -> IonResult<()> {
+    ///
+    /// // Construct an Element and serialize it as binary Ion.
+    /// use ion_rs::element::Element;
+    /// use ion_rs::IonType;
+    /// use ion_rs::lazy::binary::lazy_reader::LazyReader;
+    ///
+    /// let element: Element = "hello".into();
+    /// let binary_ion = element.to_binary()?;
+    ///
+    /// let mut lazy_reader = LazyReader::new(&binary_ion)?;
+    ///
+    /// // Get the first lazy value from the stream.
+    /// let lazy_value = lazy_reader.expect_next()?;
+    ///
+    /// // Check its type
+    /// assert_eq!(lazy_value.ion_type(), IonType::String);
+    ///
+    ///# Ok(())
+    ///# }
+    /// ```
+    pub fn ion_type(&self) -> IonType {
+        self.raw_value.ion_type()
+    }
+
+    /// Returns an iterator over the annotations on this value. If this value has no annotations,
+    /// the resulting iterator will be empty.
+    ///
+    /// ```
+    ///# use ion_rs::IonResult;
+    ///# fn main() -> IonResult<()> {
+    ///
+    /// // Construct an Element and serialize it as binary Ion.
+    /// use ion_rs::element::{Element, IntoAnnotatedElement};
+    /// use ion_rs::IonType;
+    /// use ion_rs::lazy::binary::lazy_reader::LazyReader;
+    ///
+    /// let element: Element = "hello".with_annotations(["foo", "bar", "baz"]);
+    /// let binary_ion = element.to_binary()?;
+    ///
+    /// let mut lazy_reader = LazyReader::new(&binary_ion)?;
+    ///
+    /// // Get the first lazy value from the stream.
+    /// let lazy_value = lazy_reader.expect_next()?;
+    ///
+    /// // Inspect its annotations.
+    /// let mut annotations = lazy_value.annotations();
+    /// assert_eq!(annotations.next().unwrap()?, "foo");
+    /// assert_eq!(annotations.next().unwrap()?, "bar");
+    /// assert_eq!(annotations.next().unwrap()?, "baz");
+    ///
+    ///# Ok(())
+    ///# }
+    /// ```
+    pub fn annotations(&self) -> AnnotationsIterator<'top, 'data> {
+        AnnotationsIterator {
+            raw_annotations: self.raw_value.annotations(),
+            symbol_table: self.symbol_table,
+            initial_offset: self
+                .raw_value
+                .encoded_value
+                .annotations_offset()
+                .unwrap_or(self.raw_value.encoded_value.header_offset),
+        }
+    }
+
+    /// Reads the body of this value (that is: its data) and returns it as a [`ValueRef`].
+    /// ```
+    ///# use ion_rs::IonResult;
+    ///# fn main() -> IonResult<()> {
+    ///
+    /// // Construct an Element and serialize it as binary Ion.
+    /// use ion_rs::element::{Element, IntoAnnotatedElement};
+    /// use ion_rs::IonType;
+    /// use ion_rs::lazy::binary::lazy_reader::LazyReader;
+    /// use ion_rs::lazy::value_ref::ValueRef;
+    ///
+    /// let element: Element = "hello".with_annotations(["foo", "bar", "baz"]);
+    /// let binary_ion = element.to_binary()?;
+    ///
+    /// let mut lazy_reader = LazyReader::new(&binary_ion)?;
+    ///
+    /// // Get the first lazy value from the stream.
+    /// let lazy_value = lazy_reader.expect_next()?;
+    ///
+    /// if let ValueRef::String(text) = lazy_value.read()? {
+    ///     assert_eq!(text, "hello");
+    /// } else {
+    ///     panic!("Expected a string.");
+    /// }
+    ///
+    ///# Ok(())
+    ///# }
+    /// ```
+    pub fn read(&self) -> IonResult<ValueRef<'top, 'data>>
+    where
+        'data: 'top,
+    {
+        use crate::lazy::binary::system::lazy_sequence::LazySequence;
+        use crate::lazy::binary::system::lazy_struct::LazyStruct;
+        use crate::lazy::raw_value_ref::RawValueRef::*;
+        use crate::result::decoding_error_raw;
+
+        let value_ref = match self.raw_value.read()? {
+            Null(ion_type) => ValueRef::Null(ion_type),
+            Bool(b) => ValueRef::Bool(b),
+            Int(i) => ValueRef::Int(i),
+            Float(f) => ValueRef::Float(f),
+            Decimal(d) => ValueRef::Decimal(d),
+            Timestamp(t) => ValueRef::Timestamp(t),
+            String(s) => ValueRef::String(s),
+            Symbol(s) => {
+                let symbol = match s {
+                    RawSymbolTokenRef::SymbolId(sid) => self
+                        .symbol_table
+                        .symbol_for(sid)
+                        .ok_or_else(|| {
+                            decoding_error_raw("found a symbol ID that was not in the symbol table")
+                        })?
+                        .into(),
+                    RawSymbolTokenRef::Text(text) => text.into(),
+                };
+                ValueRef::Symbol(symbol)
+            }
+            Blob(b) => ValueRef::Blob(b),
+            Clob(c) => ValueRef::Clob(c),
+            SExp(s) => {
+                let lazy_sequence = LazySequence {
+                    raw_sequence: s,
+                    symbol_table: self.symbol_table,
+                };
+                ValueRef::SExp(lazy_sequence)
+            }
+            List(l) => {
+                let lazy_sequence = LazySequence {
+                    raw_sequence: l,
+                    symbol_table: self.symbol_table,
+                };
+                ValueRef::List(lazy_sequence)
+            }
+            Struct(s) => {
+                let lazy_struct = LazyStruct {
+                    raw_struct: s,
+                    symbol_table: self.symbol_table,
+                };
+                ValueRef::Struct(lazy_struct)
+            }
+        };
+        Ok(value_ref)
+    }
+}
+
+impl<'top, 'data> TryFrom<LazyValue<'top, 'data>> for Element {
+    type Error = IonError;
+
+    fn try_from(value: LazyValue<'top, 'data>) -> Result<Self, Self::Error> {
+        let annotations: Annotations = value.annotations().try_into()?;
+        let value = Value::try_from(value.read()?)?;
+        Ok(value.with_annotations(annotations))
+    }
+}
+
+/// Iterates over a slice of bytes, lazily reading them as a sequence of VarUInt symbol IDs.
+pub struct AnnotationsIterator<'top, 'data> {
+    pub(crate) symbol_table: &'top SymbolTable,
+    pub(crate) raw_annotations: RawAnnotationsIterator<'data>,
+    pub(crate) initial_offset: usize,
+}
+
+impl<'top, 'data> AnnotationsIterator<'top, 'data>
+where
+    'data: 'top,
+{
+    /// Returns `Ok(true)` if this annotations iterator matches the provided sequence exactly, or
+    /// `Ok(false)` if not. If a decoding error occurs while visiting and resolving each annotation,
+    /// returns an `Err(IonError)`.
+    /// ```
+    ///# use ion_rs::IonResult;
+    ///# fn main() -> IonResult<()> {
+    ///
+    /// // Construct an Element and serialize it as binary Ion.
+    /// use ion_rs::element::{Element, IntoAnnotatedElement};
+    /// use ion_rs::lazy::binary::lazy_reader::LazyReader;
+    ///
+    /// let element = Element::read_one("foo::bar::baz::99")?;
+    /// let binary_ion = element.to_binary()?;
+    /// let mut lazy_reader = LazyReader::new(&binary_ion)?;
+    ///
+    /// // Get the first value from the stream
+    /// let lazy_value = lazy_reader.expect_next()?;
+    ///
+    /// assert!(lazy_value.annotations().are(["foo", "bar", "baz"])?);
+    ///
+    /// assert!(!lazy_value.annotations().are(["foo", "bar", "baz", "quux"])?);
+    /// assert!(!lazy_value.annotations().are(["baz", "bar", "foo"])?);
+    /// assert!(!lazy_value.annotations().are(["foo", "bar"])?);
+    /// assert!(!lazy_value.annotations().are(["foo"])?);
+    ///
+    ///# Ok(())
+    ///# }
+    /// ```
+    pub fn are<A: AsSymbolRef, I: IntoIterator<Item = A>>(
+        mut self,
+        annotations_to_match: I,
+    ) -> IonResult<bool> {
+        for to_match in annotations_to_match {
+            match self.next() {
+                Some(Ok(actual)) if actual == to_match => {}
+                Some(Err(e)) => return Err(e),
+                Some(_) | None => return Ok(false),
+            }
+        }
+        // We've exhausted `annotations_to_match`, now make sure `self` is empty
+        Ok(self.next().is_none())
+    }
+
+    /// Like [`Self::are`], but returns an [`IonError::DecodingError`] if the iterator's annotations
+    /// don't match the provided sequence exactly.
+    /// ```
+    ///# use ion_rs::IonResult;
+    ///# fn main() -> IonResult<()> {
+    ///
+    /// // Construct an Element and serialize it as binary Ion.
+    /// use ion_rs::element::{Element, IntoAnnotatedElement};
+    /// use ion_rs::lazy::binary::lazy_reader::LazyReader;
+    ///
+    /// let element = Element::read_one("foo::bar::baz::99")?;
+    /// let binary_ion = element.to_binary()?;
+    /// let mut lazy_reader = LazyReader::new(&binary_ion)?;
+    ///
+    /// // Get the first value from the stream
+    /// let lazy_value = lazy_reader.expect_next()?;
+    ///
+    /// assert!(lazy_value.annotations().expect(["foo", "bar", "baz"]).is_ok());
+    ///
+    /// assert!(lazy_value.annotations().expect(["foo", "bar", "baz", "quux"]).is_err());
+    /// assert!(lazy_value.annotations().expect(["baz", "bar", "foo"]).is_err());
+    /// assert!(lazy_value.annotations().expect(["foo", "bar"]).is_err());
+    /// assert!(lazy_value.annotations().expect(["foo"]).is_err());
+    ///
+    ///# Ok(())
+    ///# }
+    /// ```
+    pub fn expect<A: AsSymbolRef, I: IntoIterator<Item = A>>(
+        self,
+        annotations_to_match: I,
+    ) -> IonResult<()> {
+        if self.are(annotations_to_match)? {
+            Ok(())
+        } else {
+            decoding_error("value annotations did not match expected sequence")
+        }
+    }
+}
+
+impl<'top, 'data> Iterator for AnnotationsIterator<'top, 'data>
+where
+    'data: 'top,
+{
+    type Item = IonResult<SymbolRef<'top>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let raw_annotation = self.raw_annotations.next()?;
+        match raw_annotation {
+            Ok(RawSymbolTokenRef::SymbolId(sid)) => match self.symbol_table.symbol_for(sid) {
+                None => Some(decoding_error(
+                    "found a symbol ID that was not in the symbol table",
+                )),
+                Some(symbol) => Some(Ok(symbol.into())),
+            },
+            Ok(RawSymbolTokenRef::Text(text)) => Some(Ok(SymbolRef::with_text(text))),
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+impl<'top, 'data> TryFrom<AnnotationsIterator<'top, 'data>> for Annotations {
+    type Error = IonError;
+
+    fn try_from(iter: AnnotationsIterator<'top, 'data>) -> Result<Self, Self::Error> {
+        let annotations = iter
+            .map(|symbol_ref| match symbol_ref {
+                Ok(symbol_ref) => Ok(symbol_ref.to_owned()),
+                Err(e) => Err(e),
+            })
+            .collect::<IonResult<Vec<_>>>()?;
+        Ok(Annotations::from(annotations))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::element::{Element, IntoAnnotatedElement};
+    use crate::lazy::binary::lazy_reader::LazyReader;
+    use crate::lazy::binary::test_utilities::to_binary_ion;
+    use crate::{ion_list, ion_sexp, ion_struct, Decimal, IonResult, IonType, Symbol, Timestamp};
+    use num_traits::Float;
+    use rstest::*;
+
+    #[test]
+    fn annotations_are() -> IonResult<()> {
+        let ion_data = to_binary_ion("foo::bar::baz::5")?;
+        let mut reader = LazyReader::new(&ion_data)?;
+        let first = reader.expect_next()?;
+        assert!(first.annotations().are(["foo", "bar", "baz"])?);
+
+        // No similarity
+        assert!(!first.annotations().are(["quux", "quuz"])?);
+
+        // Prefix subset
+        assert!(!first.annotations().are(["foo", "bar"])?);
+        assert!(!first.annotations().are(["foo"])?);
+
+        // Superset
+        assert!(!first.annotations().are(["foo", "bar", "baz", "quux"])?);
+
+        Ok(())
+    }
+
+    fn lazy_value_equals(ion_text: &str, expected: impl Into<Element>) -> IonResult<()> {
+        let binary_ion = &to_binary_ion(ion_text)?;
+        let mut reader = LazyReader::new(binary_ion)?;
+        let value = reader.expect_next()?;
+        let actual: Element = value.try_into()?;
+        let expected = expected.into();
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::null("null", IonType::Null)]
+    #[case::typed_null("null.list", IonType::List)]
+    #[case::annotated_typed_null("foo::null.list", IonType::List.with_annotations(["foo"]))]
+    #[case::boolean("false", false)]
+    #[case::negative_int("-1", -1)]
+    #[case::int_zero("0", 0)]
+    #[case::positive_int("1", 1)]
+    #[case::float_zero("0e0", 0f64)]
+    #[case::float("2.5e0", 2.5f64)]
+    #[case::special_float("-inf", f64::neg_infinity())]
+    #[case::decimal("3.14159", Decimal::new(314159, -5))]
+    #[case::timestamp("2023-04-29T", Timestamp::with_ymd(2023, 4, 29).build()?)]
+    #[case::symbol("foo", Symbol::owned("foo"))]
+    #[case::string("\"hello\"", "hello")]
+    #[case::blob("{{Blob}}", Element::blob([0x06, 0x5A, 0x1B]))]
+    #[case::clob("{{\"Clob\"}}", Element::clob("Clob".as_bytes()))]
+    #[case::list("[1, 2, 3]", ion_list![1, 2, 3])]
+    #[case::sexp("(1 2 3)", ion_sexp!(1 2 3))]
+    #[case::struct_("{foo: 1, bar: 2}", ion_struct! {"foo": 1, "bar": 2})]
+    fn try_into_element(
+        #[case] ion_text: &str,
+        #[case] expected: impl Into<Element>,
+    ) -> IonResult<()> {
+        lazy_value_equals(ion_text, expected)?;
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::negative_int("-1")]
+    #[case::positive_int("1")]
+    #[case::float("2.5e0")]
+    #[case::special_float("-inf")]
+    #[case::decimal("3.14159")]
+    #[case::timestamp("2023-04-29T")]
+    #[case::symbol("foo")]
+    #[case::string("\"hello\"")]
+    #[case::blob("{{Blob}}")]
+    #[case::clob("{{\"Clob\"}}")]
+    #[case::list("[1, 2, 3]")]
+    #[case::sexp("(1 2 3)")]
+    #[case::struct_("{foo: 1, bar: 2}")]
+    fn try_into_element_error(#[case] ion_text: &str) -> IonResult<()> {
+        let mut binary_ion = to_binary_ion(ion_text)?;
+        let _oops_i_lost_a_byte = binary_ion.pop().unwrap();
+        let mut reader = LazyReader::new(&binary_ion)?;
+        let value = reader.expect_next()?;
+        let result: IonResult<Element> = value.try_into();
+        assert!(result.is_err());
+        Ok(())
+    }
+}

--- a/src/lazy/binary/system/mod.rs
+++ b/src/lazy/binary/system/mod.rs
@@ -1,0 +1,4 @@
+pub mod lazy_sequence;
+pub mod lazy_struct;
+pub mod lazy_system_reader;
+pub mod lazy_value;

--- a/src/lazy/binary/test_utilities.rs
+++ b/src/lazy/binary/test_utilities.rs
@@ -1,0 +1,15 @@
+use crate::element::Element;
+use crate::{BinaryWriterBuilder, IonResult, IonWriter};
+
+/// Transcribes text Ion to binary Ion
+pub fn to_binary_ion(text_ion: &str) -> IonResult<Vec<u8>> {
+    let mut buffer = Vec::new();
+    let mut writer = BinaryWriterBuilder::default().build(&mut buffer)?;
+    let elements = Element::read_all(text_ion)?;
+    for element in &elements {
+        element.write_to(&mut writer)?;
+    }
+    writer.flush()?;
+    drop(writer);
+    Ok(buffer)
+}

--- a/src/lazy/mod.rs
+++ b/src/lazy/mod.rs
@@ -1,0 +1,8 @@
+//! Provides an ergonomic, lazy view of an Ion stream that permits random access within each
+//! top level value.
+
+pub mod binary;
+pub mod raw_stream_item;
+pub mod raw_value_ref;
+pub mod system_stream_item;
+pub mod value_ref;

--- a/src/lazy/raw_stream_item.rs
+++ b/src/lazy/raw_stream_item.rs
@@ -1,0 +1,50 @@
+use crate::lazy::binary::raw::lazy_raw_value::LazyRawValue;
+use crate::result::{decoding_error, decoding_error_raw};
+use crate::IonResult;
+
+#[derive(Debug)]
+/// Raw stream components that a RawReader may encounter.
+pub enum RawStreamItem<'data> {
+    /// An Ion Version Marker (IVM) indicating the Ion major and minor version that were used to
+    /// encode the values that follow.
+    VersionMarker(u8, u8),
+    // TODO: Doc
+    Value(LazyRawValue<'data>),
+    /// Indicates that the reader is not positioned over anything. This can happen:
+    /// * before the reader has begun processing the stream.
+    /// * after the reader has stepped into a container, but before the reader has called next()
+    /// * after the reader has stepped out of a container, but before the reader has called next()
+    /// * after the reader has read the last item in a container
+    Nothing,
+}
+
+impl<'a> RawStreamItem<'a> {
+    pub fn version_marker(&self) -> Option<(u8, u8)> {
+        if let Self::VersionMarker(major, minor) = self {
+            Some((*major, *minor))
+        } else {
+            None
+        }
+    }
+
+    pub fn expect_ivm(self) -> IonResult<(u8, u8)> {
+        self.version_marker()
+            .ok_or_else(|| decoding_error_raw(format!("expected IVM, found {:?}", self)))
+    }
+
+    pub fn value(&self) -> Option<&LazyRawValue<'a>> {
+        if let Self::Value(value) = self {
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    pub fn expect_value(self) -> IonResult<LazyRawValue<'a>> {
+        if let Self::Value(value) = self {
+            Ok(value)
+        } else {
+            decoding_error(format!("expected value, found {:?}", self))
+        }
+    }
+}

--- a/src/lazy/raw_value_ref.rs
+++ b/src/lazy/raw_value_ref.rs
@@ -1,0 +1,264 @@
+use crate::lazy::binary::raw::lazy_raw_sequence::LazyRawSequence;
+use crate::lazy::binary::raw::lazy_raw_struct::LazyRawStruct;
+use crate::result::decoding_error;
+use crate::{Decimal, Int, IonResult, IonType, RawSymbolTokenRef, Timestamp};
+use std::fmt::{Debug, Formatter};
+
+/// As RawValueRef represents a reference to an unresolved value read from the data stream.
+/// If the value is a symbol, it only contains the information found in the data stream (a symbol ID
+/// or text literal). If it is a symbol ID, a symbol table will be needed to find its associated text.
+///
+/// For a resolved version of this type, see [crate::lazy::value_ref::ValueRef].
+pub enum RawValueRef<'a> {
+    Null(IonType),
+    Bool(bool),
+    Int(Int),
+    Float(f64),
+    Decimal(Decimal),
+    Timestamp(Timestamp),
+    String(&'a str),
+    Symbol(RawSymbolTokenRef<'a>),
+    Blob(&'a [u8]),
+    Clob(&'a [u8]),
+    SExp(LazyRawSequence<'a>),
+    List(LazyRawSequence<'a>),
+    Struct(LazyRawStruct<'a>),
+}
+
+impl<'a> Debug for RawValueRef<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RawValueRef::Null(ion_type) => write!(f, "null.{}", ion_type),
+            RawValueRef::Bool(b) => write!(f, "{}", b),
+            RawValueRef::Int(i) => write!(f, "{}", i),
+            RawValueRef::Float(float) => write!(f, "{}", float),
+            RawValueRef::Decimal(d) => write!(f, "{}", d),
+            RawValueRef::Timestamp(t) => write!(f, "{}", t),
+            RawValueRef::String(s) => write!(f, "{}", s),
+            RawValueRef::Symbol(s) => write!(f, "{:?}", s),
+            RawValueRef::Blob(b) => write!(f, "blob ({} bytes)", b.len()),
+            RawValueRef::Clob(c) => write!(f, "clob ({} bytes)", c.len()),
+            RawValueRef::SExp(s) => write!(f, "sexp={:?}", s),
+            RawValueRef::List(l) => write!(f, "{:?}", l),
+            RawValueRef::Struct(s) => write!(f, "{:?}", s),
+        }
+    }
+}
+
+impl<'a> RawValueRef<'a> {
+    pub fn expect_null(self) -> IonResult<IonType> {
+        if let RawValueRef::Null(ion_type) = self {
+            Ok(ion_type)
+        } else {
+            decoding_error("expected a null")
+        }
+    }
+
+    pub fn expect_bool(self) -> IonResult<bool> {
+        if let RawValueRef::Bool(b) = self {
+            Ok(b)
+        } else {
+            decoding_error("expected a bool")
+        }
+    }
+
+    pub fn expect_int(self) -> IonResult<Int> {
+        if let RawValueRef::Int(i) = self {
+            Ok(i)
+        } else {
+            decoding_error("expected an int")
+        }
+    }
+
+    pub fn expect_float(self) -> IonResult<f64> {
+        if let RawValueRef::Float(f) = self {
+            Ok(f)
+        } else {
+            decoding_error("expected a float")
+        }
+    }
+
+    pub fn expect_decimal(self) -> IonResult<Decimal> {
+        if let RawValueRef::Decimal(d) = self {
+            Ok(d)
+        } else {
+            decoding_error("expected a decimal")
+        }
+    }
+
+    pub fn expect_timestamp(self) -> IonResult<Timestamp> {
+        if let RawValueRef::Timestamp(t) = self {
+            Ok(t)
+        } else {
+            decoding_error("expected a timestamp")
+        }
+    }
+
+    pub fn expect_string(self) -> IonResult<&'a str> {
+        if let RawValueRef::String(s) = self {
+            Ok(s)
+        } else {
+            decoding_error("expected a string")
+        }
+    }
+
+    pub fn expect_symbol(self) -> IonResult<RawSymbolTokenRef<'a>> {
+        if let RawValueRef::Symbol(s) = self {
+            Ok(s.clone())
+        } else {
+            decoding_error("expected a symbol")
+        }
+    }
+
+    pub fn expect_blob(self) -> IonResult<&'a [u8]> {
+        if let RawValueRef::Blob(b) = self {
+            Ok(b)
+        } else {
+            decoding_error("expected a blob")
+        }
+    }
+
+    pub fn expect_clob(self) -> IonResult<&'a [u8]> {
+        if let RawValueRef::Clob(c) = self {
+            Ok(c)
+        } else {
+            decoding_error("expected a clob")
+        }
+    }
+
+    pub fn expect_list(self) -> IonResult<LazyRawSequence<'a>> {
+        if let RawValueRef::List(s) = self {
+            Ok(s)
+        } else {
+            decoding_error("expected a list")
+        }
+    }
+
+    pub fn expect_sexp(self) -> IonResult<LazyRawSequence<'a>> {
+        if let RawValueRef::SExp(s) = self {
+            Ok(s)
+        } else {
+            decoding_error("expected a sexp")
+        }
+    }
+
+    pub fn expect_struct(self) -> IonResult<LazyRawStruct<'a>> {
+        if let RawValueRef::Struct(s) = self {
+            Ok(s)
+        } else {
+            decoding_error("expected a struct")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::lazy::binary::raw::lazy_raw_reader::LazyRawReader;
+    use crate::lazy::binary::test_utilities::to_binary_ion;
+    use crate::{Decimal, IonResult, IonType, RawSymbolTokenRef, Timestamp};
+
+    #[test]
+    fn expect_type() -> IonResult<()> {
+        let ion_data = to_binary_ion(
+            r#"
+            null
+            true
+            1
+            2.5e0
+            2.5
+            2023-04-29T13:45:38.281Z
+            foo
+            "hello"
+            {{Blob}}
+            {{"Clob"}}
+            [this, is, a, list]
+            (this is a sexp)
+            {this: is, a: struct}
+        "#,
+        )?;
+        let mut reader = LazyRawReader::new(&ion_data);
+        // IVM
+        reader.next()?.expect_ivm()?;
+        // Symbol table
+        reader.next()?.expect_value()?.read()?.expect_struct()?;
+        // User data
+        assert_eq!(
+            reader.next()?.expect_value()?.read()?.expect_null()?,
+            IonType::Null
+        );
+        assert!(reader.next()?.expect_value()?.read()?.expect_bool()?);
+        assert_eq!(
+            reader.next()?.expect_value()?.read()?.expect_int()?,
+            1.into()
+        );
+        assert_eq!(
+            reader.next()?.expect_value()?.read()?.expect_float()?,
+            2.5f64
+        );
+        assert_eq!(
+            reader.next()?.expect_value()?.read()?.expect_decimal()?,
+            Decimal::new(25, -1)
+        );
+        assert_eq!(
+            reader.next()?.expect_value()?.read()?.expect_timestamp()?,
+            Timestamp::with_ymd_hms_millis(2023, 4, 29, 13, 45, 38, 281).build_at_offset(0)?
+        );
+        assert_eq!(
+            reader.next()?.expect_value()?.read()?.expect_symbol()?,
+            RawSymbolTokenRef::SymbolId(10) // foo
+        );
+        assert_eq!(
+            reader.next()?.expect_value()?.read()?.expect_string()?,
+            "hello"
+        );
+        assert_eq!(
+            reader.next()?.expect_value()?.read()?.expect_blob()?,
+            &[0x06, 0x5A, 0x1B] // Base64-decoded "Blob"
+        );
+        assert_eq!(
+            reader.next()?.expect_value()?.read()?.expect_clob()?,
+            "Clob".as_bytes()
+        );
+        assert!(reader.next()?.expect_value()?.read()?.expect_list().is_ok());
+        assert!(reader.next()?.expect_value()?.read()?.expect_sexp().is_ok());
+        assert!(reader
+            .next()?
+            .expect_value()?
+            .read()?
+            .expect_struct()
+            .is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn expect_type_error() -> IonResult<()> {
+        let ion_data = to_binary_ion(
+            r#"
+            true
+            null.bool
+        "#,
+        )?;
+        let mut reader = LazyRawReader::new(&ion_data);
+        // IVM
+        reader.next()?.expect_ivm()?;
+
+        let bool_value = reader.next()?.expect_value()?;
+        assert!(bool_value.read()?.expect_null().is_err());
+        assert!(bool_value.read()?.expect_int().is_err());
+        assert!(bool_value.read()?.expect_float().is_err());
+        assert!(bool_value.read()?.expect_decimal().is_err());
+        assert!(bool_value.read()?.expect_timestamp().is_err());
+        assert!(bool_value.read()?.expect_symbol().is_err());
+        assert!(bool_value.read()?.expect_string().is_err());
+        assert!(bool_value.read()?.expect_blob().is_err());
+        assert!(bool_value.read()?.expect_clob().is_err());
+        assert!(bool_value.read()?.expect_list().is_err());
+        assert!(bool_value.read()?.expect_sexp().is_err());
+        assert!(bool_value.read()?.expect_struct().is_err());
+
+        let null_value = reader.next()?.expect_value()?;
+        assert!(null_value.read()?.expect_bool().is_err());
+        Ok(())
+    }
+}

--- a/src/lazy/system_stream_item.rs
+++ b/src/lazy/system_stream_item.rs
@@ -1,0 +1,57 @@
+use crate::lazy::binary::system::lazy_struct::LazyStruct;
+use crate::lazy::binary::system::lazy_value::LazyValue;
+use crate::result::{decoding_error, decoding_error_raw};
+use crate::IonResult;
+use std::fmt::{Debug, Formatter};
+
+/// Raw stream elements that a SystemReader may encounter.
+pub enum SystemStreamItem<'top, 'data> {
+    VersionMarker(u8, u8),
+    SymbolTable(LazyStruct<'top, 'data>),
+    Value(LazyValue<'top, 'data>),
+    Nothing,
+}
+
+impl<'top, 'data> Debug for SystemStreamItem<'top, 'data> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SystemStreamItem::VersionMarker(major, minor) => {
+                write!(f, "version marker v{}.{}", major, minor)
+            }
+            SystemStreamItem::SymbolTable(_) => write!(f, "a symbol table"),
+            SystemStreamItem::Value(value) => write!(f, "{}", value.ion_type()),
+            SystemStreamItem::Nothing => write!(f, "<nothing>"),
+        }
+    }
+}
+
+impl<'top, 'data> SystemStreamItem<'top, 'data> {
+    pub fn version_marker(&self) -> Option<(u8, u8)> {
+        if let Self::VersionMarker(major, minor) = self {
+            Some((*major, *minor))
+        } else {
+            None
+        }
+    }
+
+    pub fn expect_ivm(self) -> IonResult<(u8, u8)> {
+        self.version_marker()
+            .ok_or_else(|| decoding_error_raw(format!("expected IVM, found {:?}", self)))
+    }
+
+    pub fn value(&self) -> Option<&LazyValue<'top, 'data>> {
+        if let Self::Value(value) = self {
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    pub fn expect_value(self) -> IonResult<LazyValue<'top, 'data>> {
+        if let Self::Value(value) = self {
+            Ok(value)
+        } else {
+            decoding_error(format!("expected value, found {:?}", self))
+        }
+    }
+}

--- a/src/lazy/value_ref.rs
+++ b/src/lazy/value_ref.rs
@@ -1,0 +1,321 @@
+use crate::element::Value;
+use crate::lazy::binary::system::lazy_sequence::LazySequence;
+use crate::lazy::binary::system::lazy_struct::LazyStruct;
+use crate::result::decoding_error;
+use crate::{Decimal, Int, IonError, IonResult, IonType, SymbolRef, Timestamp};
+use std::fmt::{Debug, Formatter};
+
+/// A [ValueRef] represents a value that has been read from the input stream. Scalar variants contain
+/// their associated data, while container variants contain a handle to traverse the container. (See
+/// [LazySequence] and [LazyStruct].)
+///
+/// Unlike a [Value], a `ValueRef` avoids heap allocation whenever possible, choosing to point instead
+/// to existing resources. Numeric values and timestamps are stored within the `ValueRef` itself.
+/// Text values and lobs hold references to either a slice of input data or text in the symbol table.
+pub enum ValueRef<'top, 'data> {
+    Null(IonType),
+    Bool(bool),
+    Int(Int),
+    Float(f64),
+    Decimal(Decimal),
+    Timestamp(Timestamp),
+    String(&'data str),
+    Symbol(SymbolRef<'top>),
+    Blob(&'data [u8]),
+    Clob(&'data [u8]),
+    // As ValueRef represents a reference to a value in the streaming APIs, the container variants
+    // simply indicate their Ion type. To access their nested data, the reader would need to step in.
+    SExp(LazySequence<'top, 'data>),
+    List(LazySequence<'top, 'data>),
+    Struct(LazyStruct<'top, 'data>),
+}
+
+impl<'top, 'data> PartialEq for ValueRef<'top, 'data> {
+    fn eq(&self, other: &Self) -> bool {
+        use ValueRef::*;
+        match (self, other) {
+            (Null(i1), Null(i2)) => i1 == i2,
+            (Bool(b1), Bool(b2)) => b1 == b2,
+            (Int(i1), Int(i2)) => i1 == i2,
+            (Float(f1), Float(f2)) => f1 == f2,
+            (Decimal(d1), Decimal(d2)) => d1 == d2,
+            (Timestamp(t1), Timestamp(t2)) => t1 == t2,
+            (String(s1), String(s2)) => s1 == s2,
+            (Symbol(s1), Symbol(s2)) => s1 == s2,
+            (Blob(b1), Blob(b2)) => b1 == b2,
+            (Clob(c1), Clob(c2)) => c1 == c2,
+            // We cannot compare lazy containers as we cannot guarantee that their complete contents
+            // are available in the buffer. Is `{foo: bar}` equal to `{foo: b`?
+            _ => false,
+        }
+    }
+}
+
+impl<'top, 'data> Debug for ValueRef<'top, 'data> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        use ValueRef::*;
+        match self {
+            Null(ion_type) => write!(f, "null.{}", ion_type),
+            Bool(b) => write!(f, "{}", b),
+            Int(i) => write!(f, "{}", i),
+            Float(float) => write!(f, "{}", float),
+            Decimal(d) => write!(f, "{}", d),
+            Timestamp(t) => write!(f, "{}", t),
+            String(s) => write!(f, "\"{}\"", s),
+            Symbol(s) => write!(f, "{}", s.text().unwrap_or("$0")),
+            Blob(b) => write!(f, "blob ({} bytes)", b.len()),
+            Clob(c) => write!(f, "clob ({} bytes)", c.len()),
+            SExp(s) => write!(f, "sexp={:?}", s),
+            List(l) => write!(f, "{:?}", l),
+            Struct(s) => write!(f, "{:?}", s),
+        }
+    }
+}
+
+impl<'top, 'data> TryFrom<ValueRef<'top, 'data>> for Value {
+    type Error = IonError;
+
+    fn try_from(value: ValueRef<'top, 'data>) -> Result<Self, Self::Error> {
+        use ValueRef::*;
+        let value = match value {
+            Null(ion_type) => Value::Null(ion_type),
+            Bool(b) => Value::Bool(b),
+            Int(i) => Value::Int(i),
+            Float(f) => Value::Float(f),
+            Decimal(d) => Value::Decimal(d),
+            Timestamp(t) => Value::Timestamp(t),
+            String(s) => Value::String(s.into()),
+            Symbol(s) => Value::Symbol(s.into()),
+            Blob(b) => Value::Blob(b.into()),
+            Clob(c) => Value::Clob(c.into()),
+            SExp(s) => Value::SExp(s.try_into()?),
+            List(l) => Value::List(l.try_into()?),
+            Struct(s) => Value::Struct(s.try_into()?),
+        };
+        Ok(value)
+    }
+}
+
+impl<'top, 'data> ValueRef<'top, 'data> {
+    pub fn expect_null(self) -> IonResult<IonType> {
+        if let ValueRef::Null(ion_type) = self {
+            Ok(ion_type)
+        } else {
+            decoding_error("expected a null")
+        }
+    }
+
+    pub fn expect_bool(self) -> IonResult<bool> {
+        if let ValueRef::Bool(b) = self {
+            Ok(b)
+        } else {
+            decoding_error("expected a bool")
+        }
+    }
+
+    pub fn expect_int(self) -> IonResult<Int> {
+        if let ValueRef::Int(i) = self {
+            Ok(i)
+        } else {
+            decoding_error("expected an int")
+        }
+    }
+
+    pub fn expect_i64(self) -> IonResult<i64> {
+        if let ValueRef::Int(Int::I64(i)) = self {
+            Ok(i)
+        } else {
+            decoding_error("expected an int (i64)")
+        }
+    }
+
+    pub fn expect_float(self) -> IonResult<f64> {
+        if let ValueRef::Float(f) = self {
+            Ok(f)
+        } else {
+            decoding_error("expected a float")
+        }
+    }
+
+    pub fn expect_decimal(self) -> IonResult<Decimal> {
+        if let ValueRef::Decimal(d) = self {
+            Ok(d)
+        } else {
+            decoding_error("expected a decimal")
+        }
+    }
+
+    pub fn expect_timestamp(self) -> IonResult<Timestamp> {
+        if let ValueRef::Timestamp(t) = self {
+            Ok(t)
+        } else {
+            decoding_error("expected a timestamp")
+        }
+    }
+
+    pub fn expect_string(self) -> IonResult<&'data str> {
+        if let ValueRef::String(s) = self {
+            Ok(s)
+        } else {
+            decoding_error("expected a string")
+        }
+    }
+
+    pub fn expect_symbol(self) -> IonResult<SymbolRef<'top>> {
+        if let ValueRef::Symbol(s) = self {
+            Ok(s)
+        } else {
+            decoding_error("expected a symbol")
+        }
+    }
+
+    pub fn expect_blob(self) -> IonResult<&'data [u8]> {
+        if let ValueRef::Blob(b) = self {
+            Ok(b)
+        } else {
+            decoding_error("expected a blob")
+        }
+    }
+
+    pub fn expect_clob(self) -> IonResult<&'data [u8]> {
+        if let ValueRef::Clob(c) = self {
+            Ok(c)
+        } else {
+            decoding_error("expected a clob")
+        }
+    }
+
+    pub fn expect_list(self) -> IonResult<LazySequence<'top, 'data>> {
+        if let ValueRef::List(s) = self {
+            Ok(s)
+        } else {
+            decoding_error("expected a list")
+        }
+    }
+
+    pub fn expect_sexp(self) -> IonResult<LazySequence<'top, 'data>> {
+        if let ValueRef::SExp(s) = self {
+            Ok(s)
+        } else {
+            decoding_error("expected a sexp")
+        }
+    }
+
+    pub fn expect_struct(self) -> IonResult<LazyStruct<'top, 'data>> {
+        if let ValueRef::Struct(s) = self {
+            Ok(s)
+        } else {
+            decoding_error("expected a struct")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::lazy::binary::lazy_reader::LazyReader;
+    use crate::lazy::binary::test_utilities::to_binary_ion;
+    use crate::lazy::value_ref::ValueRef;
+    use crate::{Decimal, IonResult, IonType, SymbolRef, Timestamp};
+
+    #[test]
+    fn expect_type() -> IonResult<()> {
+        let ion_data = to_binary_ion(
+            r#"
+            null
+            true
+            1
+            2.5e0
+            2.5
+            2023-04-29T
+            foo
+            "hello"
+            {{Blob}}
+            {{"Clob"}}
+            [this, is, a, list]
+            (this is a sexp)
+            {this: is, a: struct}
+        "#,
+        )?;
+        let mut reader = LazyReader::new(&ion_data)?;
+        assert_eq!(reader.expect_next()?.read()?.expect_null()?, IonType::Null);
+        assert!(reader.expect_next()?.read()?.expect_bool()?);
+        assert_eq!(reader.expect_next()?.read()?.expect_i64()?, 1);
+        assert_eq!(reader.expect_next()?.read()?.expect_float()?, 2.5f64);
+        assert_eq!(
+            reader.expect_next()?.read()?.expect_decimal()?,
+            Decimal::new(25, -1)
+        );
+        assert_eq!(
+            reader.expect_next()?.read()?.expect_timestamp()?,
+            Timestamp::with_ymd(2023, 4, 29).build()?
+        );
+        assert_eq!(
+            reader.expect_next()?.read()?.expect_symbol()?,
+            SymbolRef::from("foo")
+        );
+        assert_eq!(reader.expect_next()?.read()?.expect_string()?, "hello");
+        assert_eq!(
+            reader.expect_next()?.read()?.expect_blob()?,
+            &[0x06, 0x5A, 0x1B] // Base64-decoded "Blob"
+        );
+        assert_eq!(
+            reader.expect_next()?.read()?.expect_clob()?,
+            "Clob".as_bytes()
+        );
+        assert!(reader.expect_next()?.read()?.expect_list().is_ok());
+        assert!(reader.expect_next()?.read()?.expect_sexp().is_ok());
+        assert!(reader.expect_next()?.read()?.expect_struct().is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn partial_eq() -> IonResult<()> {
+        let ion_data = to_binary_ion(
+            r#"
+            null
+            true
+            1
+            2.5e0
+            2.5
+            2023-04-29T
+            foo
+            "hello"
+            {{Blob}}
+            {{"Clob"}}
+        "#,
+        )?;
+        let mut reader = LazyReader::new(&ion_data)?;
+        let first_value = reader.expect_next()?.read()?;
+        assert_ne!(first_value, ValueRef::String("it's not a string"));
+        assert_eq!(first_value, ValueRef::Null(IonType::Null));
+        assert_eq!(reader.expect_next()?.read()?, ValueRef::Bool(true));
+        assert_eq!(reader.expect_next()?.read()?, ValueRef::Int(1.into()));
+        assert_eq!(reader.expect_next()?.read()?, ValueRef::Float(2.5f64));
+        assert_eq!(
+            reader.expect_next()?.read()?,
+            ValueRef::Decimal(Decimal::new(25, -1))
+        );
+        assert_eq!(
+            reader.expect_next()?.read()?,
+            ValueRef::Timestamp(Timestamp::with_ymd(2023, 4, 29).build()?)
+        );
+        assert_eq!(
+            reader.expect_next()?.read()?,
+            ValueRef::Symbol(SymbolRef::from("foo"))
+        );
+        assert_eq!(reader.expect_next()?.read()?, ValueRef::String("hello"));
+        assert_eq!(
+            reader.expect_next()?.read()?,
+            ValueRef::Blob(&[0x06, 0x5A, 0x1B]) // Base64-decoded "Blob"
+        );
+        assert_eq!(
+            reader.expect_next()?.read()?,
+            ValueRef::Clob("Clob".as_bytes())
+        );
+
+        // PartialEq doesn't cover lazy containers
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,9 @@ mod symbol_table;
 mod system_reader;
 mod writer;
 
+#[cfg(feature = "experimental-lazy-reader")]
+pub mod lazy;
+
 #[cfg(feature = "experimental-streaming")]
 pub(crate) mod thunk;
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -121,7 +121,7 @@ pub struct UserReader<R: RawReader> {
 }
 
 impl<R: RawReader> UserReader<R> {
-    pub(crate) fn new(raw_reader: R) -> UserReader<R> {
+    pub fn new(raw_reader: R) -> UserReader<R> {
         UserReader {
             raw_reader,
             symbol_table: SymbolTable::new(),

--- a/src/symbol_ref.rs
+++ b/src/symbol_ref.rs
@@ -1,12 +1,19 @@
 use crate::Symbol;
 use std::borrow::Borrow;
+use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
 
 /// A reference to a fully resolved symbol. Like `Symbol` (a fully resolved symbol with a
 /// static lifetime), a `SymbolRef` may have known or undefined text.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub struct SymbolRef<'a> {
     text: Option<&'a str>,
+}
+
+impl<'a> Debug for SymbolRef<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.text.unwrap_or("$0"))
+    }
 }
 
 impl<'a> SymbolRef<'a> {
@@ -23,6 +30,23 @@ impl<'a> SymbolRef<'a> {
     /// Constructs a `SymbolRef` with the specified text.
     pub fn with_text(text: &str) -> SymbolRef {
         SymbolRef { text: Some(text) }
+    }
+
+    pub fn to_owned(self) -> Symbol {
+        match self.text() {
+            None => Symbol::unknown_text(),
+            Some(text) => Symbol::owned(text),
+        }
+    }
+}
+
+impl<'a, A> PartialEq<A> for SymbolRef<'a>
+where
+    A: AsSymbolRef,
+{
+    fn eq(&self, other: &A) -> bool {
+        let other_symbol_ref = other.as_symbol_ref();
+        self == &other_symbol_ref
     }
 }
 
@@ -53,6 +77,14 @@ impl<'a> Hash for SymbolRef<'a> {
 impl<'a> From<&'a str> for SymbolRef<'a> {
     fn from(text: &'a str) -> Self {
         Self { text: Some(text) }
+    }
+}
+
+impl<'a> From<&'a Symbol> for SymbolRef<'a> {
+    fn from(symbol: &'a Symbol) -> Self {
+        Self {
+            text: symbol.text(),
+        }
     }
 }
 

--- a/src/text/raw_text_writer.rs
+++ b/src/text/raw_text_writer.rs
@@ -3,6 +3,7 @@ use std::io::{BufWriter, Write};
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, FixedOffset};
 
+use crate::element::writer::TextKind;
 use crate::raw_symbol_token_ref::{AsRawSymbolTokenRef, RawSymbolTokenRef};
 use crate::result::{illegal_operation, IonResult};
 use crate::text::text_formatter::STRING_ESCAPE_CODES;
@@ -15,13 +16,22 @@ pub struct RawTextWriterBuilder {
 }
 
 impl RawTextWriterBuilder {
+    /// Constructs a text Ion writer with the specified formatting. See [`TextKind`] for details.
+    pub fn new(text_kind: TextKind) -> RawTextWriterBuilder {
+        match text_kind {
+            TextKind::Compact => Self::compact(),
+            TextKind::Lines => Self::lines(),
+            TextKind::Pretty => Self::pretty(),
+        }
+    }
+
     /// Constructs a text Ion writer with modest (but not strictly minimal) spacing.
     ///
     /// For example:
     /// ```text
     /// {foo: 1, bar: 2, baz: 3} [1, 2, 3] true "hello"
     /// ```
-    pub fn new() -> RawTextWriterBuilder {
+    pub fn compact() -> RawTextWriterBuilder {
         RawTextWriterBuilder {
             whitespace_config: COMPACT_WHITESPACE_CONFIG.clone(),
         }
@@ -126,7 +136,7 @@ impl RawTextWriterBuilder {
 
 impl Default for RawTextWriterBuilder {
     fn default() -> Self {
-        RawTextWriterBuilder::new()
+        RawTextWriterBuilder::new(TextKind::Compact)
     }
 }
 
@@ -945,7 +955,7 @@ mod tests {
     #[test]
     fn with_space_between_top_level_values() {
         writer_test_with_builder(
-            RawTextWriterBuilder::new().with_space_between_top_level_values("  "),
+            RawTextWriterBuilder::default().with_space_between_top_level_values("  "),
             |w| {
                 w.write_bool(true)?;
                 w.write_bool(false)
@@ -957,7 +967,7 @@ mod tests {
     #[test]
     fn with_space_between_nested_values() {
         writer_test_with_builder(
-            RawTextWriterBuilder::new().with_space_between_nested_values("  "),
+            RawTextWriterBuilder::default().with_space_between_nested_values("  "),
             |w| {
                 w.write_bool(true)?;
                 w.step_in(IonType::List)?;
@@ -988,7 +998,7 @@ mod tests {
     #[test]
     fn with_space_after_field_name() {
         writer_test_with_builder(
-            RawTextWriterBuilder::new().with_space_after_field_name("   "),
+            RawTextWriterBuilder::default().with_space_after_field_name("   "),
             |w| {
                 w.step_in(IonType::Struct)?;
                 w.set_field_name("a");
@@ -1002,7 +1012,7 @@ mod tests {
     #[test]
     fn with_space_after_container_start() {
         writer_test_with_builder(
-            RawTextWriterBuilder::new().with_space_after_container_start("   "),
+            RawTextWriterBuilder::default().with_space_after_container_start("   "),
             |w| {
                 w.step_in(IonType::Struct)?;
                 w.set_field_name("a");

--- a/src/text/text_writer.rs
+++ b/src/text/text_writer.rs
@@ -13,6 +13,11 @@ pub struct TextWriterBuilder {
 }
 
 impl TextWriterBuilder {
+    /// Constructs a text Ion writer with the specified formatting. See [`TextKind`] for details.
+    pub fn new(format: TextKind) -> TextWriterBuilder {
+        TextWriterBuilder { text_kind: format }
+    }
+
     /// Constructs a text Ion writer that serializes data with modest (but not strictly minimal)
     /// spacing.
     ///
@@ -20,7 +25,7 @@ impl TextWriterBuilder {
     /// ```text
     /// {foo: 1, bar: 2, baz: 3} [1, 2, 3] true "hello"
     /// ```
-    pub fn new() -> TextWriterBuilder {
+    pub fn compact() -> TextWriterBuilder {
         TextWriterBuilder {
             text_kind: TextKind::Compact,
         }
@@ -69,7 +74,7 @@ impl TextWriterBuilder {
     /// implementation.
     pub fn build<W: Write>(self, sink: W) -> IonResult<TextWriter<W>> {
         let builder = match self.text_kind {
-            TextKind::Compact => RawTextWriterBuilder::new(),
+            TextKind::Compact => RawTextWriterBuilder::default(),
             TextKind::Pretty => RawTextWriterBuilder::pretty(),
             TextKind::Lines => RawTextWriterBuilder::lines(),
         };
@@ -84,7 +89,7 @@ impl TextWriterBuilder {
 
 impl Default for TextWriterBuilder {
     fn default() -> Self {
-        TextWriterBuilder::new()
+        TextWriterBuilder::new(TextKind::Compact)
     }
 }
 
@@ -193,7 +198,7 @@ mod tests {
         // However, if you ask it to write a symbol ID (e.g. $10) for which its initial symbol
         // table has text, it will convert it to text before writing it.
         let mut buffer = Vec::new();
-        let mut text_writer = TextWriterBuilder::new().build(&mut buffer)?;
+        let mut text_writer = TextWriterBuilder::default().build(&mut buffer)?;
         // The following symbol IDs are in the system symbol table.
         // https://amazon-ion.github.io/ion-docs/docs/symbols.html#system-symbols
         text_writer.step_in(IonType::Struct)?;

--- a/src/types/symbol.rs
+++ b/src/types/symbol.rs
@@ -1,6 +1,6 @@
 use crate::ion_data::{IonEq, IonOrd};
 use crate::result::decoding_error;
-use crate::IonResult;
+use crate::{IonResult, SymbolRef};
 use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
@@ -150,6 +150,12 @@ impl From<&String> for Symbol {
 impl<'a> From<&'a Symbol> for Symbol {
     fn from(text: &'a Symbol) -> Self {
         text.clone()
+    }
+}
+
+impl<'a> From<SymbolRef<'a>> for Symbol {
+    fn from(symbol_ref: SymbolRef<'a>) -> Self {
+        symbol_ref.to_owned()
     }
 }
 

--- a/tests/ion_hash_tests.rs
+++ b/tests/ion_hash_tests.rs
@@ -260,7 +260,7 @@ fn expected_hash(struct_: &Struct) -> IonResult<Vec<u8>> {
 /// name of the test is the Ion text representation of the input value.
 fn test_case_name_from_value(test_input_ion: &Element) -> IonResult<String> {
     let mut buf = Vec::new();
-    let mut text_writer = ion_rs::TextWriterBuilder::new().build(&mut buf)?;
+    let mut text_writer = ion_rs::TextWriterBuilder::default().build(&mut buf)?;
     text_writer.write_element(test_input_ion)?;
     text_writer.flush()?;
     drop(text_writer);


### PR DESCRIPTION
The existing `IonReader` trait mimics `ion-java`'s `IonReader` interface, offering a single stateful type that can traverse an Ion stream.

Consider this example data:
```js
customer::{
    name: {
        first: "John",
        middle: "Jacob",
        last: "Jingleheimer-Schmidt",
    },
    address: {
        street: "123 Fake Street",
        city: "Toronto",
        country: "Canada",
    },
    status: legacy_rewards::gold,
}
```

In the existing streaming API, the reader can only see the value on which it is positioned. If it advances beyond that value, it cannot reference it further without materializing it. As such, it needs to fully process each field as it is encountered. Because struct fields can appear in any order, the reader must be able to handle them as they come. This requires the user to write mechanical, repetitive, error-prone dispatch logic similar to the following:

```rust
let mut reader = ...;

struct Address {...};

fn read_top_level(reader: &mut Reader) -> IonResult<Address> {
    if let StreamItem::Value(ion_type) = reader.next()? {
         if ion_type != IonType::Struct {
             return decoding_error(format!("expected a struct, found a(n) {}", ion_type);
         }
    } else {
        return decoding_error("expected a struct, found nothing");
    }
    // Ok, it's a struct. Is it a customer?
    if reaader.annotations().next()? != Some(Ok("customer")) {
        return decoding_error("expected struct to be annotated with `customer::`");
    }
    
    // Ok, it's a `customer::`-annotated struct.
    reader.step_in()?;
    handle_customer(reader)
}

fn handle_customer(reader: &mut Reader) -> IonResult {
    // We're inside the `customer::` struct.
    while let Some(ion_type) = reader.next()? {
        let field_name = reader.field_name()?;
        if field_name == "name" {
            if ion_type != IonType::Struct {
                return decoding_error("`name` field must be a struct");
            }
            handle_address(reader)
        } else if field_name == "address" {
            if ion_type != IonType::Struct {
                return decoding_error("`address` field must be a struct");
            }
            handle_address(reader)
        } else if field_name == "status" {
             if ion_type != IonType::Symbol {
                  return decoding_error("`status` field must be a symbol");
             }
        } else {
             // Ignore other fields or error out as desired
             continue;   
        }
    }
}

fn handle_name(reader: &mut Reader) -> IonResult<Name> {
    // We're inside the `name` struct
    let mut first: Option<String> = None;
    let mut middle: Option<String> = None;
    let mut last: Option<String> = None;
    while let Some(ion_type) = reader.next()? {
        if ion_type != IonType::String {
            return decoding_error("name fields must be strings");
        }
        if field_name == "first" {
            first = Some(reader.read_string()?);
        } else if field_name == "middle" {
            middle = Some(reader.read_string()?);
        } else if field_name == "last" {
            last = Some(reader.read_string()?);
        } else {
            continue;
        }
    }

    if let (Some(first), Some(middle), Some(last)) = (first, middle, last) {
        return Ok(Name::new(first, middle, last));
    }
    decoding_error("missing one or more fields from the `name` struct")
}

fn handle_address(reader: &mut Reader) -> IonResult<Address> {
    todo!("yeesh, I don't have the patience to continue this example")
}

fn handle_status(reader: &mut Reader) -> IonResult<Status> {
    todo!("thanks but no thanks")
}
```

The experimental API introduced in this PR takes advantage of the fact that Ion's encoding context (that is: the symbol table) can only change between top-level values.

Each time that the reader advances, it hands out a "lazy" value--an object containing an immutable slice of the input buffer and some calculated offsets from the encoded value it recognized in the stream. This lazy value serves two purposes:
1. The body of the lazy value can be read upon request, producing other lazy values representing nested data.
2. It immutably borrows the input buffer, effectively "freezing" it so long as any lazy value exists.

In this way, the reader can move to a top-level value and produce any number of lazy references to data within that value. What's more, those values are all immutable and can be read as many times as desired. Further, the immutability means that all of this can be achieved without reference counting, and multithreaded processing within a top-level value can be done without synchronization mechanisms.

In all, this makes it possible to expose an API for traversing top-level values that has more of a "Lazy DOM" feel to it.

Compare the above code with this version that uses the `LazyReader`:

```rust
let binary_ion: &[u8] = ...;
let mut lazy_reader = LazyReader::new(&binary_ion)?;

// Get the first value, confirm that it's a struct.
let customer = lazy_reader.expect_next()?
    .read()?
    .expect_struct()?;
// Make sure it has the `customer` annotation
customer.annotations().expect(["customer"])?;

let name_field = customer.get_expected("name")?.expect_struct()?;
let address_field = customer.get_expected("address")?.expect_struct()?;
let status = customer.get_expected("status")?.expect_symbol()?;

let full_name = Name::new(
    name_field.get_expected("first")?.expect_string()?,
    name_field.get_expected("middle")?.expect_string()?,
    name_field.get_expected("last")?.expect_string()?,
);

let address = ...;
```

Critically, this API has significantly fewer sharp edges. There are no illegal operations--only methods that are legal are exposed to the user in any context.

Perhaps surprisingly, this arrangement is 5-10% faster than the current binary reader (using static dispatch in both) despite being much more flexible. This performance improvement likely comes from 2 sources:
1. Due to everything being immutable, field names and text can live as long as everything else without materialization.
2. Modeling the different contexts the reader can be in (top level, sequence, struct) as their own types means that some sanity checking can be elided. For example, only `reader.next()` needs to check for system values; no such check has to happen in sequences or structs. Additionally, the reader does not need to maintain a stack of parent contexts to support `step_in()` and `step_out`; accessing nested data is done via methods on the lazy container values, not on the reader itself.

This initial PR contains:
* A binary-only `LazyRawReader` that reads a fixed buffer and produces `LazyRawValue`s.
* A binary-only `LazySystemReader` that reads a fixed buffer and produces `LazyValue`s.
* A binary-only `LazyReader` that reads a fixed buffer and produces `LazyValue`s.

Follow-on work includes:
* Writing a blocking wrapper for the above that recognizes `IonError::Incomplete` and shifts the buffer to a new region of input.
* Text parsing using this API
* Traits to abstract over text vs binary 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
