### PR TITLE
Makes `Int` an opaque struct

### DIFF
--- a/src/binary/non_blocking/raw_binary_reader.rs
+++ b/src/binary/non_blocking/raw_binary_reader.rs
@@ -1563,11 +1563,11 @@ mod tests {
         ];
         let mut reader = RawBinaryReader::new(data.as_slice());
         expect_value(reader.next(), IonType::Int);
-        assert_eq!(reader.read_int()?, Int::I64(1));
+        assert_eq!(reader.read_int()?, 1i64.into());
         expect_value(reader.next(), IonType::Int);
-        assert_eq!(reader.read_int()?, Int::I64(2));
+        assert_eq!(reader.read_int()?, 2i64.into());
         expect_value(reader.next(), IonType::Int);
-        assert_eq!(reader.read_int()?, Int::I64(3));
+        assert_eq!(reader.read_int()?, 3i64.into());
         // Nothing else in the buffer
         expect_eof(reader.next());
         Ok(())
@@ -1972,7 +1972,7 @@ mod tests {
         assert_eq!(reader.next()?, RawStreamItem::Nothing);
         reader.append_bytes(&[0x20])?;
         assert_eq!(reader.next()?, RawStreamItem::Value(IonType::Int));
-        assert_eq!(reader.read_int()?, Int::I64(0));
+        assert_eq!(reader.read_int()?, 0.into());
         Ok(())
     }
 

--- a/src/binary/uint.rs
+++ b/src/binary/uint.rs
@@ -126,7 +126,7 @@ impl From<DecodedUInt> for Int {
             value,
             .. // Ignore 'size_in_bytes'
         } = uint;
-        Int::from(value)
+        value.into()
     }
 }
 

--- a/src/element/element_stream_reader.rs
+++ b/src/element/element_stream_reader.rs
@@ -1,4 +1,4 @@
-use crate::result::{decoding_error, illegal_operation, illegal_operation_raw};
+use crate::result::{illegal_operation, illegal_operation_raw};
 use crate::text::parent_container::ParentContainer;
 
 use crate::element::iterators::SymbolsIterator;
@@ -216,12 +216,7 @@ impl IonReader for ElementStreamReader {
 
     fn read_i64(&mut self) -> IonResult<i64> {
         match self.current_value.as_ref() {
-            Some(element) if element.as_int().is_some() => match element.as_int().unwrap() {
-                Int::I64(value) => Ok(*value),
-                Int::BigInt(value) => {
-                    decoding_error(format!("Integer {value} is too large to fit in an i64."))
-                }
-            },
+            Some(element) if element.as_int().is_some() => element.as_int().unwrap().expect_i64(),
             _ => Err(self.expected("int value")),
         }
     }

--- a/src/element/element_stream_writer.rs
+++ b/src/element/element_stream_writer.rs
@@ -185,7 +185,7 @@ where
     }
 
     fn write_i64(&mut self, value: i64) -> IonResult<()> {
-        self.write_scalar(Value::Int(Int::I64(value)))
+        self.write_scalar(Value::Int(value.into()))
     }
 
     fn write_int(&mut self, value: &Int) -> IonResult<()> {
@@ -301,7 +301,7 @@ mod tests {
 
     use crate::types::{Bytes, Timestamp};
     use crate::writer::IonWriter;
-    use crate::{Decimal, Int, IonType, Symbol};
+    use crate::{Decimal, IonType, Symbol};
 
     #[track_caller]
     fn writer_test_with_assertion<F, E, A>(mut commands: F, expected: Vec<E>, mut assertion: A)
@@ -384,7 +384,7 @@ mod tests {
 
     #[test]
     fn write_i64() {
-        writer_scalar_test(|w| w.write_i64(7), Value::Int(Int::I64(7)));
+        writer_scalar_test(|w| w.write_i64(7), Value::Int(7i64.into()));
     }
 
     #[test]
@@ -404,7 +404,7 @@ mod tests {
                 w.set_annotations(["foo", "bar", "baz quux"]);
                 w.write_i64(7)
             },
-            Value::Int(Int::I64(7)).with_annotations(["foo", "bar", "baz quux"]),
+            Value::Int(7i64.into()).with_annotations(["foo", "bar", "baz quux"]),
         );
     }
 

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -178,13 +178,13 @@ impl From<IonType> for Value {
 
 impl From<i64> for Value {
     fn from(i64_val: i64) -> Self {
-        Value::Int(Int::I64(i64_val))
+        Value::Int(i64_val.into())
     }
 }
 
 impl From<BigInt> for Value {
     fn from(big_int_val: BigInt) -> Self {
-        Value::Int(Int::BigInt(big_int_val))
+        Value::Int(big_int_val.into())
     }
 }
 
@@ -1063,7 +1063,7 @@ mod tests {
             ops: vec![AsAnyInt],
             op_assert: Box::new(|e: &Element| {
                 let expected: Element = 100i64.into();
-                assert_eq!(Some(&Int::I64(100)), e.as_int());
+                assert_eq!(Some(&Int::from(100i64)), e.as_int());
                 assert_eq!(Some(100), e.as_i64());
                 assert_eq!(None, e.as_big_int());
                 assert_eq!(&expected, e);
@@ -1078,7 +1078,7 @@ mod tests {
             ops: vec![AsAnyInt],
             op_assert: Box::new(|e: &Element| {
                 let expected: Element = BigInt::from(100).into();
-                assert_eq!(Some(&Int::BigInt(BigInt::from(100))), e.as_int());
+                assert_eq!(Some(&Int::from(BigInt::from(100))), e.as_int());
                 assert_eq!(BigInt::from_str("100").unwrap(), *e.as_big_int().unwrap());
                 assert_eq!(&expected, e);
             }),

--- a/src/element/reader.rs
+++ b/src/element/reader.rs
@@ -247,16 +247,16 @@ mod reader_tests {
             -79228162514264337593543950336 79228162514264337593543950335
         "#,
         vec![
-            0,
+            0i64,
             -65536, 65535,
             -4294967296, 4294967295,
             -9007199254740992, 9007199254740991,
-        ].into_iter().map(Int::I64).chain(
+        ].into_iter().map(Int::from).chain(
             vec![
                 "-18446744073709551616", "18446744073709551615",
                 "-79228162514264337593543950336", "79228162514264337593543950335",
             ].into_iter()
-            .map(|v| Int::BigInt(BigInt::parse_bytes(v.as_bytes(), 10).unwrap()))
+            .map(|v| Int::from(BigInt::parse_bytes(v.as_bytes(), 10).unwrap()))
         ).map(|ai| Int(ai).into()).collect(),
     )]
     #[case::int64_threshold_as_big_int(
@@ -264,14 +264,14 @@ mod reader_tests {
         vec![
             "18446744073709551615",
         ].into_iter()
-        .map(|v| Int::BigInt(BigInt::parse_bytes(v.as_bytes(), 10).unwrap())).map(|ai| Int(ai).into()).collect(),
+        .map(|v| Int::from(BigInt::parse_bytes(v.as_bytes(), 10).unwrap())).map(|ai| Int(ai).into()).collect(),
     )]
     #[case::int64_threshold_as_int64(
         &[0xE0, 0x01, 0x00, 0xEA, 0x38, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
         vec![
             "-9223372036854775808",
         ].into_iter()
-        .map(|v| Int::BigInt(BigInt::parse_bytes(v.as_bytes(), 10).unwrap())).map(|ai| Int(ai).into()).collect(),
+        .map(|v| Int::from(BigInt::parse_bytes(v.as_bytes(), 10).unwrap())).map(|ai| Int(ai).into()).collect(),
     )]
     #[case::floats(
         br#"

--- a/src/ion_hash/type_qualifier.rs
+++ b/src/ion_hash/type_qualifier.rs
@@ -5,7 +5,6 @@
 use crate::binary::IonTypeCode;
 use crate::element::{Element, Sequence, Struct};
 use crate::{Decimal, Int, IonType, Symbol, Timestamp};
-use num_bigint::Sign;
 
 use std::slice;
 
@@ -59,13 +58,7 @@ impl TypeQualifier {
 }
 
 fn is_integer_positive(value: Option<&Int>) -> bool {
-    match value {
-        None => true,
-        Some(any) => match any {
-            Int::I64(i) => *i >= 0,
-            Int::BigInt(b) => !std::matches!(b.sign(), Sign::Minus),
-        },
-    }
+    value.map(|i| !i.is_negative()).unwrap_or(true)
 }
 
 /// For many types, the qualifier (see: [`TypeQualifier`]) is based on whether

--- a/src/lazy/binary/raw/lazy_raw_value.rs
+++ b/src/lazy/binary/raw/lazy_raw_value.rs
@@ -8,7 +8,7 @@ use crate::lazy::binary::raw::raw_annotations_iterator::RawAnnotationsIterator;
 use crate::lazy::raw_value_ref::RawValueRef;
 use crate::result::{decoding_error, decoding_error_raw, incomplete_data_error};
 use crate::types::SymbolId;
-use crate::{Decimal, IonResult, IonType, RawSymbolTokenRef, Timestamp};
+use crate::{Decimal, Int, IonResult, IonType, RawSymbolTokenRef, Timestamp};
 use bytes::{BigEndian, ByteOrder};
 use std::fmt::{Debug, Formatter};
 use std::{fmt, mem};
@@ -181,7 +181,6 @@ impl<'data> LazyRawValue<'data> {
         };
 
         use crate::binary::type_code::IonTypeCode::*;
-        use crate::Int;
         use num_traits::Zero;
         let value = match (self.encoded_value.header.ion_type_code, magnitude) {
             (PositiveInteger, integer) => integer,

--- a/src/lazy/value_ref.rs
+++ b/src/lazy/value_ref.rs
@@ -122,8 +122,8 @@ impl<'top, 'data> ValueRef<'top, 'data> {
     }
 
     pub fn expect_i64(self) -> IonResult<i64> {
-        if let ValueRef::Int(Int::I64(i)) = self {
-            Ok(i)
+        if let ValueRef::Int(i) = self {
+            i.expect_i64()
         } else {
             decoding_error("expected an int (i64)")
         }

--- a/src/stream_reader.rs
+++ b/src/stream_reader.rs
@@ -81,7 +81,7 @@ pub trait IonReader {
     /// error is encountered while reading, returns [crate::IonError].
     fn read_i64(&mut self) -> IonResult<i64>;
 
-    /// Attempts to read the current item as an Ion integer and return it as an [`Int`](crate::types::Int). If the
+    /// Attempts to read the current item as an Ion integer and return it as an [`Int`](crate::types::IntData). If the
     /// current item is not an integer or an IO error is encountered while reading, returns
     /// [crate::IonError].
     fn read_int(&mut self) -> IonResult<Int>;

--- a/src/stream_reader.rs
+++ b/src/stream_reader.rs
@@ -81,7 +81,7 @@ pub trait IonReader {
     /// error is encountered while reading, returns [crate::IonError].
     fn read_i64(&mut self) -> IonResult<i64>;
 
-    /// Attempts to read the current item as an Ion integer and return it as an [`Int`](crate::types::IntData). If the
+    /// Attempts to read the current item as an Ion integer and return it as an [`Int`](crate::types::Int). If the
     /// current item is not an integer or an IO error is encountered while reading, returns
     /// [crate::IonError].
     fn read_int(&mut self) -> IonResult<Int>;

--- a/src/text/parsers/containers.rs
+++ b/src/text/parsers/containers.rs
@@ -233,7 +233,7 @@ mod container_parsing_tests {
     use crate::raw_symbol_token::{local_sid_token, text_token};
     use crate::text::parsers::unit_test_support::{parse_test_err, parse_test_ok};
     use crate::text::text_value::TextValue;
-    use crate::types::{Decimal, Int};
+    use crate::types::Decimal;
 
     use super::*;
 
@@ -257,8 +257,8 @@ mod container_parsing_tests {
     }
 
     #[rstest]
-    #[case("5,", TextValue::Int(Int::I64(5)).without_annotations())]
-    #[case("foo::bar::5,", TextValue::Int(Int::I64(5)).with_annotations(["foo", "bar"]))]
+    #[case("5,", TextValue::Int(5.into()).without_annotations())]
+    #[case("foo::bar::5,", TextValue::Int(5.into()).with_annotations(["foo", "bar"]))]
     #[case("foo::bar,", TextValue::Symbol(text_token("bar")).with_annotations("foo"))]
     #[case("bar]", TextValue::Symbol(text_token("bar")).without_annotations())]
     #[case("7.]", TextValue::Decimal(Decimal::new(7, 0)).without_annotations())]
@@ -275,8 +275,8 @@ mod container_parsing_tests {
     #[rstest]
     #[case("'++',", Some(TextValue::Symbol(text_token("++")).without_annotations()))]
     #[case("foo::'++',", Some(TextValue::Symbol(text_token("++")).with_annotations("foo")))]
-    #[case("5    ,", Some(TextValue::Int(Int::I64(5)).without_annotations()))]
-    #[case("5]", Some(TextValue::Int(Int::I64(5)).without_annotations()))]
+    #[case("5    ,", Some(TextValue::Int(5.into()).without_annotations()))]
+    #[case("5]", Some(TextValue::Int(5.into()).without_annotations()))]
     #[case("]", None)]
     #[case("  ]", None)]
     #[case(" /*comment*/  ]", None)]
@@ -290,9 +290,9 @@ mod container_parsing_tests {
     #[rstest]
     #[case("++ ", TextValue::Symbol(text_token("++")).without_annotations())]
     #[case("foo::++ ", TextValue::Symbol(text_token("++")).with_annotations("foo"))]
-    #[case("5 ", TextValue::Int(Int::I64(5)).without_annotations())]
-    #[case("5)", TextValue::Int(Int::I64(5)).without_annotations())]
-    #[case("foo::bar::5 ", TextValue::Int(Int::I64(5)).with_annotations(["foo", "bar"]))]
+    #[case("5 ", TextValue::Int(5.into()).without_annotations())]
+    #[case("5)", TextValue::Int(5.into()).without_annotations())]
+    #[case("foo::bar::5 ", TextValue::Int(5.into()).with_annotations(["foo", "bar"]))]
     //               v--- This zero allows the parser to tell that the previous value is complete.
     #[case("foo::bar 0", TextValue::Symbol(text_token("bar")).with_annotations("foo"))]
     #[case("bar)", TextValue::Symbol(text_token("bar")).without_annotations())]
@@ -310,7 +310,7 @@ mod container_parsing_tests {
     #[rstest]
     #[case("++ ", Some(TextValue::Symbol(text_token("++")).without_annotations()))]
     #[case("foo::++ ", Some(TextValue::Symbol(text_token("++")).with_annotations("foo")))]
-    #[case("5 ", Some(TextValue::Int(Int::I64(5)).without_annotations()))]
+    #[case("5 ", Some(TextValue::Int(5.into()).without_annotations()))]
     #[case(")", None)]
     #[case("  )", None)]
     #[case(" /*comment*/  )", None)]
@@ -322,9 +322,9 @@ mod container_parsing_tests {
     }
 
     #[rstest]
-    #[case("5,", TextValue::Int(Int::I64(5)).without_annotations())]
-    #[case("5  ,", TextValue::Int(Int::I64(5)).without_annotations())]
-    #[case("foo::bar::5,", TextValue::Int(Int::I64(5)).with_annotations(["foo", "bar"]))]
+    #[case("5,", TextValue::Int(5.into()).without_annotations())]
+    #[case("5  ,", TextValue::Int(5.into()).without_annotations())]
+    #[case("foo::bar::5,", TextValue::Int(5.into()).with_annotations(["foo", "bar"]))]
     #[case("foo::bar,", TextValue::Symbol(text_token("bar")).with_annotations("foo"))]
     #[case("bar}", TextValue::Symbol(text_token("bar")).without_annotations())]
     #[case("7.}", TextValue::Decimal(Decimal::new(7, 0)).without_annotations())]

--- a/src/text/parsers/top_level.rs
+++ b/src/text/parsers/top_level.rs
@@ -90,7 +90,6 @@ mod parse_top_level_values_tests {
     use crate::text::parsers::unit_test_support::{parse_test_err, parse_test_ok, parse_unwrap};
     use crate::text::parsers::value::value;
     use crate::text::text_value::TextValue;
-    use crate::types::Int;
     use crate::IonType;
 
     use super::*;
@@ -145,7 +144,7 @@ mod parse_top_level_values_tests {
     // Here, 'END' is simply an unrelated symbol value that the parser knows to ignore.
     #[case("foo::bar::baz END", &["foo", "bar"], TextValue::Symbol(text_token("baz")))]
     #[case("foo::bar::baz END", &["foo", "bar"], TextValue::Symbol(text_token("baz")))]
-    #[case("foo::'bar'::7 END", &["foo", "bar"], TextValue::Int(Int::I64(7)))]
+    #[case("foo::'bar'::7 END", &["foo", "bar"], TextValue::Int(7.into()))]
     #[case("'foo'::'bar'::{ END", &["foo", "bar"], TextValue::StructStart)]
     #[case("'foo bar'::false END", &["foo bar"], TextValue::Bool(false))]
     fn test_parse_annotated_value(

--- a/src/text/text_formatter.rs
+++ b/src/text/text_formatter.rs
@@ -451,7 +451,7 @@ impl<'a, W: std::fmt::Write> IonValueFormatter<'a, W> {
 #[cfg(test)]
 mod formatter_test {
     use crate::text::text_formatter::IonValueFormatter;
-    use crate::{ion_list, ion_sexp, ion_struct, Int, IonResult, IonType, Timestamp};
+    use crate::{ion_list, ion_sexp, ion_struct, IonResult, IonType, Timestamp};
     use num_bigint::BigInt;
 
     fn formatter<F>(mut f: F, expected: &str)
@@ -483,18 +483,15 @@ mod formatter_test {
 
     #[test]
     fn test_format_i64() -> IonResult<()> {
-        formatter(|ivf| ivf.format_integer(&Int::I64(4)), "4");
-        formatter(|ivf| ivf.format_integer(&Int::I64(-4)), "-4");
+        formatter(|ivf| ivf.format_integer(&4i64.into()), "4");
+        formatter(|ivf| ivf.format_integer(&(-4i64).into()), "-4");
         Ok(())
     }
 
     #[test]
     fn test_format_big_int() -> IonResult<()> {
-        formatter(|ivf| ivf.format_integer(&Int::BigInt(BigInt::from(4))), "4");
-        formatter(
-            |ivf| ivf.format_integer(&Int::BigInt(BigInt::from(-4))),
-            "-4",
-        );
+        formatter(|ivf| ivf.format_integer(&BigInt::from(4).into()), "4");
+        formatter(|ivf| ivf.format_integer(&BigInt::from(-4).into()), "-4");
         Ok(())
     }
 

--- a/src/types/integer.rs
+++ b/src/types/integer.rs
@@ -8,7 +8,7 @@ use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 use std::ops::{Add, Neg};
 
-/// Provides convenient integer accessors for integer values that are like [`IntData`]
+/// Provides convenient integer accessors for integer values that are like [`Int`]
 pub trait IntAccess {
     /// Returns the value as an `i64` if it can be represented as such.
     ///

--- a/src/types/integer.rs
+++ b/src/types/integer.rs
@@ -1,12 +1,14 @@
 use crate::element::Element;
 use crate::ion_data::{IonEq, IonOrd};
+use crate::result::decoding_error;
+use crate::IonResult;
 use num_bigint::{BigInt, BigUint, ToBigUint};
-use num_traits::{Signed, ToPrimitive, Zero};
+use num_traits::{CheckedAdd, Signed, ToPrimitive, Zero};
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 use std::ops::{Add, Neg};
 
-/// Provides convenient integer accessors for integer values that are like [`Int`]
+/// Provides convenient integer accessors for integer values that are like [`IntData`]
 pub trait IntAccess {
     /// Returns the value as an `i64` if it can be represented as such.
     ///
@@ -16,8 +18,8 @@ pub trait IntAccess {
     /// # use ion_rs::element::*;
     /// # use ion_rs::types::*;
     /// # use num_bigint::*;
-    /// let big_int = Int::BigInt(BigInt::from(100));
-    /// let i64_int = Int::I64(100);
+    /// let big_int = Int::from(BigInt::from(100));
+    /// let i64_int = Int::from(100);
     /// assert_eq!(big_int.as_i64(), i64_int.as_i64());
     ///
     /// // works on element too
@@ -40,12 +42,12 @@ pub trait IntAccess {
     /// # use ion_rs::types::*;
     /// # use num_bigint::*;
     /// # use std::str::FromStr;
-    /// let big_int = Int::BigInt(BigInt::from(100));
+    /// let big_int = Int::from(BigInt::from(100));
     /// assert_eq!(
     ///     BigInt::from_str("100").unwrap(),
     ///     *big_int.as_big_int().unwrap()
     /// );
-    /// let i64_int = Int::I64(100);
+    /// let i64_int = Int::from(100);
     /// assert_eq!(None, i64_int.as_big_int());
     ///
     /// // works on element too
@@ -145,24 +147,6 @@ impl Ord for UInt {
             (BigUInt(m1), BigUInt(m2)) => m1.cmp(m2),
             (U64(m1), BigUInt(m2)) => UInt::cross_representation_cmp(*m1, m2),
             (BigUInt(m1), U64(m2)) => UInt::cross_representation_cmp(*m2, m1).reverse(),
-        }
-    }
-}
-
-impl From<UInt> for Int {
-    fn from(value: UInt) -> Self {
-        match value.data {
-            UIntData::U64(uint) => {
-                if let Ok(signed) = i64::try_from(uint) {
-                    // The u64 was successfully converted to an i64
-                    Int::I64(signed)
-                } else {
-                    // The u64 was slightly too big to be represented as an i64; it required the
-                    // 64th bit to store the magnitude. Up-convert it to a BigInt.
-                    big_integer_from_u64(uint)
-                }
-            }
-            UIntData::BigUInt(big_uint) => big_integer_from_big_uint(big_uint),
         }
     }
 }
@@ -278,18 +262,15 @@ impl TryFrom<Int> for UInt {
     type Error = ();
 
     fn try_from(value: Int) -> Result<Self, Self::Error> {
-        match value {
-            Int::I64(i) if i >= 0 => Ok(i.unsigned_abs().into()),
-            Int::I64(_i) => Err(()),
-            // num_bigint::BigInt's `into_parts` consumes the BigInt and returns a
-            // (sign: Sign, magnitude: BigUint) tuple.
-            Int::BigInt(i) => {
-                let (sign, magnitude) = i.into_parts();
-                if sign == num_bigint::Sign::Minus {
-                    Err(())
-                } else {
-                    Ok(magnitude.into())
-                }
+        match value.data {
+            IntData::I64(i) if i < 0 => Err(()),
+            IntData::I64(i) => Ok(i.unsigned_abs().into()),
+            IntData::BigInt(i) if i.sign() == num_bigint::Sign::Minus => Err(()),
+            IntData::BigInt(i) => {
+                // num_bigint::BigInt's `into_parts` consumes the BigInt and returns a
+                // (sign: Sign, magnitude: BigUint) tuple.
+                let (_, magnitude) = i.into_parts();
+                Ok(magnitude.into())
             }
         }
     }
@@ -297,41 +278,70 @@ impl TryFrom<Int> for UInt {
 
 #[inline(never)]
 fn big_integer_from_u64(value: u64) -> Int {
-    Int::BigInt(BigInt::from(value))
+    IntData::BigInt(BigInt::from(value)).into()
 }
 
 #[inline(never)]
 fn big_integer_from_big_uint(value: BigUint) -> Int {
-    Int::BigInt(BigInt::from(value))
+    IntData::BigInt(BigInt::from(value)).into()
 }
 
 /// Container for either an integer that can fit in a 64-bit word or an arbitrarily sized
 /// [`BigInt`].
-///
-/// See [`IntAccess`] for common operations.
 #[derive(Debug, Clone)]
-pub enum Int {
+pub(crate) enum IntData {
     I64(i64),
     BigInt(BigInt),
+}
+
+impl From<IntData> for Int {
+    fn from(data: IntData) -> Self {
+        Int { data }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Int {
+    pub(crate) data: IntData,
 }
 
 impl Int {
     /// Returns a [`UInt`] representing the unsigned magnitude of this `Int`.
     pub(crate) fn unsigned_abs(&self) -> UInt {
-        match self {
-            Int::I64(i) => i.unsigned_abs().into(),
-            Int::BigInt(i) => i.abs().into_parts().1.into(),
+        match &self.data {
+            IntData::I64(i) => i.unsigned_abs().into(),
+            IntData::BigInt(i) => i.abs().into_parts().1.into(),
         }
     }
 
-    /// Compares a [i64] integer with a [BigInt] to see if they are equal. This method never
+    /// Returns `true` if this value is less than zero.
+    /// If this value is greater than or equal to zero, returns `false`.
+    pub fn is_negative(&self) -> bool {
+        match &self.data {
+            IntData::I64(i) => *i < 0,
+            IntData::BigInt(i) => i.is_negative(),
+        }
+    }
+
+    /// If this value is small enough to fit in an `i64`, returns `Ok(i64)`. Otherwise,
+    /// returns a [`DecodingError`](crate::IonError::DecodingError).
+    pub fn expect_i64(&self) -> IonResult<i64> {
+        match &self.data {
+            IntData::I64(i) => Ok(*i),
+            IntData::BigInt(_) => {
+                decoding_error(format!("Int {self} is too large to fit in an i64."))
+            }
+        }
+    }
+
+    /// Compares an [i64] integer with a [BigInt] to see if they are equal. This method never
     /// allocates. It will always prefer to downgrade a BigUint and compare the two integers as
     /// u64 values. If this is not possible, then the two numbers cannot be equal anyway.
     fn cross_representation_eq(m1: i64, m2: &BigInt) -> bool {
         Int::cross_representation_cmp(m1, m2) == Ordering::Equal
     }
 
-    /// Compares a [i64] integer with a [BigInt]. This method never allocates. It will always
+    /// Compares an [i64] integer with a [BigInt]. This method never allocates. It will always
     /// prefer to downgrade a BigUint and compare the two integers as u64 values. If this is
     /// not possible, then the BigUint is larger than the u64.
     fn cross_representation_cmp(m1: i64, m2: &BigInt) -> Ordering {
@@ -348,25 +358,25 @@ impl Int {
 impl IntAccess for Int {
     #[inline]
     fn as_i64(&self) -> Option<i64> {
-        match &self {
-            Int::I64(i) => Some(*i),
-            Int::BigInt(big) => big.to_i64(),
+        match &self.data {
+            IntData::I64(i) => Some(*i),
+            IntData::BigInt(big) => big.to_i64(),
         }
     }
 
     #[inline]
     fn as_big_int(&self) -> Option<&BigInt> {
-        match &self {
-            Int::I64(_) => None,
-            Int::BigInt(big) => Some(big),
+        match &self.data {
+            IntData::I64(_) => None,
+            IntData::BigInt(big) => Some(big),
         }
     }
 }
 
 impl PartialEq for Int {
     fn eq(&self, other: &Self) -> bool {
-        use Int::*;
-        match (self, other) {
+        use IntData::*;
+        match (&self.data, &other.data) {
             (I64(m1), I64(m2)) => m1 == m2,
             (BigInt(m1), BigInt(m2)) => m1 == m2,
             (I64(m1), BigInt(m2)) => Int::cross_representation_eq(*m1, m2),
@@ -393,11 +403,12 @@ impl Neg for Int {
     type Output = Self;
 
     fn neg(self) -> Self::Output {
-        use Int::*;
-        match self {
-            I64(value) => I64(-value),
-            BigInt(value) => BigInt(-value),
+        use IntData::*;
+        match &self.data {
+            I64(value) => I64(-*value),
+            BigInt(value) => BigInt(value.neg()),
         }
+        .into()
     }
 }
 
@@ -409,8 +420,8 @@ impl PartialOrd for Int {
 
 impl Ord for Int {
     fn cmp(&self, other: &Self) -> Ordering {
-        use Int::*;
-        match (self, other) {
+        use IntData::*;
+        match (&self.data, &other.data) {
             (I64(m1), I64(m2)) => m1.cmp(m2),
             (BigInt(m1), BigInt(m2)) => m1.cmp(m2),
             (I64(m1), BigInt(m2)) => Int::cross_representation_cmp(*m1, m2),
@@ -424,31 +435,32 @@ impl Add<Self> for Int {
 
     fn add(self, rhs: Self) -> Self::Output {
         // The alias 'Big' differentiates the enum variant from the wrapped 'BigInt' type
-        use Int::{BigInt as Big, I64};
-        match (self, rhs) {
+        use IntData::{BigInt as Big, I64};
+        match (&self.data, &rhs.data) {
             (I64(this), I64(that)) => {
                 // Try to add the i64s together; if they overflow, upconvert to BigInts
                 match this.checked_add(that) {
                     Some(result) => I64(result),
-                    None => Big(BigInt::from(this).add(BigInt::from(that))),
+                    None => Big(BigInt::from(*this).add(BigInt::from(*that))),
                 }
             }
-            (I64(this), Big(that)) => Big(BigInt::from(this).add(that)),
-            (Big(this), I64(that)) => Big(this.add(&BigInt::from(that))),
-            (Big(this), Big(that)) => Big(this.add(&that)),
+            (I64(this), Big(that)) => Big(BigInt::from(*this).add(that)),
+            (Big(this), I64(that)) => Big(this.add(&BigInt::from(*that))),
+            (Big(this), Big(that)) => Big(this.add(that)),
         }
+        .into()
     }
 }
 
 impl Zero for Int {
     fn zero() -> Self {
-        Int::I64(0)
+        IntData::I64(0).into()
     }
 
     fn is_zero(&self) -> bool {
-        match self {
-            Int::I64(value) => *value == 0i64,
-            Int::BigInt(value) => value.is_zero(),
+        match &self.data {
+            IntData::I64(value) => *value == 0i64,
+            IntData::BigInt(value) => value.is_zero(),
         }
     }
 }
@@ -462,13 +474,13 @@ impl Display for UInt {
     }
 }
 
-// Trivial conversion to Int::I64 from integers that can safely be converted to an i64
+// Trivial conversion to Int from integers that can safely be converted to an i64
 macro_rules! impl_int_i64_from {
     ($($t:ty),*) => ($(
         impl From<$t> for Int {
             fn from(value: $t) -> Int {
                 let i64_value = i64::from(value);
-                Int::I64(i64_value)
+                IntData::I64(i64_value).into()
             }
         }
     )*)
@@ -481,9 +493,9 @@ macro_rules! impl_int_from {
         impl From<$t> for Int {
             fn from(value: $t) -> Int {
                 match i64::try_from(value) {
-                    Ok(i64_value) => Int::I64(i64_value),
-                    Err(_) => Int::BigInt(BigInt::from(value))
-                }
+                    Ok(i64_value) => IntData::I64(i64_value),
+                    Err(_) => IntData::BigInt(BigInt::from(value))
+                }.into()
             }
         }
     )*)
@@ -491,16 +503,43 @@ macro_rules! impl_int_from {
 
 impl_int_from!(isize, usize, u64);
 
+impl From<UInt> for Int {
+    fn from(value: UInt) -> Self {
+        match value.data {
+            UIntData::U64(uint) => {
+                if let Ok(signed) = i64::try_from(uint) {
+                    // The u64 was successfully converted to an i64
+                    signed.into()
+                } else {
+                    // The u64 was slightly too big to be represented as an i64; it required the
+                    // 64th bit to store the magnitude. Up-convert it to a BigInt.
+                    big_integer_from_u64(uint)
+                }
+            }
+            UIntData::BigUInt(big_uint) => big_integer_from_big_uint(big_uint),
+        }
+    }
+}
+
 impl From<BigUint> for Int {
     fn from(value: BigUint) -> Self {
         let big_int = BigInt::from(value);
-        Int::BigInt(big_int)
+        IntData::BigInt(big_int).into()
     }
 }
 
 impl From<BigInt> for Int {
     fn from(value: BigInt) -> Self {
-        Int::BigInt(value)
+        IntData::BigInt(value).into()
+    }
+}
+
+impl From<Int> for BigInt {
+    fn from(value: Int) -> Self {
+        match value.data {
+            IntData::I64(i) => i.into(),
+            IntData::BigInt(i) => i,
+        }
     }
 }
 
@@ -522,9 +561,9 @@ impl IntAccess for Element {
 
 impl Display for Int {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        match &self {
-            Int::I64(i) => write!(f, "{i}"),
-            Int::BigInt(i) => write!(f, "{i}"),
+        match &self.data {
+            IntData::I64(i) => write!(f, "{i}"),
+            IntData::BigInt(i) => write!(f, "{i}"),
         }
     }
 }
@@ -534,22 +573,21 @@ mod integer_tests {
     use num_bigint::BigInt;
     use std::io::Write;
 
+    use super::*;
+    use crate::types::UInt;
     use num_bigint::BigUint;
     use num_traits::Zero;
-    // The 'Big' alias helps distinguish between the enum variant and the wrapped numeric type
-    use crate::types::Int::{self, BigInt as Big, I64};
-    use crate::types::UInt;
     use rstest::*;
     use std::cmp::Ordering;
 
     #[test]
     fn is_zero() {
-        assert!(I64(0).is_zero());
-        assert!(Big(BigInt::from(0)).is_zero());
-        assert!(!I64(55).is_zero());
-        assert!(!Big(BigInt::from(55)).is_zero());
-        assert!(!I64(-55).is_zero());
-        assert!(!Big(BigInt::from(-55)).is_zero());
+        assert!(Int::from(0).is_zero());
+        assert!(Int::from(BigInt::from(0)).is_zero());
+        assert!(!Int::from(55).is_zero());
+        assert!(!Int::from(BigInt::from(55)).is_zero());
+        assert!(!Int::from(-55).is_zero());
+        assert!(!Int::from(BigInt::from(-55)).is_zero());
     }
 
     #[test]
@@ -559,31 +597,37 @@ mod integer_tests {
 
     #[test]
     fn add() {
-        assert_eq!(I64(0) + I64(0), I64(0));
-        assert_eq!(I64(5) + I64(7), I64(12));
-        assert_eq!(I64(-5) + I64(7), I64(2));
-        assert_eq!(I64(100) + Big(BigInt::from(1000)), Big(BigInt::from(1100)));
-        assert_eq!(Big(BigInt::from(100)) + I64(1000), Big(BigInt::from(1100)));
+        assert_eq!(Int::from(0) + Int::from(0), Int::from(0));
+        assert_eq!(Int::from(5) + Int::from(7), Int::from(12));
+        assert_eq!(Int::from(-5) + Int::from(7), Int::from(2));
         assert_eq!(
-            Big(BigInt::from(100)) + Big(BigInt::from(1000)),
-            Big(BigInt::from(1100))
+            Int::from(100) + Int::from(BigInt::from(1000)),
+            Int::from(BigInt::from(1100))
+        );
+        assert_eq!(
+            Int::from(BigInt::from(100)) + Int::from(1000),
+            Int::from(BigInt::from(1100))
+        );
+        assert_eq!(
+            Int::from(BigInt::from(100)) + Int::from(BigInt::from(1000)),
+            Int::from(BigInt::from(1100))
         );
     }
 
     #[rstest]
-    #[case::i64(Int::I64(5), Int::I64(4), Ordering::Greater)]
-    #[case::i64_equal(Int::I64(-5), Int::I64(-5), Ordering::Equal)]
-    #[case::i64_gt_big_int(Int::I64(4), Int::BigInt(BigInt::from(3)), Ordering::Greater)]
-    #[case::i64_eq_big_int(Int::I64(3), Int::BigInt(BigInt::from(3)), Ordering::Equal)]
-    #[case::i64_lt_big_int(Int::I64(-3), Int::BigInt(BigInt::from(5)), Ordering::Less)]
+    #[case::i64(5.into(), 4.into(), Ordering::Greater)]
+    #[case::i64_equal(Int::from(-5), Int::from(-5), Ordering::Equal)]
+    #[case::i64_gt_big_int(Int::from(4), Int::from(BigInt::from(3)), Ordering::Greater)]
+    #[case::i64_eq_big_int(Int::from(3), Int::from(BigInt::from(3)), Ordering::Equal)]
+    #[case::i64_lt_big_int(Int::from(-3), Int::from(BigInt::from(5)), Ordering::Less)]
     #[case::big_int(
-        Int::BigInt(BigInt::from(1100)),
-        Int::BigInt(BigInt::from(-1005)),
+        Int::from(BigInt::from(1100)),
+        Int::from(BigInt::from(-1005)),
         Ordering::Greater
     )]
     #[case::big_int(
-        Int::BigInt(BigInt::from(1100)),
-        Int::BigInt(BigInt::from(1100)),
+        Int::from(BigInt::from(1100)),
+        Int::from(BigInt::from(1100)),
         Ordering::Equal
     )]
     fn integer_ordering_tests(#[case] this: Int, #[case] other: Int, #[case] expected: Ordering) {
@@ -625,11 +669,11 @@ mod integer_tests {
     }
 
     #[rstest]
-    #[case(Int::I64(5), "5")]
-    #[case(Int::I64(-5), "-5")]
-    #[case(Int::I64(0), "0")]
-    #[case(Int::BigInt(BigInt::from(1100)), "1100")]
-    #[case(Int::BigInt(BigInt::from(-1100)), "-1100")]
+    #[case(Int::from(5), "5")]
+    #[case(Int::from(-5), "-5")]
+    #[case(Int::from(0), "0")]
+    #[case(Int::from(BigInt::from(1100)), "1100")]
+    #[case(Int::from(BigInt::from(-1100)), "-1100")]
     fn int_display_test(#[case] value: Int, #[case] expect: String) {
         let mut buf = Vec::new();
         write!(&mut buf, "{value}").unwrap();


### PR DESCRIPTION
The `Int` enum has been renamed to `IntData` and is now `pub(crate)`. 
A new opaque struct type called `Int` now wraps it.

Part of issue #507, related to merged PR #568. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
