### PR TITLE
Stub out types for RawTextReader_1_1

### DIFF
--- a/src/lazy/binary/raw/reader.rs
+++ b/src/lazy/binary/raw/reader.rs
@@ -1,7 +1,7 @@
 use crate::lazy::binary::immutable_buffer::ImmutableBuffer;
 use crate::lazy::binary::raw::value::LazyRawBinaryValue;
 use crate::lazy::decoder::LazyRawReader;
-use crate::lazy::encoding::BinaryEncoding;
+use crate::lazy::encoding::BinaryEncoding_1_0;
 use crate::lazy::raw_stream_item::RawStreamItem;
 use crate::result::IonFailure;
 use crate::IonResult;
@@ -32,7 +32,7 @@ impl<'data> LazyRawBinaryReader<'data> {
     fn read_ivm(
         &mut self,
         buffer: ImmutableBuffer<'data>,
-    ) -> IonResult<RawStreamItem<'data, BinaryEncoding>> {
+    ) -> IonResult<RawStreamItem<'data, BinaryEncoding_1_0>> {
         let ((major, minor), _buffer_after_ivm) = buffer.read_ivm()?;
         if (major, minor) != (1, 0) {
             return IonResult::decoding_error(format!(
@@ -48,7 +48,7 @@ impl<'data> LazyRawBinaryReader<'data> {
     fn read_value(
         &mut self,
         buffer: ImmutableBuffer<'data>,
-    ) -> IonResult<RawStreamItem<'data, BinaryEncoding>> {
+    ) -> IonResult<RawStreamItem<'data, BinaryEncoding_1_0>> {
         let lazy_value = match ImmutableBuffer::peek_sequence_value(buffer)? {
             Some(lazy_value) => lazy_value,
             None => return Ok(RawStreamItem::EndOfStream),
@@ -58,7 +58,7 @@ impl<'data> LazyRawBinaryReader<'data> {
         Ok(RawStreamItem::Value(lazy_value))
     }
 
-    pub fn next<'top>(&'top mut self) -> IonResult<RawStreamItem<'data, BinaryEncoding>>
+    pub fn next<'top>(&'top mut self) -> IonResult<RawStreamItem<'data, BinaryEncoding_1_0>>
     where
         'data: 'top,
     {
@@ -77,12 +77,12 @@ impl<'data> LazyRawBinaryReader<'data> {
     }
 }
 
-impl<'data> LazyRawReader<'data, BinaryEncoding> for LazyRawBinaryReader<'data> {
+impl<'data> LazyRawReader<'data, BinaryEncoding_1_0> for LazyRawBinaryReader<'data> {
     fn new(data: &'data [u8]) -> Self {
         LazyRawBinaryReader::new(data)
     }
 
-    fn next<'a>(&'a mut self) -> IonResult<RawStreamItem<'data, BinaryEncoding>> {
+    fn next<'a>(&'a mut self) -> IonResult<RawStreamItem<'data, BinaryEncoding_1_0>> {
         self.next()
     }
 }
@@ -219,6 +219,7 @@ mod tests {
                 RawStreamItem::VersionMarker(major, minor) => println!("IVM: v{}.{}", major, minor),
                 RawStreamItem::Value(value) => println!("{:?}", value.read()?),
                 RawStreamItem::EndOfStream => break,
+                RawStreamItem::MacroInvocation(_) => unreachable!("No macros in Ion 1.0"),
             }
         }
         Ok(())

--- a/src/lazy/binary/raw/sequence.rs
+++ b/src/lazy/binary/raw/sequence.rs
@@ -4,7 +4,7 @@ use crate::lazy::binary::raw::reader::DataSource;
 use crate::lazy::binary::raw::value::LazyRawBinaryValue;
 use crate::lazy::decoder::private::LazyContainerPrivate;
 use crate::lazy::decoder::LazyRawSequence;
-use crate::lazy::encoding::BinaryEncoding;
+use crate::lazy::encoding::BinaryEncoding_1_0;
 use crate::{IonResult, IonType};
 use std::fmt;
 use std::fmt::{Debug, Formatter};
@@ -19,7 +19,7 @@ pub struct LazyRawBinarySExp<'data> {
     pub(crate) sequence: LazyRawBinarySequence<'data>,
 }
 
-impl<'data> LazyContainerPrivate<'data, BinaryEncoding> for LazyRawBinaryList<'data> {
+impl<'data> LazyContainerPrivate<'data, BinaryEncoding_1_0> for LazyRawBinaryList<'data> {
     fn from_value(value: LazyRawBinaryValue<'data>) -> Self {
         LazyRawBinaryList {
             sequence: LazyRawBinarySequence { value },
@@ -27,7 +27,7 @@ impl<'data> LazyContainerPrivate<'data, BinaryEncoding> for LazyRawBinaryList<'d
     }
 }
 
-impl<'data> LazyRawSequence<'data, BinaryEncoding> for LazyRawBinaryList<'data> {
+impl<'data> LazyRawSequence<'data, BinaryEncoding_1_0> for LazyRawBinaryList<'data> {
     type Iterator = RawBinarySequenceIterator<'data>;
 
     fn annotations(&self) -> RawBinaryAnnotationsIterator<'data> {
@@ -47,7 +47,7 @@ impl<'data> LazyRawSequence<'data, BinaryEncoding> for LazyRawBinaryList<'data> 
     }
 }
 
-impl<'data> LazyContainerPrivate<'data, BinaryEncoding> for LazyRawBinarySExp<'data> {
+impl<'data> LazyContainerPrivate<'data, BinaryEncoding_1_0> for LazyRawBinarySExp<'data> {
     fn from_value(value: LazyRawBinaryValue<'data>) -> Self {
         LazyRawBinarySExp {
             sequence: LazyRawBinarySequence { value },
@@ -55,7 +55,7 @@ impl<'data> LazyContainerPrivate<'data, BinaryEncoding> for LazyRawBinarySExp<'d
     }
 }
 
-impl<'data> LazyRawSequence<'data, BinaryEncoding> for LazyRawBinarySExp<'data> {
+impl<'data> LazyRawSequence<'data, BinaryEncoding_1_0> for LazyRawBinarySExp<'data> {
     type Iterator = RawBinarySequenceIterator<'data>;
 
     fn annotations(&self) -> RawBinaryAnnotationsIterator<'data> {

--- a/src/lazy/binary/raw/struct.rs
+++ b/src/lazy/binary/raw/struct.rs
@@ -4,7 +4,7 @@ use crate::lazy::binary::raw::reader::DataSource;
 use crate::lazy::binary::raw::value::LazyRawBinaryValue;
 use crate::lazy::decoder::private::{LazyContainerPrivate, LazyRawFieldPrivate};
 use crate::lazy::decoder::{LazyRawField, LazyRawStruct};
-use crate::lazy::encoding::BinaryEncoding;
+use crate::lazy::encoding::BinaryEncoding_1_0;
 use crate::lazy::raw_value_ref::RawValueRef;
 use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
 use crate::{IonResult, RawSymbolTokenRef};
@@ -57,7 +57,7 @@ impl<'data> LazyRawBinaryStruct<'data> {
         Ok(None)
     }
 
-    fn get(&self, name: &str) -> IonResult<Option<RawValueRef<'data, BinaryEncoding>>> {
+    fn get(&self, name: &str) -> IonResult<Option<RawValueRef<'data, BinaryEncoding_1_0>>> {
         self.find(name)?.map(|f| f.read()).transpose()
     }
 
@@ -69,13 +69,13 @@ impl<'data> LazyRawBinaryStruct<'data> {
     }
 }
 
-impl<'data> LazyContainerPrivate<'data, BinaryEncoding> for LazyRawBinaryStruct<'data> {
+impl<'data> LazyContainerPrivate<'data, BinaryEncoding_1_0> for LazyRawBinaryStruct<'data> {
     fn from_value(value: LazyRawBinaryValue<'data>) -> Self {
         LazyRawBinaryStruct { value }
     }
 }
 
-impl<'data> LazyRawStruct<'data, BinaryEncoding> for LazyRawBinaryStruct<'data> {
+impl<'data> LazyRawStruct<'data, BinaryEncoding_1_0> for LazyRawBinaryStruct<'data> {
     type Field = LazyRawBinaryField<'data>;
     type Iterator = RawBinaryStructIterator<'data>;
 
@@ -87,7 +87,7 @@ impl<'data> LazyRawStruct<'data, BinaryEncoding> for LazyRawBinaryStruct<'data> 
         self.find(name)
     }
 
-    fn get(&self, name: &str) -> IonResult<Option<RawValueRef<'data, BinaryEncoding>>> {
+    fn get(&self, name: &str) -> IonResult<Option<RawValueRef<'data, BinaryEncoding_1_0>>> {
         self.get(name)
     }
 
@@ -145,13 +145,13 @@ impl<'data> LazyRawBinaryField<'data> {
     }
 }
 
-impl<'data> LazyRawFieldPrivate<'data, BinaryEncoding> for LazyRawBinaryField<'data> {
+impl<'data> LazyRawFieldPrivate<'data, BinaryEncoding_1_0> for LazyRawBinaryField<'data> {
     fn into_value(self) -> LazyRawBinaryValue<'data> {
         self.value
     }
 }
 
-impl<'data> LazyRawField<'data, BinaryEncoding> for LazyRawBinaryField<'data> {
+impl<'data> LazyRawField<'data, BinaryEncoding_1_0> for LazyRawBinaryField<'data> {
     fn name(&self) -> RawSymbolTokenRef<'data> {
         LazyRawBinaryField::name(self)
     }

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -9,7 +9,7 @@ use crate::lazy::binary::raw::sequence::{
 };
 use crate::lazy::decoder::private::LazyRawValuePrivate;
 use crate::lazy::decoder::LazyRawValue;
-use crate::lazy::encoding::BinaryEncoding;
+use crate::lazy::encoding::BinaryEncoding_1_0;
 use crate::lazy::raw_value_ref::RawValueRef;
 use crate::lazy::str_ref::StrRef;
 use crate::result::IonFailure;
@@ -58,7 +58,7 @@ impl<'data> LazyRawValuePrivate<'data> for LazyRawBinaryValue<'data> {
     }
 }
 
-impl<'data> LazyRawValue<'data, BinaryEncoding> for LazyRawBinaryValue<'data> {
+impl<'data> LazyRawValue<'data, BinaryEncoding_1_0> for LazyRawBinaryValue<'data> {
     fn ion_type(&self) -> IonType {
         self.ion_type()
     }
@@ -71,7 +71,7 @@ impl<'data> LazyRawValue<'data, BinaryEncoding> for LazyRawBinaryValue<'data> {
         self.annotations()
     }
 
-    fn read(&self) -> IonResult<RawValueRef<'data, BinaryEncoding>> {
+    fn read(&self) -> IonResult<RawValueRef<'data, BinaryEncoding_1_0>> {
         self.read()
     }
 }
@@ -134,7 +134,7 @@ impl<'data> LazyRawBinaryValue<'data> {
     /// calling this method will not read additional data; the `RawValueRef` will provide a
     /// [`LazyRawBinarySequence`] or [`LazyStruct`](crate::lazy::struct::LazyStruct)
     /// that can be traversed to access the container's contents.
-    pub fn read(&self) -> ValueParseResult<'data, BinaryEncoding> {
+    pub fn read(&self) -> ValueParseResult<'data, BinaryEncoding_1_0> {
         if self.is_null() {
             let raw_value_ref = RawValueRef::Null(self.ion_type());
             return Ok(raw_value_ref);
@@ -192,7 +192,7 @@ impl<'data> LazyRawBinaryValue<'data> {
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a bool.
-    fn read_bool(&self) -> ValueParseResult<'data, BinaryEncoding> {
+    fn read_bool(&self) -> ValueParseResult<'data, BinaryEncoding_1_0> {
         debug_assert!(self.encoded_value.ion_type() == IonType::Bool);
         let representation = self.encoded_value.header().length_code;
         let value = match representation {
@@ -209,7 +209,7 @@ impl<'data> LazyRawBinaryValue<'data> {
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as an int.
-    fn read_int(&self) -> ValueParseResult<'data, BinaryEncoding> {
+    fn read_int(&self) -> ValueParseResult<'data, BinaryEncoding_1_0> {
         debug_assert!(self.encoded_value.ion_type() == IonType::Int);
         // `value_body()` returns a buffer starting at the body of the value.
         // It also confirms that the entire value is in the buffer.
@@ -236,7 +236,7 @@ impl<'data> LazyRawBinaryValue<'data> {
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a float.
-    fn read_float(&self) -> ValueParseResult<'data, BinaryEncoding> {
+    fn read_float(&self) -> ValueParseResult<'data, BinaryEncoding_1_0> {
         debug_assert!(self.encoded_value.ion_type() == IonType::Float);
         let ieee_bytes = self.value_body()?;
         let number_of_bytes = self.encoded_value.value_length();
@@ -250,7 +250,7 @@ impl<'data> LazyRawBinaryValue<'data> {
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a decimal.
-    fn read_decimal(&self) -> ValueParseResult<'data, BinaryEncoding> {
+    fn read_decimal(&self) -> ValueParseResult<'data, BinaryEncoding_1_0> {
         debug_assert!(self.encoded_value.ion_type() == IonType::Decimal);
 
         if self.encoded_value.value_length() == 0 {
@@ -277,7 +277,7 @@ impl<'data> LazyRawBinaryValue<'data> {
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a timestamp.
-    fn read_timestamp(&self) -> ValueParseResult<'data, BinaryEncoding> {
+    fn read_timestamp(&self) -> ValueParseResult<'data, BinaryEncoding_1_0> {
         debug_assert!(self.encoded_value.ion_type() == IonType::Timestamp);
 
         let input = ImmutableBuffer::new(self.value_body()?);
@@ -387,14 +387,14 @@ impl<'data> LazyRawBinaryValue<'data> {
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a symbol.
-    fn read_symbol(&self) -> ValueParseResult<'data, BinaryEncoding> {
+    fn read_symbol(&self) -> ValueParseResult<'data, BinaryEncoding_1_0> {
         debug_assert!(self.encoded_value.ion_type() == IonType::Symbol);
         self.read_symbol_id()
             .map(|sid| RawValueRef::Symbol(RawSymbolTokenRef::SymbolId(sid)))
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a string.
-    fn read_string(&self) -> ValueParseResult<'data, BinaryEncoding> {
+    fn read_string(&self) -> ValueParseResult<'data, BinaryEncoding_1_0> {
         debug_assert!(self.encoded_value.ion_type() == IonType::String);
         let raw_bytes = self.value_body()?;
         let text = std::str::from_utf8(raw_bytes)
@@ -403,21 +403,21 @@ impl<'data> LazyRawBinaryValue<'data> {
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a blob.
-    fn read_blob(&self) -> ValueParseResult<'data, BinaryEncoding> {
+    fn read_blob(&self) -> ValueParseResult<'data, BinaryEncoding_1_0> {
         debug_assert!(self.encoded_value.ion_type() == IonType::Blob);
         let bytes = self.value_body()?;
         Ok(RawValueRef::Blob(bytes.into()))
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a clob.
-    fn read_clob(&self) -> ValueParseResult<'data, BinaryEncoding> {
+    fn read_clob(&self) -> ValueParseResult<'data, BinaryEncoding_1_0> {
         debug_assert!(self.encoded_value.ion_type() == IonType::Clob);
         let bytes = self.value_body()?;
         Ok(RawValueRef::Clob(bytes.into()))
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as an S-expression.
-    fn read_sexp(&self) -> ValueParseResult<'data, BinaryEncoding> {
+    fn read_sexp(&self) -> ValueParseResult<'data, BinaryEncoding_1_0> {
         debug_assert!(self.encoded_value.ion_type() == IonType::SExp);
         let lazy_value = LazyRawBinaryValue {
             encoded_value: self.encoded_value,
@@ -431,7 +431,7 @@ impl<'data> LazyRawBinaryValue<'data> {
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a list.
-    fn read_list(&self) -> ValueParseResult<'data, BinaryEncoding> {
+    fn read_list(&self) -> ValueParseResult<'data, BinaryEncoding_1_0> {
         debug_assert!(self.encoded_value.ion_type() == IonType::List);
         let lazy_value = LazyRawBinaryValue {
             encoded_value: self.encoded_value,
@@ -445,7 +445,7 @@ impl<'data> LazyRawBinaryValue<'data> {
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a struct.
-    fn read_struct(&self) -> ValueParseResult<'data, BinaryEncoding> {
+    fn read_struct(&self) -> ValueParseResult<'data, BinaryEncoding_1_0> {
         debug_assert!(self.encoded_value.ion_type() == IonType::Struct);
         let lazy_value = LazyRawBinaryValue {
             encoded_value: self.encoded_value,

--- a/src/lazy/encoding.rs
+++ b/src/lazy/encoding.rs
@@ -1,39 +1,53 @@
+#![allow(non_camel_case_types)]
 use crate::lazy::binary::raw::annotations_iterator::RawBinaryAnnotationsIterator;
 use crate::lazy::binary::raw::r#struct::LazyRawBinaryStruct;
 use crate::lazy::binary::raw::reader::LazyRawBinaryReader;
 use crate::lazy::binary::raw::sequence::{LazyRawBinaryList, LazyRawBinarySExp};
 use crate::lazy::binary::raw::value::LazyRawBinaryValue;
-use crate::lazy::decoder::LazyDecoder;
-use crate::lazy::text::raw::r#struct::LazyRawTextStruct;
+use crate::lazy::decoder::{LazyDecoder, LazyMacroInvocation};
+use crate::lazy::text::raw::r#struct::LazyRawTextStruct_1_0;
 use crate::lazy::text::raw::reader::LazyRawTextReader;
-use crate::lazy::text::raw::sequence::{LazyRawTextList, LazyRawTextSExp};
-use crate::lazy::text::value::{LazyRawTextValue, RawTextAnnotationsIterator};
+use crate::lazy::text::raw::sequence::{LazyRawTextList_1_0, LazyRawTextSExp_1_0};
+use crate::lazy::text::value::{LazyRawTextValue_1_0, RawTextAnnotationsIterator};
 
 // These types derive trait implementations in order to allow types that containing them
 // to also derive trait implementations.
 
+/// Marker trait for binary encodings of any version.
+pub trait LazyBinaryDecoder {}
+
 /// The Ion 1.0 binary encoding.
 #[derive(Clone, Debug)]
-pub struct BinaryEncoding;
+pub struct BinaryEncoding_1_0;
+impl LazyBinaryDecoder for BinaryEncoding_1_0 {}
 
 /// The Ion 1.0 text encoding.
 #[derive(Clone, Debug)]
-pub struct TextEncoding;
+pub struct TextEncoding_1_0;
 
-impl<'data> LazyDecoder<'data> for BinaryEncoding {
+impl<'data> LazyDecoder<'data> for BinaryEncoding_1_0 {
     type Reader = LazyRawBinaryReader<'data>;
     type Value = LazyRawBinaryValue<'data>;
     type SExp = LazyRawBinarySExp<'data>;
     type List = LazyRawBinaryList<'data>;
     type Struct = LazyRawBinaryStruct<'data>;
     type AnnotationsIterator = RawBinaryAnnotationsIterator<'data>;
+    // Macros are not supported in Ion 1.0
+    type MacroInvocation = ();
 }
 
-impl<'data> LazyDecoder<'data> for TextEncoding {
+impl<'data> LazyDecoder<'data> for TextEncoding_1_0 {
     type Reader = LazyRawTextReader<'data>;
-    type Value = LazyRawTextValue<'data>;
-    type SExp = LazyRawTextSExp<'data>;
-    type List = LazyRawTextList<'data>;
-    type Struct = LazyRawTextStruct<'data>;
+    type Value = LazyRawTextValue_1_0<'data>;
+    type SExp = LazyRawTextSExp_1_0<'data>;
+    type List = LazyRawTextList_1_0<'data>;
+    type Struct = LazyRawTextStruct_1_0<'data>;
     type AnnotationsIterator = RawTextAnnotationsIterator<'data>;
+    // Macros are not supported in Ion 1.0
+    type MacroInvocation = ();
+}
+
+// Ion 1.0 uses `()` as a placeholder for MacroInvocation.
+impl<'data, D: LazyDecoder<'data>> LazyMacroInvocation<'data, D> for () {
+    // Nothing for now.
 }

--- a/src/lazy/raw_stream_item.rs
+++ b/src/lazy/raw_stream_item.rs
@@ -12,6 +12,8 @@ pub enum RawStreamItem<'data, D: LazyDecoder<'data>> {
     /// data and (in the case of containers) access any nested values, see the documentation
     /// for [`LazyRawBinaryValue`](crate::lazy::binary::raw::value::LazyRawBinaryValue).
     Value(D::Value),
+    /// An Ion 1.1+ macro invocation. Ion 1.0 readers will never return a macro invocation.
+    MacroInvocation(D::MacroInvocation),
     /// The end of the stream
     EndOfStream,
 }

--- a/src/lazy/reader.rs
+++ b/src/lazy/reader.rs
@@ -3,7 +3,7 @@ use crate::element::reader::ElementReader;
 use crate::element::Element;
 use crate::lazy::any_encoding::AnyEncoding;
 use crate::lazy::decoder::LazyDecoder;
-use crate::lazy::encoding::{BinaryEncoding, TextEncoding};
+use crate::lazy::encoding::{BinaryEncoding_1_0, TextEncoding_1_0};
 use crate::lazy::system_reader::{LazySystemAnyReader, LazySystemBinaryReader, LazySystemReader};
 use crate::lazy::value::LazyValue;
 use crate::result::IonFailure;
@@ -76,8 +76,8 @@ impl<'data, D: LazyDecoder<'data>> LazyApplicationReader<'data, D> {
     }
 }
 
-pub type LazyBinaryReader<'data> = LazyApplicationReader<'data, BinaryEncoding>;
-pub type LazyTextReader<'data> = LazyApplicationReader<'data, TextEncoding>;
+pub type LazyBinaryReader<'data> = LazyApplicationReader<'data, BinaryEncoding_1_0>;
+pub type LazyTextReader<'data> = LazyApplicationReader<'data, TextEncoding_1_0>;
 pub type LazyReader<'data> = LazyApplicationReader<'data, AnyEncoding>;
 
 impl<'data> LazyReader<'data> {

--- a/src/lazy/sequence.rs
+++ b/src/lazy/sequence.rs
@@ -1,5 +1,5 @@
 use crate::lazy::decoder::{LazyDecoder, LazyRawSequence, LazyRawValue};
-use crate::lazy::encoding::BinaryEncoding;
+use crate::lazy::encoding::BinaryEncoding_1_0;
 use crate::lazy::value::{AnnotationsIterator, LazyValue};
 use crate::{Annotations, Element, IntoAnnotatedElement, Sequence, Value};
 use crate::{IonError, IonResult, IonType, SymbolTable};
@@ -49,7 +49,7 @@ pub struct LazyList<'top, 'data, D: LazyDecoder<'data>> {
     pub(crate) symbol_table: &'top SymbolTable,
 }
 
-pub type LazyBinarySequence<'top, 'data> = LazyList<'top, 'data, BinaryEncoding>;
+pub type LazyBinarySequence<'top, 'data> = LazyList<'top, 'data, BinaryEncoding_1_0>;
 
 impl<'top, 'data, D: LazyDecoder<'data>> LazyList<'top, 'data, D> {
     /// Returns the [`IonType`] of this sequence.

--- a/src/lazy/struct.rs
+++ b/src/lazy/struct.rs
@@ -1,7 +1,7 @@
 use crate::element::builders::StructBuilder;
 use crate::lazy::decoder::private::{LazyRawFieldPrivate, LazyRawValuePrivate};
 use crate::lazy::decoder::{LazyDecoder, LazyRawStruct};
-use crate::lazy::encoding::BinaryEncoding;
+use crate::lazy::encoding::BinaryEncoding_1_0;
 use crate::lazy::value::{AnnotationsIterator, LazyValue};
 use crate::lazy::value_ref::ValueRef;
 use crate::result::IonFailure;
@@ -46,7 +46,7 @@ pub struct LazyStruct<'top, 'data, D: LazyDecoder<'data>> {
     pub(crate) symbol_table: &'top SymbolTable,
 }
 
-pub type LazyBinaryStruct<'top, 'data> = LazyStruct<'top, 'data, BinaryEncoding>;
+pub type LazyBinaryStruct<'top, 'data> = LazyStruct<'top, 'data, BinaryEncoding_1_0>;
 
 // Best-effort debug formatting for LazyStruct. Any failures that occur during reading will result
 // in the output being silently truncated.

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -1,5 +1,5 @@
 use crate::lazy::any_encoding::{AnyEncoding, LazyRawAnyReader};
-use crate::lazy::encoding::{BinaryEncoding, TextEncoding};
+use crate::lazy::encoding::{BinaryEncoding_1_0, TextEncoding_1_0};
 use crate::result::IonFailure;
 use crate::{IonResult, IonType, RawSymbolTokenRef, SymbolTable};
 
@@ -77,8 +77,8 @@ pub struct LazySystemReader<'data, D: LazyDecoder<'data>> {
     pending_lst: PendingLst,
 }
 
-pub type LazySystemBinaryReader<'data> = LazySystemReader<'data, BinaryEncoding>;
-pub type LazySystemTextReader<'data> = LazySystemReader<'data, TextEncoding>;
+pub type LazySystemBinaryReader<'data> = LazySystemReader<'data, BinaryEncoding_1_0>;
+pub type LazySystemTextReader<'data> = LazySystemReader<'data, TextEncoding_1_0>;
 pub type LazySystemAnyReader<'data> = LazySystemReader<'data, AnyEncoding>;
 
 // If the reader encounters a symbol table in the stream, it will store all of the symbols that
@@ -144,6 +144,7 @@ impl<'data, D: LazyDecoder<'data>> LazySystemReader<'data, D> {
             }
             RawStreamItem::Value(lazy_raw_value) => lazy_raw_value,
             RawStreamItem::EndOfStream => return Ok(SystemStreamItem::EndOfStream),
+            RawStreamItem::MacroInvocation(_) => todo!("impl macro invocations"),
         };
         if Self::is_symbol_table_struct(&lazy_raw_value)? {
             Self::process_symbol_table(pending_lst, &lazy_raw_value)?;
@@ -177,6 +178,7 @@ impl<'data, D: LazyDecoder<'data>> LazySystemReader<'data, D> {
                 RawStreamItem::VersionMarker(_, _) => continue,
                 RawStreamItem::Value(lazy_raw_value) => lazy_raw_value,
                 RawStreamItem::EndOfStream => return Ok(None),
+                RawStreamItem::MacroInvocation(_) => todo!("impl macro invocations"),
             };
             if Self::is_symbol_table_struct(&lazy_raw_value)? {
                 // process the symbol table, but do not surface it

--- a/src/lazy/text/encoded_value.rs
+++ b/src/lazy/text/encoded_value.rs
@@ -7,7 +7,7 @@ use std::ops::Range;
 /// Represents the type, offset, and length metadata of the various components of an encoded value
 /// in a text input stream.
 ///
-/// Each [`LazyRawTextValue`](crate::lazy::text::value::LazyRawTextValue) contains an `EncodedValue`,
+/// Each [`LazyRawTextValue`](crate::lazy::text::value::LazyRawTextValue_1_0) contains an `EncodedValue`,
 /// allowing a user to re-read (that is: parse) the body of the value as many times as necessary
 /// without re-parsing its header information each time.
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/src/lazy/text/raw/mod.rs
+++ b/src/lazy/text/raw/mod.rs
@@ -1,3 +1,4 @@
 pub mod reader;
 pub mod sequence;
 pub mod r#struct;
+pub mod v1_1;

--- a/src/lazy/text/raw/reader.rs
+++ b/src/lazy/text/raw/reader.rs
@@ -1,5 +1,5 @@
 use crate::lazy::decoder::LazyRawReader;
-use crate::lazy::encoding::TextEncoding;
+use crate::lazy::encoding::TextEncoding_1_0;
 use crate::lazy::raw_stream_item::RawStreamItem;
 use crate::lazy::text::buffer::TextBufferView;
 use crate::lazy::text::parse_result::AddContext;
@@ -33,7 +33,7 @@ impl<'data> LazyRawTextReader<'data> {
         }
     }
 
-    pub fn next<'top>(&'top mut self) -> IonResult<RawStreamItem<'data, TextEncoding>>
+    pub fn next<'top>(&'top mut self) -> IonResult<RawStreamItem<'data, TextEncoding_1_0>>
     where
         'data: 'top,
     {
@@ -70,12 +70,12 @@ impl<'data> LazyRawTextReader<'data> {
     }
 }
 
-impl<'data> LazyRawReader<'data, TextEncoding> for LazyRawTextReader<'data> {
+impl<'data> LazyRawReader<'data, TextEncoding_1_0> for LazyRawTextReader<'data> {
     fn new(data: &'data [u8]) -> Self {
         LazyRawTextReader::new(data)
     }
 
-    fn next<'a>(&'a mut self) -> IonResult<RawStreamItem<'data, TextEncoding>> {
+    fn next<'a>(&'a mut self) -> IonResult<RawStreamItem<'data, TextEncoding_1_0>> {
         self.next()
     }
 }
@@ -227,7 +227,7 @@ mod tests {
 
         fn expect_next<'data>(
             reader: &mut LazyRawTextReader<'data>,
-            expected: RawValueRef<'data, TextEncoding>,
+            expected: RawValueRef<'data, TextEncoding_1_0>,
         ) {
             let lazy_value = reader
                 .next()

--- a/src/lazy/text/raw/sequence.rs
+++ b/src/lazy/text/raw/sequence.rs
@@ -1,3 +1,4 @@
+#![allow(non_camel_case_types)]
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::ops::Range;
@@ -6,68 +7,68 @@ use nom::character::streaming::satisfy;
 
 use crate::lazy::decoder::private::LazyContainerPrivate;
 use crate::lazy::decoder::{LazyRawSequence, LazyRawValue};
-use crate::lazy::encoding::TextEncoding;
+use crate::lazy::encoding::TextEncoding_1_0;
 use crate::lazy::text::buffer::TextBufferView;
 use crate::lazy::text::parse_result::AddContext;
 use crate::lazy::text::parse_result::ToIteratorOutput;
-use crate::lazy::text::value::{LazyRawTextValue, RawTextAnnotationsIterator};
+use crate::lazy::text::value::{LazyRawTextValue_1_0, RawTextAnnotationsIterator};
 use crate::{IonResult, IonType};
 
 // ===== Lists =====
 
 #[derive(Copy, Clone)]
-pub struct LazyRawTextList<'data> {
-    pub(crate) value: LazyRawTextValue<'data>,
+pub struct LazyRawTextList_1_0<'data> {
+    pub(crate) value: LazyRawTextValue_1_0<'data>,
 }
 
-impl<'data> LazyRawTextList<'data> {
+impl<'data> LazyRawTextList_1_0<'data> {
     pub fn ion_type(&self) -> IonType {
-        self.value.ion_type()
+        IonType::List
     }
 
-    pub fn iter(&self) -> RawTextListIterator<'data> {
+    pub fn iter(&self) -> RawTextListIterator_1_0<'data> {
         let open_bracket_index = self.value.encoded_value.data_offset() - self.value.input.offset();
         // Make an iterator over the input bytes that follow the initial `[`
-        RawTextListIterator::new(self.value.input.slice_to_end(open_bracket_index + 1))
+        RawTextListIterator_1_0::new(self.value.input.slice_to_end(open_bracket_index + 1))
     }
 }
 
-impl<'data> LazyContainerPrivate<'data, TextEncoding> for LazyRawTextList<'data> {
-    fn from_value(value: LazyRawTextValue<'data>) -> Self {
-        LazyRawTextList { value }
+impl<'data> LazyContainerPrivate<'data, TextEncoding_1_0> for LazyRawTextList_1_0<'data> {
+    fn from_value(value: LazyRawTextValue_1_0<'data>) -> Self {
+        LazyRawTextList_1_0 { value }
     }
 }
 
-impl<'data> LazyRawSequence<'data, TextEncoding> for LazyRawTextList<'data> {
-    type Iterator = RawTextListIterator<'data>;
+impl<'data> LazyRawSequence<'data, TextEncoding_1_0> for LazyRawTextList_1_0<'data> {
+    type Iterator = RawTextListIterator_1_0<'data>;
 
     fn annotations(&self) -> RawTextAnnotationsIterator<'data> {
         self.value.annotations()
     }
 
     fn ion_type(&self) -> IonType {
-        self.value.ion_type()
+        IonType::List
     }
 
     fn iter(&self) -> Self::Iterator {
-        LazyRawTextList::iter(self)
+        LazyRawTextList_1_0::iter(self)
     }
 
-    fn as_value(&self) -> LazyRawTextValue<'data> {
+    fn as_value(&self) -> LazyRawTextValue_1_0<'data> {
         self.value
     }
 }
 
-impl<'a, 'data> IntoIterator for &'a LazyRawTextList<'data> {
-    type Item = IonResult<LazyRawTextValue<'data>>;
-    type IntoIter = RawTextListIterator<'data>;
+impl<'a, 'data> IntoIterator for &'a LazyRawTextList_1_0<'data> {
+    type Item = IonResult<LazyRawTextValue_1_0<'data>>;
+    type IntoIter = RawTextListIterator_1_0<'data>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
 
-impl<'a> Debug for LazyRawTextList<'a> {
+impl<'a> Debug for LazyRawTextList_1_0<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "[")?;
         for value in self {
@@ -87,22 +88,22 @@ impl<'a> Debug for LazyRawTextList<'a> {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub struct RawTextListIterator<'data> {
+pub struct RawTextListIterator_1_0<'data> {
     input: TextBufferView<'data>,
     // If this iterator has returned an error, it should return `None` forever afterwards
     has_returned_error: bool,
 }
 
-impl<'data> RawTextListIterator<'data> {
-    pub(crate) fn new(input: TextBufferView<'data>) -> RawTextListIterator<'data> {
-        RawTextListIterator {
+impl<'data> RawTextListIterator_1_0<'data> {
+    pub(crate) fn new(input: TextBufferView<'data>) -> RawTextListIterator_1_0<'data> {
+        RawTextListIterator_1_0 {
             input,
             has_returned_error: false,
         }
     }
 }
 
-impl<'data> RawTextListIterator<'data> {
+impl<'data> RawTextListIterator_1_0<'data> {
     pub(crate) fn find_span(&self) -> IonResult<Range<usize>> {
         // The input has already skipped past the opening delimiter.
         let start = self.input.offset() - 1;
@@ -133,8 +134,8 @@ impl<'data> RawTextListIterator<'data> {
     }
 }
 
-impl<'data> Iterator for RawTextListIterator<'data> {
-    type Item = IonResult<LazyRawTextValue<'data>>;
+impl<'data> Iterator for RawTextListIterator_1_0<'data> {
+    type Item = IonResult<LazyRawTextValue_1_0<'data>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.has_returned_error {
@@ -161,39 +162,39 @@ impl<'data> Iterator for RawTextListIterator<'data> {
 // ===== S-Expressions =====
 
 #[derive(Copy, Clone)]
-pub struct LazyRawTextSExp<'data> {
-    pub(crate) value: LazyRawTextValue<'data>,
+pub struct LazyRawTextSExp_1_0<'data> {
+    pub(crate) value: LazyRawTextValue_1_0<'data>,
 }
 
-impl<'data> LazyRawTextSExp<'data> {
+impl<'data> LazyRawTextSExp_1_0<'data> {
     pub fn ion_type(&self) -> IonType {
-        self.value.ion_type()
+        IonType::SExp
     }
 
-    pub fn iter(&self) -> RawTextSExpIterator<'data> {
+    pub fn iter(&self) -> RawTextSExpIterator_1_0<'data> {
         let open_paren_index = self.value.encoded_value.data_offset() - self.value.input.offset();
         // Make an iterator over the input bytes that follow the initial `(`
-        RawTextSExpIterator::new(self.value.input.slice_to_end(open_paren_index + 1))
+        RawTextSExpIterator_1_0::new(self.value.input.slice_to_end(open_paren_index + 1))
     }
 }
 
 #[derive(Copy, Clone, Debug)]
-pub struct RawTextSExpIterator<'data> {
+pub struct RawTextSExpIterator_1_0<'data> {
     input: TextBufferView<'data>,
     // If this iterator has returned an error, it should return `None` forever afterwards
     has_returned_error: bool,
 }
 
-impl<'data> RawTextSExpIterator<'data> {
-    pub(crate) fn new(input: TextBufferView<'data>) -> RawTextSExpIterator<'data> {
-        RawTextSExpIterator {
+impl<'data> RawTextSExpIterator_1_0<'data> {
+    pub(crate) fn new(input: TextBufferView<'data>) -> RawTextSExpIterator_1_0<'data> {
+        RawTextSExpIterator_1_0 {
             input,
             has_returned_error: false,
         }
     }
 }
 
-impl<'data> RawTextSExpIterator<'data> {
+impl<'data> RawTextSExpIterator_1_0<'data> {
     pub(crate) fn find_span(&self) -> IonResult<Range<usize>> {
         // The input has already skipped past the opening delimiter.
         let start = self.input.offset() - 1;
@@ -216,8 +217,8 @@ impl<'data> RawTextSExpIterator<'data> {
     }
 }
 
-impl<'data> Iterator for RawTextSExpIterator<'data> {
-    type Item = IonResult<LazyRawTextValue<'data>>;
+impl<'data> Iterator for RawTextSExpIterator_1_0<'data> {
+    type Item = IonResult<LazyRawTextValue_1_0<'data>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.has_returned_error {
@@ -238,42 +239,42 @@ impl<'data> Iterator for RawTextSExpIterator<'data> {
     }
 }
 
-impl<'data> LazyContainerPrivate<'data, TextEncoding> for LazyRawTextSExp<'data> {
-    fn from_value(value: LazyRawTextValue<'data>) -> Self {
-        LazyRawTextSExp { value }
+impl<'data> LazyContainerPrivate<'data, TextEncoding_1_0> for LazyRawTextSExp_1_0<'data> {
+    fn from_value(value: LazyRawTextValue_1_0<'data>) -> Self {
+        LazyRawTextSExp_1_0 { value }
     }
 }
 
-impl<'data> LazyRawSequence<'data, TextEncoding> for LazyRawTextSExp<'data> {
-    type Iterator = RawTextSExpIterator<'data>;
+impl<'data> LazyRawSequence<'data, TextEncoding_1_0> for LazyRawTextSExp_1_0<'data> {
+    type Iterator = RawTextSExpIterator_1_0<'data>;
 
     fn annotations(&self) -> RawTextAnnotationsIterator<'data> {
         self.value.annotations()
     }
 
     fn ion_type(&self) -> IonType {
-        self.value.ion_type()
+        IonType::SExp
     }
 
     fn iter(&self) -> Self::Iterator {
-        LazyRawTextSExp::iter(self)
+        LazyRawTextSExp_1_0::iter(self)
     }
 
-    fn as_value(&self) -> LazyRawTextValue<'data> {
+    fn as_value(&self) -> LazyRawTextValue_1_0<'data> {
         self.value
     }
 }
 
-impl<'a, 'data> IntoIterator for &'a LazyRawTextSExp<'data> {
-    type Item = IonResult<LazyRawTextValue<'data>>;
-    type IntoIter = RawTextSExpIterator<'data>;
+impl<'a, 'data> IntoIterator for &'a LazyRawTextSExp_1_0<'data> {
+    type Item = IonResult<LazyRawTextValue_1_0<'data>>;
+    type IntoIter = RawTextSExpIterator_1_0<'data>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
 
-impl<'a> Debug for LazyRawTextSExp<'a> {
+impl<'a> Debug for LazyRawTextSExp_1_0<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "(")?;
         for value in self {

--- a/src/lazy/text/raw/struct.rs
+++ b/src/lazy/text/raw/struct.rs
@@ -1,24 +1,26 @@
-use crate::lazy::decoder::private::{LazyContainerPrivate, LazyRawFieldPrivate};
-use crate::lazy::decoder::{LazyRawField, LazyRawStruct, LazyRawValue};
-use crate::lazy::encoding::TextEncoding;
-use crate::lazy::raw_value_ref::RawValueRef;
-use crate::lazy::text::buffer::TextBufferView;
-use crate::lazy::text::parse_result::{AddContext, ToIteratorOutput};
-use crate::lazy::text::value::{LazyRawTextValue, RawTextAnnotationsIterator};
-use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
-use crate::{IonResult, RawSymbolTokenRef};
-use nom::character::streaming::satisfy;
+#![allow(non_camel_case_types)]
 use std::ops::Range;
 
+use nom::character::streaming::satisfy;
+
+use crate::lazy::decoder::private::{LazyContainerPrivate, LazyRawFieldPrivate};
+use crate::lazy::decoder::{LazyRawField, LazyRawStruct, LazyRawValue};
+use crate::lazy::encoding::TextEncoding_1_0;
+use crate::lazy::text::buffer::TextBufferView;
+use crate::lazy::text::parse_result::{AddContext, ToIteratorOutput};
+use crate::lazy::text::value::{LazyRawTextValue_1_0, RawTextAnnotationsIterator};
+use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
+use crate::{IonResult, RawSymbolTokenRef};
+
 #[derive(Clone, Copy, Debug)]
-pub struct RawTextStructIterator<'data> {
+pub struct RawTextStructIterator_1_0<'data> {
     input: TextBufferView<'data>,
     has_returned_error: bool,
 }
 
-impl<'data> RawTextStructIterator<'data> {
+impl<'data> RawTextStructIterator_1_0<'data> {
     pub(crate) fn new(input: TextBufferView<'data>) -> Self {
-        RawTextStructIterator {
+        RawTextStructIterator_1_0 {
             input,
             has_returned_error: false,
         }
@@ -57,8 +59,8 @@ impl<'data> RawTextStructIterator<'data> {
     }
 }
 
-impl<'data> Iterator for RawTextStructIterator<'data> {
-    type Item = IonResult<LazyRawTextField<'data>>;
+impl<'data> Iterator for RawTextStructIterator_1_0<'data> {
+    type Item = IonResult<LazyRawTextField_1_0<'data>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.has_returned_error {
@@ -80,13 +82,13 @@ impl<'data> Iterator for RawTextStructIterator<'data> {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct LazyRawTextField<'data> {
-    pub(crate) value: LazyRawTextValue<'data>,
+pub struct LazyRawTextField_1_0<'data> {
+    pub(crate) value: LazyRawTextValue_1_0<'data>,
 }
 
-impl<'data> LazyRawTextField<'data> {
-    pub(crate) fn new(value: LazyRawTextValue<'data>) -> Self {
-        LazyRawTextField { value }
+impl<'data> LazyRawTextField_1_0<'data> {
+    pub(crate) fn new(value: LazyRawTextValue_1_0<'data>) -> Self {
+        LazyRawTextField_1_0 { value }
     }
 
     pub fn name(&self) -> RawSymbolTokenRef<'data> {
@@ -109,38 +111,38 @@ impl<'data> LazyRawTextField<'data> {
             .expect("invalid struct field name")
     }
 
-    pub fn value(&self) -> LazyRawTextValue<'data> {
+    pub fn value(&self) -> LazyRawTextValue_1_0<'data> {
         self.value
     }
 
-    pub(crate) fn into_value(self) -> LazyRawTextValue<'data> {
-        self.value
-    }
-}
-
-impl<'data> LazyRawFieldPrivate<'data, TextEncoding> for LazyRawTextField<'data> {
-    fn into_value(self) -> LazyRawTextValue<'data> {
+    pub(crate) fn into_value(self) -> LazyRawTextValue_1_0<'data> {
         self.value
     }
 }
 
-impl<'data> LazyRawField<'data, TextEncoding> for LazyRawTextField<'data> {
+impl<'data> LazyRawFieldPrivate<'data, TextEncoding_1_0> for LazyRawTextField_1_0<'data> {
+    fn into_value(self) -> LazyRawTextValue_1_0<'data> {
+        self.value
+    }
+}
+
+impl<'data> LazyRawField<'data, TextEncoding_1_0> for LazyRawTextField_1_0<'data> {
     fn name(&self) -> RawSymbolTokenRef<'data> {
-        LazyRawTextField::name(self)
+        LazyRawTextField_1_0::name(self)
     }
 
-    fn value(&self) -> LazyRawTextValue<'data> {
+    fn value(&self) -> LazyRawTextValue_1_0<'data> {
         self.value()
     }
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct LazyRawTextStruct<'data> {
-    pub(crate) value: LazyRawTextValue<'data>,
+pub struct LazyRawTextStruct_1_0<'data> {
+    pub(crate) value: LazyRawTextValue_1_0<'data>,
 }
 
-impl<'data> LazyRawTextStruct<'data> {
-    fn find(&self, name: &str) -> IonResult<Option<LazyRawTextValue<'data>>> {
+impl<'data> LazyRawTextStruct_1_0<'data> {
+    fn find(&self, name: &str) -> IonResult<Option<LazyRawTextValue_1_0<'data>>> {
         let name: RawSymbolTokenRef = name.as_raw_symbol_token_ref();
         for field_result in *self {
             let field = field_result?;
@@ -152,44 +154,36 @@ impl<'data> LazyRawTextStruct<'data> {
         }
         Ok(None)
     }
+}
 
-    fn get(&self, name: &str) -> IonResult<Option<RawValueRef<'data, TextEncoding>>> {
-        self.find(name)?.map(|f| f.read()).transpose()
+impl<'data> LazyContainerPrivate<'data, TextEncoding_1_0> for LazyRawTextStruct_1_0<'data> {
+    fn from_value(value: LazyRawTextValue_1_0<'data>) -> Self {
+        LazyRawTextStruct_1_0 { value }
     }
 }
 
-impl<'data> LazyContainerPrivate<'data, TextEncoding> for LazyRawTextStruct<'data> {
-    fn from_value(value: LazyRawTextValue<'data>) -> Self {
-        LazyRawTextStruct { value }
-    }
-}
-
-impl<'data> LazyRawStruct<'data, TextEncoding> for LazyRawTextStruct<'data> {
-    type Field = LazyRawTextField<'data>;
-    type Iterator = RawTextStructIterator<'data>;
+impl<'data> LazyRawStruct<'data, TextEncoding_1_0> for LazyRawTextStruct_1_0<'data> {
+    type Field = LazyRawTextField_1_0<'data>;
+    type Iterator = RawTextStructIterator_1_0<'data>;
 
     fn annotations(&self) -> RawTextAnnotationsIterator<'data> {
         self.value.annotations()
     }
 
-    fn find(&self, name: &str) -> IonResult<Option<LazyRawTextValue<'data>>> {
+    fn find(&self, name: &str) -> IonResult<Option<LazyRawTextValue_1_0<'data>>> {
         self.find(name)
-    }
-
-    fn get(&self, name: &str) -> IonResult<Option<RawValueRef<'data, TextEncoding>>> {
-        self.get(name)
     }
 
     fn iter(&self) -> Self::Iterator {
         let open_brace_index = self.value.encoded_value.data_offset() - self.value.input.offset();
         // Slice the input to skip the opening `{`
-        RawTextStructIterator::new(self.value.input.slice_to_end(open_brace_index + 1))
+        RawTextStructIterator_1_0::new(self.value.input.slice_to_end(open_brace_index + 1))
     }
 }
 
-impl<'data> IntoIterator for LazyRawTextStruct<'data> {
-    type Item = IonResult<LazyRawTextField<'data>>;
-    type IntoIter = RawTextStructIterator<'data>;
+impl<'data> IntoIterator for LazyRawTextStruct_1_0<'data> {
+    type Item = IonResult<LazyRawTextField_1_0<'data>>;
+    type IntoIter = RawTextStructIterator_1_0<'data>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()

--- a/src/lazy/text/raw/v1_1/mod.rs
+++ b/src/lazy/text/raw/v1_1/mod.rs
@@ -1,0 +1,1 @@
+pub mod reader;

--- a/src/lazy/text/raw/v1_1/reader.rs
+++ b/src/lazy/text/raw/v1_1/reader.rs
@@ -1,0 +1,333 @@
+#![allow(non_camel_case_types)]
+
+use crate::lazy::decoder::private::{
+    LazyContainerPrivate, LazyRawFieldPrivate, LazyRawValuePrivate,
+};
+use crate::lazy::decoder::{
+    LazyDecoder, LazyMacroInvocation, LazyRawField, LazyRawReader, LazyRawSequence, LazyRawStruct,
+    LazyRawValue,
+};
+use crate::lazy::raw_stream_item::RawStreamItem;
+use crate::lazy::raw_value_ref::RawValueRef;
+use crate::lazy::text::buffer::TextBufferView;
+use crate::lazy::text::encoded_value::EncodedTextValue;
+use crate::lazy::text::raw::r#struct::{
+    LazyRawTextField_1_0, LazyRawTextStruct_1_0, RawTextStructIterator_1_0,
+};
+use crate::lazy::text::raw::sequence::{
+    LazyRawTextList_1_0, LazyRawTextSExp_1_0, RawTextListIterator_1_0, RawTextSExpIterator_1_0,
+};
+use crate::lazy::text::value::{LazyRawTextValue_1_0, RawTextAnnotationsIterator};
+use crate::{IonResult, IonType, RawSymbolTokenRef};
+
+pub struct LazyRawTextReader_1_1<'data> {
+    // The current view of the data we're reading from.
+    buffer: TextBufferView<'data>,
+    // Each time something is parsed from the buffer successfully, the caller will mark the number
+    // of bytes that may be skipped the next time the reader advances.
+    bytes_to_skip: usize,
+}
+
+// The Ion 1.1 text encoding.
+#[derive(Clone, Debug)]
+struct TextEncoding_1_1;
+
+impl<'data> LazyDecoder<'data> for TextEncoding_1_1 {
+    // TODO: Each of these associated types is currently a wrapper around the Ion 1.0 text impl's types.
+    //       These impls will be replaced by a proper v1.1 impl over time.
+    type Reader = LazyRawTextReader_1_1<'data>;
+    type Value = LazyRawTextValue_1_1<'data>;
+    type SExp = LazyRawTextSExp_1_1<'data>;
+    type List = LazyRawTextList_1_1<'data>;
+    type Struct = LazyRawTextStruct_1_1<'data>;
+    type AnnotationsIterator = RawTextAnnotationsIterator<'data>;
+    type MacroInvocation = LazyRawTextMacroInvocation<'data>;
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct LazyRawTextMacroInvocation<'data> {
+    pub(crate) encoded_expr: EncodedTextMacroInvocation,
+    pub(crate) input: TextBufferView<'data>,
+}
+
+impl<'data, D: LazyDecoder<'data>> LazyMacroInvocation<'data, D>
+    for LazyRawTextMacroInvocation<'data>
+{
+    // Nothing for now.
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct EncodedTextMacroInvocation {
+    length: usize,
+}
+
+impl<'data> LazyRawReader<'data, TextEncoding_1_1> for LazyRawTextReader_1_1<'data> {
+    fn new(data: &'data [u8]) -> Self {
+        LazyRawTextReader_1_1 {
+            buffer: TextBufferView::new(data),
+            bytes_to_skip: 0,
+        }
+    }
+
+    fn next<'a>(&'a mut self) -> IonResult<RawStreamItem<'data, TextEncoding_1_1>> {
+        todo!()
+    }
+}
+
+// ===== Placeholder implementations =====
+
+// In Ion 1.1, each of the 1.0 container types will be replaced by versions that know to look for
+// and expand macro invocations. For now, we're re-using the 1.0 types. The implementations below
+// implement the necessary traits for TextEncoding_1_1 by forwarding to the corresponding
+// TextEncoding_1_0 impl.
+
+#[derive(Debug, Copy, Clone)]
+pub struct LazyRawTextValue_1_1<'data> {
+    pub(crate) encoded_value: EncodedTextValue,
+    pub(crate) input: TextBufferView<'data>,
+}
+
+#[derive(Debug)]
+pub struct LazyRawTextList_1_1<'data> {
+    delegate: LazyRawTextList_1_0<'data>,
+}
+
+#[derive(Debug)]
+pub struct RawTextListIterator_1_1<'data> {
+    delegate: RawTextListIterator_1_0<'data>,
+}
+
+#[derive(Debug)]
+pub struct LazyRawTextSExp_1_1<'data> {
+    delegate: LazyRawTextSExp_1_0<'data>,
+}
+
+#[derive(Debug)]
+pub struct RawTextSExpIterator_1_1<'data> {
+    delegate: RawTextSExpIterator_1_0<'data>,
+}
+
+#[derive(Debug)]
+pub struct LazyRawTextStruct_1_1<'data> {
+    delegate: LazyRawTextStruct_1_0<'data>,
+}
+
+#[derive(Debug)]
+pub struct LazyRawTextField_1_1<'data> {
+    delegate: LazyRawTextField_1_0<'data>,
+}
+
+#[derive(Debug)]
+pub struct RawTextStructIterator_1_1<'data> {
+    delegate: RawTextStructIterator_1_0<'data>,
+}
+
+impl<'data> LazyRawValuePrivate<'data> for LazyRawTextValue_1_1<'data> {
+    fn field_name(&self) -> IonResult<RawSymbolTokenRef<'data>> {
+        self.encoded_value.field_name(self.input)
+    }
+}
+
+impl<'data> LazyRawValue<'data, TextEncoding_1_1> for LazyRawTextValue_1_1<'data> {
+    fn ion_type(&self) -> IonType {
+        self.encoded_value.ion_type()
+    }
+
+    fn is_null(&self) -> bool {
+        self.encoded_value.is_null()
+    }
+
+    fn annotations(&self) -> RawTextAnnotationsIterator<'data> {
+        let span = self
+            .encoded_value
+            .annotations_range()
+            .unwrap_or(self.input.offset()..self.input.offset());
+        let annotations_bytes = self
+            .input
+            .slice(span.start - self.input.offset(), span.len());
+        RawTextAnnotationsIterator::new(annotations_bytes)
+    }
+
+    fn read(&self) -> IonResult<RawValueRef<'data, TextEncoding_1_1>> {
+        let matched_input = self.input.slice(
+            self.encoded_value.data_offset() - self.input.offset(),
+            self.encoded_value.data_length(),
+        );
+        use crate::lazy::text::matched::MatchedValue::*;
+        let value_ref = match self.encoded_value.matched() {
+            Null(ion_type) => RawValueRef::Null(ion_type),
+            Bool(b) => RawValueRef::Bool(b),
+            Int(i) => RawValueRef::Int(i.read(matched_input)?),
+            Float(f) => RawValueRef::Float(f.read(matched_input)?),
+            Decimal(d) => RawValueRef::Decimal(d.read(matched_input)?),
+            Timestamp(t) => RawValueRef::Timestamp(t.read(matched_input)?),
+            String(s) => RawValueRef::String(s.read(matched_input)?),
+            Symbol(s) => RawValueRef::Symbol(s.read(matched_input)?),
+            Blob(b) => RawValueRef::Blob(b.read(matched_input)?),
+            Clob(c) => RawValueRef::Clob(c.read(matched_input)?),
+            List => RawValueRef::List(LazyRawTextList_1_1::from_value(*self)),
+            SExp => RawValueRef::SExp(LazyRawTextSExp_1_1::from_value(*self)),
+            Struct => RawValueRef::Struct(LazyRawTextStruct_1_1::from_value(*self)),
+        };
+        Ok(value_ref)
+    }
+}
+
+// ===== Convert 1.0 lazy values to 1.1 lazy values and vice versa ======
+// These conversions are only necessary for the placeholder implementations that pass through to
+// existing 1.0 parsing logic.
+
+impl<'data> From<LazyRawTextValue_1_1<'data>> for LazyRawTextValue_1_0<'data> {
+    fn from(value: LazyRawTextValue_1_1<'data>) -> Self {
+        LazyRawTextValue_1_0 {
+            encoded_value: value.encoded_value,
+            input: value.input,
+        }
+    }
+}
+
+impl<'data> From<LazyRawTextValue_1_0<'data>> for LazyRawTextValue_1_1<'data> {
+    fn from(value: LazyRawTextValue_1_0<'data>) -> Self {
+        LazyRawTextValue_1_1 {
+            encoded_value: value.encoded_value,
+            input: value.input,
+        }
+    }
+}
+
+// ===== Trait implementations =====
+
+impl<'data> LazyContainerPrivate<'data, TextEncoding_1_1> for LazyRawTextList_1_1<'data> {
+    fn from_value(value: LazyRawTextValue_1_1<'data>) -> Self {
+        LazyRawTextList_1_1 {
+            delegate: LazyRawTextList_1_0::from_value(LazyRawTextValue_1_0::from(value)),
+        }
+    }
+}
+
+impl<'data> LazyRawSequence<'data, TextEncoding_1_1> for LazyRawTextList_1_1<'data> {
+    type Iterator = RawTextListIterator_1_1<'data>;
+
+    fn annotations(&self) -> RawTextAnnotationsIterator<'data> {
+        self.delegate.annotations()
+    }
+
+    fn ion_type(&self) -> IonType {
+        self.delegate.ion_type()
+    }
+
+    fn iter(&self) -> Self::Iterator {
+        RawTextListIterator_1_1 {
+            delegate: LazyRawTextList_1_0::iter(&self.delegate),
+        }
+    }
+
+    fn as_value(&self) -> LazyRawTextValue_1_1<'data> {
+        self.delegate.value.into()
+    }
+}
+
+impl<'data> Iterator for RawTextListIterator_1_1<'data> {
+    type Item = IonResult<LazyRawTextValue_1_1<'data>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.delegate
+            .next()
+            .map(|result| result.map(|value| value.into()))
+    }
+}
+
+impl<'data> LazyContainerPrivate<'data, TextEncoding_1_1> for LazyRawTextSExp_1_1<'data> {
+    fn from_value(value: LazyRawTextValue_1_1<'data>) -> Self {
+        LazyRawTextSExp_1_1 {
+            delegate: LazyRawTextSExp_1_0::from_value(LazyRawTextValue_1_0::from(value)),
+        }
+    }
+}
+
+impl<'data> LazyRawSequence<'data, TextEncoding_1_1> for LazyRawTextSExp_1_1<'data> {
+    type Iterator = RawTextSExpIterator_1_1<'data>;
+
+    fn annotations(&self) -> RawTextAnnotationsIterator<'data> {
+        self.delegate.annotations()
+    }
+
+    fn ion_type(&self) -> IonType {
+        self.delegate.ion_type()
+    }
+
+    fn iter(&self) -> Self::Iterator {
+        RawTextSExpIterator_1_1 {
+            delegate: LazyRawTextSExp_1_0::iter(&self.delegate),
+        }
+    }
+
+    fn as_value(&self) -> LazyRawTextValue_1_1<'data> {
+        self.delegate.value.into()
+    }
+}
+
+impl<'data> Iterator for RawTextSExpIterator_1_1<'data> {
+    type Item = IonResult<LazyRawTextValue_1_1<'data>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.delegate
+            .next()
+            .map(|result| result.map(|value| value.into()))
+    }
+}
+
+impl<'data> LazyContainerPrivate<'data, TextEncoding_1_1> for LazyRawTextStruct_1_1<'data> {
+    fn from_value(value: LazyRawTextValue_1_1<'data>) -> Self {
+        LazyRawTextStruct_1_1 {
+            delegate: LazyRawTextStruct_1_0::from_value(LazyRawTextValue_1_0::from(value)),
+        }
+    }
+}
+
+impl<'data> LazyRawStruct<'data, TextEncoding_1_1> for LazyRawTextStruct_1_1<'data> {
+    type Field = LazyRawTextField_1_1<'data>;
+    type Iterator = RawTextStructIterator_1_1<'data>;
+
+    fn annotations(&self) -> RawTextAnnotationsIterator<'data> {
+        self.delegate.annotations()
+    }
+
+    fn find(&self, name: &str) -> IonResult<Option<LazyRawTextValue_1_1<'data>>> {
+        self.delegate
+            .find(name)
+            .map(|option| option.map(|value| value.into()))
+    }
+
+    fn iter(&self) -> Self::Iterator {
+        RawTextStructIterator_1_1 {
+            delegate: self.delegate.iter(),
+        }
+    }
+}
+
+impl<'data> LazyRawFieldPrivate<'data, TextEncoding_1_1> for LazyRawTextField_1_1<'data> {
+    fn into_value(self) -> LazyRawTextValue_1_1<'data> {
+        self.delegate.value.into()
+    }
+}
+
+impl<'data> LazyRawField<'data, TextEncoding_1_1> for LazyRawTextField_1_1<'data> {
+    fn name(&self) -> RawSymbolTokenRef<'data> {
+        self.delegate.name()
+    }
+
+    fn value(&self) -> LazyRawTextValue_1_1<'data> {
+        self.delegate.value().into()
+    }
+}
+
+impl<'data> Iterator for RawTextStructIterator_1_1<'data> {
+    type Item = IonResult<LazyRawTextField_1_1<'data>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.delegate
+            .next()
+            .map(|result| result.map(|field| LazyRawTextField_1_1 { delegate: field }))
+    }
+}

--- a/src/lazy/text/value.rs
+++ b/src/lazy/text/value.rs
@@ -1,20 +1,21 @@
+#![allow(non_camel_case_types)]
+
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 
-use crate::lazy::decoder::private::LazyRawValuePrivate;
-use crate::lazy::decoder::{LazyDecoder, LazyRawValue};
-use crate::lazy::encoding::TextEncoding;
+use crate::lazy::decoder::private::{LazyContainerPrivate, LazyRawValuePrivate};
+use crate::lazy::decoder::LazyRawValue;
+use crate::lazy::encoding::TextEncoding_1_0;
 use crate::lazy::raw_value_ref::RawValueRef;
 use crate::lazy::text::buffer::TextBufferView;
 use crate::lazy::text::encoded_value::EncodedTextValue;
-use crate::lazy::text::matched::MatchedValue;
-use crate::lazy::text::raw::r#struct::LazyRawTextStruct;
-use crate::lazy::text::raw::sequence::{LazyRawTextList, LazyRawTextSExp};
+use crate::lazy::text::raw::r#struct::LazyRawTextStruct_1_0;
+use crate::lazy::text::raw::sequence::{LazyRawTextList_1_0, LazyRawTextSExp_1_0};
 use crate::{IonResult, IonType, RawSymbolTokenRef};
 
 /// A value that has been identified in the text input stream but whose data has not yet been read.
 ///
-/// If only part of the value is in the input buffer, calls to [`LazyRawTextValue::read`] (which examines
+/// If only part of the value is in the input buffer, calls to [`LazyRawTextValue_1_0::read`] (which examines
 /// bytes beyond the value's header) may return [`IonError::Incomplete`](crate::result::IonError::Incomplete).
 ///
 /// `LazyRawTextValue`s are "unresolved," which is to say that symbol values, annotations, and
@@ -23,18 +24,18 @@ use crate::{IonResult, IonType, RawSymbolTokenRef};
 /// includes a text definition for these items whenever one exists, see
 /// [`crate::lazy::value::LazyValue`].
 #[derive(Copy, Clone)]
-pub struct LazyRawTextValue<'data> {
+pub struct LazyRawTextValue_1_0<'data> {
     pub(crate) encoded_value: EncodedTextValue,
     pub(crate) input: TextBufferView<'data>,
 }
 
-impl<'data> LazyRawValuePrivate<'data> for LazyRawTextValue<'data> {
+impl<'data> LazyRawValuePrivate<'data> for LazyRawTextValue_1_0<'data> {
     fn field_name(&self) -> IonResult<RawSymbolTokenRef<'data>> {
         self.encoded_value.field_name(self.input)
     }
 }
 
-impl<'data> LazyRawValue<'data, TextEncoding> for LazyRawTextValue<'data> {
+impl<'data> LazyRawValue<'data, TextEncoding_1_0> for LazyRawTextValue_1_0<'data> {
     fn ion_type(&self) -> IonType {
         self.encoded_value.ion_type()
     }
@@ -43,7 +44,7 @@ impl<'data> LazyRawValue<'data, TextEncoding> for LazyRawTextValue<'data> {
         self.encoded_value.is_null()
     }
 
-    fn annotations(&self) -> <TextEncoding as LazyDecoder<'data>>::AnnotationsIterator {
+    fn annotations(&self) -> RawTextAnnotationsIterator<'data> {
         let span = self
             .encoded_value
             .annotations_range()
@@ -54,40 +55,33 @@ impl<'data> LazyRawValue<'data, TextEncoding> for LazyRawTextValue<'data> {
         RawTextAnnotationsIterator::new(annotations_bytes)
     }
 
-    fn read(&self) -> IonResult<RawValueRef<'data, TextEncoding>> {
+    fn read(&self) -> IonResult<RawValueRef<'data, TextEncoding_1_0>> {
         let matched_input = self.input.slice(
             self.encoded_value.data_offset() - self.input.offset(),
             self.encoded_value.data_length(),
         );
+
+        use crate::lazy::text::matched::MatchedValue::*;
         let value_ref = match self.encoded_value.matched() {
-            MatchedValue::Null(ion_type) => RawValueRef::Null(ion_type),
-            MatchedValue::Bool(b) => RawValueRef::Bool(b),
-            MatchedValue::Int(i) => RawValueRef::Int(i.read(matched_input)?),
-            MatchedValue::Float(f) => RawValueRef::Float(f.read(matched_input)?),
-            MatchedValue::Decimal(d) => RawValueRef::Decimal(d.read(matched_input)?),
-            MatchedValue::Timestamp(t) => RawValueRef::Timestamp(t.read(matched_input)?),
-            MatchedValue::String(s) => RawValueRef::String(s.read(matched_input)?),
-            MatchedValue::Symbol(s) => RawValueRef::Symbol(s.read(matched_input)?),
-            MatchedValue::Blob(b) => RawValueRef::Blob(b.read(matched_input)?),
-            MatchedValue::Clob(c) => RawValueRef::Clob(c.read(matched_input)?),
-            MatchedValue::List => {
-                let lazy_list = LazyRawTextList { value: *self };
-                RawValueRef::List(lazy_list)
-            }
-            MatchedValue::SExp => {
-                let lazy_sexp = LazyRawTextSExp { value: *self };
-                RawValueRef::SExp(lazy_sexp)
-            }
-            MatchedValue::Struct => {
-                let lazy_struct = LazyRawTextStruct { value: *self };
-                RawValueRef::Struct(lazy_struct)
-            } // ...and the rest!
+            Null(ion_type) => RawValueRef::Null(ion_type),
+            Bool(b) => RawValueRef::Bool(b),
+            Int(i) => RawValueRef::Int(i.read(matched_input)?),
+            Float(f) => RawValueRef::Float(f.read(matched_input)?),
+            Decimal(d) => RawValueRef::Decimal(d.read(matched_input)?),
+            Timestamp(t) => RawValueRef::Timestamp(t.read(matched_input)?),
+            String(s) => RawValueRef::String(s.read(matched_input)?),
+            Symbol(s) => RawValueRef::Symbol(s.read(matched_input)?),
+            Blob(b) => RawValueRef::Blob(b.read(matched_input)?),
+            Clob(c) => RawValueRef::Clob(c.read(matched_input)?),
+            List => RawValueRef::List(LazyRawTextList_1_0::from_value(*self)),
+            SExp => RawValueRef::SExp(LazyRawTextSExp_1_0::from_value(*self)),
+            Struct => RawValueRef::Struct(LazyRawTextStruct_1_0::from_value(*self)),
         };
         Ok(value_ref)
     }
 }
 
-impl<'a> Debug for LazyRawTextValue<'a> {
+impl<'a> Debug for LazyRawTextValue_1_0<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -103,7 +97,7 @@ pub struct RawTextAnnotationsIterator<'data> {
 }
 
 impl<'data> RawTextAnnotationsIterator<'data> {
-    fn new(input: TextBufferView<'data>) -> Self {
+    pub(crate) fn new(input: TextBufferView<'data>) -> Self {
         RawTextAnnotationsIterator {
             input,
             has_returned_error: false,
@@ -142,7 +136,6 @@ impl<'data> Iterator for RawTextAnnotationsIterator<'data> {
 
 #[cfg(test)]
 mod tests {
-
     use crate::lazy::text::buffer::TextBufferView;
     use crate::lazy::text::value::RawTextAnnotationsIterator;
     use crate::{IonResult, RawSymbolTokenRef};

--- a/src/lazy/value.rs
+++ b/src/lazy/value.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use crate::lazy::decoder::{LazyDecoder, LazyRawValue};
-use crate::lazy::encoding::BinaryEncoding;
+use crate::lazy::encoding::BinaryEncoding_1_0;
 use crate::lazy::r#struct::LazyStruct;
 use crate::lazy::sequence::{LazyList, LazySExp};
 use crate::lazy::value_ref::ValueRef;
@@ -58,7 +58,7 @@ pub struct LazyValue<'top, 'data, D: LazyDecoder<'data>> {
     pub(crate) symbol_table: &'top SymbolTable,
 }
 
-pub type LazyBinaryValue<'top, 'data> = LazyValue<'top, 'data, BinaryEncoding>;
+pub type LazyBinaryValue<'top, 'data> = LazyValue<'top, 'data, BinaryEncoding_1_0>;
 
 impl<'top, 'data, D: LazyDecoder<'data>> LazyValue<'top, 'data, D> {
     pub(crate) fn new(


### PR DESCRIPTION
This PR makes superficial changes that affect a large number of lines of code:
* It stubs out the types necessary to introduce a raw text Ion 1.1 reader, providing those stub types with minimal implementations that forward calls to the existing 1.0 types/implementations. These types will be replaced by actual 1.1 implementations in subsequent PRs.
* It splits the `TextEncoding` type into `TextEncoding_1_0` and `TextEncoding_1_1`
* It renames `BinaryEncoding` to `BinaryEncoding_1_0` to make way for an eventual `BinaryEncoding_1_1`.

This PR contains no logic changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
