### PR TITLE
Adds Decimal methods to access the coefficient and exponent

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,7 @@ pub use raw_symbol_token_ref::RawSymbolTokenRef;
 pub use symbol_ref::SymbolRef;
 pub use symbol_table::SymbolTable;
 
-pub use types::{Decimal, Int, IonType, Str, Symbol, Timestamp};
+pub use types::{decimal::Decimal, Int, IonType, Str, Symbol, Timestamp};
 
 pub use ion_data::IonData;
 

--- a/src/types/decimal/coefficient.rs
+++ b/src/types/decimal/coefficient.rs
@@ -2,6 +2,7 @@ use num_bigint::{BigInt, BigUint};
 use num_traits::Zero;
 
 use crate::result::{IonError, IonFailure};
+use crate::types::decimal::magnitude::Magnitude;
 use crate::types::integer::UIntData;
 use crate::types::{Int, UInt};
 use crate::IonResult;
@@ -16,67 +17,6 @@ pub enum Sign {
     Negative,
     Positive,
 }
-
-/// A simple wrapper type around a [`UInt`]. Users are not expected to construct
-/// instances of `Magnitude` directly; it is provided for conversion ergonomics.
-///
-/// Signed integer types cannot implement `Into<UInt>`. Instead, they implement
-/// `TryInto<UInt>` and report an error if the input integer is negative.
-///
-/// Signed integers can infallibly implement `Into<Magnitude>` by using their
-/// absolute value.
-pub struct Magnitude(UInt);
-
-impl Magnitude {
-    fn new<I: Into<UInt>>(value: I) -> Self {
-        Magnitude(value.into())
-    }
-}
-
-impl From<UInt> for Magnitude {
-    fn from(value: UInt) -> Self {
-        Magnitude(value)
-    }
-}
-
-impl From<Magnitude> for UInt {
-    fn from(value: Magnitude) -> Self {
-        value.0
-    }
-}
-
-impl From<BigUint> for Magnitude {
-    fn from(value: BigUint) -> Self {
-        let uint: UInt = value.into();
-        Magnitude(uint)
-    }
-}
-
-macro_rules! impl_magnitude_from_small_unsigned_int_types {
-    ($($t:ty),*) => ($(
-        impl From<$t> for Magnitude {
-            fn from(value: $t) -> Magnitude {
-                let uint: UInt = value.into();
-                Magnitude(uint)
-            }
-        }
-    )*)
-}
-
-impl_magnitude_from_small_unsigned_int_types!(u8, u16, u32, u64, u128, usize);
-
-macro_rules! impl_magnitude_from_small_signed_int_types {
-    ($($t:ty),*) => ($(
-        impl From<$t> for Magnitude {
-            fn from(value: $t) -> Magnitude {
-                let uint: UInt = (value.unsigned_abs() as u64).into();
-                Magnitude(uint)
-            }
-        }
-    )*)
-}
-
-impl_magnitude_from_small_signed_int_types!(i8, i16, i32, i64, isize);
 
 /// A signed integer that can be used as the coefficient of a Decimal value. This type does not
 /// consider `0` and `-0` to be equal and supports magnitudes of arbitrary size.
@@ -95,12 +35,16 @@ impl Coefficient {
         Coefficient { sign, magnitude }
     }
 
-    pub(crate) fn sign(&self) -> Sign {
+    pub fn sign(&self) -> Sign {
         self.sign
     }
 
-    pub(crate) fn magnitude(&self) -> &UInt {
+    pub fn magnitude(&self) -> &UInt {
         &self.magnitude
+    }
+
+    pub fn is_negative(&self) -> bool {
+        self.sign == Sign::Negative
     }
 
     /// Returns the number of digits in the base-10 representation of the coefficient
@@ -116,26 +60,26 @@ impl Coefficient {
         }
     }
 
-    /// Returns true if the Coefficient represents positive zero.
-    pub(crate) fn is_negative_zero(&self) -> bool {
-        match (self.sign, &self.magnitude.data) {
-            (Sign::Negative, UIntData::U64(0)) => true,
-            (Sign::Negative, UIntData::BigUInt(b)) if b.is_zero() => true,
-            _ => false,
-        }
+    /// Returns true if the Coefficient represents negative zero.
+    pub fn is_negative_zero(&self) -> bool {
+        self.is_zero_with_sign(Sign::Negative)
     }
 
     /// Returns true if the Coefficient represents positive zero.
-    pub(crate) fn is_positive_zero(&self) -> bool {
+    pub fn is_positive_zero(&self) -> bool {
+        self.is_zero_with_sign(Sign::Positive)
+    }
+
+    pub(crate) fn is_zero_with_sign(&self, test_sign: Sign) -> bool {
         match (self.sign, &self.magnitude.data) {
-            (Sign::Positive, UIntData::U64(0)) => true,
-            (Sign::Positive, UIntData::BigUInt(b)) if b.is_zero() => true,
+            (sign, UIntData::U64(0)) if sign == test_sign => true,
+            (sign, UIntData::BigUInt(b)) if sign == test_sign && b.is_zero() => true,
             _ => false,
         }
     }
 
     /// Returns true if the Coefficient represents a zero of any sign.
-    pub(crate) fn is_zero(&self) -> bool {
+    pub fn is_zero(&self) -> bool {
         match (self.sign, &self.magnitude.data) {
             (_, UIntData::U64(0)) => true,
             (_, UIntData::BigUInt(b)) if b.is_zero() => true,
@@ -192,7 +136,7 @@ impl TryFrom<Coefficient> for BigInt {
     /// converted is a negative zero, which BigInt cannot represent. Returns Ok otherwise.
     fn try_from(value: Coefficient) -> Result<Self, Self::Error> {
         if value.is_negative_zero() {
-            IonResult::illegal_operation("Cannot convert negative zero Decimal to BigInt")?;
+            IonResult::illegal_operation("cannot convert negative zero Coefficient to BigInt")?;
         }
         let mut big_int: BigInt = match value.magnitude.data {
             UIntData::U64(m) => m.into(),
@@ -202,6 +146,47 @@ impl TryFrom<Coefficient> for BigInt {
             big_int.mul_assign(-1);
         }
         Ok(big_int)
+    }
+}
+
+impl TryFrom<Coefficient> for Int {
+    type Error = IonError;
+
+    fn try_from(value: Coefficient) -> Result<Self, Self::Error> {
+        if value.is_negative_zero() {
+            return IonResult::illegal_operation("cannot convert negative zero Coefficient to Int");
+        }
+        if value.is_negative() {
+            return Ok(Int::from(value.magnitude).neg());
+        }
+        Ok(Int::from(value.magnitude))
+    }
+}
+
+impl TryFrom<&Coefficient> for Int {
+    type Error = IonError;
+
+    fn try_from(value: &Coefficient) -> Result<Self, Self::Error> {
+        value.clone().try_into()
+    }
+}
+
+impl TryFrom<Coefficient> for UInt {
+    type Error = IonError;
+
+    fn try_from(value: Coefficient) -> Result<Self, Self::Error> {
+        if value.is_negative() {
+            return IonResult::illegal_operation("cannot convert a negative Coefficient to a UInt");
+        }
+        Ok(value.magnitude)
+    }
+}
+
+impl TryFrom<&Coefficient> for UInt {
+    type Error = IonError;
+
+    fn try_from(value: &Coefficient) -> Result<Self, Self::Error> {
+        value.clone().try_into()
     }
 }
 
@@ -218,7 +203,7 @@ impl TryFrom<BigInt> for Coefficient {
                     Sign::Positive
                 } else {
                     return IonResult::illegal_operation(
-                        "Cannot convert sign-less non-zero BigInt to Decimal.",
+                        "cannot convert sign-less non-zero BigInt to Decimal",
                     );
                 }
             }
@@ -243,9 +228,12 @@ impl Display for Coefficient {
 #[cfg(test)]
 mod coefficient_tests {
     use crate::ion_data::IonEq;
-    use num_bigint::BigUint;
+    use crate::Int;
+    use num_bigint::{BigInt, BigUint};
+    use std::ops::Neg;
+    use std::str::FromStr;
 
-    use crate::types::{Coefficient, Decimal};
+    use crate::types::{Coefficient, Decimal, Sign, UInt};
 
     fn eq_test<I1, I2>(c1: I1, c2: I2)
     where
@@ -284,5 +272,82 @@ mod coefficient_tests {
 
         assert_eq!(pos_zero, pos_zero);
         assert!(pos_zero.ion_eq(&pos_zero));
+    }
+
+    #[test]
+    fn is_negative_zero() {
+        assert!(Coefficient::negative_zero().is_negative_zero());
+        assert!(!Coefficient::new(Sign::Positive, 0).is_negative_zero());
+        assert!(!Coefficient::new(Sign::Positive, 5).is_negative_zero());
+    }
+
+    #[test]
+    fn is_positive_zero() {
+        assert!(Coefficient::new(Sign::Positive, 0).is_positive_zero());
+        assert!(!Coefficient::new(Sign::Positive, 5).is_positive_zero());
+        assert!(!Coefficient::negative_zero().is_positive_zero());
+    }
+
+    #[test]
+    fn is_negative() {
+        assert!(Coefficient::negative_zero().is_negative());
+        assert!(Coefficient::new(Sign::Negative, 5).is_negative());
+        assert!(!Coefficient::new(Sign::Positive, 5).is_negative());
+    }
+
+    #[test]
+    fn sign() {
+        assert_eq!(Coefficient::negative_zero().sign(), Sign::Negative);
+        assert_eq!(Coefficient::new(Sign::Positive, 0).sign(), Sign::Positive);
+        assert_eq!(Coefficient::new(Sign::Negative, 5).sign(), Sign::Negative);
+        assert_eq!(Coefficient::new(Sign::Positive, 5).sign(), Sign::Positive);
+    }
+
+    #[test]
+    fn magnitude() {
+        assert_eq!(Coefficient::negative_zero().magnitude(), &UInt::from(0u32));
+        assert_eq!(
+            Coefficient::new(Sign::Positive, 0).magnitude(),
+            &UInt::from(0u32)
+        );
+        assert_eq!(
+            Coefficient::new(Sign::Negative, 5).magnitude(),
+            &UInt::from(5u32)
+        );
+        assert_eq!(
+            Coefficient::new(Sign::Positive, 5).magnitude(),
+            &UInt::from(5u32)
+        );
+    }
+
+    #[test]
+    fn convert_to_int() {
+        // i64
+        assert_eq!(
+            Int::try_from(Coefficient::new(Sign::Positive, 5)),
+            Ok(Int::from(5))
+        );
+        assert_eq!(
+            Int::try_from(Coefficient::new(Sign::Negative, 5)),
+            Ok(Int::from(-5))
+        );
+
+        // BigInt
+        let enormous_int = BigInt::from_str("1234567890123456789012345678901234567890").unwrap();
+        assert_eq!(
+            Int::try_from(Coefficient::new(Sign::Positive, enormous_int.clone())),
+            Ok(Int::from(enormous_int.clone()))
+        );
+        assert_eq!(
+            Int::try_from(Coefficient::new(Sign::Negative, enormous_int.clone())),
+            Ok(Int::from(enormous_int.clone().neg()))
+        );
+
+        // Zeros
+        assert_eq!(
+            Int::try_from(Coefficient::new(Sign::Positive, 0)),
+            Ok(Int::from(0))
+        );
+        assert!(Int::try_from(Coefficient::negative_zero()).is_err());
     }
 }

--- a/src/types/decimal/coefficient.rs
+++ b/src/types/decimal/coefficient.rs
@@ -340,7 +340,7 @@ mod coefficient_tests {
         );
         assert_eq!(
             Int::try_from(Coefficient::new(Sign::Negative, enormous_int.clone())),
-            Ok(Int::from(enormous_int.clone().neg()))
+            Ok(Int::from(enormous_int.neg()))
         );
 
         // Zeros

--- a/src/types/decimal/magnitude.rs
+++ b/src/types/decimal/magnitude.rs
@@ -1,0 +1,70 @@
+use crate::types::UInt;
+use num_bigint::{BigInt, BigUint};
+
+/// A simple wrapper type around a [`UInt`]. Users are not expected to construct
+/// instances of `Magnitude` directly; it is provided for conversion ergonomics.
+///
+/// Signed integer types cannot implement `Into<UInt>`. Instead, they implement
+/// `TryInto<UInt>` and report an error if the input integer is negative.
+///
+/// Signed integers can infallibly implement `Into<Magnitude>` by using their
+/// absolute value.
+pub struct Magnitude(UInt);
+
+impl Magnitude {
+    fn new<I: Into<UInt>>(value: I) -> Self {
+        Magnitude(value.into())
+    }
+}
+
+impl From<UInt> for Magnitude {
+    fn from(value: UInt) -> Self {
+        Magnitude(value)
+    }
+}
+
+impl From<Magnitude> for UInt {
+    fn from(value: Magnitude) -> Self {
+        value.0
+    }
+}
+
+impl From<BigUint> for Magnitude {
+    fn from(value: BigUint) -> Self {
+        let uint: UInt = value.into();
+        Magnitude(uint)
+    }
+}
+
+impl From<BigInt> for Magnitude {
+    fn from(value: BigInt) -> Self {
+        let uint: UInt = value.into_parts().1.into();
+        Magnitude(uint)
+    }
+}
+
+macro_rules! impl_magnitude_from_small_unsigned_int_types {
+    ($($t:ty),*) => ($(
+        impl From<$t> for Magnitude {
+            fn from(value: $t) -> Magnitude {
+                let uint: UInt = value.into();
+                Magnitude(uint)
+            }
+        }
+    )*)
+}
+
+impl_magnitude_from_small_unsigned_int_types!(u8, u16, u32, u64, u128, usize);
+
+macro_rules! impl_magnitude_from_small_signed_int_types {
+    ($($t:ty),*) => ($(
+        impl From<$t> for Magnitude {
+            fn from(value: $t) -> Magnitude {
+                let uint: UInt = (value.unsigned_abs() as u64).into();
+                Magnitude(uint)
+            }
+        }
+    )*)
+}
+
+impl_magnitude_from_small_signed_int_types!(i8, i16, i32, i64, isize);

--- a/src/types/decimal/mod.rs
+++ b/src/types/decimal/mod.rs
@@ -19,6 +19,9 @@ mod magnitude;
 
 /// An arbitrary-precision Decimal type with a distinct representation of negative zero (`-0`).
 ///
+/// A `Decimal` can be thought of as a `(coefficient, exponent)` pair, and its value can be
+/// calculated using the formula `coefficient * 10^exponent`.
+///
 /// ```
 /// # use ion_rs::IonResult;
 /// # fn main() -> IonResult<()> {
@@ -59,8 +62,7 @@ impl Decimal {
         &self.coefficient
     }
 
-    /// Returns the decimal's exponent, which can be combined with the coefficient to calculate
-    /// the complete decimal value using this formula: `coefficient * 10^exponent`
+    /// Returns this `Decimal`'s exponent.
     pub fn exponent(&self) -> i64 {
         self.exponent
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -5,8 +5,7 @@
 pub type SymbolId = usize;
 
 mod bytes;
-mod coefficient;
-mod decimal;
+pub(crate) mod decimal;
 pub(crate) mod integer;
 mod list;
 mod lob;
@@ -18,7 +17,7 @@ mod symbol;
 mod timestamp;
 
 pub use crate::types::bytes::Bytes;
-pub use coefficient::{Coefficient, Sign};
+pub use decimal::coefficient::{Coefficient, Sign};
 pub use decimal::Decimal;
 pub use integer::{Int, IntAccess, UInt};
 pub use list::List;


### PR DESCRIPTION
This PR:
* Makes `Coefficient` a publicly visible type.
* Adds a `Decimal::coefficient` method to access the coefficient.
* Adds a `Decimal::exponent` method to access the exponent.
* Makes the `decimal` module a directory instead of a flat file
* Moves the `Magnitude` newtype to its own module
* Conversions to/from `Int`, `UInt`, and `Decimal` now return `IonError` instead of `()` in the event of a failure.

Fixes #405.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
