### PR TITLE
Makes `UInt` an opaque struct type

### DIFF
--- a/src/binary/decimal.rs
+++ b/src/binary/decimal.rs
@@ -11,6 +11,7 @@ use crate::binary::var_int::VarInt;
 use crate::binary::var_uint::VarUInt;
 use crate::ion_data::IonEq;
 use crate::result::IonResult;
+use crate::types::integer::UIntData;
 use crate::types::{Coefficient, Decimal, Sign, UInt};
 use crate::IonError;
 
@@ -18,7 +19,9 @@ const DECIMAL_BUFFER_SIZE: usize = 32;
 const DECIMAL_POSITIVE_ZERO: Decimal = Decimal {
     coefficient: Coefficient {
         sign: Sign::Positive,
-        magnitude: UInt::U64(0),
+        magnitude: UInt {
+            data: UIntData::U64(0),
+        },
     },
     exponent: 0,
 };
@@ -69,9 +72,9 @@ where
             }
         } else {
             // Otherwise, allocate a Vec<u8> with the necessary representation.
-            let mut coefficient_bytes = match decimal.coefficient.magnitude() {
-                UInt::U64(unsigned) => unsigned.to_be_bytes().into(),
-                UInt::BigUInt(big) => big.to_bytes_be(),
+            let mut coefficient_bytes = match &decimal.coefficient.magnitude().data {
+                UIntData::U64(unsigned) => unsigned.to_be_bytes().into(),
+                UIntData::BigUInt(big) => big.to_bytes_be(),
             };
 
             let first_byte: &mut u8 = &mut coefficient_bytes[0];

--- a/src/lazy/binary/immutable_buffer.rs
+++ b/src/lazy/binary/immutable_buffer.rs
@@ -288,7 +288,7 @@ impl<'a> ImmutableBuffer<'a> {
             .ok_or_else(|| incomplete_data_error_raw("a UInt", self.offset()))?;
         let magnitude = DecodedUInt::small_uint_from_slice(uint_bytes);
         Ok((
-            DecodedUInt::new(UInt::U64(magnitude), length),
+            DecodedUInt::new(UInt::from(magnitude), length),
             self.consume(length),
         ))
     }
@@ -311,7 +311,7 @@ impl<'a> ImmutableBuffer<'a> {
 
         let magnitude = BigUint::from_bytes_be(uint_bytes);
         Ok((
-            DecodedUInt::new(UInt::BigUInt(magnitude), length),
+            DecodedUInt::new(UInt::from(magnitude), length),
             self.consume(length),
         ))
     }
@@ -823,7 +823,7 @@ mod tests {
         let buffer = ImmutableBuffer::new(&[0b1000_0000]);
         let var_int = buffer.read_uint(buffer.len())?.0;
         assert_eq!(var_int.size_in_bytes(), 1);
-        assert_eq!(var_int.value(), &UInt::U64(128));
+        assert_eq!(var_int.value(), &UInt::from(128));
         Ok(())
     }
 
@@ -832,7 +832,7 @@ mod tests {
         let buffer = ImmutableBuffer::new(&[0b0111_1111, 0b1111_1111]);
         let var_int = buffer.read_uint(buffer.len())?.0;
         assert_eq!(var_int.size_in_bytes(), 2);
-        assert_eq!(var_int.value(), &UInt::U64(32_767));
+        assert_eq!(var_int.value(), &UInt::from(32_767));
         Ok(())
     }
 
@@ -841,7 +841,7 @@ mod tests {
         let buffer = ImmutableBuffer::new(&[0b0011_1100, 0b1000_0111, 0b1000_0001]);
         let var_int = buffer.read_uint(buffer.len())?.0;
         assert_eq!(var_int.size_in_bytes(), 3);
-        assert_eq!(var_int.value(), &UInt::U64(3_966_849));
+        assert_eq!(var_int.value(), &UInt::from(3_966_849));
         Ok(())
     }
 
@@ -853,7 +853,7 @@ mod tests {
         assert_eq!(uint.size_in_bytes(), 10);
         assert_eq!(
             uint.value(),
-            &UInt::BigUInt(BigUint::from_str_radix("ffffffffffffffffffff", 16).unwrap())
+            &UInt::from(BigUint::from_str_radix("ffffffffffffffffffff", 16).unwrap())
         );
         Ok(())
     }

--- a/src/text/parsers/decimal.rs
+++ b/src/text/parsers/decimal.rs
@@ -90,12 +90,12 @@ fn decimal_from_text_components<'a>(
         let value = u64::from_str(&magnitude_text)
             .or_fatal_parse_error(input, "parsing coefficient magnitude as u64 failed")?
             .1;
-        UInt::U64(value)
+        value.into()
     } else {
         let value = BigUint::from_str(&magnitude_text)
             .or_fatal_parse_error(input, "parsing coefficient magnitude as u64 failed")?
             .1;
-        UInt::BigUInt(value)
+        value.into()
     };
 
     let coefficient = Coefficient::new(sign, magnitude);

--- a/src/types/decimal.rs
+++ b/src/types/decimal.rs
@@ -16,14 +16,14 @@ use std::ops::Neg;
 /// An arbitrary-precision Decimal type with a distinct representation of negative zero (`-0`).
 #[derive(Clone, Debug)]
 pub struct Decimal {
-    // A Coefficient is a Sign/UInteger pair supporting integers of arbitrary size
+    // A Coefficient is a `(Sign, UInt)` pair supporting integers of arbitrary size
     pub(crate) coefficient: Coefficient,
     pub(crate) exponent: i64,
 }
 
 impl Decimal {
-    /// Constructs a new Decimal with the provided components. The value of the decimal is
-    ///    (coefficient * 10^exponent) * (if sign == Sign::Negative { -1 } else { 1 })
+    /// Constructs a new Decimal with the provided components. The value of the decimal is:
+    ///    `coefficient * 10^exponent`
     pub fn new<I: Into<Coefficient>>(coefficient: I, exponent: i64) -> Decimal {
         let coefficient = coefficient.into();
         Decimal {

--- a/src/types/decimal.rs
+++ b/src/types/decimal.rs
@@ -5,6 +5,7 @@ use num_bigint::{BigInt, BigUint, ToBigInt, ToBigUint};
 
 use crate::ion_data::{IonEq, IonOrd};
 use crate::result::{illegal_operation, illegal_operation_raw, IonError};
+use crate::types::integer::UIntData;
 use crate::types::{Coefficient, Sign, UInt};
 use num_integer::Integer;
 use num_traits::{ToPrimitive, Zero};
@@ -66,9 +67,9 @@ impl Decimal {
 
     /// Returns `true` if this Decimal is a zero of any sign or exponent.
     pub fn is_zero(&self) -> bool {
-        match self.coefficient.magnitude() {
-            UInt::U64(0) => true,
-            UInt::BigUInt(m) => m.is_zero(),
+        match &self.coefficient.magnitude().data {
+            UIntData::U64(0) => true,
+            UIntData::BigUInt(m) => m.is_zero(),
             _ => false,
         }
     }
@@ -76,9 +77,9 @@ impl Decimal {
     /// Returns true if this Decimal's coefficient has a negative sign AND a magnitude greater than
     /// zero. Otherwise, returns false. (Negative zero returns false.)
     pub fn is_less_than_zero(&self) -> bool {
-        match (self.coefficient.sign(), self.coefficient.magnitude()) {
-            (Sign::Negative, UInt::U64(m)) if *m > 0 => true,
-            (Sign::Negative, UInt::BigUInt(m)) if m > &BigUint::zero() => true,
+        match (self.coefficient.sign(), &self.coefficient.magnitude().data) {
+            (Sign::Negative, UIntData::U64(m)) if *m > 0 => true,
+            (Sign::Negative, UIntData::BigUInt(m)) if m > &BigUint::zero() => true,
             _ => false,
         }
     }
@@ -87,9 +88,9 @@ impl Decimal {
     pub(crate) fn is_greater_than_or_equal_to_one(&self) -> bool {
         // If the coefficient has a magnitude of zero, the Decimal is a zero of some precision
         // and so is not >= 1.
-        match &self.coefficient.magnitude {
-            UInt::U64(magnitude) if magnitude.is_zero() => return false,
-            UInt::BigUInt(magnitude) if magnitude.is_zero() => return false,
+        match &self.coefficient.magnitude.data {
+            UIntData::U64(magnitude) if magnitude.is_zero() => return false,
+            UIntData::BigUInt(magnitude) if magnitude.is_zero() => return false,
             _ => {}
         }
 
@@ -166,7 +167,7 @@ impl Decimal {
         // This lets us compare 80 and 80, determining that the decimals are equal.
         let mut scaled_coefficient: BigUint = d1.coefficient.magnitude().to_biguint().unwrap();
         scaled_coefficient *= BigUint::from(10u64).pow(exponent_delta as u32);
-        UInt::BigUInt(scaled_coefficient).cmp(d2.coefficient.magnitude())
+        UInt::from(scaled_coefficient).cmp(d2.coefficient.magnitude())
     }
 
     /// Extract the integer and fractional parts and the exponents of this as a `(BigInt, (BigInt, i64))`

--- a/src/types/integer.rs
+++ b/src/types/integer.rs
@@ -253,7 +253,7 @@ macro_rules! impl_int_types_from_uint {
     )*)
 }
 
-impl_int_types_from_uint!(i8, i16, i32, i64, i128, u8, u16, u32, u64, u128);
+impl_int_types_from_uint!(i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize);
 
 impl From<i128> for UInt {
     fn from(value: i128) -> UInt {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -7,7 +7,7 @@ pub type SymbolId = usize;
 mod bytes;
 mod coefficient;
 mod decimal;
-mod integer;
+pub(crate) mod integer;
 mod list;
 mod lob;
 mod sequence;

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -2,8 +2,9 @@ use crate::ion_data::{IonEq, IonOrd};
 use crate::result::{
     encoding_error, illegal_operation, illegal_operation_raw, IonError, IonResult,
 };
+use crate::types::integer::UIntData;
+use crate::types::Decimal;
 use crate::types::Sign::Negative;
-use crate::types::{Decimal, UInt};
 use chrono::{
     DateTime, Datelike, FixedOffset, LocalResult, NaiveDate, NaiveDateTime, TimeZone, Timelike,
 };
@@ -243,9 +244,9 @@ impl Timestamp {
             Some(Arbitrary(decimal)) => {
                 const NANOSECONDS_EXPONENT: i64 = -9;
                 let exponent_delta = decimal.exponent - NANOSECONDS_EXPONENT;
-                let magnitude = match decimal.coefficient.magnitude() {
-                    UInt::U64(magnitude) => *magnitude,
-                    UInt::BigUInt(magnitude) => {
+                let magnitude = match &decimal.coefficient.magnitude().data {
+                    UIntData::U64(magnitude) => *magnitude,
+                    UIntData::BigUInt(magnitude) => {
                         // If the magnitude is small enough to fit in a u64, do the conversion.
                         if let Ok(small_magnitude) = u64::try_from(magnitude) {
                             small_magnitude


### PR DESCRIPTION
Prior to this patch, `UInt` was an enum offering two storage
options: `u64` and `BigUint`.

This patch wraps that enum (now a private type called `UIntData`) in
an opaque struct, giving us the ability to change that representation
in the future without a breaking change.

This also provides a `TryFrom<&UInt>` implementation for all primitive
integer types.

Related to #507.

A follow-on PR will make the same change for the signed `Int` type.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
