### PR TITLE
Removes `IonDataSource` and vestigial `read()` impls

### DIFF
--- a/src/binary/int.rs
+++ b/src/binary/int.rs
@@ -1,11 +1,9 @@
 use std::mem;
 
-use crate::data_source::IonDataSource;
-use crate::result::{IonFailure, IonResult};
+use crate::result::IonResult;
 use crate::types;
 use crate::types::integer::Int;
 use crate::types::Coefficient;
-use num_bigint::{BigInt, Sign};
 use num_traits::Zero;
 use std::io::Write;
 
@@ -24,7 +22,7 @@ const MAX_INT_SIZE_IN_BYTES: usize = 2048;
 pub struct DecodedInt {
     size_in_bytes: usize,
     value: Int,
-    // [Integer] is not capable of natively representing negative zero. We track the sign
+    // [Int] is not capable of natively representing negative zero. We track the sign
     // of the value separately so we can distinguish between 0 and -0.
     is_negative: bool,
 }
@@ -39,81 +37,7 @@ impl DecodedInt {
         }
     }
 
-    /// Reads an Int with `length` bytes from the provided data source.
-    pub fn read<R: IonDataSource>(data_source: &mut R, length: usize) -> IonResult<DecodedInt> {
-        if length == 0 {
-            return Ok(DecodedInt {
-                size_in_bytes: 0,
-                value: 0i64.into(),
-                is_negative: false,
-            });
-        } else if length > MAX_INT_SIZE_IN_BYTES {
-            return IonResult::decoding_error(format!(
-                "Found a {length}-byte Int. Max supported size is {MAX_INT_SIZE_IN_BYTES} bytes."
-            ));
-        }
-
-        if length <= INT_STACK_BUFFER_SIZE {
-            let buffer = &mut [0u8; INT_STACK_BUFFER_SIZE];
-            DecodedInt::read_using_buffer(data_source, length, buffer)
-        } else {
-            // We're reading an enormous int. Heap-allocate a Vec to use as storage.
-            let mut buffer = vec![0u8; length];
-            DecodedInt::read_using_buffer(data_source, length, buffer.as_mut_slice())
-        }
-    }
-
-    pub fn read_using_buffer<R: IonDataSource>(
-        data_source: &mut R,
-        length: usize,
-        buffer: &mut [u8],
-    ) -> IonResult<DecodedInt> {
-        // Get a mutable reference to a portion of the buffer just big enough to fit
-        // the requested number of bytes.
-        let buffer = &mut buffer[0..length];
-
-        data_source.read_exact(buffer)?;
-        let mut byte_iter = buffer.iter();
-        let mut is_negative: bool = false;
-
-        let value = if length <= mem::size_of::<i64>() {
-            // This Int will fit in an i64.
-            let first_byte: i64 = i64::from(byte_iter.next().copied().unwrap());
-            let sign: i64 = if first_byte & 0b1000_0000 == 0 {
-                1
-            } else {
-                is_negative = true;
-                -1
-            };
-            let mut magnitude: i64 = first_byte & 0b0111_1111;
-            for &byte in byte_iter {
-                let byte = i64::from(byte);
-                magnitude <<= 8;
-                magnitude |= byte;
-            }
-            (sign * magnitude).into()
-        } else {
-            // This Int is too big for an i64, we'll need to use a BigInt
-            let sign: num_bigint::Sign = if buffer[0] & 0b1000_0000 == 0 {
-                Sign::Plus
-            } else {
-                is_negative = true;
-                Sign::Minus
-            };
-            // We're going to treat the buffer's contents like the big-endian bytes of an
-            // unsigned integer. Now that we've made a note of the sign, set the sign bit
-            // in the buffer to zero.
-            buffer[0] &= 0b0111_1111;
-            let value = BigInt::from_bytes_be(sign, buffer);
-            value.into()
-        };
-
-        Ok(DecodedInt {
-            size_in_bytes: length,
-            value,
-            is_negative,
-        })
-    }
+    // Note: read functionality lives in the `BinaryBuffer` type
 
     /// Encodes the provided `value` as an Int and writes it to the provided `sink`.
     /// Returns the number of bytes written.
@@ -135,7 +59,7 @@ impl DecodedInt {
         Ok(bytes_to_write.len())
     }
 
-    /// Encodes a negative zero as an `Int` and writes it to the privided `sink`.
+    /// Encodes a negative zero as an `Int` and writes it to the provided `sink`.
     /// Returns the number of bytes written.
     ///
     /// This method is similar to [Self::write_i64]. However, because an i64 cannot represent a negative
@@ -207,77 +131,8 @@ impl From<DecodedInt> for Coefficient {
 mod tests {
     use super::*;
     use crate::result::IonResult;
-    use std::io;
-    use std::io::Cursor;
 
     const READ_ERROR_MESSAGE: &str = "Failed to read an Int from the provided cursor.";
-
-    #[test]
-    fn test_read_three_byte_positive_int() {
-        let data = &[0b0011_1100, 0b1000_0111, 0b1000_0001];
-        let int = DecodedInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
-        assert_eq!(int.size_in_bytes(), 3);
-        assert_eq!(int.value(), &Int::from(3_966_849i64));
-    }
-
-    #[test]
-    fn test_read_three_byte_negative_int() {
-        let data = &[0b1011_1100, 0b1000_0111, 0b1000_0001];
-        let int = DecodedInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
-        assert_eq!(int.size_in_bytes(), 3);
-        assert_eq!(int.value(), &Int::from(-3_966_849i64));
-    }
-
-    #[test]
-    fn test_read_int_negative_zero() {
-        let data = &[0b1000_0000]; // Negative zero
-        let int = DecodedInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
-        assert_eq!(int.size_in_bytes(), 1);
-        assert_eq!(int.value(), &Int::from(0i64));
-        assert!(int.is_negative_zero());
-    }
-
-    #[test]
-    fn test_read_int_positive_zero() {
-        let data = &[0b0000_0000]; // Positive zero
-        let int = DecodedInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
-        assert_eq!(int.size_in_bytes(), 1);
-        assert_eq!(int.value(), &Int::from(0i64));
-        assert!(!int.is_negative_zero());
-    }
-
-    #[test]
-    fn test_read_two_byte_positive_int() {
-        let data = &[0b0111_1111, 0b1111_1111];
-        let int = DecodedInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
-        assert_eq!(int.size_in_bytes(), 2);
-        assert_eq!(int.value(), &Int::from(32_767i64));
-    }
-
-    #[test]
-    fn test_read_two_byte_negative_int() {
-        let data = &[0b1111_1111, 0b1111_1111];
-        let int = DecodedInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
-        assert_eq!(int.size_in_bytes(), 2);
-        assert_eq!(int.value(), &Int::from(-32_767i64));
-    }
-
-    #[test]
-    fn test_read_int_length_zero() {
-        let data = &[];
-        let int = DecodedInt::read(&mut Cursor::new(data), data.len()).expect(READ_ERROR_MESSAGE);
-        assert_eq!(int.size_in_bytes(), 0);
-        assert_eq!(int.value(), &Int::from(0i64));
-    }
-
-    #[test]
-    fn test_read_int_overflow() {
-        // A Vec of bytes that's one beyond the maximum allowable Int size. Each byte is a 1.
-        let buffer = vec![1; MAX_INT_SIZE_IN_BYTES + 1];
-        let data = buffer.as_slice();
-        let _int = DecodedInt::read(&mut Cursor::new(data), data.len())
-            .expect_err("This exceeded the configured max Int size.");
-    }
 
     fn write_int_test(value: i64, expected_bytes: &[u8]) -> IonResult<()> {
         let mut buffer: Vec<u8> = vec![];
@@ -329,8 +184,11 @@ mod tests {
     fn test_write_int_max_i64() -> IonResult<()> {
         let mut buffer: Vec<u8> = vec![];
         let length = DecodedInt::write_i64(&mut buffer, i64::MAX)?;
-        let i = DecodedInt::read(&mut io::Cursor::new(buffer.as_slice()), length)?;
-        assert_eq!(i.value, i64::MAX.into());
+        assert_eq!(length, 8);
+        assert_eq!(
+            buffer.as_slice(),
+            &[0x7fu8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]
+        );
         Ok(())
     }
 }

--- a/src/binary/var_int.rs
+++ b/src/binary/var_int.rs
@@ -1,5 +1,4 @@
-use crate::data_source::IonDataSource;
-use crate::result::{IonFailure, IonResult};
+use crate::result::IonResult;
 use std::io::Write;
 use std::mem;
 
@@ -44,48 +43,6 @@ impl VarInt {
             value,
             is_negative,
         }
-    }
-
-    /// Reads a VarInt from the provided data source.
-    pub fn read<R: IonDataSource>(data_source: &mut R) -> IonResult<VarInt> {
-        // Unlike VarUInt's encoding, the first byte in a VarInt is a special case because
-        // bit #6 (0-indexed, from the right) indicates whether the value is positive (0) or
-        // negative (1).
-
-        let first_byte: u8 = data_source.next_byte()?.unwrap();
-        let no_more_bytes: bool = first_byte >= 0b1000_0000; // If the first bit is 1, we're done.
-        let is_positive: bool = (first_byte & 0b0100_0000) == 0;
-        let sign: VarIntStorage = if is_positive { 1 } else { -1 };
-        let mut magnitude = (first_byte & 0b0011_1111) as VarIntStorage;
-
-        if no_more_bytes {
-            return Ok(VarInt {
-                size_in_bytes: 1,
-                value: magnitude * sign,
-                is_negative: !is_positive,
-            });
-        }
-
-        let mut byte_processor = |byte: u8| {
-            let lower_seven = (0b0111_1111 & byte) as VarIntStorage;
-            magnitude <<= 7;
-            magnitude |= lower_seven;
-            byte < 0b1000_0000
-        };
-
-        let encoded_size_in_bytes = 1 + data_source.read_next_byte_while(&mut byte_processor)?;
-
-        if encoded_size_in_bytes > MAX_ENCODED_SIZE_IN_BYTES {
-            return IonResult::decoding_error(format!(
-                "Found a {encoded_size_in_bytes}-byte VarInt. Max supported size is {MAX_ENCODED_SIZE_IN_BYTES} bytes."
-            ));
-        }
-
-        Ok(VarInt {
-            size_in_bytes: encoded_size_in_bytes,
-            value: magnitude * sign,
-            is_negative: !is_positive,
-        })
     }
 
     /// Writes an `i64` to `sink`, returning the number of bytes written.
@@ -189,77 +146,6 @@ impl VarInt {
 mod tests {
     use super::VarInt;
     use crate::result::IonResult;
-    use std::io::{BufReader, Cursor};
-
-    const ERROR_MESSAGE: &str = "Failed to read a VarUInt from the provided data.";
-
-    #[test]
-    fn test_read_negative_var_int() {
-        let var_int = VarInt::read(&mut Cursor::new(&[0b0111_1001, 0b0000_1111, 0b1000_0001]))
-            .expect(ERROR_MESSAGE);
-        assert_eq!(var_int.size_in_bytes(), 3);
-        assert_eq!(var_int.value(), -935_809);
-    }
-
-    #[test]
-    fn test_read_positive_var_int() {
-        let var_int = VarInt::read(&mut Cursor::new(&[0b0011_1001, 0b0000_1111, 0b1000_0001]))
-            .expect(ERROR_MESSAGE);
-        assert_eq!(var_int.size_in_bytes(), 3);
-        assert_eq!(var_int.value(), 935_809);
-    }
-
-    #[test]
-    fn test_read_var_uint_small_buffer() {
-        let var_uint = VarInt::read(
-            // Construct a BufReader whose input buffer cannot hold all of the data at once
-            // to ensure that reads that span multiple I/O operations work as expected
-            &mut BufReader::with_capacity(1, Cursor::new(&[0b0111_1001, 0b0000_1111, 0b1000_0001])),
-        )
-        .expect(ERROR_MESSAGE);
-        assert_eq!(var_uint.size_in_bytes(), 3);
-        assert_eq!(var_uint.value(), -935_809);
-    }
-
-    #[test]
-    fn test_read_var_int_zero() {
-        let var_int = VarInt::read(&mut Cursor::new(&[0b1000_0000])).expect(ERROR_MESSAGE);
-        assert_eq!(var_int.size_in_bytes(), 1);
-        assert_eq!(var_int.value(), 0);
-    }
-
-    #[test]
-    fn test_read_var_int_min_negative_two_byte_encoding() {
-        let var_int =
-            VarInt::read(&mut Cursor::new(&[0b0111_1111, 0b1111_1111])).expect(ERROR_MESSAGE);
-        assert_eq!(var_int.size_in_bytes(), 2);
-        assert_eq!(var_int.value(), -8_191);
-    }
-
-    #[test]
-    fn test_read_var_int_max_positive_two_byte_encoding() {
-        let var_int =
-            VarInt::read(&mut Cursor::new(&[0b0011_1111, 0b1111_1111])).expect(ERROR_MESSAGE);
-        assert_eq!(var_int.size_in_bytes(), 2);
-        assert_eq!(var_int.value(), 8_191);
-    }
-
-    #[test]
-    fn test_read_var_int_overflow_detection() {
-        let _var_uint = VarInt::read(&mut Cursor::new(&[
-            0b0111_1111,
-            0b0111_1111,
-            0b0111_1111,
-            0b0111_1111,
-            0b0111_1111,
-            0b0111_1111,
-            0b0111_1111,
-            0b0111_1111,
-            0b0111_1111,
-            0b1111_1111,
-        ]))
-        .expect_err("This should have failed due to overflow.");
-    }
 
     fn var_int_encoding_test(value: i64, expected_encoding: &[u8]) -> IonResult<()> {
         let mut buffer = vec![];

--- a/src/binary/var_uint.rs
+++ b/src/binary/var_uint.rs
@@ -1,5 +1,4 @@
-use crate::data_source::IonDataSource;
-use crate::result::{IonFailure, IonResult};
+use crate::result::IonResult;
 use std::io::Write;
 use std::mem;
 
@@ -30,42 +29,6 @@ impl VarUInt {
             value,
             size_in_bytes,
         }
-    }
-
-    /// Reads a VarUInt from the provided data source.
-    pub fn read<R: IonDataSource>(data_source: &mut R) -> IonResult<VarUInt> {
-        let mut magnitude: usize = 0;
-
-        let mut byte_processor = |byte: u8| {
-            let lower_seven = (LOWER_7_BITMASK & byte) as usize;
-            magnitude <<= 7; // Shifts 0 to 0 in the first iteration
-            magnitude |= lower_seven;
-            byte < HIGHEST_BIT_VALUE // If the highest bit is zero, continue reading
-        };
-
-        let encoded_size_in_bytes = data_source.read_next_byte_while(&mut byte_processor)?;
-
-        // Prevent overflow by checking that the VarUInt was not too large to safely fit in the
-        // data type being used to house the decoded value.
-        //
-        // This approach has two drawbacks:
-        // * When using a u64, we only allow up to 63 bits of encoded magnitude data.
-        // * It will return an error for inefficiently-encoded small values that use more bytes
-        //   than required. (e.g. A 10-byte encoding of the number 0 will be rejected.)
-        //
-        // However, reading VarUInt values is a very hot code path for reading binary Ion. This
-        // compromise allows us to prevent overflows for the cost of a single branch per VarUInt
-        // rather than performing extra bookkeeping logic on a per-byte basis.
-        if encoded_size_in_bytes > MAX_ENCODED_SIZE_IN_BYTES {
-            return IonResult::decoding_error(format!(
-                "Found a {encoded_size_in_bytes}-byte VarUInt. Max supported size is {MAX_ENCODED_SIZE_IN_BYTES} bytes."
-            ));
-        }
-
-        Ok(VarUInt {
-            size_in_bytes: encoded_size_in_bytes,
-            value: magnitude,
-        })
     }
 
     /// Encodes the given unsigned int value as a VarUInt and writes it to the
@@ -124,61 +87,6 @@ impl VarUInt {
 mod tests {
     use super::VarUInt;
     use crate::result::IonResult;
-    use std::io::{BufReader, Cursor};
-
-    const ERROR_MESSAGE: &str = "Failed to read a VarUInt from the provided data.";
-
-    #[test]
-    fn test_read_var_uint() {
-        let var_uint = VarUInt::read(&mut Cursor::new(&[0b0111_1001, 0b0000_1111, 0b1000_0001]))
-            .expect(ERROR_MESSAGE);
-        assert_eq!(3, var_uint.size_in_bytes());
-        assert_eq!(1_984_385, var_uint.value());
-    }
-
-    #[test]
-    fn test_read_var_uint_small_buffer() {
-        let var_uint = VarUInt::read(
-            // Construct a BufReader whose input buffer cannot hold all of the data at once
-            // to ensure that reads that span multiple I/O operations work as expected
-            &mut BufReader::with_capacity(1, Cursor::new(&[0b0111_1001, 0b0000_1111, 0b1000_0001])),
-        )
-        .expect(ERROR_MESSAGE);
-        assert_eq!(var_uint.size_in_bytes(), 3);
-        assert_eq!(var_uint.value(), 1_984_385);
-    }
-
-    #[test]
-    fn test_read_var_uint_zero() {
-        let var_uint = VarUInt::read(&mut Cursor::new(&[0b1000_0000])).expect(ERROR_MESSAGE);
-        assert_eq!(var_uint.size_in_bytes(), 1);
-        assert_eq!(var_uint.value(), 0);
-    }
-
-    #[test]
-    fn test_read_var_uint_two_bytes_max_value() {
-        let var_uint =
-            VarUInt::read(&mut Cursor::new(&[0b0111_1111, 0b1111_1111])).expect(ERROR_MESSAGE);
-        assert_eq!(var_uint.size_in_bytes(), 2);
-        assert_eq!(var_uint.value(), 16_383);
-    }
-
-    #[test]
-    fn test_read_var_uint_overflow_detection() {
-        let _var_uint = VarUInt::read(&mut Cursor::new(&[
-            0b0111_1111,
-            0b0111_1111,
-            0b0111_1111,
-            0b0111_1111,
-            0b0111_1111,
-            0b0111_1111,
-            0b0111_1111,
-            0b0111_1111,
-            0b0111_1111,
-            0b1111_1111,
-        ]))
-        .expect_err("This should have failed due to overflow.");
-    }
 
     fn var_uint_encoding_test(value: u64, expected_encoding: &[u8]) -> IonResult<()> {
         let mut buffer = vec![];

--- a/src/blocking_reader.rs
+++ b/src/blocking_reader.rs
@@ -2,7 +2,7 @@ use delegate::delegate;
 use std::ops::Range;
 
 use crate::binary::non_blocking::raw_binary_reader::RawBinaryReader;
-use crate::data_source::ToIonDataSource;
+use crate::data_source::IonDataSource;
 use crate::element::{Blob, Clob};
 use crate::ion_reader::IonReader;
 use crate::raw_reader::BufferedRawReader;
@@ -16,7 +16,7 @@ pub type BlockingRawBinaryReader<T> = BlockingRawReader<RawBinaryReader<Vec<u8>>
 
 /// The BlockingRawReader wraps a non-blocking RawReader that implements the BufferedReader trait,
 /// providing a blocking RawReader.
-pub struct BlockingRawReader<R: BufferedRawReader, T: ToIonDataSource> {
+pub struct BlockingRawReader<R: BufferedRawReader, T: IonDataSource> {
     source: T::DataSource,
     reader: R,
     expected_read_size: usize,
@@ -24,7 +24,7 @@ pub struct BlockingRawReader<R: BufferedRawReader, T: ToIonDataSource> {
 
 const READER_DEFAULT_BUFFER_CAPACITY: usize = 1024 * 4;
 
-impl<R: BufferedRawReader, T: ToIonDataSource> BlockingRawReader<R, T> {
+impl<R: BufferedRawReader, T: IonDataSource> BlockingRawReader<R, T> {
     pub fn read_source(&mut self, length: usize) -> IonResult<usize> {
         let mut bytes_read = 0;
         loop {
@@ -53,7 +53,7 @@ impl<R: BufferedRawReader, T: ToIonDataSource> BlockingRawReader<R, T> {
     }
 }
 
-impl<R: BufferedRawReader, T: ToIonDataSource> IonReader for BlockingRawReader<R, T> {
+impl<R: BufferedRawReader, T: IonDataSource> IonReader for BlockingRawReader<R, T> {
     type Item = R::Item;
     type Symbol = R::Symbol;
 
@@ -197,7 +197,7 @@ impl<R: BufferedRawReader, T: ToIonDataSource> IonReader for BlockingRawReader<R
     }
 }
 
-impl<T: ToIonDataSource> BlockingRawReader<RawBinaryReader<Vec<u8>>, T> {
+impl<T: IonDataSource> BlockingRawReader<RawBinaryReader<Vec<u8>>, T> {
     delegate! {
         to self.reader {
             pub fn raw_bytes(&self) ->  Option<&[u8]>;

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -2,273 +2,14 @@ use std::fs::File;
 use std::io;
 use std::io::{BufRead, BufReader, Read, StdinLock};
 
-use crate::result::{IonFailure, IonResult};
-
-/// Optimized read operations for parsing Ion.
-///
-/// The [binary Ion spec](https://amazon-ion.github.io/ion-docs/docs/binary.html) calls for a number of reading
-/// patterns, including:
-///
-/// * Type descriptor octets (value headers) require that a single byte be read from input.
-/// * Variable length integers (both signed and unsigned) require that a single byte at a time be
-///   read from the data source until some condition is met.
-/// * Fixed length values require that `n` bytes be read from the data source and interpreted as a
-///   single value.
-/// * Skipping over values, partial or whole, requires that the next `n` bytes of the data source be
-///   ignored altogether.
-///
-/// The IonDataSource trait extends functionality offered by the [BufRead] trait by providing
-/// methods that are tailored to these use cases. They have been optimized to prefer operating
-/// on data that's already in the input buffer in-place rather than copying it out to another
-/// byte array.
-pub trait IonDataSource: BufRead {
-    /// Ignore the next `number_of_bytes` bytes in the data source.
-    fn skip_bytes(&mut self, number_of_bytes: usize) -> IonResult<()> {
-        let mut bytes_skipped = 0;
-        while bytes_skipped < number_of_bytes {
-            let buffer = self.fill_buf()?;
-            if buffer.is_empty() {
-                // TODO: IonResult should have a distinct `IncompleteData` error case
-                //       https://github.com/amazon-ion/ion-rust/issues/299
-                return IonResult::decoding_error("Unexpected end of stream.");
-            }
-            let bytes_in_buffer = buffer.len();
-            let bytes_to_skip = (number_of_bytes - bytes_skipped).min(bytes_in_buffer);
-            self.consume(bytes_to_skip);
-            bytes_skipped += bytes_to_skip;
-        }
-        Ok(())
-    }
-
-    /// Returns the next byte in the data source if available.
-    fn next_byte(&mut self) -> IonResult<Option<u8>> {
-        match self.fill_buf()?.first() {
-            Some(&byte) => {
-                self.consume(1);
-                Ok(Some(byte))
-            }
-            None => Ok(None),
-        }
-    }
-
-    /// Calls `byte_processor` on each byte in the data source until it returns false.
-    /// Returns the number of bytes that were read and processed.
-    fn read_next_byte_while<F>(&mut self, byte_processor: &mut F) -> IonResult<usize>
-    where
-        F: FnMut(u8) -> bool,
-    {
-        // The number of bytes that have been processed by the provided closure
-        let mut number_of_bytes_processed: usize = 0;
-        // The number of bytes currently available in the data source's input buffer
-        let mut number_of_buffered_bytes: usize;
-        // The number of bytes that have been flushed from the input buffer after processing them
-        let mut number_of_bytes_consumed: usize = 0;
-
-        loop {
-            // Get a reference to the data source's input buffer, refilling it if it's empty.
-            let buffer = self.fill_buf()?;
-            number_of_buffered_bytes = buffer.len();
-
-            if number_of_buffered_bytes == 0 {
-                // TODO: IonResult should have a distinct `IncompleteData` error case
-                //       https://github.com/amazon-ion/ion-rust/issues/299
-                return IonResult::decoding_error("Unexpected end of stream.");
-            }
-
-            // Iterate over the bytes already in the buffer, calling the provided lambda on each
-            // one.
-            for byte in buffer {
-                number_of_bytes_processed += 1;
-                if !byte_processor(*byte) {
-                    // If the lambda is finished reading, notify the data source of how many bytes
-                    // we've read from the buffer so they can be removed.
-                    self.consume(number_of_bytes_processed - number_of_bytes_consumed);
-                    return Ok(number_of_bytes_processed);
-                }
-            }
-
-            // If we read all of the available data in the buffer but the lambda isn't finished yet,
-            // empty the buffer so the next loop iteration will refill it.
-            self.consume(number_of_buffered_bytes);
-            number_of_bytes_consumed += number_of_buffered_bytes;
-        }
-    }
-
-    /// Calls `slice_processor` on a slice containing the next `length` bytes from the
-    /// data source. If the required bytes are already in the input buffer, a reference to that
-    /// slice of the input buffer will be used. If they are not, the required bytes will be read
-    /// into `fallback_buffer` and that will be used instead. If `fallback_buffer` does not have
-    /// enough capacity to store the requested data, it will be resized. It will never be shrunk,
-    /// however--it is the caller's responsibility to manage this memory.
-    fn read_slice<T, F>(
-        &mut self,
-        length: usize,
-        fallback_buffer: &mut Vec<u8>,
-        slice_processor: F,
-    ) -> IonResult<T>
-    where
-        F: FnOnce(&[u8]) -> IonResult<T>,
-    {
-        // Get a reference to the data source's input buffer, refilling it if it's empty.
-        let buffer = self.fill_buf()?;
-
-        // If the buffer is still empty, we've run out of data.
-        if buffer.is_empty() && length > 0 {
-            // TODO: IonResult should have a distinct `IncompleteData` error case
-            //       https://github.com/amazon-ion/ion-rust/issues/299
-            return IonResult::decoding_error("Unexpected end of stream.");
-        }
-
-        // If the requested value is already in our input buffer, there's no need to copy it out
-        // into a separate buffer. We can return a slice of the input buffer and consume() that
-        // number of bytes.
-        if buffer.len() >= length {
-            let result = slice_processor(&buffer[..length]);
-            self.consume(length);
-            return result;
-        }
-
-        // Grow the Vec to accommodate the requested data if needed
-        let buffer: &mut [u8] = if fallback_buffer.len() < length {
-            fallback_buffer.resize(length, 0);
-            // Get a mutable reference to the underlying byte array
-            fallback_buffer.as_mut()
-        } else {
-            // Otherwise, split the Vec's underlying storage to get a &mut [u8] slice of the
-            // required size
-            let (required_buffer, _) = fallback_buffer.split_at_mut(length);
-            required_buffer
-        };
-
-        // Fill the fallback buffer with bytes from the data source
-        match self.read_exact(buffer) {
-            Ok(()) => slice_processor(buffer),
-            Err(ref e) if e.kind() == io::ErrorKind::UnexpectedEof =>
-            // TODO: IonResult should have a distinct `IncompleteData` error case
-            //       https://github.com/amazon-ion/ion-rust/issues/299
-            {
-                IonResult::decoding_error("Unexpected end of stream.")
-            }
-            Err(io_error) => Err(io_error.into()),
-        }
-    }
-}
-
-impl<T> IonDataSource for T where T: BufRead {}
-
-#[cfg(test)]
-mod tests {
-    use super::IonDataSource;
-    use crate::result::IonError;
-    use std::io::BufReader;
-
-    fn test_data(buffer_size: usize, data: &'static [u8]) -> impl IonDataSource {
-        BufReader::with_capacity(buffer_size, data)
-    }
-
-    #[test]
-    fn test_next_byte() {
-        let mut data_source = test_data(2, &[1, 2, 3, 4, 5]);
-
-        assert_eq!(Some(1), data_source.next_byte().unwrap());
-        assert_eq!(Some(2), data_source.next_byte().unwrap());
-        assert_eq!(Some(3), data_source.next_byte().unwrap());
-        assert_eq!(Some(4), data_source.next_byte().unwrap());
-        assert_eq!(Some(5), data_source.next_byte().unwrap());
-    }
-
-    #[test]
-    fn test_skip_bytes() {
-        let mut data_source = test_data(2, &[1, 2, 3, 4, 5]);
-        data_source.skip_bytes(3).unwrap();
-        assert_eq!(Some(4), data_source.next_byte().unwrap());
-        data_source.skip_bytes(1).unwrap();
-        assert_eq!(None, data_source.next_byte().unwrap());
-    }
-
-    #[test]
-    fn test_read_next_byte_while() {
-        let mut data_source = test_data(2, &[1, 2, 3, 4, 5]);
-        let mut sum: u64 = 0;
-        let processor = &mut |byte: u8| {
-            sum += byte as u64;
-            byte < 4
-        };
-        let number_of_bytes_processed = data_source.read_next_byte_while(processor).unwrap();
-        assert_eq!(number_of_bytes_processed, 4);
-        assert_eq!(sum, 10);
-    }
-
-    #[test]
-    fn test_read_slice() {
-        let mut data_source = test_data(2, &[1, 2, 3, 4, 5]);
-        let processor = &mut |data: &[u8]| Ok(data.iter().map(|byte| *byte as i32).sum());
-        let sum = data_source
-            .read_slice(4, &mut Vec::new(), processor)
-            .unwrap();
-        assert_eq!(10, sum);
-    }
-
-    #[test]
-    fn test_eof_during_skip_bytes() {
-        let mut data_source = test_data(2, &[1, 2, 3, 4, 5]);
-
-        // We expect to encounter an end-of-file error because we're skipping more bytes than
-        // we have in input.
-        let result = data_source.skip_bytes(42);
-
-        // TODO: IonResult should have a distinct `IncompleteData` error case
-        //       https://github.com/amazon-ion/ion-rust/issues/299
-        assert!(matches!(result, Err(IonError::Decoding { .. })));
-    }
-
-    #[test]
-    fn test_eof_during_read_next_byte_while() {
-        let mut data_source = test_data(2, &[1, 2, 3, 4, 5]);
-        let mut sum: u64 = 0;
-        // This processor reads until it finds a 6, which our data does not contain.
-        let processor = &mut |byte: u8| {
-            sum += byte as u64;
-            byte != 6
-        };
-        // We expect to encounter an end-of-file error because the data ends before the processor
-        // is satisfied.
-        let result = data_source.read_next_byte_while(processor);
-
-        // TODO: IonResult should have a distinct `IncompleteData` error case
-        //       https://github.com/amazon-ion/ion-rust/issues/299
-        assert!(matches!(result, Err(IonError::Decoding { .. })));
-    }
-
-    #[test]
-    fn test_eof_during_read_slice() {
-        let mut data_source = test_data(2, &[1, 2, 3, 4, 5]);
-        let mut fallback_buffer = vec![];
-        // This trivial processor will report the length of the slice it's passed.
-        // It will not be used because we expect to encounter an error before then.
-        let processor = &mut |bytes: &[u8]| Ok(bytes.len());
-        // We expect to encounter an end-of-file error because the input buffer doesn't have
-        // enough data.
-        let result = data_source.read_slice(
-            42, // Number of bytes requested from input
-            &mut fallback_buffer,
-            processor,
-        );
-
-        // TODO: IonResult should have a distinct `IncompleteData` error case
-        //       https://github.com/amazon-ion/ion-rust/issues/299
-        assert!(matches!(result, Err(IonError::Decoding { .. })));
-    }
-}
-
 /// Types that implement this trait can be converted into an implementation of [BufRead], allowing
 /// users to deserialize Ion from a variety of types that might not define I/O operations on their own.
-pub trait ToIonDataSource {
-    type DataSource: IonDataSource;
+pub trait IonDataSource {
+    type DataSource: BufRead;
     fn to_ion_data_source(self) -> Self::DataSource;
 }
 
-impl ToIonDataSource for String {
+impl IonDataSource for String {
     type DataSource = io::Cursor<Self>;
 
     fn to_ion_data_source(self) -> Self::DataSource {
@@ -276,7 +17,7 @@ impl ToIonDataSource for String {
     }
 }
 
-impl<'a> ToIonDataSource for &'a str {
+impl<'a> IonDataSource for &'a str {
     type DataSource = io::Cursor<Self>;
 
     fn to_ion_data_source(self) -> Self::DataSource {
@@ -284,7 +25,7 @@ impl<'a> ToIonDataSource for &'a str {
     }
 }
 
-impl<'a> ToIonDataSource for &'a [u8] {
+impl<'a> IonDataSource for &'a [u8] {
     type DataSource = io::Cursor<Self>;
 
     fn to_ion_data_source(self) -> Self::DataSource {
@@ -292,7 +33,7 @@ impl<'a> ToIonDataSource for &'a [u8] {
     }
 }
 
-impl<'a, const N: usize> ToIonDataSource for &'a [u8; N] {
+impl<'a, const N: usize> IonDataSource for &'a [u8; N] {
     type DataSource = io::Cursor<Self>;
 
     fn to_ion_data_source(self) -> Self::DataSource {
@@ -300,7 +41,7 @@ impl<'a, const N: usize> ToIonDataSource for &'a [u8; N] {
     }
 }
 
-impl ToIonDataSource for Vec<u8> {
+impl IonDataSource for Vec<u8> {
     type DataSource = io::Cursor<Self>;
 
     fn to_ion_data_source(self) -> Self::DataSource {
@@ -308,7 +49,7 @@ impl ToIonDataSource for Vec<u8> {
     }
 }
 
-impl<T: BufRead, U: BufRead> ToIonDataSource for io::Chain<T, U> {
+impl<T: BufRead, U: BufRead> IonDataSource for io::Chain<T, U> {
     type DataSource = Self;
 
     fn to_ion_data_source(self) -> Self::DataSource {
@@ -316,7 +57,7 @@ impl<T: BufRead, U: BufRead> ToIonDataSource for io::Chain<T, U> {
     }
 }
 
-impl<T> ToIonDataSource for io::Cursor<T>
+impl<T> IonDataSource for io::Cursor<T>
 where
     T: AsRef<[u8]>,
 {
@@ -327,7 +68,7 @@ where
     }
 }
 
-impl<T: Read> ToIonDataSource for BufReader<T> {
+impl<T: Read> IonDataSource for BufReader<T> {
     type DataSource = Self;
 
     fn to_ion_data_source(self) -> Self::DataSource {
@@ -335,7 +76,7 @@ impl<T: Read> ToIonDataSource for BufReader<T> {
     }
 }
 
-impl ToIonDataSource for File {
+impl IonDataSource for File {
     type DataSource = BufReader<Self>;
 
     fn to_ion_data_source(self) -> Self::DataSource {
@@ -344,7 +85,7 @@ impl ToIonDataSource for File {
 }
 
 // Allows Readers to consume Ion directly from STDIN
-impl<'a> ToIonDataSource for StdinLock<'a> {
+impl<'a> IonDataSource for StdinLock<'a> {
     type DataSource = Self;
 
     fn to_ion_data_source(self) -> Self::DataSource {

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -33,7 +33,7 @@ pub mod reader;
 pub mod writer;
 
 // Re-export the Value variant types and traits so they can be accessed directly from this module.
-use crate::data_source::ToIonDataSource;
+use crate::data_source::IonDataSource;
 use crate::element::writer::ElementWriter;
 use crate::reader::ReaderBuilder;
 pub use crate::types::{Blob, Bytes, Clob};
@@ -576,7 +576,7 @@ impl Element {
     /// Returns an iterator over the Elements in the provided Ion data source.
     /// If the data source cannot be read or contains invalid Ion data, this method
     /// will return an `Err`.
-    pub fn iter<'a, I: ToIonDataSource + 'a>(
+    pub fn iter<'a, I: IonDataSource + 'a>(
         source: I,
     ) -> IonResult<impl Iterator<Item = IonResult<Element>> + 'a> {
         Ok(ReaderBuilder::default().build(source)?.into_elements())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,8 +206,6 @@ pub mod thunk;
 pub mod tokens;
 
 #[doc(inline)]
-pub use data_source::IonDataSource;
-#[doc(inline)]
 pub use raw_symbol_token::RawSymbolToken;
 #[doc(inline)]
 pub use raw_symbol_token_ref::RawSymbolTokenRef;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -7,7 +7,7 @@ use delegate::delegate;
 use crate::binary::constants::v1_0::IVM;
 use crate::binary::non_blocking::raw_binary_reader::RawBinaryReader;
 use crate::blocking_reader::{BlockingRawBinaryReader, BlockingRawTextReader};
-use crate::data_source::ToIonDataSource;
+use crate::data_source::IonDataSource;
 use crate::element::{Blob, Clob};
 use crate::ion_reader::IonReader;
 use crate::raw_reader::{Expandable, RawReader};
@@ -35,7 +35,7 @@ impl ReaderBuilder {
     /// reading some data from the beginning of `input` to detect whether its content is
     /// text or binary Ion. If this read operation fails, `build` will return an `Err`
     /// describing the problem it encountered.
-    pub fn build<'a, I: 'a + ToIonDataSource>(self, input: I) -> IonResult<Reader<'a>> {
+    pub fn build<'a, I: 'a + IonDataSource>(self, input: I) -> IonResult<Reader<'a>> {
         // Convert the provided input into an implementation of `BufRead`
         let mut input = input.to_ion_data_source();
         // Stack-allocated buffer to hold the first four bytes from input
@@ -86,12 +86,12 @@ impl ReaderBuilder {
         }
     }
 
-    fn make_text_reader<'a, I: 'a + ToIonDataSource>(data: I) -> IonResult<Reader<'a>> {
+    fn make_text_reader<'a, I: 'a + IonDataSource>(data: I) -> IonResult<Reader<'a>> {
         let raw_reader = Box::new(BlockingRawTextReader::new(data)?);
         Ok(Reader::new(raw_reader))
     }
 
-    fn make_binary_reader<'a, I: 'a + ToIonDataSource>(data: I) -> IonResult<Reader<'a>> {
+    fn make_binary_reader<'a, I: 'a + IonDataSource>(data: I) -> IonResult<Reader<'a>> {
         let raw_reader = Box::new(BlockingRawBinaryReader::new(data)?);
         Ok(Reader::new(raw_reader))
     }

--- a/src/tokens/reader_stream.rs
+++ b/src/tokens/reader_stream.rs
@@ -347,7 +347,7 @@ where
 mod tests {
     use super::Instruction::*;
     use super::*;
-    use crate::data_source::ToIonDataSource;
+    use crate::data_source::IonDataSource;
     use crate::element::{Blob as ElemBlob, Clob as ElemClob};
     use crate::tokens::{ContainerType, ScalarValue, Value};
     use crate::{Decimal, IonError, IonResult, ReaderBuilder, Symbol};
@@ -474,7 +474,7 @@ mod tests {
     #[case::ann(annotate_first_srcs(["a", "b", "c"], single_src(false)), "a::b::c::false")]
     fn stream_test<S>(#[case] expected: IonResult<Srcs>, #[case] data: S) -> IonResult<()>
     where
-        S: ToIonDataSource,
+        S: IonDataSource,
     {
         use Content::*;
         let mut expected_src = expected?;


### PR DESCRIPTION
The original implementation of the binary reader used a trait called `IonDataSource` that provided extension methods for implementations of `BufRead`. The binary reader was later rewritten to use a type called `BinaryBuffer`, but `IonDataSource` and its methods were never removed.

This PR removes `IonDataSource` and the vestigial implementations of `read()` for various encoding primitives that relied upon `IonDataSource`.

Finally, it renames the single-method trait `ToIonDataSource` (which suggested types could be converted to an `IonDataSource`) to `IonDataSource`, reclaiming the name for a better use.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
