### PR TITLE
Disable the "oldtime" feature of chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ experimental-streaming = []
 base64 = "0.12"
 bigdecimal = "0.3.0"
 bytes = "0.4"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std", "wasmbind"] }
 delegate = "0.9.0"
 thiserror = "1.0"
 nom = "7.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ experimental-streaming = []
 base64 = "0.12"
 bigdecimal = "0.3.0"
 bytes = "0.4"
+# chrono < 0.5 brings in a deprecated version of the `time` crate via `oldtime` feature by default
+# this makes it explicitly not do this as there is an advisory warning against this:
+# See: https://github.com/chronotope/chrono/issues/602
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "wasmbind"] }
 delegate = "0.9.0"
 thiserror = "1.0"


### PR DESCRIPTION
This feature, enabled by default in chrono versions <5, includes a dependency on the deprecated time@0.1.x. A security advisory is issued for this verion of time.

Some details available here: https://github.com/chronotope/chrono/issues/602

The `oldtime` feature does not appear to be used by this crate. I verified tests pass locally for me. I hope you will consider merging this change, and thank your for your work on this project!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.