### PR TITLE
Version bump to 1.0.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
   "**/ion-tests/iontestdata/**",
   "*.pdf"
 ]
-version = "0.18.1"
+version = "1.0.0-rc.1"
 edition = "2021"
 # We need at least 1.65 for GATs
 # https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html


### PR DESCRIPTION
Bumps the crate version from `0.18.1` to `1.0.0-rc.1`, the first release candidate for v1.0.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
