### PR TITLE
Fix conversion to Decimal from f64 for values greater than +/- i64::MAX and smaller than +/- 1e-15

### DIFF
--- a/src/types/coefficient.rs
+++ b/src/types/coefficient.rs
@@ -128,7 +128,7 @@ impl TryFrom<Coefficient> for BigInt {
     /// converted is a negative zero, which BigInt cannot represent. Returns Ok otherwise.
     fn try_from(value: Coefficient) -> Result<Self, Self::Error> {
         if value.is_negative_zero() {
-            illegal_operation("Cannot convert negative zero Decimal to BigDecimal")?;
+            illegal_operation("Cannot convert negative zero Decimal to BigInt")?;
         }
         let mut big_int: BigInt = match value.magnitude {
             UInt::U64(m) => m.into(),
@@ -138,6 +138,22 @@ impl TryFrom<Coefficient> for BigInt {
             big_int.mul_assign(-1);
         }
         Ok(big_int)
+    }
+}
+
+impl TryFrom<BigInt> for Coefficient {
+    type Error = IonError;
+
+    fn try_from(value: BigInt) -> Result<Self, Self::Error> {
+        let (sign, magnitude) = value.into_parts();
+        let sign = match sign {
+            num_bigint::Sign::Minus => Sign::Negative,
+            num_bigint::Sign::Plus => Sign::Positive,
+            num_bigint::Sign::NoSign => {
+                return illegal_operation("Cannot convert sign-less BigInt to Decimal.")
+            }
+        };
+        Ok(Coefficient::new(sign, magnitude))
     }
 }
 

--- a/src/types/coefficient.rs
+++ b/src/types/coefficient.rs
@@ -150,7 +150,13 @@ impl TryFrom<BigInt> for Coefficient {
             num_bigint::Sign::Minus => Sign::Negative,
             num_bigint::Sign::Plus => Sign::Positive,
             num_bigint::Sign::NoSign => {
-                return illegal_operation("Cannot convert sign-less BigInt to Decimal.")
+                if magnitude.is_zero() {
+                    Sign::Positive
+                } else {
+                    return illegal_operation(
+                        "Cannot convert sign-less non-zero BigInt to Decimal.",
+                    );
+                }
             }
         };
         Ok(Coefficient::new(sign, magnitude))

--- a/src/types/decimal.rs
+++ b/src/types/decimal.rs
@@ -368,10 +368,9 @@ impl TryFrom<f64> for Decimal {
         }
 
         // If the f64 is an integer value, we can convert it to a decimal trivially.
-        // The `fract()` method returns the fractional part of the value. If fract() returns zero,
-        // then `value` is an integer.
+        // The `fract()` method returns the fractional part of the value.
+        // If fract() is zero, then `value` is an integer.
         if value.fract().is_zero() {
-            // The `trunc()` method returns the integer part of the value.
             try_convert(value, 0)
         } else {
             // If the f64 is not a round number, attempt to preserve as many decimal places of precision


### PR DESCRIPTION
Currently, `TryFrom<f64> for Decimal` unconditionally casts the `f64` coefficient to an `i64`, effectively clamping values larger than `i64::MAX` to `i64::MAX`.

This introduces an alternative code path for values larger than `i64::MAX` to create the `Coefficient` through a `BigInt`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
