### PR TITLE
Error types now hold a Cow<str> instead of requiring a String

### DIFF
--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -33,7 +33,6 @@ impl Catalog for MapCatalog {
         if name.is_empty() {
             return None;
         }
-      
         let versions: &BTreeMap<usize, SharedSymbolTable> = self.tables_by_name.get(name)?;
 
         let (_highest_version, table) = versions.iter().next_back()?;

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -42,7 +42,7 @@ impl Catalog for MapCatalog {
                 ))
             })?;
 
-        let (_highest_version, table) = versions.iter().rev().next().ok_or_else(|| {
+        let (_highest_version, table) = versions.iter().next_back().ok_or_else(|| {
             IonError::illegal_operation(format!("symbol table with name: {name} does not exist"))
         })?;
         Ok(table.to_owned())

--- a/src/element/builders.rs
+++ b/src/element/builders.rs
@@ -209,7 +209,7 @@ impl StructBuilder {
 
     /// Builds a [`Struct`] with the previously specified fields.
     pub fn build(self) -> Struct {
-        Struct::from_iter(self.fields.into_iter())
+        Struct::from_iter(self.fields)
     }
 }
 

--- a/src/element/reader.rs
+++ b/src/element/reader.rs
@@ -209,7 +209,7 @@ impl<'a, R: IonReader<Item = StreamItem, Symbol = Symbol> + ?Sized> ElementLoade
             child_elements.push((field_name, value));
         }
         self.reader.step_out()?;
-        Ok(Struct::from_iter(child_elements.into_iter()))
+        Ok(Struct::from_iter(child_elements))
     }
 }
 

--- a/src/element/sequence.rs
+++ b/src/element/sequence.rs
@@ -88,7 +88,7 @@ impl IntoIterator for Sequence {
 
 impl FromIterator<Element> for Sequence {
     fn from_iter<T: IntoIterator<Item = Element>>(iter: T) -> Self {
-        Vec::from_iter(iter.into_iter()).into()
+        Vec::from_iter(iter).into()
     }
 }
 

--- a/src/result/decoding_error.rs
+++ b/src/result/decoding_error.rs
@@ -1,13 +1,14 @@
+use std::borrow::Cow;
 use thiserror::Error;
 
 #[derive(Clone, Debug, Error, PartialEq)]
 #[error("{description}")]
 pub struct DecodingError {
-    description: String,
+    description: Cow<'static, str>,
 }
 
 impl DecodingError {
-    pub(crate) fn new(description: impl Into<String>) -> Self {
+    pub(crate) fn new(description: impl Into<Cow<'static, str>>) -> Self {
         DecodingError {
             description: description.into(),
         }

--- a/src/result/encoding_error.rs
+++ b/src/result/encoding_error.rs
@@ -1,13 +1,14 @@
+use std::borrow::Cow;
 use thiserror::Error;
 
 #[derive(Clone, Debug, Error, PartialEq)]
 #[error("{description}")]
 pub struct EncodingError {
-    description: String,
+    description: Cow<'static, str>,
 }
 
 impl EncodingError {
-    pub(crate) fn new(description: impl Into<String>) -> Self {
+    pub(crate) fn new(description: impl Into<Cow<'static, str>>) -> Self {
         EncodingError {
             description: description.into(),
         }

--- a/src/result/illegal_operation.rs
+++ b/src/result/illegal_operation.rs
@@ -1,19 +1,20 @@
+use std::borrow::Cow;
 use thiserror::Error;
 
 #[derive(Clone, Debug, Error, PartialEq)]
 #[error("the user has performed an operation that is not legal in the current state: {operation}")]
 pub struct IllegalOperation {
-    operation: String,
+    operation: Cow<'static, str>,
 }
 
 impl IllegalOperation {
-    pub(crate) fn new(description: impl Into<String>) -> Self {
+    pub(crate) fn new(description: impl Into<Cow<'static, str>>) -> Self {
         IllegalOperation {
             operation: description.into(),
         }
     }
 
     pub fn operation(&self) -> &str {
-        self.operation.as_str()
+        self.operation.as_ref()
     }
 }

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::convert::From;
 use std::fmt::{Debug, Error};
 use std::{fmt, io};
@@ -80,9 +81,9 @@ pub(crate) trait IonFailure {
     // Because this trait is only crate-visible, methods can be added/changed as needed in
     // the future.
     fn incomplete(label: &'static str, position: impl Into<Position>) -> Self;
-    fn decoding_error<S: Into<String>>(description: S) -> Self;
-    fn encoding_error<S: Into<String>>(description: S) -> Self;
-    fn illegal_operation<S: Into<String>>(operation: S) -> Self;
+    fn decoding_error<S: Into<Cow<'static, str>>>(description: S) -> Self;
+    fn encoding_error<S: Into<Cow<'static, str>>>(description: S) -> Self;
+    fn illegal_operation<S: Into<Cow<'static, str>>>(operation: S) -> Self;
 }
 
 impl IonFailure for IonError {
@@ -90,15 +91,15 @@ impl IonFailure for IonError {
         IncompleteError::new(label, position).into()
     }
 
-    fn decoding_error<S: Into<String>>(description: S) -> Self {
+    fn decoding_error<S: Into<Cow<'static, str>>>(description: S) -> Self {
         DecodingError::new(description).into()
     }
 
-    fn encoding_error<S: Into<String>>(description: S) -> Self {
+    fn encoding_error<S: Into<Cow<'static, str>>>(description: S) -> Self {
         EncodingError::new(description).into()
     }
 
-    fn illegal_operation<S: Into<String>>(operation: S) -> Self {
+    fn illegal_operation<S: Into<Cow<'static, str>>>(operation: S) -> Self {
         IllegalOperation::new(operation).into()
     }
 }
@@ -108,15 +109,15 @@ impl<T> IonFailure for IonResult<T> {
         Err(IonError::incomplete(label, position))
     }
 
-    fn decoding_error<S: Into<String>>(description: S) -> Self {
+    fn decoding_error<S: Into<Cow<'static, str>>>(description: S) -> Self {
         Err(IonError::decoding_error(description))
     }
 
-    fn encoding_error<S: Into<String>>(description: S) -> Self {
+    fn encoding_error<S: Into<Cow<'static, str>>>(description: S) -> Self {
         Err(IonError::encoding_error(description))
     }
 
-    fn illegal_operation<S: Into<String>>(operation: S) -> Self {
+    fn illegal_operation<S: Into<Cow<'static, str>>>(operation: S) -> Self {
         Err(IonError::illegal_operation(operation))
     }
 }

--- a/src/text/parsers/string.rs
+++ b/src/text/parsers/string.rs
@@ -197,7 +197,7 @@ mod string_parsing_tests {
         // Leading whitespace not accepted
         parse_fails(" \"Hello, world\" ");
         // Unicode escape producing invalid surrogate
-        parse_fails(r#"'''\ud800'''\n"#);
+        parse_fails(r"'''\ud800'''\n");
     }
 
     #[test]
@@ -217,7 +217,7 @@ mod string_parsing_tests {
 
     #[test]
     fn long_string_escapes() {
-        parse_equals(r#"'''foo\nbar''' '''\nbaz\n''' 1"#, "foo\nbar\nbaz\n");
+        parse_equals(r"'''foo\nbar''' '''\nbaz\n''' 1", "foo\nbar\nbaz\n");
         parse_equals("'''foo\\\r\nbar''' 1", "foobar"); // Escaped newline
     }
 }

--- a/src/tokens/reader_stream.rs
+++ b/src/tokens/reader_stream.rs
@@ -403,7 +403,7 @@ mod tests {
     {
         names
             .into_iter()
-            .zip(srcs?.into_iter())
+            .zip(srcs?)
             .map(|(name, (insn, a_tok))| {
                 Ok((
                     insn,

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -803,7 +803,7 @@ impl<T> TimestampBuilder<T> {
         // If we ever discover a performance difference, this entire function could be replaced with one line.
         // unsafe { std::mem::transmute(self) }
         TimestampBuilder {
-            _state: PhantomData::default(),
+            _state: PhantomData,
             fields_are_utc: self.fields_are_utc,
             precision: self.precision,
             offset: self.offset,


### PR DESCRIPTION
Prior to this patch, error structs like `DecodingError` each held a `String`, which meant that if a caller passed in a static string literal, it would always be unnecessarily copied to the heap.

This PR modifies each type and their corresponding constructors in the `IonFailure` trait to operate in terms of `Cow<'static, str>` and `Into<Cow<'static, str>>`, allowing static strings to avoid cloning while still supporting more complex error `String`s constructed with `format!` and the like.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
