### PR TITLE
Signed type impls of Into<UInt> are now fallible

### DIFF
--- a/src/binary/int.rs
+++ b/src/binary/int.rs
@@ -197,7 +197,7 @@ impl From<DecodedInt> for Coefficient {
         } = int;
         use types::Sign::{Negative, Positive};
         let sign = if is_negative { Negative } else { Positive };
-        Coefficient::new(sign, value)
+        Coefficient::new(sign, value.unsigned_abs())
     }
 }
 

--- a/src/binary/non_blocking/binary_buffer.rs
+++ b/src/binary/non_blocking/binary_buffer.rs
@@ -690,7 +690,7 @@ mod tests {
         let mut buffer = BinaryBuffer::new(&[0b1000_0000]);
         let var_int = buffer.read_uint(buffer.remaining())?;
         assert_eq!(var_int.size_in_bytes(), 1);
-        assert_eq!(var_int.value(), &UInt::from(128));
+        assert_eq!(var_int.value(), &UInt::from(128u64));
         Ok(())
     }
 
@@ -699,7 +699,7 @@ mod tests {
         let mut buffer = BinaryBuffer::new(&[0b0111_1111, 0b1111_1111]);
         let var_int = buffer.read_uint(buffer.remaining())?;
         assert_eq!(var_int.size_in_bytes(), 2);
-        assert_eq!(var_int.value(), &UInt::from(32_767));
+        assert_eq!(var_int.value(), &UInt::from(32_767u64));
         Ok(())
     }
 
@@ -708,7 +708,7 @@ mod tests {
         let mut buffer = BinaryBuffer::new(&[0b0011_1100, 0b1000_0111, 0b1000_0001]);
         let var_int = buffer.read_uint(buffer.remaining())?;
         assert_eq!(var_int.size_in_bytes(), 3);
-        assert_eq!(var_int.value(), &UInt::from(3_966_849));
+        assert_eq!(var_int.value(), &UInt::from(3_966_849u64));
         Ok(())
     }
 

--- a/src/binary/uint.rs
+++ b/src/binary/uint.rs
@@ -221,7 +221,7 @@ mod tests {
         let data = &[0b1000_0000];
         let uint = DecodedUInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
         assert_eq!(uint.size_in_bytes(), 1);
-        assert_eq!(uint.value(), &UInt::from(128));
+        assert_eq!(uint.value(), &UInt::from(128u64));
     }
 
     #[test]
@@ -229,7 +229,7 @@ mod tests {
         let data = &[0b0111_1111, 0b1111_1111];
         let uint = DecodedUInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
         assert_eq!(uint.size_in_bytes(), 2);
-        assert_eq!(uint.value(), &UInt::from(32_767));
+        assert_eq!(uint.value(), &UInt::from(32_767u64));
     }
 
     #[test]
@@ -237,7 +237,7 @@ mod tests {
         let data = &[0b0011_1100, 0b1000_0111, 0b1000_0001];
         let uint = DecodedUInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
         assert_eq!(uint.size_in_bytes(), 3);
-        assert_eq!(uint.value(), &UInt::from(3_966_849));
+        assert_eq!(uint.value(), &UInt::from(3_966_849u64));
     }
 
     #[test]

--- a/src/lazy/binary/immutable_buffer.rs
+++ b/src/lazy/binary/immutable_buffer.rs
@@ -823,7 +823,7 @@ mod tests {
         let buffer = ImmutableBuffer::new(&[0b1000_0000]);
         let var_int = buffer.read_uint(buffer.len())?.0;
         assert_eq!(var_int.size_in_bytes(), 1);
-        assert_eq!(var_int.value(), &UInt::from(128));
+        assert_eq!(var_int.value(), &UInt::from(128u64));
         Ok(())
     }
 
@@ -832,7 +832,7 @@ mod tests {
         let buffer = ImmutableBuffer::new(&[0b0111_1111, 0b1111_1111]);
         let var_int = buffer.read_uint(buffer.len())?.0;
         assert_eq!(var_int.size_in_bytes(), 2);
-        assert_eq!(var_int.value(), &UInt::from(32_767));
+        assert_eq!(var_int.value(), &UInt::from(32_767u64));
         Ok(())
     }
 
@@ -841,7 +841,7 @@ mod tests {
         let buffer = ImmutableBuffer::new(&[0b0011_1100, 0b1000_0111, 0b1000_0001]);
         let var_int = buffer.read_uint(buffer.len())?.0;
         assert_eq!(var_int.size_in_bytes(), 3);
-        assert_eq!(var_int.value(), &UInt::from(3_966_849));
+        assert_eq!(var_int.value(), &UInt::from(3_966_849u64));
         Ok(())
     }
 


### PR DESCRIPTION
Fixes #569.

* Signed integer primitives now implement `TryInto<UInt>` and fail if they are negative.
* `Coefficient::new` now takes `I: Into<Magnitude>` where `Magnitude` is a wrapper that signed integers infallibly convert to via absolute value.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
