### PR TITLE
Removes Coefficient and Sign from the root

### DIFF
--- a/src/binary/decimal.rs
+++ b/src/binary/decimal.rs
@@ -9,11 +9,11 @@ use crate::binary::int::DecodedInt;
 use crate::binary::raw_binary_writer::MAX_INLINE_LENGTH;
 use crate::binary::var_int::VarInt;
 use crate::binary::var_uint::VarUInt;
+use crate::decimal::coefficient::{Coefficient, Sign};
 use crate::ion_data::IonEq;
 use crate::result::{IonFailure, IonResult};
 use crate::types::integer::UIntData;
-use crate::IonError;
-use crate::{Coefficient, Decimal, Sign, UInt};
+use crate::{Decimal, IonError, UInt};
 
 const DECIMAL_BUFFER_SIZE: usize = 32;
 const DECIMAL_POSITIVE_ZERO: Decimal = Decimal {

--- a/src/binary/int.rs
+++ b/src/binary/int.rs
@@ -1,8 +1,8 @@
 use std::mem;
 
+use crate::decimal::coefficient::{Coefficient, Sign};
 use crate::result::IonResult;
-use crate::types;
-use crate::{Coefficient, Int};
+use crate::Int;
 use num_traits::Zero;
 use std::io::Write;
 
@@ -120,8 +120,11 @@ impl From<DecodedInt> for Coefficient {
             is_negative,
             .. // ignore `size_in_bytes`
         } = int;
-        use types::Sign::{Negative, Positive};
-        let sign = if is_negative { Negative } else { Positive };
+        let sign = if is_negative {
+            Sign::Negative
+        } else {
+            Sign::Positive
+        };
         Coefficient::new(sign, value.unsigned_abs())
     }
 }

--- a/src/element/writer.rs
+++ b/src/element/writer.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates.
 
-//! Provides utility to serialize Ion data from [`Element`](super::Element) into common targets
+//! Provides utility to serialize Ion data from [`Element`] into common targets
 //! such as byte buffers or files.
 
 use crate::result::IonResult;
@@ -13,12 +13,11 @@ use crate::{Element, Value};
 
 /// Serializes [`Element`] instances into some kind of output sink.
 pub trait ElementWriter {
+    /// Serializes a single [`Value`] at the current depth of the writer.
+    fn write_value(&mut self, value: &Value) -> IonResult<()>;
+
     /// Serializes a single [`Element`] at the current depth of the writer.
     fn write_element(&mut self, element: &Element) -> IonResult<()>;
-
-    /// Serializes a single [`Value`] at the current depth of the writer.
-    // TODO: consider extracting this to a ValueWriter trait.
-    fn write_value(&mut self, value: &Value) -> IonResult<()>;
 
     /// Serializes a collection of [`Element`].
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,9 +207,12 @@ pub use symbol_ref::SymbolRef;
 pub use symbol_table::SymbolTable;
 #[doc(inline)]
 pub use types::{
-    decimal::Decimal, Blob, Bytes, Clob, Coefficient, Int, IonType, List, SExp, Sign, Str, Struct,
-    Symbol, SymbolId, Timestamp, TimestampPrecision, UInt,
+    decimal::Decimal, Blob, Bytes, Clob, Int, IonType, List, SExp, Str, Struct, Symbol, SymbolId,
+    Timestamp, TimestampPrecision, UInt,
 };
+
+// Allow access to less commonly used types like decimal::coefficient::{Coefficient, Sign}
+pub use types::decimal;
 
 // These re-exports are only visible if the "experimental-reader" feature is enabled.
 #[cfg(feature = "experimental-reader")]

--- a/src/text/parsers/decimal.rs
+++ b/src/text/parsers/decimal.rs
@@ -8,12 +8,13 @@ use nom::combinator::{map, opt};
 use nom::sequence::{pair, preceded, terminated};
 use num_bigint::BigUint;
 
+use crate::decimal::coefficient::{Coefficient, Sign};
 use crate::text::parsers::numeric_support::{
     digits_before_dot, exponent_digits, floating_point_number_components,
 };
 use crate::text::parsers::stop_character;
 use crate::text::text_value::TextValue;
-use crate::{Coefficient, Decimal, Sign, UInt};
+use crate::{Decimal, UInt};
 
 /// Matches the text representation of a decimal value and returns the resulting [Decimal]
 /// as a [TextValue::Decimal].

--- a/src/types/decimal/coefficient.rs
+++ b/src/types/decimal/coefficient.rs
@@ -233,7 +233,8 @@ mod coefficient_tests {
     use std::ops::Neg;
     use std::str::FromStr;
 
-    use crate::{Coefficient, Decimal, Sign, UInt};
+    use super::*;
+    use crate::{Decimal, UInt};
 
     fn eq_test<I1, I2>(c1: I1, c2: I2)
     where

--- a/src/types/decimal/mod.rs
+++ b/src/types/decimal/mod.rs
@@ -2,18 +2,18 @@ use std::cmp::{max, Ordering};
 
 use num_bigint::{BigInt, BigUint, ToBigInt, ToBigUint};
 
+use crate::decimal::coefficient::{Coefficient, Sign};
 use crate::ion_data::{IonEq, IonOrd};
 use crate::result::{IonError, IonFailure};
 use crate::types::integer::UIntData;
-use crate::{Coefficient, Sign, UInt};
-use crate::{Int, IonResult};
+use crate::{Int, IonResult, UInt};
 use num_integer::Integer;
 use num_traits::{ToPrimitive, Zero};
 use std::convert::{TryFrom, TryInto};
 use std::fmt::{Display, Formatter};
 use std::ops::Neg;
 
-pub(crate) mod coefficient;
+pub mod coefficient;
 mod magnitude;
 
 /// An arbitrary-precision Decimal type with a distinct representation of negative zero (`-0`).
@@ -24,7 +24,8 @@ mod magnitude;
 /// ```
 /// # use ion_rs::IonResult;
 /// # fn main() -> IonResult<()> {
-/// use ion_rs::{Int, Decimal, Sign, UInt};
+/// use ion_rs::{Int, Decimal, UInt};
+/// use ion_rs::decimal::coefficient::Sign;
 /// // Equivalent to: 1225 * 10^-2, or 12.25
 /// let decimal = Decimal::new(1225, -2);
 /// // The coefficient can be viewed as a sign/magnitude pair...
@@ -495,8 +496,9 @@ impl Display for Decimal {
 
 #[cfg(test)]
 mod decimal_tests {
+    use crate::decimal::coefficient::{Coefficient, Sign};
     use crate::result::IonResult;
-    use crate::{Coefficient, Decimal, Int, Sign, UInt};
+    use crate::{Decimal, Int, UInt};
     use num_bigint::{BigInt, BigUint};
 
     use num_traits::Float;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -5,7 +5,7 @@
 pub type SymbolId = usize;
 
 mod bytes;
-pub(crate) mod decimal;
+pub mod decimal;
 pub(crate) mod integer;
 mod list;
 mod lob;
@@ -17,7 +17,6 @@ mod timestamp;
 
 pub use crate::element::Sequence;
 pub use crate::types::bytes::Bytes;
-pub use decimal::coefficient::{Coefficient, Sign};
 pub use decimal::Decimal;
 pub use integer::{Int, UInt};
 pub use list::List;

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -1,8 +1,8 @@
+use crate::decimal::coefficient::Sign;
 use crate::ion_data::{IonEq, IonOrd};
 use crate::result::{IonError, IonFailure, IonResult};
 use crate::types::integer::UIntData;
 use crate::types::Decimal;
-use crate::types::Sign::Negative;
 use chrono::{
     DateTime, Datelike, FixedOffset, LocalResult, NaiveDate, NaiveDateTime, TimeZone, Timelike,
 };
@@ -405,7 +405,7 @@ impl Timestamp {
                 }
                 if coefficient.is_negative_zero() {
                     write!(output, "0")?;
-                } else if coefficient.sign == Negative {
+                } else if coefficient.sign == Sign::Negative {
                     return IonResult::encoding_error(
                         "fractional seconds cannot have a negative coefficient (other than -0)",
                     );


### PR DESCRIPTION
Removes the re-export of `Sign` and `Coefficient` from the crate root. They can still be accessed at: `ion_rs::decimal::coefficient::{Coefficient, Sign}`.

Fixes #586.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
