### PR TITLE
Adds experimental serde feature

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,0 +1,38 @@
+name: Miri test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Test with Miri
+    runs-on: ${{ matrix.os }}
+    # We want to run on external PRs, but not on internal ones as push automatically builds
+    # H/T: https://github.com/Dart-Code/Dart-Code/commit/612732d5879730608baa9622bf7f5e5b7b51ae65
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-rust'
+    strategy:
+      matrix:
+        # See https://github.com/amazon-ion/ion-rust/issues/353
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        # build and test for experimental features with miri
+        features: ['experimental']
+    permissions:
+      checks: write
+
+    steps:
+      - name: Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: miri
+          override: true
+      - name: Install Miri
+        run: |
+          rustup toolchain install nightly --component miri
+          rustup override set nightly
+          cargo miri setup
+      - name: Test with Miri
+        uses: actions-rs/cargo@v1
+        with:
+          command: miri test
+          args: serde --features "${{ matrix.features }}"

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -19,6 +19,10 @@ jobs:
       checks: write
 
     steps:
+      - name: Git Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Rust Toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -31,8 +35,12 @@ jobs:
           rustup toolchain install nightly --component miri
           rustup override set nightly
           cargo miri setup
-      - name: Test with Miri
-        uses: actions-rs/cargo@v1
-        with:
-          command: miri
-          args: test serde --features "${{ matrix.features }}"
+      - name: Test with Miri (ubuntu and macos)
+        # miri test for Linux and macOS os, since Windows os requires a different syntax to enable miri flags
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+        # We need to pass the miri flag to disable host isolation in order to access host for clock information on timestamps
+        # more information can be found: https://github.com/rust-lang/miri#miri--z-flags-and-environment-variables
+        run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test serde --features "${{ matrix.features }}"
+      - name: Test with Miri (windows)
+        if: matrix.os == 'windows-latest'
+        run: $env:MIRIFLAGS="-Zmiri-disable-isolation" ; cargo miri test serde --features "${{ matrix.features }}"

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -32,7 +32,4 @@ jobs:
           rustup override set nightly
           cargo miri setup
       - name: Test with Miri
-        uses: actions-rs/cargo@v1
-        with:
-          command: miri test
-          args: serde --features "${{ matrix.features }}"
+        run: cargo miri test serde --features "experimental"

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -32,4 +32,7 @@ jobs:
           rustup override set nightly
           cargo miri setup
       - name: Test with Miri
-        run: cargo miri test serde --features "experimental"
+        uses: actions-rs/cargo@v1
+        with:
+          command: miri
+          args: test serde --features "${{ matrix.features }}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ experimental = [
   "experimental-lazy-reader",
   "experimental-reader",
   "experimental-writer",
-  "experimental-streaming"
+  "experimental-streaming",
+  "experimental-serde"
 ]
 
 # Experimental streaming APIs
@@ -52,6 +53,9 @@ experimental-writer = []
 # an inexpensive form of 'rewind' functionality.
 experimental-lazy-reader = []
 
+# Experimental serde API to serialize and deserialize Ion data into Rust objects using serde crate
+experimental-serde = ["dep:serde_with", "dep:serde"]
+
 [dependencies]
 base64 = "0.12"
 bytes = "0.4"
@@ -69,6 +73,8 @@ arrayvec = "0.7"
 smallvec = {version ="1.9.0", features = ["const_generics"]}
 digest = { version = "0.9", optional = true }
 sha2 = { version = "0.9", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_with = { verison = "2.0", optional = true }
 
 [dev-dependencies]
 rstest = "0.17.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ experimental = [
   "experimental-reader",
   "experimental-writer",
   "experimental-streaming",
-  "experimental-serde"
+  "experimental-serde",
 ]
 
 # Experimental streaming APIs
@@ -74,7 +74,7 @@ smallvec = {version ="1.9.0", features = ["const_generics"]}
 digest = { version = "0.9", optional = true }
 sha2 = { version = "0.9", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
-serde_with = { verison = "2.0", optional = true }
+serde_with = { version = "2.0", optional = true }
 
 [dev-dependencies]
 rstest = "0.17.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,8 @@ pub mod ion_hash;
 pub mod lazy;
 // Experimental Streaming APIs
 mod position;
+#[cfg(feature = "experimental-serde")]
+pub mod serde;
 #[cfg(feature = "experimental-streaming")]
 pub mod thunk;
 #[cfg(feature = "experimental-streaming")]

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -7,6 +7,9 @@ use std::{fmt, io};
 
 use thiserror::Error;
 
+#[cfg(feature = "experimental-serde")]
+use serde::{de, ser};
+
 mod decoding_error;
 mod encoding_error;
 mod illegal_operation;
@@ -69,6 +72,26 @@ impl From<io::ErrorKind> for IonError {
 
 impl From<fmt::Error> for IonError {
     fn from(error: Error) -> Self {
+        EncodingError::new(error.to_string()).into()
+    }
+}
+
+#[cfg(feature = "experimental-serde")]
+impl de::Error for IonError {
+    fn custom<T>(error: T) -> Self
+    where
+        T: std::fmt::Display,
+    {
+        DecodingError::new(error.to_string()).into()
+    }
+}
+
+#[cfg(feature = "experimental-serde")]
+impl ser::Error for IonError {
+    fn custom<T>(error: T) -> Self
+    where
+        T: std::fmt::Display,
+    {
         EncodingError::new(error.to_string()).into()
     }
 }

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -1,0 +1,883 @@
+use crate::data_source::IonDataSource;
+use crate::result::IonFailure;
+use crate::serde::timestamp::ION_BINARY;
+use crate::{IonError, IonReader, IonResult, IonType, ReaderBuilder, StreamItem, Symbol};
+use chrono::{DateTime, FixedOffset};
+use serde::de;
+use serde::de::{DeserializeSeed, EnumAccess, MapAccess, SeqAccess, Visitor};
+use serde::Deserialize;
+use std::borrow::Cow;
+use std::iter::FusedIterator;
+use std::marker::PhantomData;
+
+/// Generic method that can deserialize an object from any given object
+/// that implements `ToIonDateSource`. It also enables `ION_BINARY`
+/// to ensure that `Timestamp` objects are correctly deserialized.
+pub fn from_ion<'a, T, S>(s: S) -> IonResult<T>
+where
+    T: Deserialize<'a>,
+    S: IonDataSource,
+{
+    ION_BINARY.with(move |cell| {
+        cell.set(true);
+        let mut deserializer = Deserializer {
+            reader: ReaderBuilder::new().build(s)?,
+        };
+
+        // If we are hovering over nothing call next till we have an object
+        while StreamItem::Nothing == deserializer.reader.current() {
+            deserializer.reader.next()?;
+        }
+
+        let result = T::deserialize(&mut deserializer)?;
+        cell.set(false);
+        Ok(result)
+    })
+}
+
+/// The deserializer for Ion, it doesn't care about
+/// whether the reader is reading binary or text representation.
+#[derive(Debug)]
+pub struct Deserializer<R> {
+    pub(crate) reader: R,
+}
+
+impl<'de, 'a, R> serde::de::Deserializer<'de> for &'a mut Deserializer<R>
+where
+    R: IonReader<Symbol = Symbol, Item = StreamItem>,
+{
+    type Error = IonError;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if let Some(ion_type) = self.reader.ion_type() {
+            match ion_type {
+                IonType::Null => self.deserialize_unit(visitor),
+                IonType::Blob | IonType::Clob => self.deserialize_bytes(visitor),
+                IonType::String | IonType::Symbol => self.deserialize_string(visitor),
+                IonType::Float => self.deserialize_f64(visitor),
+                IonType::Int => self.deserialize_i64(visitor),
+                IonType::Decimal => self.deserialize_newtype_struct("$__ion_rs_decimal__", visitor),
+                IonType::Bool => self.deserialize_bool(visitor),
+                IonType::List => self.deserialize_seq(visitor),
+                IonType::Struct => self.deserialize_struct("", &[], visitor),
+                IonType::Timestamp => {
+                    self.deserialize_newtype_struct("$__ion_rs_timestamp__", visitor)
+                }
+                _ => IonResult::decoding_error("unexpected ion type".to_string()),
+            }
+        } else {
+            IonResult::decoding_error("unexpected end of file".to_string())
+        }
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_bool(self.reader.read_bool()?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_i8(self.reader.read_i64().map(|x| x as i8)?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_i16(self.reader.read_i64().map(|x| x as i16)?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_i32(self.reader.read_i64().map(|x| x as i32)?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_i64(self.reader.read_i64()?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_u8(self.reader.read_i64().map(|x| x as u8)?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_u16(self.reader.read_i64().map(|x| x as u16)?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_u32(self.reader.read_i64().map(|x| x as u32)?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_u64(self.reader.read_i64().map(|x| x as u64)?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_f32(self.reader.read_f32()?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_f64(self.reader.read_f64()?);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_char(
+            self.reader
+                .read_string()
+                .map(|x| x.to_string().chars().collect::<Vec<char>>()[0])?,
+        );
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_string(self.reader.read_string()?.to_string());
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_string(self.reader.read_str()?.to_owned());
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_bytes(self.reader.read_blob()?.as_slice());
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_byte_buf(self.reader.read_blob()?.as_slice().to_vec());
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if self.reader.is_null() {
+            self.reader.next()?;
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(self)
+        }
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if self.reader.is_null() {
+            self.reader.next()?;
+            visitor.visit_unit()
+        } else {
+            IonResult::decoding_error("expected a null value".to_string())
+        }
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_unit(visitor)
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if name == "$__ion_rs_timestamp__" {
+            let timestamp = self.reader.read_timestamp()?;
+            let datetime: DateTime<FixedOffset> = timestamp.try_into()?;
+            let datetime_str = datetime.to_rfc3339();
+
+            let result = visitor.visit_str(&datetime_str);
+            self.reader.next()?;
+            return result;
+        } else if name == "$__ion_rs_decimal__" {
+            let decimal = self.reader.read_decimal()?;
+            let result = visitor.visit_str(&decimal.to_string());
+            self.reader.next()?;
+            return result;
+        }
+        self.reader.step_in()?;
+        self.reader.next()?;
+        let result = visitor.visit_newtype_struct(&mut *self)?;
+        self.reader.next()?;
+        Ok(result)
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.reader.step_in()?;
+        self.reader.next()?;
+        let result = visitor.visit_seq(&mut *self);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.reader.step_in()?;
+        self.reader.next()?;
+        let result = visitor.visit_seq(&mut *self);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.reader.step_in()?;
+        self.reader.next()?;
+        let result = visitor.visit_seq(&mut *self);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.reader.step_in()?;
+        self.reader.next()?;
+        let result = visitor.visit_map(&mut *self);
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.reader.step_in()?;
+        self.reader.next()?;
+        let result = visitor.visit_map(&mut *self)?;
+        self.reader.next()?;
+        Ok(result)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if let Some(ion_type) = self.reader.ion_type() {
+            match ion_type {
+                IonType::String => visitor.visit_enum(UnitVariantAccess::new(self)),
+                IonType::Struct => {
+                    self.reader.step_in()?;
+                    self.reader.next()?;
+                    let value = visitor.visit_enum(VariantAccess::new(self))?;
+                    self.reader.step_out()?;
+                    self.reader.next()?;
+                    Ok(value)
+                }
+                _ => IonResult::decoding_error("expected an enumeration".to_string()),
+            }
+        } else {
+            IonResult::decoding_error("unexpected end of file".to_string())
+        }
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_string(self.reader.read_string()?.to_string());
+        self.reader.next()?;
+        result
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_any(visitor)
+    }
+}
+
+impl<'de, 'a, R> SeqAccess<'de> for &'a mut Deserializer<R>
+where
+    R: IonReader<Symbol = Symbol, Item = StreamItem>,
+{
+    type Error = IonError;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        if self.reader.ion_type().is_none() {
+            if self.reader.depth() > 0 {
+                self.reader.step_out()?;
+            }
+            Ok(None)
+        } else {
+            seed.deserialize(&mut **self).map(Some)
+        }
+    }
+}
+
+impl<'de, 'a, R> MapAccess<'de> for &'a mut Deserializer<R>
+where
+    R: IonReader<Symbol = Symbol, Item = StreamItem>,
+{
+    type Error = IonError;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        if self.reader.ion_type().is_none() {
+            self.reader.step_out()?;
+            Ok(None)
+        } else {
+            let key = self
+                .reader
+                .field_name()
+                .map(|x| x.text().unwrap().to_string())?;
+            let deserializer = MapKeyDeserializer { key };
+            let result = seed.deserialize(deserializer).map(Some)?;
+            Ok(result)
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        seed.deserialize(&mut **self)
+    }
+}
+
+struct VariantAccess<'a, R: 'a> {
+    de: &'a mut Deserializer<R>,
+}
+
+impl<'a, R: 'a> VariantAccess<'a, R> {
+    fn new(de: &'a mut Deserializer<R>) -> Self {
+        VariantAccess { de }
+    }
+}
+
+impl<'de, 'a, R: 'a> EnumAccess<'de> for VariantAccess<'a, R>
+where
+    R: IonReader<Symbol = Symbol, Item = StreamItem>,
+{
+    type Error = IonError;
+    type Variant = Self;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        Ok((seed.deserialize(&mut *self.de)?, self))
+    }
+}
+
+impl<'de, 'a, R: 'a> de::VariantAccess<'de> for VariantAccess<'a, R>
+where
+    R: IonReader<Symbol = Symbol, Item = StreamItem>,
+{
+    type Error = IonError;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        de::Deserialize::deserialize(self.de)
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        seed.deserialize(self.de)
+    }
+
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        de::Deserializer::deserialize_seq(self.de, visitor)
+    }
+
+    fn struct_variant<V>(
+        self,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        de::Deserializer::deserialize_struct(self.de, "", fields, visitor)
+    }
+}
+
+struct UnitVariantAccess<'a, R: 'a> {
+    de: &'a mut Deserializer<R>,
+}
+
+impl<'a, R: 'a> UnitVariantAccess<'a, R> {
+    fn new(de: &'a mut Deserializer<R>) -> Self {
+        UnitVariantAccess { de }
+    }
+}
+
+impl<'de, 'a, R: 'a> EnumAccess<'de> for UnitVariantAccess<'a, R>
+where
+    R: IonReader<Symbol = Symbol, Item = StreamItem>,
+{
+    type Error = IonError;
+    type Variant = Self;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let variant = seed.deserialize(&mut *self.de)?;
+        Ok((variant, self))
+    }
+}
+
+impl<'de, 'a, R: 'a> de::VariantAccess<'de> for UnitVariantAccess<'a, R>
+where
+    R: IonReader<Symbol = Symbol, Item = StreamItem>,
+{
+    type Error = IonError;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T>(self, _seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        IonResult::decoding_error("Unexpected newtype variant".to_string())
+    }
+
+    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("Unexpected tuple variant".to_string())
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("Unexpected struct variant".to_string())
+    }
+}
+
+struct MapKeyDeserializer {
+    key: String,
+}
+
+impl<'de> de::Deserializer<'de> for MapKeyDeserializer {
+    type Error = IonError;
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_bool<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_i8<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_i16<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_i32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_i64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_u8<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_u16<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_u32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_u64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_f32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_f64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_str(self.key.as_str())
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_string(self.key)
+    }
+
+    fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_option<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_unit<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_seq<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_map<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = visitor.visit_string(self.key);
+        result
+    }
+
+    fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        IonResult::decoding_error("expected a string value".to_string())
+    }
+}
+
+struct StrDeserializer<'a> {
+    key: Cow<'a, str>,
+}
+
+impl<'a> StrDeserializer<'a> {
+    fn new(key: Cow<'a, str>) -> StrDeserializer<'a> {
+        StrDeserializer { key }
+    }
+}
+
+impl<'de> de::Deserializer<'de> for StrDeserializer<'de> {
+    type Error = IonError;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, IonError>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.key {
+            Cow::Borrowed(s) => visitor.visit_borrowed_str(s),
+            Cow::Owned(s) => visitor.visit_string(s),
+        }
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
+        bytes byte_buf map struct option unit newtype_struct
+        ignored_any unit_struct tuple_struct tuple enum identifier
+    }
+}
+
+pub struct StreamDeserializer<'de, R, T> {
+    de: Deserializer<R>,
+    output: PhantomData<T>,
+    lifetime: PhantomData<&'de ()>,
+}
+
+impl<'de, R, T> StreamDeserializer<'de, R, T>
+where
+    T: de::Deserialize<'de>,
+    R: IonReader<Symbol = Symbol, Item = StreamItem>,
+{
+    pub fn new(read: R) -> Self {
+        Self {
+            de: Deserializer { reader: read },
+            output: PhantomData,
+            lifetime: PhantomData,
+        }
+    }
+}
+
+impl<'de, R, T> Iterator for StreamDeserializer<'de, R, T>
+where
+    R: IonReader<Symbol = Symbol, Item = StreamItem>,
+    T: de::Deserialize<'de>,
+{
+    type Item = IonResult<T>;
+
+    fn next(&mut self) -> Option<IonResult<T>> {
+        // Skip any nothing
+        while let StreamItem::Nothing = self.de.reader.current() {
+            match self.de.reader.next() {
+                Ok(_) => (),
+                Err(_) => return None,
+            };
+        }
+
+        Some(T::deserialize(&mut self.de))
+    }
+}
+
+impl<'de, R, T> FusedIterator for StreamDeserializer<'de, R, T>
+where
+    R: IonReader<Symbol = Symbol, Item = StreamItem>,
+    T: de::Deserialize<'de>,
+{
+}

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -297,7 +297,7 @@ where
             );
             // # Safety
             // compiler doesn't understand that the generic Timestamp here is actually V::Value here
-            // the assert statement above that compares sizes of both the Timestamp and V::Value ensures the conversion performed below is safe
+            // The assert statement above that compares the sizes of the Timestamp and V::Value types
             let visitor_value =
                 unsafe { std::mem::transmute_copy::<Timestamp, V::Value>(&timestamp) };
             self.reader.next()?;
@@ -310,7 +310,7 @@ where
             );
             // # Safety
             // compiler doesn't understand that the generic Decimal here is actually V::Value here
-            // the assert statement above that compares sizes of both the Decimal and V::Value ensures the conversion performed below is safe
+            // The assert statement above that compares the sizes of the Decimal and V::Value types
             let visitor_value = unsafe { std::mem::transmute_copy::<Decimal, V::Value>(&decimal) };
             self.reader.next()?;
             return Ok(visitor_value);

--- a/src/serde/decimal.rs
+++ b/src/serde/decimal.rs
@@ -1,0 +1,78 @@
+use crate::serde::timestamp::ION_BINARY;
+use crate::{Decimal, Element};
+use serde::de::Error;
+use serde::{self, de, Deserialize, Serialize};
+use std::fmt;
+
+/// Serialization for Ion `Decimal`
+/// This serialization internally uses `serialize_newtype_struct` to trick serde to serialize a number value into decimal.
+/// This `newtype_struct` is named with `$__ion_rs_decimal__` to distinguish it from an actual `newtype_struct`.
+/// More information on `newtype_struct` can be found in the serde data model: https://serde.rs/data-model.html#types
+impl Serialize for Decimal {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        ION_BINARY.with(move |cell| {
+            let decimal: Decimal = self.clone();
+            if cell.get() {
+                serializer
+                    .serialize_newtype_struct("$__ion_rs_decimal__", decimal.to_string().as_str())
+            } else {
+                serializer.serialize_str(decimal.to_string().as_str())
+            }
+        })
+    }
+}
+
+/// Deserialization for Ion `Decimal`
+/// This deserialization internally uses `serialize_newtype_struct` to trick serde to deserialize a number value into decimal.
+/// This `newtype_struct` is named with `$__ion_rs_decimal__` to distinguish it from an actual `newtype_struct`.
+/// More information on `newtype_struct` can be found in the serde data model: https://serde.rs/data-model.html#types
+impl<'de> Deserialize<'de> for Decimal {
+    fn deserialize<D>(deserializer: D) -> Result<Decimal, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        ION_BINARY.with(move |cell| {
+            if cell.get() {
+                struct DecimalVisitor;
+
+                impl<'de> de::Visitor<'de> for DecimalVisitor {
+                    type Value = Decimal;
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                        formatter.write_str("an Ion Decimal")
+                    }
+
+                    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+                    where
+                        E: Error,
+                    {
+                        let decimal = Element::read_one(s)
+                            .ok()
+                            .and_then(|e| e.as_decimal().map(|d| d.to_owned()))
+                            .ok_or(E::custom(format!(
+                                "Decimal deserialization failed for: {}",
+                                s
+                            )))?;
+                        Ok(decimal)
+                    }
+                }
+
+                deserializer.deserialize_newtype_struct("$__ion_rs_decimal__", DecimalVisitor)
+            } else {
+                let string_rep = String::deserialize(deserializer)?;
+                let decimal = Element::read_one(&string_rep)
+                    .ok()
+                    .and_then(|e| e.as_decimal().map(|d| d.to_owned()))
+                    .ok_or(Error::custom(format!(
+                        "Decimal deserialization failed for: {}",
+                        string_rep
+                    )))?;
+                Ok(decimal)
+            }
+        })
+    }
+}

--- a/src/serde/decimal.rs
+++ b/src/serde/decimal.rs
@@ -7,7 +7,7 @@ use std::fmt;
 /// Serialization for Ion `Decimal`
 /// This serialization internally uses `serialize_newtype_struct` to trick serde to serialize a number value into decimal.
 /// This `newtype_struct` is named with `$__ion_rs_decimal__` to distinguish it from an actual `newtype_struct`.
-/// More information on `newtype_struct` can be found in the serde data model: https://serde.rs/data-model.html#types
+/// More information on `newtype_struct` can be found in the serde data model: `<https://serde.rs/data-model.html#types>`
 impl Serialize for Decimal {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -29,7 +29,7 @@ impl Serialize for Decimal {
 /// Deserialization for Ion `Decimal`
 /// This deserialization internally uses `serialize_newtype_struct` to trick serde to deserialize a number value into decimal.
 /// This `newtype_struct` is named with `$__ion_rs_decimal__` to distinguish it from an actual `newtype_struct`.
-/// More information on `newtype_struct` can be found in the serde data model: https://serde.rs/data-model.html#types
+/// More information on `newtype_struct` can be found in the serde data model: `<https://serde.rs/data-model.html#types>`
 impl<'de> Deserialize<'de> for Decimal {
     fn deserialize<D>(deserializer: D) -> Result<Decimal, D::Error>
     where

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -74,7 +74,7 @@ mod tests {
         assert_eq!(back_result.date, my_date.clone());
         assert_eq!(back_result.date0, my_date0.clone());
         assert_eq!(back_result.date1, datetime.clone());
-        assert_eq!(back_result.nested_struct.boolean, true);
+        assert!(back_result.nested_struct.boolean);
         assert_eq!(&back_result.nested_struct.str, "hello");
     }
 }

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -1,0 +1,80 @@
+pub mod de;
+pub mod decimal;
+pub mod ser;
+pub mod timestamp;
+
+pub use de::{from_ion, Deserializer};
+pub use ser::{to_binary, to_pretty, to_string, Serializer};
+
+#[cfg(test)]
+#[cfg(feature = "experimental-serde")]
+mod tests {
+    use crate::serde::{from_ion, to_string};
+
+    use crate::{Decimal, Timestamp};
+    use chrono::{DateTime, FixedOffset, Utc};
+    use serde::{Deserialize, Serialize};
+    use serde_with::serde_as;
+
+    #[test]
+    fn test_struct() {
+        #[serde_as]
+        #[derive(Serialize, Deserialize)]
+        struct Test {
+            int: u32,
+            float: f64,
+            binary: Vec<u8>,
+            seq: Vec<String>,
+            decimal: Decimal,
+            date: Timestamp,
+            #[serde_as(as = "crate::Timestamp")]
+            date0: DateTime<Utc>,
+            #[serde_as(as = "crate::Timestamp")]
+            date1: DateTime<FixedOffset>,
+            nested_struct: NestedTest,
+        }
+
+        #[serde_as]
+        #[derive(Serialize, Deserialize)]
+        struct NestedTest {
+            boolean: bool,
+            str: String,
+        }
+
+        let datetime: DateTime<FixedOffset> = Utc::now().into();
+        let my_date0 = Utc::now();
+        let my_date = Timestamp::from(datetime);
+        let my_decimal = Decimal::new(1225, -2);
+        let test = Test {
+            int: 1,
+            float: 3.46,
+            binary: b"EDO".to_vec(),
+            seq: vec!["a".to_string(), "b".to_string()],
+            decimal: my_decimal.clone(),
+            date: my_date.clone(),
+            date0: my_date0,
+            date1: datetime,
+            nested_struct: NestedTest {
+                boolean: true,
+                str: "hello".to_string(),
+            },
+        };
+
+        let result = to_string(&test).expect("failed to serialize");
+
+        let back_result: Test = from_ion(result.as_str()).expect("failed to deserialize");
+
+        assert_eq!(back_result.int, 1);
+        assert_eq!(back_result.float, 3.46);
+        assert_eq!(back_result.binary, b"EDO");
+        assert_eq!(back_result.seq.len(), 2);
+        assert_eq!(back_result.seq[0], "a");
+        assert_eq!(back_result.seq[1], "b");
+        assert_eq!(back_result.decimal, my_decimal.clone());
+        assert_eq!(back_result.date, my_date.clone());
+        assert_eq!(back_result.date0, my_date0.clone());
+        assert_eq!(back_result.date1, datetime.clone());
+        assert_eq!(back_result.nested_struct.boolean, true);
+        assert_eq!(&back_result.nested_struct.str, "hello");
+    }
+}

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -39,7 +39,7 @@
 //!| option | None - null, Some - based on other mappings |
 //!| unit, unit_struct | null |
 //!| seq, tuple, tuple_struct, tuple_variant | list |
-//!| newtype_struct ,newtype_variant, map, struct, struct_variant | struct |
+//!| newtype_struct, newtype_variant, map, struct, struct_variant | struct |
 //!
 //! _Note: Since the serde framework doesn't support [Ion decimal] and [Ion timestamp] types, distinct serialization and deserialization of these types are defined in this module.
 //! It uses `newtype_struct` with `$__ion_rs_decimal__` and `$__ion_rs_timestamp__` as struct names from [serde data model],

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -202,14 +202,14 @@ where
             // # Safety
             // compiler doesn't understand that the generic T here is actually Timestamp here since
             // we are using TUNNELED_TIMESTAMP_TYPE_NAME flag here which indicates a timestamp value
-            // the assert statement above that compares sizes of both the Timestamp and value ensures the conversion performed below is safe
+            // The assert statement above that compares the sizes of the Timestamp and value types
             let timestamp = unsafe { std::mem::transmute_copy::<&T, &Timestamp>(&value) };
             self.writer.write_timestamp(timestamp)
         } else if name == TUNNELED_DECIMAL_TYPE_NAME {
             // # Safety
             // compiler doesn't understand that the generic T here is actually Decimal here since
             // we are using TUNNELED_DECIMAL_TYPE_NAME flag here which indicates a decimal value
-            // the assert statement above that compares sizes of both the Decimal and value ensures the conversion performed below is safe
+            // The assert statement above that compares the sizes of the Decimal and value types
             assert_eq!(std::mem::size_of_val(value), std::mem::size_of::<Decimal>());
             let decimal = unsafe { std::mem::transmute_copy::<&T, &Decimal>(&value) };
             self.writer.write_decimal(decimal)

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -1,0 +1,991 @@
+use chrono::DateTime;
+use std::io::Cursor;
+
+use crate::ion_writer::IonWriter;
+use crate::result::IonFailure;
+use crate::serde::timestamp::ION_BINARY;
+use crate::types::Int;
+use crate::{
+    BinaryWriterBuilder, Element, IonError, IonResult, IonType, TextKind, TextWriterBuilder,
+    Timestamp,
+};
+use serde::ser::Impossible;
+use serde::{ser, Serialize};
+
+/// Serialize an object into pretty formatted Ion text
+pub fn to_pretty<T>(value: &T) -> IonResult<String>
+where
+    T: Serialize,
+{
+    ION_BINARY.with(move |cell| {
+        cell.set(true);
+        let mut cursor = Cursor::new(Vec::new());
+        let mut serializer = Serializer {
+            writer: TextWriterBuilder::pretty().build(&mut cursor)?,
+        };
+
+        value.serialize(&mut serializer)?;
+        serializer.writer.flush()?;
+        drop(serializer);
+        cell.set(false);
+
+        let bytes = cursor.get_ref().clone();
+
+        match String::from_utf8(bytes) {
+            Ok(data) => Ok(data),
+            Err(e) => IonResult::encoding_error(e.to_string()),
+        }
+    })
+}
+
+/// Serialize an object into compact Ion text format
+pub fn to_string<T>(value: &T) -> IonResult<String>
+where
+    T: Serialize,
+{
+    ION_BINARY.with(move |cell| {
+        cell.set(true);
+        let mut cursor = Cursor::new(Vec::new());
+        let mut serializer = Serializer {
+            writer: TextWriterBuilder::new(TextKind::Compact).build(&mut cursor)?,
+        };
+
+        value.serialize(&mut serializer)?;
+        serializer.writer.flush()?;
+        drop(serializer);
+        cell.set(false);
+
+        let bytes = cursor.get_ref().clone();
+
+        match String::from_utf8(bytes) {
+            Ok(data) => Ok(data),
+            Err(e) => IonResult::encoding_error(e.to_string()),
+        }
+    })
+}
+
+/// Serialize an object into Ion binary format
+pub fn to_binary<T>(value: &T) -> IonResult<Vec<u8>>
+where
+    T: Serialize,
+{
+    ION_BINARY.with(move |cell| {
+        cell.set(true);
+        let mut cursor = Cursor::new(Vec::new());
+        let mut serializer = Serializer {
+            writer: BinaryWriterBuilder::new().build(&mut cursor)?,
+        };
+
+        value.serialize(&mut serializer)?;
+        serializer.writer.flush()?;
+        drop(serializer);
+        cell.set(false);
+
+        Ok(cursor.get_ref().clone())
+    })
+}
+
+/// Implements a standard serializer for Ion
+pub struct Serializer<E> {
+    pub(crate) writer: E,
+}
+
+impl<'a, E> ser::Serializer for &'a mut Serializer<E>
+where
+    E: IonWriter,
+{
+    type Ok = ();
+    type Error = IonError;
+
+    type SerializeSeq = Self;
+    type SerializeTuple = Self;
+    type SerializeTupleStruct = Self;
+    type SerializeTupleVariant = Self;
+    type SerializeMap = Self;
+    type SerializeStruct = Self;
+    type SerializeStructVariant = Self;
+
+    /// Serialize a boolean to a bool value
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_bool(v)
+    }
+
+    /// Serialize all integer types using the `Integer` intermediary type.
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_int(&Int::from(v))
+    }
+
+    /// Serialize all integer types using the `Integer` intermediary type.
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_int(&Int::from(v))
+    }
+
+    /// Serialize all integer types using the `Integer` intermediary type.
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_int(&Int::from(v))
+    }
+
+    /// Serialize all integer types using the `Integer` intermediary type.
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_int(&Int::from(v))
+    }
+
+    /// Serialize all integer types using the `Integer` intermediary type.
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_int(&Int::from(v))
+    }
+
+    /// Serialize all integer types using the `Integer` intermediary type.
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_int(&Int::from(v))
+    }
+
+    /// Serialize all integer types using the `Integer` intermediary type.
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_int(&Int::from(v))
+    }
+
+    /// Serialize all integer types using the `Integer` intermediary type.
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_int(&Int::from(v))
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_f32(v)
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_f64(v)
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_string(v.to_string())
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_string(v)
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_blob(v)
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_null(IonType::Null)
+    }
+
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        self.serialize_none()
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        self.serialize_unit()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.serialize_str(variant)
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        if name == "$__ion_rs_timestamp__" {
+            value.serialize(TimestampSerializer { serializer: self })
+        } else if name == "$__ion_rs_decimal__" {
+            value.serialize(DecimalSerializer { serializer: self })
+        } else {
+            value.serialize(self)
+        }
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        self.writer.step_in(IonType::Struct)?;
+        self.writer.set_field_name(variant);
+        value.serialize(&mut *self)?;
+        self.writer.step_out()
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        self.writer.step_in(IonType::List)?;
+        Ok(self)
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        self.writer.step_in(IonType::List)?;
+        Ok(self)
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        self.writer.step_in(IonType::List)?;
+        Ok(self)
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        self.writer.step_in(IonType::List)?;
+        Ok(self)
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        self.writer.step_in(IonType::Struct)?;
+        Ok(self)
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        self.writer.step_in(IonType::Struct)?;
+        Ok(self)
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        self.writer.step_in(IonType::Struct)?;
+        Ok(self)
+    }
+}
+
+impl<'a, E> ser::SerializeSeq for &'a mut Serializer<E>
+where
+    E: IonWriter,
+{
+    type Ok = ();
+    type Error = IonError;
+
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.step_out()
+    }
+}
+
+impl<'a, E> ser::SerializeTuple for &'a mut Serializer<E>
+where
+    E: IonWriter,
+{
+    type Ok = ();
+    type Error = IonError;
+
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.step_out()
+    }
+}
+
+impl<'a, E> ser::SerializeTupleStruct for &'a mut Serializer<E>
+where
+    E: IonWriter,
+{
+    type Ok = ();
+    type Error = IonError;
+
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.step_out()
+    }
+}
+
+impl<'a, E> ser::SerializeTupleVariant for &'a mut Serializer<E>
+where
+    E: IonWriter,
+{
+    type Ok = ();
+    type Error = IonError;
+
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.step_out()
+    }
+}
+
+impl<'a, E> ser::SerializeMap for &'a mut Serializer<E>
+where
+    E: IonWriter,
+{
+    type Ok = ();
+    type Error = IonError;
+
+    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        // We need to verify that the key is a string type or can be converted
+        // to string
+        let mk_serializer = MapKeySerializer {};
+        let field: String = key.serialize(mk_serializer)?;
+        self.writer.set_field_name(field);
+        Ok(())
+    }
+
+    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.step_out()
+    }
+}
+
+impl<'a, E> ser::SerializeStructVariant for &'a mut Serializer<E>
+where
+    E: IonWriter,
+{
+    type Ok = ();
+    type Error = IonError;
+
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        self.writer.set_field_name(key);
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.step_out()
+    }
+}
+
+impl<'a, E> ser::SerializeStruct for &'a mut Serializer<E>
+where
+    E: IonWriter,
+{
+    type Ok = ();
+    type Error = IonError;
+
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        self.writer.set_field_name(key);
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<(), IonError> {
+        self.writer.step_out()?;
+        Ok(())
+    }
+}
+
+/// This serializer is utilized for handling maps with ion. Ion
+/// does not support non-string keys for maps. However, we can support
+/// other key types as long as the key type implements to_string.
+struct MapKeySerializer {}
+
+fn key_must_be_a_string() -> IonError {
+    IonError::encoding_error("Ion does not support non-string keys for maps".to_string())
+}
+
+impl ser::Serializer for MapKeySerializer {
+    type Ok = String;
+    type Error = IonError;
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Ok(variant.to_string())
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(self)
+    }
+
+    type SerializeSeq = Impossible<String, IonError>;
+    type SerializeTuple = Impossible<String, IonError>;
+    type SerializeTupleStruct = Impossible<String, IonError>;
+    type SerializeTupleVariant = Impossible<String, IonError>;
+    type SerializeMap = Impossible<String, IonError>;
+    type SerializeStruct = Impossible<String, IonError>;
+    type SerializeStructVariant = Impossible<String, IonError>;
+
+    fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        Ok(v.to_string())
+    }
+
+    fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+}
+
+/// Handles the `Timestamp` serialization by extracting the datetime
+/// out of the interim structure and writing it properly to the Ion writer
+pub struct TimestampSerializer<'a, E> {
+    serializer: &'a mut Serializer<E>,
+}
+
+impl<'a, E> ser::Serializer for TimestampSerializer<'a, E>
+where
+    E: IonWriter,
+{
+    type Ok = ();
+    type Error = IonError;
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        let datetime =
+            DateTime::parse_from_rfc3339(v).map_err(|e| IonError::encoding_error(e.to_string()))?;
+        let timestamp = Timestamp::from(datetime);
+        self.serializer.writer.write_timestamp(&timestamp)
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        let datetime = DateTime::parse_from_rfc3339(variant)
+            .map_err(|e| IonError::encoding_error(e.to_string()))?;
+        let timestamp = Timestamp::from(datetime);
+        self.serializer.writer.write_timestamp(&timestamp)
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(self)
+    }
+
+    type SerializeSeq = Impossible<(), IonError>;
+    type SerializeTuple = Impossible<(), IonError>;
+    type SerializeTupleStruct = Impossible<(), IonError>;
+    type SerializeTupleVariant = Impossible<(), IonError>;
+    type SerializeMap = Impossible<(), IonError>;
+    type SerializeStruct = Impossible<(), IonError>;
+    type SerializeStructVariant = Impossible<(), IonError>;
+
+    fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+}
+
+/// Serializer for Ion `Decimal`
+pub struct DecimalSerializer<'a, E> {
+    serializer: &'a mut Serializer<E>,
+}
+
+impl<'a, E> ser::Serializer for DecimalSerializer<'a, E>
+where
+    E: IonWriter,
+{
+    type Ok = ();
+    type Error = IonError;
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        let e = Element::read_one(v)?;
+        let decimal = e.as_decimal().ok_or(IonError::encoding_error(format!(
+            "Decimal serialization failed for: {}",
+            v
+        )))?;
+        self.serializer.writer.write_decimal(decimal)
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        let e = Element::read_one(variant)?;
+        // TODO: remove unwrap
+        let decimal = e.as_decimal().unwrap();
+        self.serializer.writer.write_decimal(decimal)
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(self)
+    }
+
+    type SerializeSeq = Impossible<(), IonError>;
+    type SerializeTuple = Impossible<(), IonError>;
+    type SerializeTupleStruct = Impossible<(), IonError>;
+    type SerializeTupleVariant = Impossible<(), IonError>;
+    type SerializeMap = Impossible<(), IonError>;
+    type SerializeStruct = Impossible<(), IonError>;
+    type SerializeStructVariant = Impossible<(), IonError>;
+
+    fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(key_must_be_a_string())
+    }
+}

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -3,7 +3,9 @@ use std::io::Cursor;
 
 use crate::ion_writer::IonWriter;
 use crate::result::IonFailure;
-use crate::serde::timestamp::ION_BINARY;
+use crate::serde::decimal::ION_DECIMAL;
+use crate::serde::timestamp::ION_TIMESTAMP;
+use crate::serde::SERDE_AS_ION;
 use crate::types::Int;
 use crate::{
     BinaryWriterBuilder, Element, IonError, IonResult, IonType, TextKind, TextWriterBuilder,
@@ -17,7 +19,7 @@ pub fn to_pretty<T>(value: &T) -> IonResult<String>
 where
     T: Serialize,
 {
-    ION_BINARY.with(move |cell| {
+    SERDE_AS_ION.with(move |cell| {
         cell.set(true);
         let mut cursor = Cursor::new(Vec::new());
         let mut serializer = Serializer {
@@ -43,7 +45,7 @@ pub fn to_string<T>(value: &T) -> IonResult<String>
 where
     T: Serialize,
 {
-    ION_BINARY.with(move |cell| {
+    SERDE_AS_ION.with(move |cell| {
         cell.set(true);
         let mut cursor = Cursor::new(Vec::new());
         let mut serializer = Serializer {
@@ -69,7 +71,7 @@ pub fn to_binary<T>(value: &T) -> IonResult<Vec<u8>>
 where
     T: Serialize,
 {
-    ION_BINARY.with(move |cell| {
+    SERDE_AS_ION.with(move |cell| {
         cell.set(true);
         let mut cursor = Cursor::new(Vec::new());
         let mut serializer = Serializer {
@@ -206,9 +208,9 @@ where
     where
         T: Serialize,
     {
-        if name == "$__ion_rs_timestamp__" {
+        if name == ION_TIMESTAMP {
             value.serialize(TimestampSerializer { serializer: self })
-        } else if name == "$__ion_rs_decimal__" {
+        } else if name == ION_DECIMAL {
             value.serialize(DecimalSerializer { serializer: self })
         } else {
             value.serialize(self)

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -100,37 +100,37 @@ where
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_int(&Int::from(v))
+        self.writer.write_i64(v.into())
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_int(&Int::from(v))
+        self.writer.write_i64(v.into())
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_int(&Int::from(v))
+        self.writer.write_i64(v.into())
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_int(&Int::from(v))
+        self.writer.write_i64(v.into())
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_int(&Int::from(v))
+        self.writer.write_i64(v.into())
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_int(&Int::from(v))
+        self.writer.write_i64(v.into())
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_int(&Int::from(v))
+        self.writer.write_i64(v)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
@@ -199,13 +199,17 @@ where
                 std::mem::size_of_val(value),
                 std::mem::size_of::<Timestamp>()
             );
+            // # Safety
             // compiler doesn't understand that the generic T here is actually Timestamp here since
             // we are using TUNNELED_TIMESTAMP_TYPE_NAME flag here which indicates a timestamp value
+            // the assert statement above that compares sizes of both the Timestamp and value ensures the conversion performed below is safe
             let timestamp = unsafe { std::mem::transmute_copy::<&T, &Timestamp>(&value) };
             self.writer.write_timestamp(timestamp)
         } else if name == TUNNELED_DECIMAL_TYPE_NAME {
+            // # Safety
             // compiler doesn't understand that the generic T here is actually Decimal here since
             // we are using TUNNELED_DECIMAL_TYPE_NAME flag here which indicates a decimal value
+            // the assert statement above that compares sizes of both the Decimal and value ensures the conversion performed below is safe
             assert_eq!(std::mem::size_of_val(value), std::mem::size_of::<Decimal>());
             let decimal = unsafe { std::mem::transmute_copy::<&T, &Decimal>(&value) };
             self.writer.write_decimal(decimal)

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -1,0 +1,135 @@
+use crate::{IonError, Timestamp};
+use chrono::{DateTime, FixedOffset, Utc};
+use serde::de::Error;
+use serde::{self, de, ser, Deserialize, Serialize};
+use serde_with::{DeserializeAs, SerializeAs};
+use std::cell::Cell;
+use std::fmt;
+
+thread_local! {
+    /// Cell that contains a flag to determine when serialization and deserialization
+    /// is occurring with an Ion serializer. This allows us to know when to encode
+    /// Timestamps as ion timestamps
+    pub(crate) static ION_BINARY: Cell<bool> = Cell::new(false);
+}
+
+/// Serialization for Ion `Timestamp`
+/// This serialization internally uses `serialize_newtype_struct` to trick serde to serialize a datetime value into timestamp.
+/// This `newtype_struct` is named with `$__ion_rs_timestamp__` to distinguish it from an actual `newtype_struct`.
+/// More information on `newtype_struct` can be found in the serde data model: https://serde.rs/data-model.html#types
+impl Serialize for Timestamp {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        ION_BINARY.with(move |cell| {
+            let datetime: DateTime<FixedOffset> = self
+                .clone()
+                .try_into()
+                .map_err(|e: IonError| ser::Error::custom(e.to_string()))?;
+            if cell.get() {
+                serializer.serialize_newtype_struct(
+                    "$__ion_rs_timestamp__",
+                    datetime.to_rfc3339().as_str(),
+                )
+            } else {
+                serializer.serialize_str(datetime.to_rfc3339().as_str())
+            }
+        })
+    }
+}
+
+/// Deserialization for Ion `Timestamp`
+/// This deserialization internally uses `serialize_newtype_struct` to trick serde to deserialize a datetime value into timestamp.
+/// This `newtype_struct` is named with `$__ion_rs_timestamp__` to distinguish it from an actual `newtype_struct`.
+/// More information on `newtype_struct` can be found in the serde data model: https://serde.rs/data-model.html#types
+impl<'de> Deserialize<'de> for Timestamp {
+    fn deserialize<D>(deserializer: D) -> Result<Timestamp, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        ION_BINARY.with(move |cell| {
+            if cell.get() {
+                struct TimestampVisitor;
+
+                impl<'de> de::Visitor<'de> for TimestampVisitor {
+                    type Value = Timestamp;
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                        formatter.write_str("an Ion Timestamp")
+                    }
+
+                    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+                    where
+                        E: Error,
+                    {
+                        let naive: DateTime<FixedOffset> = match DateTime::parse_from_rfc3339(s) {
+                            Ok(data) => Ok(data),
+                            Err(e) => Err(de::Error::custom(e.to_string())),
+                        }?;
+                        Ok(Timestamp::from(naive))
+                    }
+                }
+
+                deserializer.deserialize_newtype_struct("$__ion_rs_timestamp__", TimestampVisitor)
+            } else {
+                let string_rep = String::deserialize(deserializer)?;
+                let fixed_date: DateTime<FixedOffset> =
+                    match DateTime::parse_from_rfc3339(string_rep.as_str()) {
+                        Ok(data) => Ok(data),
+                        Err(e) => Err(de::Error::custom(e.to_string())),
+                    }?;
+                Ok(Timestamp::from(fixed_date))
+            }
+        })
+    }
+}
+
+impl SerializeAs<DateTime<Utc>> for Timestamp {
+    fn serialize_as<S>(source: &chrono::DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        let dt0: DateTime<FixedOffset> = (*source).into();
+        let dt1 = Timestamp::from(dt0);
+        dt1.serialize(serializer)
+    }
+}
+
+impl SerializeAs<DateTime<FixedOffset>> for Timestamp {
+    fn serialize_as<S>(
+        source: &chrono::DateTime<FixedOffset>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        let dt = Timestamp::from(*source);
+        dt.serialize(serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, DateTime<Utc>> for Timestamp {
+    fn deserialize_as<D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let d0 = Timestamp::deserialize(deserializer)?;
+        let d1: DateTime<FixedOffset> = d0
+            .try_into()
+            .map_err(|e: IonError| de::Error::custom(e.to_string()))?;
+        Ok(d1.into())
+    }
+}
+
+impl<'de> DeserializeAs<'de, DateTime<FixedOffset>> for Timestamp {
+    fn deserialize_as<D>(deserializer: D) -> Result<DateTime<FixedOffset>, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let d0 = Timestamp::deserialize(deserializer)?;
+        d0.try_into()
+            .map_err(|e: IonError| de::Error::custom(e.to_string()))
+    }
+}

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -16,7 +16,7 @@ thread_local! {
 /// Serialization for Ion `Timestamp`
 /// This serialization internally uses `serialize_newtype_struct` to trick serde to serialize a datetime value into timestamp.
 /// This `newtype_struct` is named with `$__ion_rs_timestamp__` to distinguish it from an actual `newtype_struct`.
-/// More information on `newtype_struct` can be found in the serde data model: https://serde.rs/data-model.html#types
+/// More information on `newtype_struct` can be found in the serde data model: `<https://serde.rs/data-model.html#types>`
 impl Serialize for Timestamp {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -43,7 +43,7 @@ impl Serialize for Timestamp {
 /// Deserialization for Ion `Timestamp`
 /// This deserialization internally uses `serialize_newtype_struct` to trick serde to deserialize a datetime value into timestamp.
 /// This `newtype_struct` is named with `$__ion_rs_timestamp__` to distinguish it from an actual `newtype_struct`.
-/// More information on `newtype_struct` can be found in the serde data model: https://serde.rs/data-model.html#types
+/// More information on `newtype_struct` can be found in the serde data model: `<https://serde.rs/data-model.html#types>`
 impl<'de> Deserialize<'de> for Timestamp {
     fn deserialize<D>(deserializer: D) -> Result<Timestamp, D::Error>
     where

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -1,12 +1,10 @@
-use crate::serde::SERDE_AS_ION;
 use crate::{IonError, Timestamp};
 use chrono::{DateTime, FixedOffset, Utc};
-use serde::de::Error;
-use serde::{self, de, ser, Deserialize, Serialize};
+use serde::{self, de, ser, Deserialize, Serialize, Serializer};
 use serde_with::{DeserializeAs, SerializeAs};
 use std::fmt;
 
-pub(crate) const ION_TIMESTAMP: &str = "$__ion_rs_timestamp__";
+pub(crate) const TUNNELED_TIMESTAMP_TYPE_NAME: &str = "$__ion_rs_timestamp__";
 
 /// Serialization for Ion `Timestamp`
 /// This serialization internally uses `serialize_newtype_struct` to trick serde to serialize a datetime value into timestamp.
@@ -16,22 +14,9 @@ impl Serialize for Timestamp {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::ser::Serializer,
+        S: Serializer,
     {
-        SERDE_AS_ION.with(move |cell| {
-            let datetime: DateTime<FixedOffset> = self
-                .clone()
-                .try_into()
-                .map_err(|e: IonError| ser::Error::custom(e.to_string()))?;
-            if cell.get() {
-                serializer.serialize_newtype_struct(
-                    "$__ion_rs_timestamp__",
-                    datetime.to_rfc3339().as_str(),
-                )
-            } else {
-                serializer.serialize_str(datetime.to_rfc3339().as_str())
-            }
-        })
+        serializer.serialize_newtype_struct(TUNNELED_TIMESTAMP_TYPE_NAME, self)
     }
 }
 
@@ -44,40 +29,17 @@ impl<'de> Deserialize<'de> for Timestamp {
     where
         D: de::Deserializer<'de>,
     {
-        SERDE_AS_ION.with(move |cell| {
-            if cell.get() {
-                struct TimestampVisitor;
+        struct TimestampVisitor;
 
-                impl<'de> de::Visitor<'de> for TimestampVisitor {
-                    type Value = Timestamp;
+        impl<'de> de::Visitor<'de> for TimestampVisitor {
+            type Value = Timestamp;
 
-                    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                        formatter.write_str("an Ion Timestamp")
-                    }
-
-                    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
-                    where
-                        E: Error,
-                    {
-                        let naive: DateTime<FixedOffset> = match DateTime::parse_from_rfc3339(s) {
-                            Ok(data) => Ok(data),
-                            Err(e) => Err(de::Error::custom(e.to_string())),
-                        }?;
-                        Ok(Timestamp::from(naive))
-                    }
-                }
-
-                deserializer.deserialize_newtype_struct("$__ion_rs_timestamp__", TimestampVisitor)
-            } else {
-                let string_rep = String::deserialize(deserializer)?;
-                let fixed_date: DateTime<FixedOffset> =
-                    match DateTime::parse_from_rfc3339(string_rep.as_str()) {
-                        Ok(data) => Ok(data),
-                        Err(e) => Err(de::Error::custom(e.to_string())),
-                    }?;
-                Ok(Timestamp::from(fixed_date))
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an Ion Timestamp")
             }
-        })
+        }
+
+        deserializer.deserialize_newtype_struct(TUNNELED_TIMESTAMP_TYPE_NAME, TimestampVisitor)
     }
 }
 


### PR DESCRIPTION
*Related PR: #402*

*Description of changes:*
This PR continues on a [previous PR](#402) to implement `serde` for `ion-rs` and adds an experimental `serde` feature. 

*List of changes:*
* adds serde module which defines `ser` (serialization) and `de` (deserialization) for Ion data model.
* adds `timestamp` which is a special case for `serde` since serde data model doesn't support Ion timestamps, we use `newtype_struct` to serialize and deserialize timestamps.
* adds `timestamp` which is a special case for `serde` since serde data model doesn't support Ion timestamps, we use `newtype_struct` to serialize and deserialize timestamps.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
