### PR TITLE
Adds Into<Value>, Into<Element> impl for all ints

### DIFF
--- a/src/types/integer.rs
+++ b/src/types/integer.rs
@@ -501,7 +501,7 @@ macro_rules! impl_int_from {
     )*)
 }
 
-impl_int_from!(isize, usize, u64);
+impl_int_from!(isize, i128, usize, u64, u128);
 
 impl From<UInt> for Int {
     fn from(value: UInt) -> Self {


### PR DESCRIPTION
Adds a blanket implementation of `Into<Value>` for all integer types, which allows them to transitively benefit from the `Into<Element>` implementation that exists for `T: Into<Element>`.

Fixes #573.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
