### PR TITLE
Hotfix v0.18.1: Exposes raw bytes accessors in the `SystemReader`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
   "**/ion-tests/iontestdata/**",
   "*.pdf"
 ]
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 # We need at least 1.65 for GATs
 # https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html

--- a/src/system_reader.rs
+++ b/src/system_reader.rs
@@ -1,15 +1,15 @@
 use delegate::delegate;
-use std::io;
 use std::ops::Range;
 
+use crate::binary::non_blocking::raw_binary_reader::RawBinaryReader;
 use crate::constants::v1_0::{system_symbol_ids, SYSTEM_SYMBOLS};
 use crate::element::{Blob, Clob};
-use crate::raw_reader::{RawReader, RawStreamItem};
+use crate::raw_reader::{Expandable, RawReader, RawStreamItem};
 use crate::raw_symbol_token::RawSymbolToken;
 use crate::result::{decoding_error, decoding_error_raw, illegal_operation, IonError, IonResult};
 use crate::system_reader::LstPosition::*;
 use crate::types::{Decimal, Int, Str, Symbol, Timestamp};
-use crate::{BlockingRawBinaryReader, IonReader, IonType, SymbolTable};
+use crate::{IonReader, IonType, SymbolTable};
 
 /// Tracks where the [SystemReader] is in the process of reading a local symbol table.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -698,7 +698,7 @@ impl<R: RawReader> IonReader for SystemReader<R> {
 
 /// Functionality that is only available if the data source we're reading from is in-memory, like
 /// a `Vec<u8>` or `&[u8]`.
-impl<T: AsRef<[u8]>> SystemReader<BlockingRawBinaryReader<io::Cursor<T>>> {
+impl<T: AsRef<[u8]> + Expandable> SystemReader<RawBinaryReader<T>> {
     delegate! {
         to self.raw_reader {
             pub fn raw_bytes(&self) -> Option<&[u8]>;


### PR DESCRIPTION
While upgrading the `ion-cli` to use `ion-rs` v0.18.0 (see amazon-ion/ion-cli#52), I noticed that the `SystemReader` required a very specific configuration in order to access the raw bytes of the underlying stream. In particular, it required a `BlockingRawBinaryReader` to be the underlying raw reader. Unfortunately, using the raw bytes accessors in that configuration would access the ~4KB internal buffer of the blocking reader, causing a panic once you tried to access data beyond the first 4KB. This patch addresses that problem and bumps the version to 0.18.1 so the fix can be accessed by the `ion-cli`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
