### PR TITLE
Adds doc comments, `Element::write_all_as` method

### DIFF
--- a/src/element/builders.rs
+++ b/src/element/builders.rs
@@ -8,7 +8,7 @@ use crate::{Element, Sequence, Struct};
 /// use ion_rs::{Element, Sequence};
 /// let actual: Sequence = Sequence::builder().push(1).push(true).push("foo").build();
 /// let expected: Sequence = Sequence::new([
-///     Element::integer(1),
+///     Element::int(1),
 ///     Element::boolean(true),
 ///     Element::string("foo"),
 /// ]);
@@ -23,7 +23,7 @@ use crate::{Element, Sequence, Struct};
 ///     .push("foo")
 ///     .build_list();
 /// let expected: List = List(Sequence::new([
-///     Element::integer(1),
+///     Element::int(1),
 ///     Element::boolean(true),
 ///     Element::string("foo"),
 /// ]));
@@ -38,7 +38,7 @@ use crate::{Element, Sequence, Struct};
 ///     .push("foo")
 ///     .build_sexp();
 /// let expected: SExp = SExp(Sequence::new([
-///     Element::integer(1),
+///     Element::int(1),
 ///     Element::boolean(true),
 ///     Element::string("foo"),
 /// ]));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@
 //! ## Traversing an `Element`
 //!
 //! ```
-//! use ion_rs::IonResult;
+//! # use ion_rs::IonResult;
 //! # fn main() -> IonResult<()> {
 //! use ion_rs::{Element, Value, ion_list, ion_struct};
 //! let element: Element = ion_struct! {
@@ -134,9 +134,9 @@
 //! ## Writing an `Element` to an `io::Write`
 //!
 //! ```
-//! use ion_rs::{Format, IonResult, TextKind};
+//! # use ion_rs::IonResult;
 //! # fn main() -> IonResult<()> {
-//! use ion_rs::{Element, ion_list, ion_struct};
+//! use ion_rs::{Element, Format, TextKind, ion_list, ion_struct};
 //! let element: Element = ion_struct! {
 //!   "foo": "hello",
 //!   "bar": true,

--- a/src/types/integer.rs
+++ b/src/types/integer.rs
@@ -7,8 +7,7 @@ use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 use std::ops::{Add, Neg};
 
-/// Represents a UInt of any size. Used for reading binary integers and symbol Ids.
-/// Used to represent the unsigned magnitude of Decimal values and fractional seconds.
+/// Represents an unsigned integer of any size.
 #[derive(Debug, Clone)]
 pub struct UInt {
     pub(crate) data: UIntData,
@@ -339,6 +338,26 @@ impl From<IntData> for Int {
 }
 
 #[derive(Debug, Clone)]
+/// A signed integer of arbitrary size.
+/// ```
+/// # use ion_rs::IonResult;
+/// # fn main() -> IonResult<()> {
+/// use ion_rs::{Element, Int};
+///
+/// let element = Element::read_one("-42")?;
+///
+/// // Access the element's integer value...
+/// let int: &Int = element.expect_int()?;
+/// // ...and convert it to an i64. `as_i64()` will return `None` if
+/// // the Int is too large to fit in an i64.
+/// assert_eq!(int.as_i64(), Some(-42i64));
+///
+/// // The `expect_i64()` is similar to `as_i64()`, but returns an
+/// // `IonError` instead of `None` if the conversion cannot be completed.
+/// assert_eq!(element.expect_i64()?, -42i64);
+/// # Ok(())
+/// # }
+/// ```
 pub struct Int {
     pub(crate) data: IntData,
 }

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -13,7 +13,7 @@ use std::fmt::{Display, Formatter};
 /// # fn main() -> IonResult<()> {
 /// let list = ion_list![1, 2, 3];
 /// assert_eq!(list.len(), 3);
-/// assert_eq!(list.get(1), Some(&Element::integer(2)));
+/// assert_eq!(list.get(1), Some(&Element::int(2)));
 /// # Ok(())
 /// # }
 /// ```

--- a/src/types/sexp.rs
+++ b/src/types/sexp.rs
@@ -13,7 +13,7 @@ use std::fmt::{Display, Formatter};
 /// # fn main() -> IonResult<()> {
 /// let sexp = ion_sexp!(1 2 3);
 /// assert_eq!(sexp.len(), 3);
-/// assert_eq!(sexp.get(1), Some(&Element::integer(2)));
+/// assert_eq!(sexp.get(1), Some(&Element::int(2)));
 /// # Ok(())
 /// # }
 /// ```

--- a/src/types/struct.rs
+++ b/src/types/struct.rs
@@ -332,6 +332,6 @@ mod tests {
                 baz_value = Some(value);
             }
         }
-        assert_eq!(baz_value, Some(&Element::integer(3)));
+        assert_eq!(baz_value, Some(&Element::int(3)));
     }
 }


### PR DESCRIPTION
* Adds doc comments to the `Int` type.
* Renames the `Element::integer(...)` constructor to `Element::int(...)` for consistency with the `IonType::*` names.
* Adds an `Element::write_all_as` that works with any iterable collection of `Element`. This method allows a stream with more than one top-level value to be written, resulting in more compact output through symtab reuse.

Partially addresses #587.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
