### PR TITLE
Removes `SymbolTable` and `Catalog` from the public API

### DIFF
--- a/src/binary/binary_writer.rs
+++ b/src/binary/binary_writer.rs
@@ -3,7 +3,7 @@ use crate::constants::v1_0::system_symbol_ids;
 use crate::ion_writer::IonWriter;
 use crate::raw_symbol_token_ref::{AsRawSymbolTokenRef, RawSymbolTokenRef};
 use crate::result::{IonFailure, IonResult};
-use crate::SymbolTable;
+use crate::symbol_table::SymbolTable;
 use crate::{Decimal, Int, IonType, SymbolId, Timestamp};
 use delegate::delegate;
 use std::io::Write;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ use rstest_reuse;
 // Private modules that serve to organize implementation details.
 mod binary;
 mod blocking_reader;
-pub mod catalog;
+mod catalog;
 mod constants;
 mod data_source;
 mod ion_data;
@@ -204,7 +204,6 @@ pub use element::{
 };
 pub use ion_data::IonData;
 pub use symbol_ref::SymbolRef;
-pub use symbol_table::SymbolTable;
 #[doc(inline)]
 pub use types::{
     decimal::Decimal, Blob, Bytes, Clob, Int, IonType, List, SExp, Str, Struct, Symbol, SymbolId,
@@ -226,6 +225,7 @@ pub use {
     // Public as a workaround for: https://github.com/amazon-ion/ion-rust/issues/484
     reader::integration_testing,
     reader::{Reader, ReaderBuilder, StreamItem, UserReader},
+    symbol_table::SymbolTable,
     system_reader::{SystemReader, SystemStreamItem},
     text::non_blocking::raw_text_reader::RawTextReader,
     text::raw_text_writer::{RawTextWriter, RawTextWriterBuilder},

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -20,7 +20,7 @@ impl Default for SymbolTable {
 
 impl SymbolTable {
     /// Constructs a new symbol table pre-populated with the system symbols defined in the spec.
-    pub fn new() -> SymbolTable {
+    pub(crate) fn new() -> SymbolTable {
         let mut symbol_table = SymbolTable {
             symbols_by_id: Vec::with_capacity(v1_0::SYSTEM_SYMBOLS.len()),
             ids_by_text: HashMap::new(),
@@ -30,13 +30,13 @@ impl SymbolTable {
     }
 
     // Interns the v1.0 system symbols
-    fn initialize(&mut self) {
+    pub(crate) fn initialize(&mut self) {
         for &text in v1_0::SYSTEM_SYMBOLS.iter() {
             self.intern_or_add_placeholder(text);
         }
     }
 
-    pub fn reset(&mut self) {
+    pub(crate) fn reset(&mut self) {
         self.symbols_by_id.clear();
         self.ids_by_text.clear();
         self.initialize();
@@ -44,7 +44,7 @@ impl SymbolTable {
 
     /// If `text` is already in the symbol table, returns the corresponding [SymbolId].
     /// Otherwise, adds `text` to the symbol table and returns the newly assigned [SymbolId].
-    pub fn intern<A: AsRef<str>>(&mut self, text: A) -> SymbolId {
+    pub(crate) fn intern<A: AsRef<str>>(&mut self, text: A) -> SymbolId {
         let text = text.as_ref();
         // If the text is already in the symbol table, return the ID associated with it.
         if let Some(id) = self.ids_by_text.get(text) {
@@ -62,7 +62,7 @@ impl SymbolTable {
 
     /// Assigns unknown text to the next available symbol ID. This is used when an Ion reader
     /// encounters null or non-string values in a stream's symbol table.
-    pub fn add_placeholder(&mut self) -> SymbolId {
+    pub(crate) fn add_placeholder(&mut self) -> SymbolId {
         let sid = self.symbols_by_id.len();
         self.symbols_by_id.push(Symbol::unknown_text());
         sid
@@ -70,7 +70,10 @@ impl SymbolTable {
 
     /// If `maybe_text` is `Some(text)`, this method is equivalent to `intern(text)`.
     /// If `maybe_text` is `None`, this method is equivalent to `add_placeholder()`.
-    pub fn intern_or_add_placeholder<A: AsRef<str>>(&mut self, maybe_text: Option<A>) -> SymbolId {
+    pub(crate) fn intern_or_add_placeholder<A: AsRef<str>>(
+        &mut self,
+        maybe_text: Option<A>,
+    ) -> SymbolId {
         match maybe_text {
             Some(text) => self.intern(text),
             None => self.add_placeholder(),
@@ -123,7 +126,8 @@ impl SymbolTable {
     ///
     /// The symbol table can contain symbols with unknown text; see the documentation for
     /// [Symbol] for more information.
-    pub fn symbols_tail(&self, start: usize) -> &[Symbol] {
+    // TODO: Is this necessary vs just taking a slice of the `symbols()` method above?
+    pub(crate) fn symbols_tail(&self, start: usize) -> &[Symbol] {
         &self.symbols_by_id[start..]
     }
 

--- a/src/system_reader.rs
+++ b/src/system_reader.rs
@@ -8,9 +8,10 @@ use crate::ion_reader::IonReader;
 use crate::raw_reader::{Expandable, RawReader, RawStreamItem};
 use crate::raw_symbol_token::RawSymbolToken;
 use crate::result::{IonError, IonFailure, IonResult};
+use crate::symbol_table::SymbolTable;
 use crate::system_reader::LstPosition::*;
+use crate::IonType;
 use crate::{Blob, Clob, Decimal, Int, Str, Symbol, Timestamp};
-use crate::{IonType, SymbolTable};
 
 /// Tracks where the [SystemReader] is in the process of reading a local symbol table.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/src/text/text_writer.rs
+++ b/src/text/text_writer.rs
@@ -1,11 +1,12 @@
 use crate::ion_writer::IonWriter;
 use crate::raw_symbol_token_ref::{AsRawSymbolTokenRef, RawSymbolTokenRef};
 use crate::result::IonResult;
+use crate::symbol_table::SymbolTable;
 use crate::text::raw_text_writer::RawTextWriter;
 use crate::text::raw_text_writer::RawTextWriterBuilder;
 use crate::TextKind;
 use crate::{Decimal, Timestamp};
-use crate::{Int, IonType, SymbolTable};
+use crate::{Int, IonType};
 use delegate::delegate;
 use std::io::Write;
 


### PR DESCRIPTION
Removes the `SymbolTable` and `Catalog`/`MapCatalog` types from the public API. Also marks any mutating methods on `SymbolTable` as `pub(crate)`; users do not need to modify the symbol table.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
