### PR TITLE
Result doc comments

### DIFF
--- a/src/result/decoding_error.rs
+++ b/src/result/decoding_error.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use thiserror::Error;
 
+/// Indicates that a read operation failed due to invalid input.
 #[derive(Clone, Debug, Error, PartialEq)]
 #[error("{description}")]
 pub struct DecodingError {

--- a/src/result/encoding_error.rs
+++ b/src/result/encoding_error.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use thiserror::Error;
 
+/// Indicates that a write operation failed to serialize the given data.
 #[derive(Clone, Debug, Error, PartialEq)]
 #[error("{description}")]
 pub struct EncodingError {

--- a/src/result/illegal_operation.rs
+++ b/src/result/illegal_operation.rs
@@ -1,6 +1,8 @@
 use std::borrow::Cow;
 use thiserror::Error;
 
+/// Indicates that the user has performed an operation that was not legal in the application's
+/// current state.
 #[derive(Clone, Debug, Error, PartialEq)]
 #[error("the user has performed an operation that is not legal in the current state: {operation}")]
 pub struct IllegalOperation {

--- a/src/result/incomplete.rs
+++ b/src/result/incomplete.rs
@@ -1,6 +1,8 @@
 use crate::position::Position;
 use thiserror::Error;
 
+/// For non-blocking readers, indicates that there was not enough data available in the input buffer
+/// to complete the requested action.
 #[derive(Clone, Debug, Error, PartialEq)]
 #[error("ran out of input while reading {label} at offset {position}")]
 pub struct IncompleteError {

--- a/src/result/io_error.rs
+++ b/src/result/io_error.rs
@@ -1,6 +1,7 @@
 use std::io;
 use thiserror::Error;
 
+/// Indicates that a read or write operation failed due to an I/O error.
 #[derive(Debug, Error)]
 #[error("{source:?}")]
 pub struct IoError {

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -1,3 +1,5 @@
+//! Types for reporting various modes of success or failure.
+
 use std::borrow::Cow;
 use std::convert::From;
 use std::fmt::{Debug, Error};

--- a/src/types/decimal/coefficient.rs
+++ b/src/types/decimal/coefficient.rs
@@ -1,3 +1,5 @@
+//! A representation of a decimal value's coefficient.
+
 use num_bigint::{BigInt, BigUint};
 use num_traits::Zero;
 
@@ -10,18 +12,16 @@ use std::convert::TryFrom;
 use std::fmt::{Display, Formatter};
 use std::ops::{MulAssign, Neg};
 
-/// Indicates whether the Coefficient's magnitude is less than 0 (negative) or not (positive).
-/// When the magnitude is zero, the Sign can be used to distinguish between -0 and 0.
+/// Indicates whether the `Coefficient`'s magnitude is less than 0 (negative) or not (positive).
+/// When the magnitude is zero, the `Sign` can be used to distinguish between -0 and 0.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum Sign {
     Negative,
     Positive,
 }
 
-/// A signed integer that can be used as the coefficient of a Decimal value. This type does not
+/// A signed integer that can be used as the coefficient of a [`Decimal`] value. This type does not
 /// consider `0` and `-0` to be equal and supports magnitudes of arbitrary size.
-// These trait derivations rely closely on the manual implementations of PartialEq and Ord on
-// [Magnitude].
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct Coefficient {
     pub(crate) sign: Sign,

--- a/src/types/decimal/coefficient.rs
+++ b/src/types/decimal/coefficient.rs
@@ -20,8 +20,8 @@ pub enum Sign {
     Positive,
 }
 
-/// A signed integer that can be used as the coefficient of a [`Decimal`] value. This type does not
-/// consider `0` and `-0` to be equal and supports magnitudes of arbitrary size.
+/// A signed integer that can be used as the coefficient of a [`Decimal`](crate::Decimal) value.
+/// This type does not consider `0` and `-0` to be equal and supports magnitudes of arbitrary size.
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct Coefficient {
     pub(crate) sign: Sign,

--- a/src/types/decimal/mod.rs
+++ b/src/types/decimal/mod.rs
@@ -1,3 +1,5 @@
+//! Types related to [`Decimal`], the in-memory representation of an Ion decimal value.
+
 use std::cmp::{max, Ordering};
 
 use num_bigint::{BigInt, BigUint, ToBigInt, ToBigUint};


### PR DESCRIPTION
Adds doc comments to:
* The `decimal` module
* The `decimal::coefficient` module
* The `result` module and its nested error types

Fixes #587. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
