### PR TITLE
Replaces `Vec<Element>` with `Sequence`

### DIFF
--- a/src/element/builders.rs
+++ b/src/element/builders.rs
@@ -255,7 +255,7 @@ impl StructBuilder {
 /// ```
 #[macro_export]
 macro_rules! ion_list {
-    ($($element:expr),*) => {{
+    ($($element:expr),* $(,)?) => {{
         use $crate::element::Sequence;
         Sequence::builder()$(.push($element))*.build_list()
     }};
@@ -339,7 +339,7 @@ macro_rules! ion_sexp {
 /// ```
 #[macro_export]
 macro_rules! ion_struct {
-    ($($field_name:tt : $element:expr),*) => {{
+    ($($field_name:tt : $element:expr),* $(,)?) => {{
         use $crate::element::Struct;
         Struct::builder()$(.with_field($field_name, $element))*.build()
     }};
@@ -413,6 +413,9 @@ mod tests {
     fn make_list_with_macro() {
         let actual: Element = ion_list![1, true, "foo", Symbol::owned("bar")].into();
         let expected = Element::read_one(r#"[1, true, "foo", bar]"#).unwrap();
+        assert_eq!(actual, expected);
+        // Trailing commas are allowed
+        let actual: Element = ion_list![1, true, "foo", Symbol::owned("bar"),].into();
         assert_eq!(actual, expected);
     }
 
@@ -515,6 +518,16 @@ mod tests {
         }
         .into();
         let expected = Element::read_one(r#"{a: 1, b: true, c: "foo", d: bar}"#).unwrap();
+        assert_eq!(actual, expected);
+
+        // Trailing commas are allowed
+        let actual: Element = ion_struct! {
+            "a": 1,
+            "b": true,
+            "c": "foo",
+            "d": Symbol::owned("bar"), // <-- trailing comma
+        }
+        .into();
         assert_eq!(actual, expected);
     }
 

--- a/src/element/builders.rs
+++ b/src/element/builders.rs
@@ -345,6 +345,29 @@ macro_rules! ion_struct {
     }};
 }
 
+/// Constructs a [`Sequence`] with the specified child values.
+///
+/// Note that a `Sequence` is NOT a type of `Element`. However, one can convert a `Sequence` into a
+/// `List` or `SExp`.
+///
+/// ```
+/// use ion_rs::element::{Element, Sequence};
+/// use ion_rs::{ion_seq, ion_list};
+/// // Construct a Sequence from Rust values
+/// let actual: Sequence = ion_seq!["foo" 7 false ion_list![1.5f64, -8.25f64]];
+/// // Construct a Sequence from serialized Ion data
+/// let expected: Sequence = Element::read_all(r#" "foo" 7 false [1.5e0, -8.25e0] "#).unwrap();
+/// // Compare the two Sequences
+/// assert_eq!(expected, actual);
+/// ```
+#[macro_export]
+macro_rules! ion_seq {
+    ($($element:expr)*) => {{
+        use $crate::element::Sequence;
+        Sequence::builder()$(.push($element))*.build()
+    }};
+}
+
 use crate::types::{List, SExp};
 pub use {ion_list, ion_sexp, ion_struct};
 

--- a/src/element/iterators.rs
+++ b/src/element/iterators.rs
@@ -41,7 +41,7 @@ create_new_slice_iterator_type!(
     // Used for iterating over an Element's annotations
     SymbolsIterator => Symbol,
     // Used for iterating over a Sequence's Elements
-    ElementsIterator => Element
+    SequenceIterator => Element
 );
 
 /// Consuming iterator for [`Annotations`](crate::element::Annotations).

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -1,5 +1,5 @@
 use crate::element::builders::SequenceBuilder;
-use crate::element::iterators::ElementsIterator;
+use crate::element::iterators::SequenceIterator;
 use crate::element::{Element, Sequence};
 use crate::ion_data::IonEq;
 use crate::text::text_formatter::IonValueFormatter;
@@ -32,7 +32,7 @@ impl List {
     delegate! {
         to self.0 {
             pub fn clone_builder(&self) -> SequenceBuilder;
-            pub fn elements(&self) -> ElementsIterator<'_>;
+            pub fn elements(&self) -> SequenceIterator<'_>;
             pub fn get(&self, index: usize) -> Option<&Element>;
             pub fn len(&self) -> usize;
             pub fn is_empty(&self) -> bool;
@@ -56,7 +56,7 @@ impl AsRef<Sequence> for List {
 // Allows `for element in &list {...}` syntax
 impl<'a> IntoIterator for &'a List {
     type Item = &'a Element;
-    type IntoIter = ElementsIterator<'a>;
+    type IntoIter = SequenceIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.elements()

--- a/src/types/sexp.rs
+++ b/src/types/sexp.rs
@@ -1,5 +1,5 @@
 use crate::element::builders::SequenceBuilder;
-use crate::element::iterators::ElementsIterator;
+use crate::element::iterators::SequenceIterator;
 use crate::element::{Element, Sequence};
 use crate::ion_data::IonEq;
 use crate::text::text_formatter::IonValueFormatter;
@@ -32,7 +32,7 @@ impl SExp {
     delegate! {
         to self.0 {
             pub fn clone_builder(&self) -> SequenceBuilder;
-            pub fn elements(&self) -> ElementsIterator<'_>;
+            pub fn elements(&self) -> SequenceIterator<'_>;
             pub fn get(&self, index: usize) -> Option<&Element>;
             pub fn len(&self) -> usize;
             pub fn is_empty(&self) -> bool;
@@ -56,7 +56,7 @@ impl AsRef<Sequence> for SExp {
 // Allows `for element in &sexp {...}` syntax
 impl<'a> IntoIterator for &'a SExp {
     type Item = &'a Element;
-    type IntoIter = ElementsIterator<'a>;
+    type IntoIter = SequenceIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.elements()

--- a/tests/element_test_vectors.rs
+++ b/tests/element_test_vectors.rs
@@ -398,7 +398,7 @@ mod impl_display_for_element_tests {
         }
 
         let data = read(file_name).unwrap();
-        let result: IonResult<Vec<Element>> = Element::read_all(data.as_slice());
+        let result: IonResult<Sequence> = Element::read_all(data.as_slice());
         let elements = result.unwrap_or_else(|e| {
             panic!("Expected to be able to read Ion values for contents of file {file_name}: {e:?}")
         });

--- a/tests/ion_hash_tests.rs
+++ b/tests/ion_hash_tests.rs
@@ -4,7 +4,7 @@
 use digest::consts::U4096;
 use digest::{FixedOutput, Reset, Update};
 use ion_rs::element::writer::ElementWriter;
-use ion_rs::element::{Element, Struct};
+use ion_rs::element::{Element, Sequence, Struct};
 use ion_rs::ion_hash::IonHasher;
 use ion_rs::result::{illegal_operation, IonResult};
 use ion_rs::types::IntAccess;
@@ -126,7 +126,7 @@ fn test_file(file_name: &str) -> IonHashTestResult<()> {
     test_all(elems)
 }
 
-fn test_all(elems: Vec<Element>) -> IonHashTestResult<()> {
+fn test_all(elems: Sequence) -> IonHashTestResult<()> {
     let mut failures: Vec<IonHashTestError> = vec![];
     for case in &elems {
         let annotated_test_name = test_case_name_from_annotation(case);


### PR DESCRIPTION
APIs that returned `Vec<Element>` now return a `Sequence` instead. This allows us to change the storage type without a breaking change. It also means that you can trivially construct a `List` or `SExp` from the output of `Element::read_all`.

This also renames `ElementsIterator` to `SequenceIterator` to avoid confusion with the similarly named `ElementIterator`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
