### PR TITLE
Initial implementation of the Ion 1.1 text reader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ num-integer = "0.1.44"
 num-traits = "0.2"
 arrayvec = "0.7"
 smallvec = {version ="1.9.0", features = ["const_generics"]}
+bumpalo = {version = "3.13.0", features = ["collections"]}
 digest = { version = "0.9", optional = true }
 sha2 = { version = "0.9", optional = true }
 

--- a/examples/lazy_read_all_values.rs
+++ b/examples/lazy_read_all_values.rs
@@ -74,7 +74,7 @@ mod lazy_reader_example {
     fn count_struct_children(lazy_struct: &LazyBinaryStruct) -> IonResult<usize> {
         let mut count = 0;
         for field in lazy_struct {
-            count += count_value_and_children(field?.value())?;
+            count += count_value_and_children(&field?.value())?;
         }
         Ok(count)
     }

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -362,10 +362,16 @@ impl IonOrd for Element {
 }
 
 /// An `(annotations, value)` pair representing an Ion value.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Element {
     annotations: Annotations,
     value: Value,
+}
+
+impl std::fmt::Debug for Element {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        <Element as Display>::fmt(self, f)
+    }
 }
 
 impl Element {

--- a/src/element/reader.rs
+++ b/src/element/reader.rs
@@ -67,7 +67,7 @@ pub trait ElementReader {
     /// returning the complete sequence as a `Vec<Element>`.
     ///
     /// If an error occurs while reading, returns `Err(IonError)`.
-    fn read_all_elements(&mut self) -> IonResult<Vec<Element>> {
+    fn read_all_elements(&mut self) -> IonResult<Sequence> {
         self.elements().collect()
     }
 }

--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -1,7 +1,6 @@
 #![allow(non_camel_case_types)]
 
 use std::fmt::Debug;
-use std::marker::PhantomData;
 
 use crate::lazy::binary::raw::annotations_iterator::RawBinaryAnnotationsIterator;
 use crate::lazy::binary::raw::r#struct::{LazyRawBinaryStruct, RawBinaryStructIterator};

--- a/src/lazy/binary/raw/reader.rs
+++ b/src/lazy/binary/raw/reader.rs
@@ -171,8 +171,8 @@ mod tests {
         let value = reader.next()?.expect_value()?;
         let lazy_struct = value.read()?.expect_struct()?;
         let mut fields = lazy_struct.iter();
-        let field1 = fields.next().expect("field 1")?;
-        assert_eq!(field1.name(), 4.as_raw_symbol_token_ref()); // 'name'
+        let (name, _value) = fields.next().expect("field 1")?.expect_name_value()?;
+        assert_eq!(name, 4.as_raw_symbol_token_ref()); // 'name'
         Ok(())
     }
 
@@ -191,13 +191,28 @@ mod tests {
         // Exercise the `Debug` impl
         println!("Lazy Raw Sequence: {:?}", lazy_list);
         let mut list_values = lazy_list.sequence.iter();
-        assert_eq!(list_values.next().expect("first")?.ion_type(), IonType::Int);
         assert_eq!(
-            list_values.next().expect("second")?.ion_type(),
+            list_values
+                .next()
+                .expect("first")?
+                .expect_value()?
+                .ion_type(),
+            IonType::Int
+        );
+        assert_eq!(
+            list_values
+                .next()
+                .expect("second")?
+                .expect_value()?
+                .ion_type(),
             IonType::Bool
         );
         assert_eq!(
-            list_values.next().expect("third")?.ion_type(),
+            list_values
+                .next()
+                .expect("third")?
+                .expect_value()?
+                .ion_type(),
             IonType::Symbol
         );
         Ok(())
@@ -219,7 +234,7 @@ mod tests {
                 RawStreamItem::VersionMarker(major, minor) => println!("IVM: v{}.{}", major, minor),
                 RawStreamItem::Value(value) => println!("{:?}", value.read()?),
                 RawStreamItem::EndOfStream => break,
-                RawStreamItem::MacroInvocation(_) => unreachable!("No macros in Ion 1.0"),
+                RawStreamItem::EExpression(_) => unreachable!("No macros in Ion 1.0"),
             }
         }
         Ok(())

--- a/src/lazy/bytes_ref.rs
+++ b/src/lazy/bytes_ref.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::Deref;
 
+#[derive(Clone)]
 pub struct BytesRef<'data> {
     data: Cow<'data, [u8]>,
 }

--- a/src/lazy/encoding.rs
+++ b/src/lazy/encoding.rs
@@ -1,29 +1,72 @@
 #![allow(non_camel_case_types)]
+
 use crate::lazy::binary::raw::annotations_iterator::RawBinaryAnnotationsIterator;
 use crate::lazy::binary::raw::r#struct::LazyRawBinaryStruct;
 use crate::lazy::binary::raw::reader::LazyRawBinaryReader;
 use crate::lazy::binary::raw::sequence::{LazyRawBinaryList, LazyRawBinarySExp};
 use crate::lazy::binary::raw::value::LazyRawBinaryValue;
-use crate::lazy::decoder::{LazyDecoder, LazyMacroInvocation};
+use crate::lazy::decoder::LazyDecoder;
+use crate::lazy::expanded::macro_evaluator::{ArgumentKind, MacroInvocation, ToArgumentKind};
+use crate::lazy::expanded::EncodingContext;
 use crate::lazy::text::raw::r#struct::LazyRawTextStruct_1_0;
-use crate::lazy::text::raw::reader::LazyRawTextReader;
+use crate::lazy::text::raw::reader::LazyRawTextReader_1_0;
 use crate::lazy::text::raw::sequence::{LazyRawTextList_1_0, LazyRawTextSExp_1_0};
-use crate::lazy::text::value::{LazyRawTextValue_1_0, RawTextAnnotationsIterator};
+use crate::lazy::text::raw::v1_1::reader::{
+    LazyRawTextList_1_1, LazyRawTextReader_1_1, LazyRawTextSExp_1_1, LazyRawTextStruct_1_1,
+    MacroIdRef, RawTextMacroInvocation,
+};
+use crate::lazy::text::value::{
+    LazyRawTextValue_1_0, LazyRawTextValue_1_1, MatchedRawTextValue, RawTextAnnotationsIterator,
+};
+use crate::IonResult;
 
 // These types derive trait implementations in order to allow types that containing them
 // to also derive trait implementations.
 
 /// Marker trait for binary encodings of any version.
-pub trait LazyBinaryDecoder {}
+pub trait BinaryEncoding {}
+
+/// Marker trait for encodings that support macros.
+pub trait EncodingWithMacroSupport {}
+impl EncodingWithMacroSupport for TextEncoding_1_1 {}
+
+/// Marker trait for text encodings.
+pub trait TextEncoding<'data>:
+    LazyDecoder<'data, AnnotationsIterator = RawTextAnnotationsIterator<'data>>
+{
+    fn value_from_matched(
+        matched: MatchedRawTextValue<'data>,
+    ) -> <Self as LazyDecoder<'data>>::Value;
+}
+impl<'data> TextEncoding<'data> for TextEncoding_1_0 {
+    fn value_from_matched(
+        matched: MatchedRawTextValue<'data>,
+    ) -> <Self as LazyDecoder<'data>>::Value {
+        LazyRawTextValue_1_0::from(matched)
+    }
+}
+impl<'data> TextEncoding<'data> for TextEncoding_1_1 {
+    fn value_from_matched(
+        matched: MatchedRawTextValue<'data>,
+    ) -> <Self as LazyDecoder<'data>>::Value {
+        LazyRawTextValue_1_1::from(matched)
+    }
+}
 
 /// The Ion 1.0 binary encoding.
 #[derive(Clone, Debug)]
 pub struct BinaryEncoding_1_0;
-impl LazyBinaryDecoder for BinaryEncoding_1_0 {}
+impl BinaryEncoding for BinaryEncoding_1_0 {}
 
 /// The Ion 1.0 text encoding.
 #[derive(Clone, Debug)]
 pub struct TextEncoding_1_0;
+
+/// An uninhabited type that signals to the compiler that related code paths are not reachable.
+#[derive(Debug, Copy, Clone)]
+pub enum Never {
+    // Has no variants, cannot be instantiated.
+}
 
 impl<'data> LazyDecoder<'data> for BinaryEncoding_1_0 {
     type Reader = LazyRawBinaryReader<'data>;
@@ -33,21 +76,58 @@ impl<'data> LazyDecoder<'data> for BinaryEncoding_1_0 {
     type Struct = LazyRawBinaryStruct<'data>;
     type AnnotationsIterator = RawBinaryAnnotationsIterator<'data>;
     // Macros are not supported in Ion 1.0
-    type MacroInvocation = ();
+    type MacroInvocation = Never;
 }
 
 impl<'data> LazyDecoder<'data> for TextEncoding_1_0 {
-    type Reader = LazyRawTextReader<'data>;
+    type Reader = LazyRawTextReader_1_0<'data>;
     type Value = LazyRawTextValue_1_0<'data>;
     type SExp = LazyRawTextSExp_1_0<'data>;
     type List = LazyRawTextList_1_0<'data>;
     type Struct = LazyRawTextStruct_1_0<'data>;
     type AnnotationsIterator = RawTextAnnotationsIterator<'data>;
     // Macros are not supported in Ion 1.0
-    type MacroInvocation = ();
+    type MacroInvocation = Never;
 }
 
-// Ion 1.0 uses `()` as a placeholder for MacroInvocation.
-impl<'data, D: LazyDecoder<'data>> LazyMacroInvocation<'data, D> for () {
-    // Nothing for now.
+// Ion 1.0 uses `Never` as a placeholder type for MacroInvocation.
+// The compiler should optimize these methods away.
+impl<'data, D: LazyDecoder<'data>> MacroInvocation<'data, D> for Never {
+    type ArgumentExpr = Never;
+    // This uses a Box<dyn> to avoid defining yet another placeholder type.
+    type ArgumentsIterator = Box<dyn Iterator<Item = IonResult<Never>>>;
+
+    fn id(&self) -> MacroIdRef<'_> {
+        unreachable!("macro in Ion 1.0 (method: id)")
+    }
+
+    fn arguments(&self) -> Self::ArgumentsIterator {
+        unreachable!("macro in Ion 1.0 (method: arguments)")
+    }
+}
+
+impl<'data, D: LazyDecoder<'data>> ToArgumentKind<'data, D, Self> for Never {
+    fn to_arg_expr<'top>(
+        self,
+        _context: EncodingContext<'top>,
+    ) -> ArgumentKind<'top, 'data, D, Self>
+    where
+        Self: 'top,
+    {
+        unreachable!("macro in Ion 1.0 (method: to_value_expr)")
+    }
+}
+
+// The Ion 1.1 text encoding.
+#[derive(Clone, Debug)]
+pub struct TextEncoding_1_1;
+
+impl<'data> LazyDecoder<'data> for TextEncoding_1_1 {
+    type Reader = LazyRawTextReader_1_1<'data>;
+    type Value = LazyRawTextValue_1_1<'data>;
+    type SExp = LazyRawTextSExp_1_1<'data>;
+    type List = LazyRawTextList_1_1<'data>;
+    type Struct = LazyRawTextStruct_1_1<'data>;
+    type AnnotationsIterator = RawTextAnnotationsIterator<'data>;
+    type MacroInvocation = RawTextMacroInvocation<'data>;
 }

--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -1,0 +1,35 @@
+//! Types and traits representing an e-expression in an Ion stream.
+
+use crate::lazy::decoder::{LazyDecoder, LazyRawValueExpr};
+use crate::lazy::expanded::macro_evaluator::{ArgumentKind, ToArgumentKind};
+use crate::lazy::expanded::{EncodingContext, ExpandedValueSource, LazyExpandedValue};
+
+// When a `LazyRawValueExpr` appears in argument position within an e-expression, this trait
+// implementation recognizes it as either a value or another macro invocation.
+impl<'data, D: LazyDecoder<'data>> ToArgumentKind<'data, D, D::MacroInvocation>
+    for LazyRawValueExpr<'data, D>
+{
+    fn to_arg_expr<'top>(
+        self,
+        context: EncodingContext<'top>,
+    ) -> ArgumentKind<'top, 'data, D, D::MacroInvocation>
+    where
+        Self: 'top,
+    {
+        match self {
+            // In this implementation, we're reading arguments to an E-expression in the data stream.
+            // Because e-expressions appear in the data stream (and not in a template), there is no
+            // environment of named variables. We do not attempt to resolve symbols as though they
+            // were variable names and instead pass them along as value literals.
+            LazyRawValueExpr::ValueLiteral(value) => {
+                ArgumentKind::ValueLiteral(LazyExpandedValue {
+                    context,
+                    source: ExpandedValueSource::ValueLiteral(value),
+                })
+            }
+            LazyRawValueExpr::MacroInvocation(invocation) => {
+                ArgumentKind::MacroInvocation(invocation)
+            }
+        }
+    }
+}

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -1,0 +1,782 @@
+//! Traits and types to evaluate e-expressions and template macro invocations.
+//!
+//! Macro invocations can appear in two different contexts:
+//!   1. As an *encoding expression* (e-expression) in the data stream. In text Ion, this is written
+//!      out using `(:macro_id param1 param2 [...] paramN)` syntax. E-expressions can be found
+//!      anywhere that an Ion value literal can appear, including nested within containers or as
+//!      arguments to other e-expressions.
+//!   2. As an unquoted s-expression within the body of a template macro.
+//!
+//! The evaluation logic is the same for macros in both contexts, though there are differences in
+//! encoding and argument handling that must be considered. For more information, see the
+//! documentation for the types below.
+
+use std::fmt::{Debug, Formatter};
+use std::marker::PhantomData;
+
+use bumpalo::collections::{String as BumpString, Vec as BumpVec};
+
+use crate::lazy::decoder::LazyDecoder;
+use crate::lazy::expanded::macro_table::MacroKind;
+use crate::lazy::expanded::stack::Stack;
+use crate::lazy::expanded::EncodingContext;
+use crate::lazy::expanded::{ExpandedValueRef, ExpandedValueSource, LazyExpandedValue};
+use crate::lazy::str_ref::StrRef;
+use crate::lazy::text::raw::v1_1::reader::MacroIdRef;
+use crate::result::IonFailure;
+use crate::{IonError, IonResult, RawSymbolTokenRef, Sequence};
+
+/// A syntactic entity that represents the invocation of a macro in some context.
+///
+/// This entity may be an item from a binary stream, a text stream, or a template definition.
+/// Implementors must specify how their type can be mapped to a macro ID and a sequence of arguments.
+pub trait MacroInvocation<'data, D: LazyDecoder<'data>>: Copy + Clone + Debug {
+    /// A syntax-specific type that represents an argument in this macro invocation.
+    type ArgumentExpr: ToArgumentKind<'data, D, Self>;
+
+    /// An iterator that yields the macro invocation's arguments in order.
+    type ArgumentsIterator: Iterator<Item = IonResult<Self::ArgumentExpr>>;
+
+    /// The macro name or address specified at the head of this macro invocation.
+    fn id(&self) -> MacroIdRef;
+
+    /// The arguments that follow the macro name or address in this macro invocation.
+    fn arguments(&self) -> Self::ArgumentsIterator;
+}
+
+/// A single expression appearing in argument position within a macro invocation.
+pub enum ArgumentKind<'top, 'data: 'top, D: LazyDecoder<'data>, M: MacroInvocation<'data, D>> {
+    /// An Ion value that requires no further evaluation.
+    ValueLiteral(LazyExpandedValue<'top, 'data, D>),
+    /// A variable name that requires expansion.
+    Variable(RawSymbolTokenRef<'top>),
+    /// A macro invocation that requires evaluation.
+    MacroInvocation(M),
+}
+
+/// Converts a syntactic element appearing in argument position into an [`ArgumentKind`] using the
+/// provided [`EncodingContext`].
+pub trait ToArgumentKind<'data, D: LazyDecoder<'data>, M: MacroInvocation<'data, D>> {
+    fn to_arg_expr<'top>(self, context: EncodingContext<'top>) -> ArgumentKind<'top, 'data, D, M>
+    where
+        Self: 'top;
+}
+
+/// Indicates which of the supported macros this represents and stores the state necessary to
+/// continue evaluating that macro.
+pub enum MacroExpansionKind<'data, D: LazyDecoder<'data>, M: MacroInvocation<'data, D>> {
+    Void,
+    Values(ValuesExpansion<'data, D, M>),
+    MakeString(MakeStringExpansion<'data, D, M>),
+    // TODO: The others, including template macros.
+    // TODO: Treat variables as a special kind of macro invocation, similar to `values` but without
+    //       an accessible entry in the macro table.
+}
+
+/// A macro in the process of being evaluated. Stores both the state of the evaluation and the
+/// syntactic element that represented the macro invocation.
+pub struct MacroExpansion<'data, D: LazyDecoder<'data>, M: MacroInvocation<'data, D>> {
+    kind: MacroExpansionKind<'data, D, M>,
+    invocation: M,
+}
+
+impl<'data, D: LazyDecoder<'data>, M: MacroInvocation<'data, D>> Debug
+    for MacroExpansion<'data, D, M>
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<expansion of {:?}>", self.invocation)
+    }
+}
+
+impl<'data, D: LazyDecoder<'data>, M: MacroInvocation<'data, D>> MacroExpansion<'data, D, M> {
+    /// Continues evaluating this macro until it:
+    ///   * produces another value.
+    ///   * encounters another macro or variable that needs to be expanded.
+    ///   * is completed.
+    fn next<'top>(
+        &mut self,
+        context: EncodingContext<'top>,
+    ) -> IonResult<MacroExpansionStep<'top, 'data, D, M>>
+    where
+        M: 'data + 'top,
+    {
+        use MacroExpansionKind::*;
+        // Delegate the call to `next()` based on the macro kind.
+        match &mut self.kind {
+            MakeString(make_string_expansion) => make_string_expansion.next(context),
+            Values(values_expansion) => values_expansion.next(context),
+            // `void` is trivial and requires no delegation
+            Void => Ok(MacroExpansionStep::Complete),
+        }
+    }
+}
+
+/// Represents a single step in the process of evaluating a macro.
+pub enum MacroExpansionStep<'top, 'data: 'top, D: LazyDecoder<'data>, M: MacroInvocation<'data, D>>
+{
+    /// The next value produced by continuing the macro evaluation.
+    ExpandedValue(LazyExpandedValue<'top, 'data, D>),
+    /// Another macro that will need to be evaluated before an expanded value can be returned.
+    AnotherMacroToEvaluate(M),
+    /// This macro will not produce any further values.
+    Complete,
+}
+
+/// Evaluates macro invocations recursively, yielding a single expanded value at a time.
+///
+/// This evaluator can be used in a variety of contexts. It supports the cross product of three
+/// use case dimensions:
+///
+///   {e-expression, template macro invocation}
+///   x {text, binary}
+///   x {eager, lazy}
+pub struct MacroEvaluator<
+    'data,
+    // The Ion format of the data stream
+    D: LazyDecoder<'data>,
+    // The syntactic element representing the e-expression or template macro invocation
+    M: MacroInvocation<'data, D>,
+    // The storage being used to store the macro expansion stack. (Either a long-lived `Vec` or
+    // a bumpalo [`Bump`](BumpVec) whose contents only live as long as the reader is parked on
+    // the same top-level value).
+    S: Stack<MacroExpansion<'data, D, M>>,
+> {
+    // A stack of all of the macro invocations currently being evaluated.
+    macro_stack: S,
+    spooky: PhantomData<(&'data D, &'data M)>,
+}
+
+impl<
+        'data,
+        D: LazyDecoder<'data>,
+        M: MacroInvocation<'data, D>,
+        S: Stack<MacroExpansion<'data, D, M>>,
+    > MacroEvaluator<'data, D, M, S>
+{
+    /// Constructs a `MacroEvaluator` that uses storage with a static lifetime.
+    pub fn new() -> MacroEvaluator<'data, D, M, Vec<MacroExpansion<'data, D, M>>> {
+        MacroEvaluator {
+            macro_stack: Vec::new(),
+            spooky: PhantomData,
+        }
+    }
+
+    /// Constructs a `MacroEvaluator` with a lifetime tied to the current [`EncodingContext`].
+    pub fn new_transient<'top>(
+        context: EncodingContext<'top>,
+    ) -> MacroEvaluator<'data, D, M, BumpVec<MacroExpansion<'data, D, M>>> {
+        MacroEvaluator {
+            macro_stack: BumpVec::new_in(context.allocator),
+            spooky: PhantomData,
+        }
+    }
+
+    /// Finds the macro corresponding to the ID in the invocation in the specified encoding context.
+    /// Returns an error if the macro cannot be found. Otherwise, returns a [`MacroExpansion`]
+    /// containing the original invocation and the initialized state needed to evaluate it.
+    fn resolve_invocation<'top>(
+        context: EncodingContext<'top>,
+        invocation_to_evaluate: M,
+        initial_eval_stack_depth: usize,
+    ) -> IonResult<MacroExpansion<'data, D, M>> {
+        // Get the `MacroKind` corresponding to the given ID. It contains either a name (`&str`) or
+        // an address (`usize`).
+        let macro_kind = match invocation_to_evaluate.id() {
+            MacroIdRef::LocalName(name) => {
+                context.macro_table.macro_with_name(name).ok_or_else(|| {
+                    IonError::decoding_error(format!(
+                        "unrecognized macro name '{name}' in {:?}",
+                        invocation_to_evaluate
+                    ))
+                })
+            }
+            MacroIdRef::LocalAddress(address) => context
+                .macro_table
+                .macro_at_address(address)
+                .ok_or_else(|| {
+                    IonError::decoding_error(format!(
+                        "invalid macro address '{address}' in {:?}",
+                        invocation_to_evaluate
+                    ))
+                }),
+        }?;
+
+        // Initialize a `MacroExpansionKind` with the state necessary to evaluate the requested
+        // macro.
+        let expansion_kind = match macro_kind {
+            MacroKind::Void => MacroExpansionKind::Void,
+            MacroKind::Values => MacroExpansionKind::Values(ValuesExpansion {
+                arguments: invocation_to_evaluate.arguments(),
+                initial_eval_stack_depth,
+            }),
+            MacroKind::MakeString => MacroExpansionKind::MakeString(MakeStringExpansion::new(
+                invocation_to_evaluate.arguments(),
+            )),
+        };
+        Ok(MacroExpansion {
+            kind: expansion_kind,
+            invocation: invocation_to_evaluate,
+        })
+    }
+
+    /// Given a syntactic element representing a macro invocation, attempt to resolve it with the
+    /// current encoding context and push the resulting `MacroExpansion` onto the stack.
+    pub fn push(&mut self, context: EncodingContext, invocation: M) -> IonResult<()> {
+        let expansion = Self::resolve_invocation(context, invocation, self.stack_depth() + 1)?;
+        self.macro_stack.push(expansion);
+        Ok(())
+    }
+
+    /// The number of macros in the process of being evaluated.
+    pub fn stack_depth(&self) -> usize {
+        self.macro_stack.len()
+    }
+
+    /// Continues evaluating the macro at the top of the stack until either:
+    ///   * a value is yielded
+    ///   * the evaluation of the macro at stack depth `depth_to_exhaust` is completed
+    ///
+    /// If a macro invocation is encountered in the process of expanding the next value, that
+    /// invocation will be pushed onto the stack. This means that the stack's depth can grow
+    /// by any number of levels in a single call to `next()`. (Note though that macros do not
+    /// support recursion, so it is not trivial to grow the stack to great depths.)
+    ///
+    /// If `depth_to_exhaust` is the stack's current depth, `next()` will return `None` when the
+    /// macro at the top of the stack is completed/popped off the stack. If `depth_to_exhaust`
+    /// is `0`, `next()` will return `None` when all macros on the stack are exhausted.
+    ///
+    /// The caller must verify that the stack's depth is greater than or equal to `depth_to_exhaust`
+    /// before calling `next()`.
+    pub fn next<'top>(
+        &mut self,
+        context: EncodingContext<'top>,
+        depth_to_exhaust: usize,
+    ) -> IonResult<Option<LazyExpandedValue<'top, 'data, D>>>
+    where
+        'data: 'top,
+    {
+        debug_assert!(
+            self.stack_depth() >= depth_to_exhaust,
+            "asked to exhaust a macro at an invalid depth"
+        );
+        loop {
+            // Get the expansion at the top of the stack.
+            let current_expansion = match self.macro_stack.peek_mut() {
+                // NOTE: If the user specifies a `depth_to_exhaust` of 0, this is where the loop
+                //       will end. Behaviorally, this is identical to a `depth_to_exhaust` of 1,
+                //       which would return `Ok(None)` at the bottom of this method. It is always
+                //       legal to call `next()` with a `depth_to_exhaust` of 0; however, it is
+                //       illegal to call it with a `depth_to_exhaust` of 1 when the stack is empty.
+                None => return Ok(None),
+                Some(expansion) => expansion,
+            };
+
+            // Ask that expansion to continue its evaluation by one step.
+            use MacroExpansionStep::*;
+            match current_expansion.next(context)? {
+                // If we get a value, return it to the caller.
+                ExpandedValue(value) => return Ok(Some(value)),
+                // If we get another macro, push it onto the stack and continue evaluation.
+                AnotherMacroToEvaluate(invocation) => {
+                    // If we encounter another macro invocation, put it on top of the stack.
+                    self.push(context, invocation)?;
+                    continue;
+                }
+                // If the current macro reports that its expansion is complete...
+                Complete => {
+                    // ...pop it off the stack...
+                    let _popped = self.macro_stack.pop().unwrap();
+                    // ...and see that was the macro the caller was interested in evaluating.
+                    if self.stack_depth() < depth_to_exhaust {
+                        // If so, there are no more values to yield, even though there may still
+                        // be macros on the stack.
+                        return Ok(None);
+                    }
+                    // Otherwise, the caller is interested in one of the previously invoked macros.
+                    continue;
+                }
+            }
+        }
+    }
+
+    /// Attempts to resolve the provided `invocation` in the specified `context`. Upon success,
+    /// returns an iterator that lazily computes the expansion of the macro invocation and yields
+    /// its values.
+    pub(crate) fn evaluate<'top>(
+        &mut self,
+        context: EncodingContext<'top>,
+        invocation: M,
+    ) -> IonResult<EvaluatingIterator<'_, 'top, 'data, D, M, S>> {
+        self.push(context, invocation)?;
+        Ok(EvaluatingIterator::new(self, context))
+    }
+}
+
+// ===== Type aliases for commonly used flavors of `MacroEvaluator` =====
+
+/// A [`MacroEvaluator`] for expanding e-expressions found in the data stream of the format `D`.
+pub type EExpEvaluator<'data, D> = MacroEvaluator<
+    'data,
+    D,
+    <D as LazyDecoder<'data>>::MacroInvocation,
+    // A Vec with a static lifetime allows this to carry state over between top-level values.
+    Vec<MacroExpansion<'data, D, <D as LazyDecoder<'data>>::MacroInvocation>>,
+>;
+
+/// Like [`EExpEvaluator`], but can only be used for the duration of the lifetime `'top`. This is
+/// used when a macro expansion needs to perform expansions of its own without yielding flow control
+/// to the primary evaluator.
+///
+/// For example, the `(:make_string ...)` macro needs to evaluate each of its arguments to produce
+/// a series of text values that it can concatenate. Those arguments may themselves be macro
+/// invocations. However, we need to eagerly evaluate them to return `:make_string`'s only output
+/// value:
+///
+/// ```ion_1_1
+///     (:make_string
+///         (:values a b c)      // Macro invocation argument
+///         (:make_string d e)   // Macro invocation argument
+///         f)                   // => "abcdef"
+/// ```
+///
+/// The MacroExpansion holding `:make_string`'s mutable state lives in the stack of the primary
+/// evaluator, making it (practically) impossible to modify the stack by pushing another
+/// MacroExpansion onto it. Instead, it creates an evaluator of its own using short-lived,
+/// bump-allocated storage and fully evaluates each argument.
+pub type TransientEExpEvaluator<'top, 'data, D> = MacroEvaluator<
+    'data,
+    D,
+    <D as LazyDecoder<'data>>::MacroInvocation,
+    // A BumpVec allows us to very cheaply store state knowing that it must be discarded when the
+    // reader advances to the next top-level value.
+    BumpVec<'top, MacroExpansion<'data, D, <D as LazyDecoder<'data>>::MacroInvocation>>,
+>;
+
+/// A [`MacroEvaluator`] for expanding macro invocations found in a template body, all in the context
+/// of a data stream in the format `D`.
+pub type TdlTemplateEvaluator<'top, 'data, D> =
+    MacroEvaluator<'data, D, &'top Sequence, Vec<MacroExpansion<'data, D, &'top Sequence>>>;
+
+/// Yields the values produced by incrementally evaluating the macro that was at the top of the
+/// evaluator's stack when the iterator was created.
+pub struct EvaluatingIterator<
+    'iter,
+    'top: 'iter,
+    'data: 'top,
+    D: LazyDecoder<'data>,
+    M: MacroInvocation<'data, D>,
+    S: Stack<MacroExpansion<'data, D, M>>,
+> {
+    evaluator: &'iter mut MacroEvaluator<'data, D, M, S>,
+    context: EncodingContext<'top>,
+    initial_stack_depth: usize,
+    spooky: PhantomData<&'data D>,
+}
+
+impl<
+        'iter,
+        'top: 'iter,
+        'data: 'top,
+        D: LazyDecoder<'data>,
+        M: MacroInvocation<'data, D>,
+        S: Stack<MacroExpansion<'data, D, M>>,
+    > EvaluatingIterator<'iter, 'top, 'data, D, M, S>
+{
+    pub fn new(
+        evaluator: &'iter mut MacroEvaluator<'data, D, M, S>,
+        context: EncodingContext<'top>,
+    ) -> Self {
+        let initial_stack_depth = evaluator.stack_depth();
+        Self {
+            evaluator,
+            context,
+            initial_stack_depth,
+            spooky: PhantomData,
+        }
+    }
+}
+
+impl<
+        'iter,
+        'top,
+        'data: 'top,
+        D: LazyDecoder<'data>,
+        M: MacroInvocation<'data, D>,
+        S: Stack<MacroExpansion<'data, D, M>>,
+    > Iterator for EvaluatingIterator<'iter, 'top, 'data, D, M, S>
+{
+    type Item = IonResult<LazyExpandedValue<'top, 'data, D>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.evaluator
+            .next(self.context, self.initial_stack_depth)
+            .transpose()
+    }
+}
+
+// ===== Implementation of the `values` macro =====
+
+/// The evaluation state of the `values` macro.
+///
+/// `(:values ...)` expands each of its arguments in turn, yielding individual values to the caller.
+///
+/// This allows a writer to group several expressions' output together into a single expression.
+///
+/// Examples:
+///   (:values 1)                 => 1
+///   (:values 1 2 3)             => 1 2 3
+///   (:values 1 2 (:values 3 4)) => 1 2 3 4
+pub struct ValuesExpansion<'data, D: LazyDecoder<'data>, M: MacroInvocation<'data, D>> {
+    // Which argument the macro is in the process of expanding
+    arguments: M::ArgumentsIterator,
+    // The stack depth where this `values` call lives. When the stack shrinks below this depth,
+    // evaluation is complete.
+    initial_eval_stack_depth: usize,
+}
+
+impl<'data, D: LazyDecoder<'data>, M: MacroInvocation<'data, D>> ValuesExpansion<'data, D, M> {
+    pub fn new(arguments: M::ArgumentsIterator, initial_eval_stack_depth: usize) -> Self {
+        Self {
+            arguments,
+            initial_eval_stack_depth,
+        }
+    }
+
+    /// Yields the next [`MacroExpansionStep`] in this macro's evaluation.
+    pub fn next<'top>(
+        &mut self,
+        context: EncodingContext<'top>,
+    ) -> IonResult<MacroExpansionStep<'top, 'data, D, M>>
+    where
+        M: 'top,
+    {
+        // We visit the argument expressions in the invocation in order from left to right.
+        let arg_expr = match self.arguments.next() {
+            Some(Err(e)) => return Err(e),
+            Some(Ok(arg)) => arg.to_arg_expr(context),
+            None => return Ok(MacroExpansionStep::Complete),
+        };
+
+        match arg_expr {
+            // If the argument is a value, return it.
+            ArgumentKind::ValueLiteral(value) => Ok(MacroExpansionStep::ExpandedValue(value)),
+            ArgumentKind::Variable(_variable) => todo!("variable expansion"),
+            // If the argument is a macro invocation, yield it that so the evaluator can push it onto the stack.
+            ArgumentKind::MacroInvocation(invocation) => {
+                Ok(MacroExpansionStep::AnotherMacroToEvaluate(invocation))
+            }
+        }
+    }
+}
+
+// ===== Implementation of the `make_string` macro =====
+
+/// The evaluation state of the `make_string` macro.
+///
+/// `(:make_string ...)` eagerly expands each of its arguments in turn, concatenating the resulting
+/// string and symbol values in order to make a single string.
+///
+/// This allows a writer to construct a string from fragments, some or all of which may reside
+/// in the symbol or macro tables.
+///
+/// If any of the arguments expand to a non-text value, `make_string` will return an error.
+///
+/// Examples:
+///   (:make_string "foo" "bar")              => "foobar"
+///   (:make_string foo bar)                  => "foobar"
+///   (:make_string "foo" bar)                => "foobar"
+///   (:make_string "first_" $4)              => "first_name"
+///   (:make_string (:values "first" "_") $4) => "first_name"
+///   (:make_string)                          => ""
+///   (:make_string "foo" 7)                  => Error
+pub struct MakeStringExpansion<'data, D: LazyDecoder<'data>, M: MacroInvocation<'data, D>> {
+    arguments: M::ArgumentsIterator,
+    is_complete: bool,
+    spooky: PhantomData<M>,
+}
+
+impl<'data, D: LazyDecoder<'data>, M: MacroInvocation<'data, D>> MakeStringExpansion<'data, D, M> {
+    pub fn new(arguments: M::ArgumentsIterator) -> Self {
+        Self {
+            arguments,
+            is_complete: false,
+            spooky: Default::default(),
+        }
+    }
+
+    /// Yields the next [`MacroExpansionStep`] in this macro's evaluation.
+    pub fn next<'top>(
+        &mut self,
+        context: EncodingContext<'top>,
+    ) -> IonResult<MacroExpansionStep<'top, 'data, D, M>>
+    where
+        M: 'data + 'top,
+    {
+        // `make_string` always produces a single value. Once that value has been returned, it needs
+        // to report `Complete` on the following call to `next()`.
+        if self.is_complete {
+            return Ok(MacroExpansionStep::Complete);
+        }
+
+        // Create a bump-allocated buffer to hold our constructed string
+        let mut buffer = BumpString::new_in(context.allocator);
+
+        // We need to eagerly evaluate all of the arguments to `make_string` to produce its next
+        // (and only) value. However, because `&mut self` (the expansion state) lives in a stack
+        // inside the evaluator, we cannot get a simultaneous mutable reference to the evaluator
+        // itself. Instead, we use the bump allocator the make a transient macro evaluator
+        // whose resources can be trivially reclaimed when the expansion is done.
+        let mut evaluator =
+            MacroEvaluator::<'data, D, M, BumpVec<'top, MacroExpansion<D, M>>>::new();
+
+        for arg in self.arguments.by_ref() {
+            let arg_expr: ArgumentKind<D, M> = arg?.to_arg_expr(context);
+            match arg_expr {
+                ArgumentKind::ValueLiteral(value) => {
+                    Self::append_expanded_raw_text_value(context, &mut buffer, value.read()?)?
+                }
+                ArgumentKind::Variable(_variable) => todo!("variable expansion"),
+                ArgumentKind::MacroInvocation(invocation) => {
+                    for value_result in evaluator.evaluate(context, invocation)? {
+                        let value = value_result?;
+                        let expanded = value.read()?;
+                        Self::append_expanded_raw_text_value(context, &mut buffer, expanded)?
+                    }
+                }
+            }
+        }
+
+        let empty_annotations = BumpVec::new_in(context.allocator);
+
+        // Convert our BumpString<'bump> into a &'bump str that we can wrap in an `ExpandedValueRef`
+        let constructed_text = buffer.into_bump_str();
+        let expanded_value_ref = ExpandedValueRef::String(StrRef::from(constructed_text));
+
+        self.is_complete = true;
+
+        Ok(MacroExpansionStep::ExpandedValue(LazyExpandedValue {
+            context,
+            source: ExpandedValueSource::Constructed((empty_annotations, expanded_value_ref)),
+        }))
+    }
+
+    /// Appends a string fragment to the `BumpString` being constructed.
+    fn append_expanded_raw_text_value(
+        context: EncodingContext<'_>,
+        buffer: &mut BumpString,
+        value: ExpandedValueRef<'_, 'data, D>,
+    ) -> IonResult<()> {
+        match value {
+            ExpandedValueRef::String(text) => buffer.push_str(text.as_ref()),
+            ExpandedValueRef::Symbol(RawSymbolTokenRef::Text(text)) => {
+                buffer.push_str(text.as_ref())
+            }
+            ExpandedValueRef::Symbol(RawSymbolTokenRef::SymbolId(sid)) => {
+                let symbol = context.symbol_table.symbol_for(sid).ok_or_else(|| {
+                    IonError::decoding_error(format!(
+                        "found unknown symbol ID {sid} in call to `make_string`"
+                    ))
+                })?;
+                if let Some(text) = symbol.text() {
+                    buffer.push_str(text);
+                } else {
+                    return IonResult::decoding_error(format!(
+                        "found a symbol ID {sid} with unknown text in call to `make_string`"
+                    ));
+                }
+            }
+            other => {
+                return IonResult::decoding_error(format!(
+                    "found a non-text parameter to `make_string`: {:?}",
+                    other
+                ))
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bumpalo::Bump as BumpAllocator;
+
+    use crate::lazy::decoder::LazyRawReader;
+    use crate::lazy::encoding::TextEncoding_1_1;
+    use crate::lazy::expanded::macro_evaluator::TdlTemplateEvaluator;
+    use crate::lazy::expanded::macro_table::MacroTable;
+    use crate::lazy::expanded::EncodingContext;
+    use crate::lazy::expanded::ExpandedStreamItem;
+    use crate::lazy::expanded::LazyExpandingReader;
+    use crate::lazy::reader::LazyTextReader_1_1;
+    use crate::lazy::text::raw::v1_1::reader::LazyRawTextReader_1_1;
+    use crate::{Element, ElementReader, IonResult, SymbolTable};
+
+    /// Reads `input` and `expected` using an expanding reader and asserts that their output
+    /// is the same.
+    fn eval_enc_expr<'data>(input: &'data str, expected: &'data str) -> IonResult<()> {
+        let mut actual_reader = LazyTextReader_1_1::new(input.as_bytes())?;
+        let actual = actual_reader.read_all_elements()?;
+
+        let mut expected_reader = LazyTextReader_1_1::new(expected.as_bytes())?;
+        // For the moment, this is using the old reader impl.
+        let expected = expected_reader.read_all_elements()?;
+
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    /// Constructs a TdlTemplateEvaluator and evaluates the TDL macro invocation.
+    /// Note that the current implementation of TDL template evaluation is very limited; templates
+    /// cannot:
+    /// * Be defined by an encoding directive
+    /// * Be invoked by an e-expression (that is: from a data stream)
+    /// * Have parameters
+    /// * Expand variables
+    ///
+    /// This test exists to demonstrate that macro evaluation within the TDL context works the
+    /// same as evaluation in the data stream.
+    fn eval_tdl_template_invocation(invocation: &str, expected: &str) -> IonResult<()> {
+        let macro_table = MacroTable::new();
+        let symbol_table = SymbolTable::new();
+        let allocator = BumpAllocator::new();
+        let context = EncodingContext::new(&macro_table, &symbol_table, &allocator);
+        let mut evaluator = TdlTemplateEvaluator::<TextEncoding_1_1>::new();
+        let invocation = Element::read_one(invocation)?;
+        let actuals = evaluator.evaluate(context, invocation.expect_sexp()?)?;
+        let raw_reader = LazyRawTextReader_1_1::new(expected.as_ref());
+        let mut expected_reader = LazyExpandingReader::<TextEncoding_1_1>::new(raw_reader);
+        for actual in actuals {
+            // Read the next expected value as a raw value, then wrap it in an `ExpandedRawValueRef`
+            // so it can be directly compared to the actual.
+            let expected = expected_reader.next(context)?.expect_value()?.read()?;
+            assert_eq!(actual?.read()?, expected);
+        }
+        assert!(matches!(
+            expected_reader.next(context),
+            Ok(ExpandedStreamItem::EndOfStream)
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn values_tdl_macro_invocation() -> IonResult<()> {
+        eval_tdl_template_invocation(
+            r"(values 1 2 (values 3 4 (values 5 6) 7 8) 9 10)",
+            "1 2 3 4 5 6 7 8 9 10",
+        )
+    }
+
+    #[test]
+    fn values_e_expression() -> IonResult<()> {
+        eval_enc_expr(
+            r"(:values 1 2 (:values 3 4 (:values 5 6) 7 8) 9 10)",
+            "1 2 3 4 5 6 7 8 9 10",
+        )
+    }
+
+    #[test]
+    fn void_e_expression() -> IonResult<()> {
+        eval_enc_expr(r"(:values (:void) (:void) (:void) )", "/* nothing */")
+    }
+
+    #[test]
+    fn void_tdl_macro_invocation() -> IonResult<()> {
+        eval_tdl_template_invocation(r"(values (void) (void) (void))", "/* nothing */")
+    }
+
+    #[test]
+    fn make_string_e_expression() -> IonResult<()> {
+        let e_expression = r#"
+        (:values
+            (:make_string foo bar baz)
+            (:make_string "foo" '''bar''' baz)
+            (:make_string "first " $4)
+            (:make_string "Hello" ", " "world!"))
+        "#;
+        eval_enc_expr(
+            e_expression,
+            r#" "foobarbaz" "foobarbaz" "first name" "Hello, world!" "#,
+        )
+    }
+
+    #[test]
+    fn make_string_tdl_macro_invocation() -> IonResult<()> {
+        let invocation = r#"
+        (values
+            (make_string "foo" '''bar''' "\x62\u0061\U0000007A")
+            (make_string 
+                '''Hello'''  
+                ''', '''
+                "world!"))
+        "#;
+        eval_tdl_template_invocation(invocation, r#" "foobarbaz" "Hello, world!" "#)
+    }
+
+    #[test]
+    fn e_expressions_inside_a_list() -> IonResult<()> {
+        eval_enc_expr(
+            "[1, 2, (:values 3 4), 5, 6, (:make_string (:values foo bar) baz), 7]",
+            r#"[1, 2, 3, 4, 5, 6, "foobarbaz", 7]"#,
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn e_expressions_inside_a_sexp() -> IonResult<()> {
+        eval_enc_expr(
+            "(1 2 (:values 3 4) 5 6 (:make_string (:values foo bar) baz) 7)",
+            r#"(1 2 3 4 5 6 "foobarbaz" 7)"#,
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn e_expressions_inside_a_struct() -> IonResult<()> {
+        eval_enc_expr(
+            r#"
+            {
+                a: 1,
+                
+                // When a macro in field value position produces more than one value,
+                // a field will be emitted for each value. The same field name will be used for
+                // each one.
+                b: (:values 2 3),
+                
+                c: 4,
+                
+                // If the value-position-macro doesn't produce any values, the field will not
+                // appear in the expansion.
+                d: (:void),
+                
+                // If a single value is produced, a single field with that value will appear in the
+                // output.
+                e: (:make_string foo bar baz),
+                
+                f: 5,
+                
+                // If a macro appears in field name position, it MUST produce a single struct (which
+                // may be empty). That struct's fields will be merged into the host struct.  
+                (:values {g: 6, h: 7}),
+                
+                g: 8
+            }
+            "#,
+            r#"
+            {
+                a: 1,
+                b: 2,
+                b: 3,
+                c: 4,
+                // no 'd',
+                e: "foobarbaz",
+                f: 5,
+                g: 6,
+                h: 7,
+                g: 8
+            }
+            "#,
+        )?;
+        Ok(())
+    }
+}

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
-/// The kinds of macros supported by [`MacroEvaluator`]. This list parallels
+/// The kinds of macros supported by
+/// [`MacroEvaluator`](crate::lazy::expanded::macro_evaluator::MacroEvaluator).
+/// This list parallels
 /// [`MacroExpansionKind`](crate::lazy::expanded::macro_evaluator::MacroExpansionKind),
 /// but its variants do not hold any associated state.
 #[derive(Debug)]

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -1,0 +1,47 @@
+use std::collections::HashMap;
+
+/// The kinds of macros supported by [`MacroEvaluator`]. This list parallels
+/// [`MacroExpansionKind`](crate::lazy::expanded::macro_evaluator::MacroExpansionKind),
+/// but its variants do not hold any associated state.
+#[derive(Debug)]
+pub enum MacroKind {
+    Void,
+    Values,
+    MakeString,
+}
+
+/// Allows callers to resolve a macro ID (that is: name or address) to a [`MacroKind`], confirming
+/// its validity and allowing evaluation to begin.
+#[derive(Debug)]
+pub struct MacroTable {
+    macros_by_address: Vec<MacroKind>,
+    macros_by_name: HashMap<String, MacroKind>,
+}
+
+impl Default for MacroTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MacroTable {
+    pub fn new() -> Self {
+        let macros_by_id = vec![MacroKind::Void, MacroKind::Values, MacroKind::MakeString];
+        let mut macros_by_name = HashMap::new();
+        macros_by_name.insert("void".to_owned(), MacroKind::Void);
+        macros_by_name.insert("values".to_owned(), MacroKind::Values);
+        macros_by_name.insert("make_string".to_owned(), MacroKind::MakeString);
+        Self {
+            macros_by_address: macros_by_id,
+            macros_by_name,
+        }
+    }
+
+    pub fn macro_at_address(&self, id: usize) -> Option<&MacroKind> {
+        self.macros_by_address.get(id)
+    }
+
+    pub fn macro_with_name(&self, name: &str) -> Option<&MacroKind> {
+        self.macros_by_name.get(name)
+    }
+}

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -1,0 +1,562 @@
+//! A view of the Ion data with all e-expressions lazily expanded.
+//!
+//! The types defined in this module each wrap their corresponding type from the "raw" view of the
+//! data, replacing the word `Raw` with the word `Expanded` in the type name.
+//!
+//! The expanded types expose largely the same API, with some key differences:
+//!   1. Most method invocations require an [`EncodingContext`] to be specified, giving the
+//!      evaluator access to the necessary macro definitions and the symbol table.
+//!   2. All macro invocations encountered in the raw layer are fully expanded, meaning that
+//!      values surfaced by calls to `next()` on readers/iterators may be the result of macro
+//!      evaluation. Said differently: not every value returned by `next()` has a corresponding
+//!      literal in the input stream.
+//!
+//! Note that symbol tokens MAY be resolved in the process of evaluating a macro, but where possible
+//! they will remain unresolved. For example, this e-expression:
+//! ```ion_1_1
+//!     (:repeat 3 $4)
+//! ```
+//! would expand to this stream of raw values:
+//! ```ion_1_1
+//!     $4 $4 $4
+//! ```
+//! while this e-expression:
+//! ```ion_1_1
+//!     `(:make_string "What's your " $4 "?")`
+//! ```
+//! would resolve the `$4` in the process of evaluating `make_string`, expanding to:
+//! ```ion_1_1
+//!     `"What's your name?"`
+//! ```
+//!
+//! Leaving symbol tokens unresolved is an optimization; annotations, field names, and symbol values
+//! that are ignored by the reader do not incur the cost of symbol table resolution.
+
+use std::fmt::{Debug, Formatter};
+use std::iter::empty;
+
+use bumpalo::collections::Vec as BumpVec;
+use bumpalo::Bump as BumpAllocator;
+
+use sequence::{LazyExpandedList, LazyExpandedSExp};
+
+use crate::element::iterators::SymbolsIterator;
+use crate::lazy::bytes_ref::BytesRef;
+use crate::lazy::decoder::{LazyDecoder, LazyRawReader, LazyRawValue};
+use crate::lazy::expanded::macro_evaluator::EExpEvaluator;
+use crate::lazy::expanded::macro_table::MacroTable;
+use crate::lazy::expanded::r#struct::LazyExpandedStruct;
+use crate::lazy::raw_stream_item::RawStreamItem;
+use crate::lazy::raw_value_ref::RawValueRef;
+use crate::lazy::str_ref::StrRef;
+use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
+use crate::result::IonFailure;
+use crate::{
+    Decimal, Element, Int, IonResult, IonType, RawSymbolTokenRef, SymbolTable, Timestamp, Value,
+};
+
+// All of these modules (and most of their types) are currently `pub` as the lazy reader is gated
+// behind an experimental feature flag. We may constrain access to them in the future as the code
+// stabilizes.
+pub mod e_expression;
+pub mod macro_evaluator;
+pub mod macro_table;
+pub mod sequence;
+pub mod stack;
+pub mod r#struct;
+pub mod tdl_macro;
+pub mod template;
+
+/// A collection of resources that can be used to encode or decode Ion values.
+/// The `'top` lifetime associated with the [`EncodingContext`] reflects the fact that it can only
+/// be used as long as the reader is positioned on the same top level value (i.e. the symbol and
+/// macro tables are guaranteed not to change).
+//  It should be possible to loosen this definition of `'top` to include several top level values
+//  as long as the macro and symbol tables do not change between them, though this would require
+//  carefully designing the API to emphasize that the sequence of values is either the set that
+//  happens to be available in the buffer OR the set that leads up to the next encoding directive.
+//  The value proposition of being able to lazily explore multiple top level values concurrently
+//  would need to be proved out first.
+#[derive(Copy, Clone, Debug)]
+pub struct EncodingContext<'top> {
+    pub(crate) macro_table: &'top MacroTable,
+    pub(crate) symbol_table: &'top SymbolTable,
+    pub(crate) allocator: &'top BumpAllocator,
+}
+
+impl<'top> EncodingContext<'top> {
+    pub fn new(
+        macro_table: &'top MacroTable,
+        symbol_table: &'top SymbolTable,
+        allocator: &'top BumpAllocator,
+    ) -> Self {
+        Self {
+            macro_table,
+            symbol_table,
+            allocator,
+        }
+    }
+}
+
+#[derive(Debug)]
+/// Stream components emitted by a LazyExpandingReader. These items may be encoded directly in the
+/// stream, or may have been produced by the evaluation of an encoding expression (e-expression).
+pub enum ExpandedStreamItem<'top, 'data, D: LazyDecoder<'data>> {
+    /// An Ion Version Marker (IVM) indicating the Ion major and minor version that were used to
+    /// encode the values that follow.
+    VersionMarker(u8, u8),
+    /// An Ion value whose data has not yet been read. For more information about how to read its
+    /// data and (in the case of containers) access any nested values, see the documentation
+    /// for [`LazyRawBinaryValue`](crate::lazy::binary::raw::value::LazyRawBinaryValue).
+    Value(LazyExpandedValue<'top, 'data, D>),
+    /// The end of the stream
+    EndOfStream,
+}
+
+impl<'top, 'data, D: LazyDecoder<'data>> ExpandedStreamItem<'top, 'data, D> {
+    /// Returns an error if this stream item is a version marker or the end of the stream.
+    /// Otherwise, returns the lazy value it contains.
+    fn expect_value(&self) -> IonResult<&LazyExpandedValue<'top, 'data, D>> {
+        match self {
+            ExpandedStreamItem::Value(value) => Ok(value),
+            _ => IonResult::decoding_error(format!("Expected a value, but found a {:?}", self)),
+        }
+    }
+}
+
+/// A reader that evaluates macro invocations in the data stream and surfaces the resulting
+/// raw values to the caller.
+pub struct LazyExpandingReader<'data, D: LazyDecoder<'data>> {
+    raw_reader: D::Reader,
+    evaluator: EExpEvaluator<'data, D>,
+}
+
+impl<'data, D: LazyDecoder<'data>> LazyExpandingReader<'data, D> {
+    pub(crate) fn new(raw_reader: D::Reader) -> Self {
+        Self {
+            raw_reader,
+            evaluator: EExpEvaluator::new(),
+        }
+    }
+
+    /// Returns the next [`ExpandedStreamItem`] either by continuing to evaluate a macro invocation
+    /// in progress or by pulling a value from the input stream.
+    pub fn next<'top>(
+        &mut self,
+        context: EncodingContext<'top>,
+    ) -> IonResult<ExpandedStreamItem<'top, 'data, D>>
+    where
+        'data: 'top,
+    {
+        loop {
+            if self.evaluator.stack_depth() > 0 {
+                // If the evaluator still has macro expansions in its stack, we need to give it the
+                // opportunity to produce the next value.
+                match self.evaluator.next(context, 0) {
+                    Ok(Some(value)) => return Ok(ExpandedStreamItem::Value(value)),
+                    Ok(None) => {
+                        // While the evaluator had macros in its stack, they did not produce any more
+                        // values. The stack is now empty.
+                    }
+                    Err(e) => return Err(e),
+                };
+            }
+
+            // If we reach this point, the evaluator's macro stack is empty. We'll pull another
+            // expression from the input stream.
+            use RawStreamItem::*;
+            let expanded_item = match self.raw_reader.next()? {
+                VersionMarker(major, minor) => ExpandedStreamItem::VersionMarker(major, minor),
+                // We got our value; return it.
+                Value(raw_value) => ExpandedStreamItem::Value(LazyExpandedValue {
+                    source: ExpandedValueSource::ValueLiteral(raw_value),
+                    context,
+                }),
+                // It's another macro invocation, we'll start evaluating it.
+                EExpression(e_exp) => {
+                    // Push the invocation onto the evaluation stack.
+                    self.evaluator.push(context, e_exp)?;
+                    // Return to the top of the loop to pull the next value (if any) from the evaluator.
+                    continue;
+                }
+                EndOfStream => ExpandedStreamItem::EndOfStream,
+            };
+            return Ok(expanded_item);
+        }
+    }
+}
+
+/// The source of data backing a [`LazyExpandedValue`].
+#[derive(Debug, Clone)]
+pub enum ExpandedValueSource<'top, 'data, D: LazyDecoder<'data>> {
+    /// This value was a literal in the input stream.
+    ValueLiteral(D::Value),
+    /// This value was part of a template definition.
+    Template(&'top Element),
+    /// This value was the computed result of a macro invocation like `(:make_string ...)`.
+    Constructed(
+        // TODO: Make this an associated type on the LazyDecoder trait so 1.0 types can set
+        //       it to `Never` and the compiler can eliminate this code path where applicable.
+        (
+            // A collection of bump-allocated annotation strings
+            BumpVec<'top, &'top str>,
+            ExpandedValueRef<'top, 'data, D>,
+        ),
+    ),
+}
+
+/// A value produced by expanding the 'raw' view of the input data.
+#[derive(Clone)]
+pub struct LazyExpandedValue<'top, 'data, D: LazyDecoder<'data>> {
+    pub(crate) context: EncodingContext<'top>,
+    pub(crate) source: ExpandedValueSource<'top, 'data, D>,
+}
+
+impl<'top, 'data: 'top, D: LazyDecoder<'data>> Debug for LazyExpandedValue<'top, 'data, D> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.source)
+    }
+}
+
+impl<'top, 'data: 'top, D: LazyDecoder<'data>> LazyExpandedValue<'top, 'data, D> {
+    pub fn ion_type(&self) -> IonType {
+        use ExpandedValueSource::*;
+        match &self.source {
+            ValueLiteral(value) => value.ion_type(),
+            Template(element) => element.ion_type(),
+            Constructed((_annotations, value)) => value.ion_type(),
+        }
+    }
+
+    pub fn is_null(&self) -> bool {
+        use ExpandedValueSource::*;
+        match &self.source {
+            ValueLiteral(value) => value.is_null(),
+            Template(element) => element.is_null(),
+            Constructed((_annotations, value)) => {
+                matches!(value, ExpandedValueRef::Null(_))
+            }
+        }
+    }
+
+    pub fn annotations(&self) -> ExpandedAnnotationsIterator<'top, 'data, D> {
+        use ExpandedValueSource::*;
+        match &self.source {
+            ValueLiteral(value) => ExpandedAnnotationsIterator::new(
+                ExpandedAnnotationsSource::ValueLiteral(value.annotations()),
+            ),
+            Template(element) => ExpandedAnnotationsIterator::new(
+                ExpandedAnnotationsSource::Template(element.annotations().iter()),
+            ),
+            Constructed((_annotations, _value)) => {
+                // TODO: iterate over constructed annotations
+                // For now we return an empty iterator
+                ExpandedAnnotationsIterator::new(ExpandedAnnotationsSource::Constructed(Box::new(
+                    empty(),
+                )))
+            }
+        }
+    }
+
+    pub fn read(&self) -> IonResult<ExpandedValueRef<'top, 'data, D>> {
+        use ExpandedValueSource::*;
+        match &self.source {
+            ValueLiteral(value) => Ok(ExpandedValueRef::from_raw(self.context, value.read()?)),
+            Template(element) => Ok(ExpandedValueRef::from_template(element, self.context)),
+            Constructed((_annotations, value)) => Ok((*value).clone()),
+        }
+    }
+
+    pub fn context(&self) -> EncodingContext<'top> {
+        self.context
+    }
+}
+
+pub enum ExpandedAnnotationsSource<'top, 'data, D: LazyDecoder<'data>> {
+    ValueLiteral(D::AnnotationsIterator),
+    Template(SymbolsIterator<'top>),
+    // TODO: This is a placeholder impl and always returns an empty iterator
+    Constructed(Box<dyn Iterator<Item = IonResult<RawSymbolTokenRef<'top>>> + 'top>),
+}
+
+pub struct ExpandedAnnotationsIterator<'top, 'data, D: LazyDecoder<'data>> {
+    source: ExpandedAnnotationsSource<'top, 'data, D>,
+}
+
+impl<'top, 'data, D: LazyDecoder<'data>> ExpandedAnnotationsIterator<'top, 'data, D> {
+    pub fn new(source: ExpandedAnnotationsSource<'top, 'data, D>) -> Self {
+        Self { source }
+    }
+}
+
+impl<'top, 'data: 'top, D: LazyDecoder<'data>> Iterator
+    for ExpandedAnnotationsIterator<'top, 'data, D>
+{
+    type Item = IonResult<RawSymbolTokenRef<'top>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        use ExpandedAnnotationsSource::*;
+        match &mut self.source {
+            ValueLiteral(value_annotations_iter) => value_annotations_iter.next(),
+            Template(element_annotations_iter) => element_annotations_iter
+                .next()
+                .map(|symbol| Ok(symbol.as_raw_symbol_token_ref())),
+            Constructed(iter) => iter.next(),
+        }
+    }
+}
+
+// TODO: This type does not implement `Copy` because some of its variants can own heap resources.
+//       (Specifically: Int, Decimal, String, Symbol, Blob, Clob.) If plumb the bump allocator all
+//       the way down to the raw readers, then the situations that require allocation can
+//       hold a 'top reference to a bump allocation instead of a static reference to a heap allocation.
+//       This will enable us to remove several calls to `clone()`, which can be much slower than copies.
+#[derive(Clone)]
+pub enum ExpandedValueRef<'top, 'data, D: LazyDecoder<'data>> {
+    Null(IonType),
+    Bool(bool),
+    Int(Int),
+    Float(f64),
+    Decimal(Decimal),
+    Timestamp(Timestamp),
+    String(StrRef<'top>),
+    Symbol(RawSymbolTokenRef<'top>),
+    Blob(BytesRef<'top>),
+    Clob(BytesRef<'top>),
+    SExp(LazyExpandedSExp<'top, 'data, D>),
+    List(LazyExpandedList<'top, 'data, D>),
+    Struct(LazyExpandedStruct<'top, 'data, D>),
+}
+
+impl<'top, 'data: 'top, D: LazyDecoder<'data>> PartialEq for ExpandedValueRef<'top, 'data, D> {
+    fn eq(&self, other: &Self) -> bool {
+        use ExpandedValueRef::*;
+        match (self, other) {
+            (Null(i1), Null(i2)) => i1 == i2,
+            (Bool(b1), Bool(b2)) => b1 == b2,
+            (Int(i1), Int(i2)) => i1 == i2,
+            (Float(i1), Float(i2)) => i1 == i2,
+            (Decimal(i1), Decimal(i2)) => i1 == i2,
+            (Timestamp(i1), Timestamp(i2)) => i1 == i2,
+            (String(i1), String(i2)) => i1 == i2,
+            (Symbol(i1), Symbol(i2)) => i1 == i2,
+            (Blob(i1), Blob(i2)) => i1 == i2,
+            (Clob(i1), Clob(i2)) => i1 == i2,
+            _ => false,
+        }
+    }
+}
+
+impl<'top, 'data: 'top, D: LazyDecoder<'data>> ExpandedValueRef<'top, 'data, D> {
+    fn expected<T>(self, expected_name: &str) -> IonResult<T> {
+        IonResult::decoding_error(format!(
+            "expected a(n) {} but found a {:?}",
+            expected_name, self
+        ))
+    }
+
+    pub fn expect_null(self) -> IonResult<IonType> {
+        if let ExpandedValueRef::Null(ion_type) = self {
+            Ok(ion_type)
+        } else {
+            self.expected("null")
+        }
+    }
+
+    pub fn expect_bool(self) -> IonResult<bool> {
+        if let ExpandedValueRef::Bool(b) = self {
+            Ok(b)
+        } else {
+            self.expected("bool")
+        }
+    }
+
+    pub fn expect_int(self) -> IonResult<Int> {
+        if let ExpandedValueRef::Int(i) = self {
+            Ok(i)
+        } else {
+            self.expected("int")
+        }
+    }
+
+    pub fn expect_i64(self) -> IonResult<i64> {
+        if let ExpandedValueRef::Int(i) = self {
+            i.expect_i64()
+        } else {
+            self.expected("i64 (int)")
+        }
+    }
+
+    pub fn expect_float(self) -> IonResult<f64> {
+        if let ExpandedValueRef::Float(f) = self {
+            Ok(f)
+        } else {
+            self.expected("float")
+        }
+    }
+
+    pub fn expect_decimal(self) -> IonResult<Decimal> {
+        if let ExpandedValueRef::Decimal(d) = self {
+            Ok(d)
+        } else {
+            self.expected("decimal")
+        }
+    }
+
+    pub fn expect_timestamp(self) -> IonResult<Timestamp> {
+        if let ExpandedValueRef::Timestamp(t) = self {
+            Ok(t)
+        } else {
+            self.expected("timestamp")
+        }
+    }
+
+    pub fn expect_string(self) -> IonResult<StrRef<'top>> {
+        if let ExpandedValueRef::String(s) = self {
+            Ok(s)
+        } else {
+            self.expected("string")
+        }
+    }
+
+    pub fn expect_symbol(self) -> IonResult<RawSymbolTokenRef<'top>> {
+        if let ExpandedValueRef::Symbol(s) = self {
+            Ok(s.clone())
+        } else {
+            self.expected("symbol")
+        }
+    }
+
+    pub fn expect_blob(self) -> IonResult<BytesRef<'top>> {
+        if let ExpandedValueRef::Blob(b) = self {
+            Ok(b)
+        } else {
+            self.expected("blob")
+        }
+    }
+
+    pub fn expect_clob(self) -> IonResult<BytesRef<'top>> {
+        if let ExpandedValueRef::Clob(c) = self {
+            Ok(c)
+        } else {
+            self.expected("clob")
+        }
+    }
+
+    pub fn expect_list(self) -> IonResult<LazyExpandedList<'top, 'data, D>> {
+        if let ExpandedValueRef::List(s) = self {
+            Ok(s)
+        } else {
+            self.expected("list")
+        }
+    }
+
+    pub fn expect_sexp(self) -> IonResult<LazyExpandedSExp<'top, 'data, D>> {
+        if let ExpandedValueRef::SExp(s) = self {
+            Ok(s)
+        } else {
+            self.expected("sexp")
+        }
+    }
+
+    pub fn expect_struct(self) -> IonResult<LazyExpandedStruct<'top, 'data, D>> {
+        if let ExpandedValueRef::Struct(s) = self {
+            Ok(s)
+        } else {
+            self.expected("struct")
+        }
+    }
+
+    fn from_raw(context: EncodingContext<'top>, value: RawValueRef<'data, D>) -> Self {
+        use RawValueRef::*;
+        match value {
+            Null(ion_type) => ExpandedValueRef::Null(ion_type),
+            Bool(b) => ExpandedValueRef::Bool(b),
+            Int(i) => ExpandedValueRef::Int(i),
+            Float(f) => ExpandedValueRef::Float(f),
+            Decimal(d) => ExpandedValueRef::Decimal(d),
+            Timestamp(t) => ExpandedValueRef::Timestamp(t),
+            String(s) => ExpandedValueRef::String(s),
+            Symbol(s) => ExpandedValueRef::Symbol(s),
+            Blob(b) => ExpandedValueRef::Blob(b),
+            Clob(c) => ExpandedValueRef::Clob(c),
+            SExp(s) => ExpandedValueRef::SExp(LazyExpandedSExp::from_literal(context, s)),
+            List(l) => ExpandedValueRef::List(LazyExpandedList::from_literal(context, l)),
+            Struct(s) => ExpandedValueRef::Struct(LazyExpandedStruct::from_literal(context, s)),
+        }
+    }
+}
+
+impl<'top, 'data, D: LazyDecoder<'data>> Debug for ExpandedValueRef<'top, 'data, D> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        use ExpandedValueRef::*;
+        match self {
+            Null(ion_type) => write!(f, "null.{}", ion_type),
+            Bool(b) => write!(f, "{}", b),
+            Int(i) => write!(f, "{}", i),
+            Float(float) => write!(f, "{}", float),
+            Decimal(d) => write!(f, "{}", d),
+            Timestamp(t) => write!(f, "{}", t),
+            String(s) => write!(f, "{}", s),
+            Symbol(s) => write!(f, "{:?}", s),
+            Blob(b) => write!(f, "blob ({} bytes)", b.len()),
+            Clob(c) => write!(f, "clob ({} bytes)", c.len()),
+            // TODO: Debug impls for LazyExpandedRaw[ContainerType]
+            SExp(_s) => write!(f, "<sexp>"),
+            List(_l) => write!(f, "<list>"),
+            Struct(_s) => write!(f, "<struct>"),
+        }
+    }
+}
+
+impl<'top, 'data: 'top, D: LazyDecoder<'data>> ExpandedValueRef<'top, 'data, D> {
+    fn from_template(element: &'top Element, context: EncodingContext<'top>) -> Self {
+        use Value::*;
+        match element.value() {
+            Null(ion_type) => ExpandedValueRef::Null(*ion_type),
+            Bool(b) => ExpandedValueRef::Bool(*b),
+            Int(i) => ExpandedValueRef::Int(i.clone()),
+            Float(f) => ExpandedValueRef::Float(*f),
+            Decimal(d) => ExpandedValueRef::Decimal(d.clone()),
+            Timestamp(t) => ExpandedValueRef::Timestamp(t.clone()),
+            String(s) => ExpandedValueRef::String(StrRef::from(s.text())),
+            Symbol(s) => ExpandedValueRef::Symbol(s.as_raw_symbol_token_ref()),
+            Blob(b) => ExpandedValueRef::Blob(BytesRef::from(b.as_ref())),
+            Clob(c) => ExpandedValueRef::Clob(BytesRef::from(c.as_ref())),
+            List(s) => ExpandedValueRef::List(LazyExpandedList::from_template(
+                context,
+                element.annotations(),
+                s,
+            )),
+            SExp(s) => ExpandedValueRef::SExp(LazyExpandedSExp::from_template(
+                context,
+                element.annotations(),
+                s,
+            )),
+            Struct(s) => ExpandedValueRef::Struct(LazyExpandedStruct::from_template(
+                context,
+                element.annotations(),
+                s,
+            )),
+        }
+    }
+
+    fn ion_type(&self) -> IonType {
+        use ExpandedValueRef::*;
+        match self {
+            Null(ion_type) => *ion_type,
+            Bool(_) => IonType::Bool,
+            Int(_) => IonType::Int,
+            Float(_) => IonType::Float,
+            Decimal(_) => IonType::Decimal,
+            Timestamp(_) => IonType::Timestamp,
+            String(_) => IonType::String,
+            Symbol(_) => IonType::Symbol,
+            Blob(_) => IonType::Blob,
+            Clob(_) => IonType::Clob,
+            SExp(_) => IonType::SExp,
+            List(_) => IonType::List,
+            Struct(_) => IonType::Struct,
+        }
+    }
+}

--- a/src/lazy/expanded/sequence.rs
+++ b/src/lazy/expanded/sequence.rs
@@ -1,0 +1,246 @@
+use crate::lazy::decoder::{LazyDecoder, LazyRawSequence, LazyRawValueExpr};
+use crate::lazy::expanded::macro_evaluator::TransientEExpEvaluator;
+use crate::lazy::expanded::template::TemplateSequenceIterator;
+use crate::lazy::expanded::{
+    EncodingContext, ExpandedAnnotationsIterator, ExpandedAnnotationsSource, ExpandedValueSource,
+    LazyExpandedValue,
+};
+use crate::{Annotations, IonResult, IonType, Sequence};
+
+#[derive(Clone)]
+pub enum ExpandedListSource<'top, 'data, D: LazyDecoder<'data>> {
+    ValueLiteral(D::List),
+    Template(&'top Annotations, &'top Sequence),
+    // TODO: Constructed
+}
+
+#[derive(Clone)]
+pub struct LazyExpandedList<'top, 'data, D: LazyDecoder<'data>> {
+    pub(crate) context: EncodingContext<'top>,
+    pub(crate) source: ExpandedListSource<'top, 'data, D>,
+}
+
+impl<'top, 'data, D: LazyDecoder<'data>> LazyExpandedList<'top, 'data, D> {
+    pub fn from_literal(
+        context: EncodingContext<'top>,
+        list: D::List,
+    ) -> LazyExpandedList<'top, 'data, D> {
+        let source = ExpandedListSource::ValueLiteral(list);
+        Self { source, context }
+    }
+
+    pub fn from_template(
+        context: EncodingContext<'top>,
+        annotations: &'top Annotations,
+        sequence: &'top Sequence,
+    ) -> LazyExpandedList<'top, 'data, D> {
+        let source = ExpandedListSource::Template(annotations, sequence);
+        Self { source, context }
+    }
+
+    pub fn ion_type(&self) -> IonType {
+        IonType::List
+    }
+
+    pub fn annotations(&self) -> ExpandedAnnotationsIterator<'top, 'data, D> {
+        match self.source {
+            ExpandedListSource::ValueLiteral(value) => ExpandedAnnotationsIterator {
+                source: ExpandedAnnotationsSource::ValueLiteral(value.annotations()),
+            },
+            ExpandedListSource::Template(annotations, _sequence) => ExpandedAnnotationsIterator {
+                source: ExpandedAnnotationsSource::Template(annotations.iter()),
+            },
+        }
+    }
+
+    pub fn iter(&self) -> ExpandedListIterator<'top, 'data, D> {
+        let source = match &self.source {
+            ExpandedListSource::ValueLiteral(list) => {
+                let evaluator = TransientEExpEvaluator::new_transient(self.context);
+                ExpandedListIteratorSource::ValueLiteral(evaluator, list.iter())
+            }
+            ExpandedListSource::Template(_annotations, sequence) => {
+                ExpandedListIteratorSource::Template(TemplateSequenceIterator::new(
+                    self.context,
+                    sequence,
+                ))
+            }
+        };
+        ExpandedListIterator {
+            context: self.context,
+            source,
+        }
+    }
+}
+
+pub enum ExpandedListIteratorSource<'top, 'data: 'top, D: LazyDecoder<'data>> {
+    ValueLiteral(
+        // Giving the list iterator its own evaluator means that we can abandon the iterator
+        // at any time without impacting the evaluation state of its parent container.
+        TransientEExpEvaluator<'top, 'data, D>,
+        <D::List as LazyRawSequence<'data, D>>::Iterator,
+    ),
+    Template(TemplateSequenceIterator<'top>),
+    // TODO: Constructed
+}
+
+pub struct ExpandedListIterator<'top, 'data, D: LazyDecoder<'data>> {
+    context: EncodingContext<'top>,
+    source: ExpandedListIteratorSource<'top, 'data, D>,
+}
+
+impl<'top, 'data, D: LazyDecoder<'data>> Iterator for ExpandedListIterator<'top, 'data, D> {
+    type Item = IonResult<LazyExpandedValue<'top, 'data, D>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.source {
+            ExpandedListIteratorSource::ValueLiteral(evaluator, iter) => {
+                expand_next_sequence_value(self.context, evaluator, iter)
+            }
+            ExpandedListIteratorSource::Template(iter) => iter.next().map(|element| {
+                Ok(LazyExpandedValue {
+                    source: ExpandedValueSource::Template(element),
+                    context: self.context,
+                })
+            }),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum ExpandedSExpSource<'top, 'data, D: LazyDecoder<'data>> {
+    ValueLiteral(D::SExp),
+    Template(&'top Annotations, &'top Sequence),
+}
+
+#[derive(Clone)]
+pub struct LazyExpandedSExp<'top, 'data, D: LazyDecoder<'data>> {
+    source: ExpandedSExpSource<'top, 'data, D>,
+    context: EncodingContext<'top>,
+}
+
+impl<'top, 'data, D: LazyDecoder<'data>> LazyExpandedSExp<'top, 'data, D> {
+    pub fn ion_type(&self) -> IonType {
+        IonType::SExp
+    }
+
+    pub fn annotations(&self) -> ExpandedAnnotationsIterator<'top, 'data, D> {
+        match self.source {
+            ExpandedSExpSource::ValueLiteral(value) => ExpandedAnnotationsIterator {
+                source: ExpandedAnnotationsSource::ValueLiteral(value.annotations()),
+            },
+            ExpandedSExpSource::Template(annotations, _sequence) => ExpandedAnnotationsIterator {
+                source: ExpandedAnnotationsSource::Template(annotations.iter()),
+            },
+        }
+    }
+
+    pub fn iter(&self) -> ExpandedSExpIterator<'top, 'data, D> {
+        let source = match &self.source {
+            ExpandedSExpSource::ValueLiteral(sexp) => {
+                let evaluator = TransientEExpEvaluator::new_transient(self.context);
+                ExpandedSExpIteratorSource::ValueLiteral(evaluator, sexp.iter())
+            }
+            ExpandedSExpSource::Template(_annotations, sequence) => {
+                ExpandedSExpIteratorSource::Template(TemplateSequenceIterator::new(
+                    self.context,
+                    sequence,
+                ))
+            }
+        };
+        ExpandedSExpIterator {
+            context: self.context,
+            source,
+        }
+    }
+
+    pub fn from_literal(
+        context: EncodingContext<'top>,
+        sexp: D::SExp,
+    ) -> LazyExpandedSExp<'top, 'data, D> {
+        let source = ExpandedSExpSource::ValueLiteral(sexp);
+        Self { source, context }
+    }
+
+    pub fn from_template(
+        context: EncodingContext<'top>,
+        annotations: &'top Annotations,
+        sequence: &'top Sequence,
+    ) -> LazyExpandedSExp<'top, 'data, D> {
+        let source = ExpandedSExpSource::Template(annotations, sequence);
+        Self { source, context }
+    }
+}
+
+pub enum ExpandedSExpIteratorSource<'top, 'data: 'top, D: LazyDecoder<'data>> {
+    ValueLiteral(
+        // Giving the sexp iterator its own evaluator means that we can abandon the iterator
+        // at any time without impacting the evaluation state of its parent container.
+        TransientEExpEvaluator<'top, 'data, D>,
+        <D::SExp as LazyRawSequence<'data, D>>::Iterator,
+    ),
+    Template(TemplateSequenceIterator<'top>),
+    // TODO: Constructed
+}
+
+pub struct ExpandedSExpIterator<'top, 'data, D: LazyDecoder<'data>> {
+    context: EncodingContext<'top>,
+    source: ExpandedSExpIteratorSource<'top, 'data, D>,
+}
+
+impl<'top, 'data, D: LazyDecoder<'data>> Iterator for ExpandedSExpIterator<'top, 'data, D> {
+    type Item = IonResult<LazyExpandedValue<'top, 'data, D>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.source {
+            ExpandedSExpIteratorSource::ValueLiteral(evaluator, iter) => {
+                expand_next_sequence_value(self.context, evaluator, iter)
+            }
+            ExpandedSExpIteratorSource::Template(iter) => iter.next().map(|element| {
+                Ok(LazyExpandedValue {
+                    source: ExpandedValueSource::Template(element),
+                    context: self.context,
+                })
+            }),
+        }
+    }
+}
+
+/// For both lists and s-expressions, yields the next sequence value by either continuing a macro
+/// evaluation already in progress or reading the next item from the input stream.
+fn expand_next_sequence_value<'top, 'data, D: LazyDecoder<'data>>(
+    context: EncodingContext<'top>,
+    evaluator: &mut TransientEExpEvaluator<'top, 'data, D>,
+    iter: &mut impl Iterator<Item = IonResult<LazyRawValueExpr<'data, D>>>,
+) -> Option<IonResult<LazyExpandedValue<'top, 'data, D>>> {
+    loop {
+        // If the evaluator's stack is not empty, it's still expanding a macro.
+        if evaluator.stack_depth() > 0 {
+            let value = evaluator.next(context, 0).transpose();
+            if value.is_some() {
+                // The `Some` may contain a value or an error; either way, that's the next return value.
+                return value;
+            }
+            // It's possible for a macro to produce zero values. If that happens, we continue on to
+            // pull another expression from the list iterator.
+        }
+
+        match iter.next() {
+            None => return None,
+            Some(Ok(LazyRawValueExpr::ValueLiteral(value))) => {
+                return Some(Ok(LazyExpandedValue {
+                    source: ExpandedValueSource::ValueLiteral(value),
+                    context,
+                }))
+            }
+            Some(Ok(LazyRawValueExpr::MacroInvocation(invocation))) => {
+                let begin_expansion_result = evaluator.push(context, invocation);
+                if let Err(e) = begin_expansion_result {
+                    return Some(Err(e));
+                }
+                continue;
+            }
+            Some(Err(e)) => return Some(Err(e)),
+        }
+    }
+}

--- a/src/lazy/expanded/stack.rs
+++ b/src/lazy/expanded/stack.rs
@@ -1,7 +1,7 @@
 use bumpalo::collections::Vec as BumpVec;
 use std::fmt::Debug;
 
-/// Backing storage for the [`MacroEvaluator`](crate::lazy::expanded::MacroEvaluator).
+/// Backing storage for the [`MacroEvaluator`](crate::lazy::expanded::macro_evaluator::MacroEvaluator).
 ///
 /// This is implemented both by `Vec` (which has a static lifetime) and [`BumpVec`](bumpalo::collections::Vec),
 /// which uses storage tied to the encoding context's lifetime.

--- a/src/lazy/expanded/stack.rs
+++ b/src/lazy/expanded/stack.rs
@@ -1,0 +1,72 @@
+use bumpalo::collections::Vec as BumpVec;
+use std::fmt::Debug;
+
+/// Backing storage for the [`MacroEvaluator`](crate::lazy::expanded::MacroEvaluator).
+///
+/// This is implemented both by `Vec` (which has a static lifetime) and [`BumpVec`](bumpalo::collections::Vec),
+/// which uses storage tied to the encoding context's lifetime.
+pub trait Stack<T>: Debug {
+    fn push(&mut self, value: T);
+    fn pop(&mut self) -> Option<T>;
+
+    fn peek(&self) -> Option<&T>;
+    fn peek_mut(&mut self) -> Option<&mut T>;
+
+    fn clear(&mut self);
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<T: Debug> Stack<T> for Vec<T> {
+    fn push(&mut self, value: T) {
+        self.push(value)
+    }
+
+    fn pop(&mut self) -> Option<T> {
+        self.pop()
+    }
+
+    fn peek(&self) -> Option<&T> {
+        self.last()
+    }
+
+    fn peek_mut(&mut self) -> Option<&mut T> {
+        self.last_mut()
+    }
+
+    fn clear(&mut self) {
+        self.clear()
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<'a, T: Debug> Stack<T> for BumpVec<'a, T> {
+    fn push(&mut self, value: T) {
+        self.push(value)
+    }
+
+    fn pop(&mut self) -> Option<T> {
+        self.pop()
+    }
+
+    fn peek(&self) -> Option<&T> {
+        self.last()
+    }
+
+    fn peek_mut(&mut self) -> Option<&mut T> {
+        self.last_mut()
+    }
+
+    fn clear(&mut self) {
+        self.clear()
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+}

--- a/src/lazy/expanded/struct.rs
+++ b/src/lazy/expanded/struct.rs
@@ -1,0 +1,277 @@
+use crate::lazy::decoder::{LazyDecoder, LazyRawFieldExpr, LazyRawStruct, LazyRawValueExpr};
+use crate::lazy::expanded::macro_evaluator::{MacroEvaluator, TransientEExpEvaluator};
+use crate::lazy::expanded::{
+    EncodingContext, ExpandedAnnotationsIterator, ExpandedAnnotationsSource, ExpandedValueRef,
+    ExpandedValueSource, LazyExpandedValue,
+};
+use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
+use crate::result::IonFailure;
+use crate::{Annotations, IonError, IonResult, RawSymbolTokenRef, Struct};
+
+#[derive(Debug, Clone)]
+pub struct LazyExpandedField<'top, 'data, D: LazyDecoder<'data>> {
+    name: RawSymbolTokenRef<'top>,
+    pub(crate) value: LazyExpandedValue<'top, 'data, D>,
+}
+
+impl<'top, 'data, D: LazyDecoder<'data>> LazyExpandedField<'top, 'data, D> {
+    pub fn new(name: RawSymbolTokenRef<'top>, value: LazyExpandedValue<'top, 'data, D>) -> Self {
+        Self { name, value }
+    }
+
+    pub fn name(&self) -> RawSymbolTokenRef<'top> {
+        self.name.clone()
+    }
+
+    pub fn value(&self) -> &LazyExpandedValue<'top, 'data, D> {
+        &self.value
+    }
+}
+
+#[derive(Clone)]
+pub enum ExpandedStructSource<'top, 'data, D: LazyDecoder<'data>> {
+    ValueLiteral(D::Struct),
+    Template(&'top Annotations, &'top Struct),
+    // TODO: Constructed
+}
+
+#[derive(Clone)]
+pub struct LazyExpandedStruct<'top, 'data, D: LazyDecoder<'data>> {
+    context: EncodingContext<'top>,
+    source: ExpandedStructSource<'top, 'data, D>,
+}
+
+impl<'top, 'data: 'top, D: LazyDecoder<'data>> LazyExpandedStruct<'top, 'data, D> {
+    pub fn from_literal(
+        context: EncodingContext<'top>,
+        sexp: D::Struct,
+    ) -> LazyExpandedStruct<'top, 'data, D> {
+        let source = ExpandedStructSource::ValueLiteral(sexp);
+        Self { source, context }
+    }
+
+    pub fn from_template(
+        context: EncodingContext<'top>,
+        annotations: &'top Annotations,
+        struct_: &'top Struct,
+    ) -> LazyExpandedStruct<'top, 'data, D> {
+        let source = ExpandedStructSource::Template(annotations, struct_);
+        Self { source, context }
+    }
+
+    pub fn annotations(&self) -> ExpandedAnnotationsIterator<'top, 'data, D> {
+        match self.source {
+            ExpandedStructSource::ValueLiteral(value) => ExpandedAnnotationsIterator {
+                source: ExpandedAnnotationsSource::ValueLiteral(value.annotations()),
+            },
+            ExpandedStructSource::Template(annotations, _struct) => ExpandedAnnotationsIterator {
+                source: ExpandedAnnotationsSource::Template(annotations.iter()),
+            },
+        }
+    }
+
+    pub fn iter(&self) -> ExpandedStructIterator<'top, 'data, D> {
+        let source = match self.source {
+            ExpandedStructSource::ValueLiteral(raw_struct) => {
+                ExpandedStructIteratorSource::ValueLiteral(
+                    MacroEvaluator::<
+                        D,
+                        <D as LazyDecoder<'_>>::MacroInvocation,
+                        bumpalo::collections::Vec<'top, _>,
+                    >::new_transient(self.context),
+                    raw_struct.iter(),
+                )
+            }
+            ExpandedStructSource::Template(_, _) => {
+                todo!("iterate over struct from template")
+            }
+        };
+        ExpandedStructIterator {
+            context: self.context,
+            source,
+            state: ExpandedStructIteratorState::ReadingFieldFromSource,
+        }
+    }
+
+    pub fn bump_iter(&self) -> &'top mut ExpandedStructIterator<'top, 'data, D> {
+        self.context.allocator.alloc_with(|| self.iter())
+    }
+
+    fn find(&self, name: &str) -> IonResult<Option<LazyExpandedValue<'top, 'data, D>>> {
+        for field_result in self.iter() {
+            let field = field_result?;
+            if field.name() == name.as_raw_symbol_token_ref() {
+                return Ok(Some(field.value().clone()));
+            }
+        }
+        Ok(None)
+    }
+
+    fn get(&self, name: &str) -> IonResult<Option<ExpandedValueRef<'top, 'data, D>>> {
+        self.find(name)?.map(|f| f.read()).transpose()
+    }
+
+    fn get_expected(&self, name: &str) -> IonResult<ExpandedValueRef<'top, 'data, D>> {
+        if let Some(value) = self.get(name)? {
+            Ok(value)
+        } else {
+            IonResult::decoding_error(format!("did not find expected struct field '{}'", name))
+        }
+    }
+}
+
+pub enum ExpandedStructIteratorSource<'top, 'data: 'top, D: LazyDecoder<'data>> {
+    ValueLiteral(
+        // Giving the struct iterator its own evaluator means that we can abandon the iterator
+        // at any time without impacting the evaluation state of its parent container.
+        TransientEExpEvaluator<'top, 'data, D>,
+        <D::Struct as LazyRawStruct<'data, D>>::Iterator,
+    ),
+    // TODO: Template
+    // TODO: Constructed
+}
+
+pub struct ExpandedStructIterator<'top, 'data, D: LazyDecoder<'data>> {
+    context: EncodingContext<'top>,
+    source: ExpandedStructIteratorSource<'top, 'data, D>,
+    // Stores information about any operations that are still in progress.
+    state: ExpandedStructIteratorState<'top, 'data, D>,
+}
+
+/// Ion 1.1's struct is very versatile, and supports a variety of expansion operations. This
+/// types indicates which operation is in the process of being carried out.
+enum ExpandedStructIteratorState<'top, 'data, D: LazyDecoder<'data>> {
+    // The iterator is not performing any operations. It is ready to pull the next field from its
+    // source.
+    ReadingFieldFromSource,
+    // The iterator is expanding a macro invocation that was found in value position; for example:
+    //     foo: (:values 1 2 3)
+    // would be expanded to:
+    //     foo: 1,
+    //     foo: 2,
+    //     foo: 3,
+    // This variant holds the field name that will be repeated for every value in the macro's
+    // expansion.
+    ExpandingValueExpr(RawSymbolTokenRef<'top>),
+    // The iterator is in the process of incrementally inlining a macro found in field name
+    // position that expands to a struct; for example:
+    //     (:values {foo: 1, bar: 2})
+    // would expand to:
+    //     foo: 1,
+    //     bar: 2,
+    // This variant holds a pointer to that struct's iterator living in the
+    // EncodingContext's bump allocator.
+    InliningAStruct(
+        LazyExpandedStruct<'top, 'data, D>,
+        &'top mut ExpandedStructIterator<'top, 'data, D>,
+    ),
+}
+
+impl<'top, 'data, D: LazyDecoder<'data>> Iterator for ExpandedStructIterator<'top, 'data, D> {
+    type Item = IonResult<LazyExpandedField<'top, 'data, D>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            context,
+            ref mut source,
+            ref mut state,
+        } = *self;
+        match source {
+            ExpandedStructIteratorSource::ValueLiteral(evaluator, iter) => {
+                loop {
+                    use ExpandedStructIteratorState::*;
+                    match state {
+                        ReadingFieldFromSource => {
+                            match iter.next()? {
+                                Err(e) => {
+                                    return Some(
+                                        Err::<LazyExpandedField<'top, 'data, D>, IonError>(e),
+                                    );
+                                }
+                                // Plain (name, value literal) pair. For example: `foo: 1`
+                                Ok(LazyRawFieldExpr::NameValuePair(
+                                    name,
+                                    LazyRawValueExpr::ValueLiteral(value),
+                                )) => {
+                                    return Some(Ok(LazyExpandedField::new(
+                                        name,
+                                        LazyExpandedValue {
+                                            context,
+                                            source: ExpandedValueSource::ValueLiteral(value),
+                                        },
+                                    )));
+                                }
+                                // (name, macro invocation) pair. For example: `foo: (:bar)`
+                                Ok(LazyRawFieldExpr::NameValuePair(
+                                    name,
+                                    LazyRawValueExpr::MacroInvocation(invocation),
+                                )) => {
+                                    if let Err(e) = evaluator.push(context, invocation) {
+                                        return Some(Err(e));
+                                    };
+                                    *state = ExpandingValueExpr(name);
+                                    continue;
+                                }
+                                // Macro invocation in field name position.
+                                Ok(LazyRawFieldExpr::MacroInvocation(invocation)) => {
+                                    // The next item was a macro. We expect it to expand to a single
+                                    // struct whose fields will be merged into the one we're iterating
+                                    // over. For example:
+                                    //     {a: 1, (:make_struct b 2 c 3), d: 4}
+                                    // expands to:
+                                    //     {a: 1, b: 2, c: 3, d: 4}
+                                    let mut evaluation =
+                                        match evaluator.evaluate(context, invocation) {
+                                            Ok(iter) => iter,
+                                            Err(e) => return Some(Err(e)),
+                                        };
+                                    let expanded_value = match evaluation.next() {
+                                        Some(Ok(item)) => item,
+                                        Some(Err(e)) => return Some(Err(e)),
+                                        None => return Some(IonResult::decoding_error(format!("macros in field name position must produce a single struct; '{:?}' produced nothing", invocation))),
+                                    };
+                                    let struct_ = match expanded_value.read() {
+                                        Ok(ExpandedValueRef::Struct(s)) => s,
+                                        Ok(other) => return Some(IonResult::decoding_error(format!("macros in field name position must produce structs; '{:?}' produced: {:?}", invocation, other))),
+                                        Err(e) => return Some(Err(e)),
+                                    };
+                                    let iter: &'top mut ExpandedStructIterator<'top, 'data, D> =
+                                        struct_.bump_iter();
+                                    *state = InliningAStruct(struct_, iter);
+                                    continue;
+                                }
+                            };
+                        }
+                        InliningAStruct(_struct, struct_iter) => {
+                            if let Some(inlined_field) = struct_iter.next() {
+                                // We pulled another field from the struct we're inlining.
+                                return Some(inlined_field);
+                            } else {
+                                // We're done inlining this struct. Switch back to reading from the source.
+                                *state = ReadingFieldFromSource;
+                            }
+                        }
+                        ExpandingValueExpr(field_name) => {
+                            match evaluator.next(context, 0) {
+                                Err(e) => return Some(Err(e)),
+                                Ok(Some(next_value)) => {
+                                    // We got another value from the macro we're evaluating. Emit
+                                    // it as another field using the same field_name.
+                                    return Some(Ok(LazyExpandedField::new(
+                                        field_name.clone(),
+                                        next_value,
+                                    )));
+                                }
+                                Ok(None) => {
+                                    // The macro in the value position is no longer emitting values. Switch
+                                    // back to reading from the source.
+                                    *state = ReadingFieldFromSource;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/lazy/expanded/tdl_macro.rs
+++ b/src/lazy/expanded/tdl_macro.rs
@@ -1,0 +1,95 @@
+//! Types and traits representing a macro invocation within a template.
+
+use crate::element::iterators::SequenceIterator;
+use crate::lazy::decoder::LazyDecoder;
+use crate::lazy::expanded::macro_evaluator::{ArgumentKind, MacroInvocation, ToArgumentKind};
+use crate::lazy::text::raw::v1_1::reader::MacroIdRef;
+
+use crate::lazy::expanded::{EncodingContext, ExpandedValueSource, LazyExpandedValue};
+use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
+use crate::{Element, IonResult, Sequence, Value};
+
+impl<'top, 'data, D: LazyDecoder<'data>> MacroInvocation<'data, D> for &'top Sequence {
+    type ArgumentExpr = &'top Element;
+    type ArgumentsIterator = OkAdapter<SequenceIterator<'top>>;
+
+    // TODO: This dummy implementation using `&'top Sequence` will be replaced by a purpose-built
+    //       type that validates the invocation before reaching this method. For now, this method can
+    //       panic if the input is malformed.
+    fn id(&self) -> MacroIdRef {
+        match self.get(0).expect("TDL macro call missing ID").value() {
+            Value::Int(address) => MacroIdRef::LocalAddress(
+                usize::try_from(address.expect_i64().unwrap())
+                    .expect("macro address int out of bounds for usize"),
+            ),
+            Value::Symbol(name) => {
+                MacroIdRef::LocalName(name.text().expect("cannot use $0 as macro name"))
+            }
+            _ => panic!("macro IDs must be an int or symbol"),
+        }
+    }
+
+    fn arguments(&self) -> Self::ArgumentsIterator {
+        let mut children = self.elements();
+        let _id = children.next().unwrap();
+        OkAdapter { iterator: children }
+    }
+}
+
+/// Wraps an infallible iterator's output items in `Result::Ok`.
+pub struct OkAdapter<I>
+where
+    I: Iterator,
+{
+    iterator: I,
+}
+
+impl<I> OkAdapter<I>
+where
+    I: Iterator,
+{
+    pub fn new(iterator: I) -> Self {
+        Self { iterator }
+    }
+}
+
+impl<I: Iterator> Iterator for OkAdapter<I> {
+    type Item = IonResult<<I as Iterator>::Item>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iterator.next().map(Ok)
+    }
+}
+
+// When an `&Element` appears in macro argument position within a template, this trait implementation
+// recognizes whether the `&Element` represents a value, a variable, or another template invocation.
+impl<'element, 'data, D: LazyDecoder<'data>> ToArgumentKind<'data, D, &'element Sequence>
+    for &'element Element
+{
+    fn to_arg_expr<'top>(
+        self,
+        context: EncodingContext<'top>,
+    ) -> ArgumentKind<'top, 'data, D, &'element Sequence>
+    where
+        Self: 'top,
+    {
+        // In this implementation, we are reading the arguments to a template macro invocation.
+        // For example:
+        //
+        //     (macro twice (a)
+        //        // Inside a template definition, calling the `values` macro with two arguments
+        //        (values a a)
+        //     )
+        // In this context, there are named variables to consider. If we encounter a symbol like `a`
+        // in argument position, we must flag it as a variable so the caller has the opportunity to
+        // resolve it to a value stream.
+        match self.value() {
+            Value::SExp(sequence) => ArgumentKind::MacroInvocation(sequence),
+            Value::Symbol(variable) => ArgumentKind::Variable(variable.as_raw_symbol_token_ref()),
+            _ => ArgumentKind::ValueLiteral(LazyExpandedValue {
+                context,
+                source: ExpandedValueSource::Template(self),
+            }),
+        }
+    }
+}

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -1,0 +1,67 @@
+use bumpalo::collections::Vec as BumpVec;
+
+use crate::lazy::expanded::EncodingContext;
+use crate::{Element, Sequence};
+
+pub type TdlMacroInvocation<'top> = &'top Element;
+
+pub struct TemplateSequenceIterator<'top> {
+    // The list element over which we're iterating
+    sequence: &'top Sequence,
+    index: usize,
+    macro_stack: BumpVec<'top, TdlMacroInvocation<'top>>,
+}
+
+impl<'top> TemplateSequenceIterator<'top> {
+    pub fn new(context: EncodingContext<'top>, sequence: &'top Sequence) -> Self {
+        Self {
+            sequence,
+            index: 0,
+            macro_stack: BumpVec::new_in(context.allocator),
+        }
+    }
+}
+
+impl<'top> Iterator for TemplateSequenceIterator<'top> {
+    type Item = &'top Element;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.sequence.get(self.index) {
+            Some(element) => {
+                self.index += 1;
+                Some(element)
+            }
+            None => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bumpalo::Bump;
+
+    use crate::lazy::expanded::macro_table::MacroTable;
+    use crate::lazy::expanded::template::TemplateSequenceIterator;
+    use crate::lazy::expanded::EncodingContext;
+    use crate::{Element, IonResult, SymbolTable};
+
+    #[test]
+    fn template_list() -> IonResult<()> {
+        let data = "[1, (values 2 3 4), 5]";
+        let element = Element::read_one(data)?;
+        let sequence = element.as_list().expect("list");
+        let macro_table = MacroTable::new();
+        let symtab = SymbolTable::new();
+        let allocator = Bump::new();
+        let context = EncodingContext {
+            macro_table: &macro_table,
+            symbol_table: &symtab,
+            allocator: &allocator,
+        };
+        let iter = TemplateSequenceIterator::new(context, sequence);
+        for value in iter {
+            println!("{:?}", value);
+        }
+        Ok(())
+    }
+}

--- a/src/lazy/mod.rs
+++ b/src/lazy/mod.rs
@@ -6,6 +6,7 @@ pub mod binary;
 pub mod bytes_ref;
 pub mod decoder;
 pub(crate) mod encoding;
+pub mod expanded;
 pub mod raw_stream_item;
 pub mod raw_value_ref;
 pub mod reader;

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -1,19 +1,24 @@
+#![allow(non_camel_case_types)]
+
+use std::cell::RefCell;
+
+use bumpalo::Bump as BumpAllocator;
+
 use crate::lazy::any_encoding::{AnyEncoding, LazyRawAnyReader};
-use crate::lazy::encoding::{BinaryEncoding_1_0, TextEncoding_1_0};
+use crate::lazy::binary::raw::reader::LazyRawBinaryReader;
+use crate::lazy::decoder::LazyDecoder;
+use crate::lazy::decoder::LazyRawReader;
+use crate::lazy::encoding::{BinaryEncoding_1_0, TextEncoding_1_0, TextEncoding_1_1};
+use crate::lazy::expanded::macro_table::MacroTable;
+use crate::lazy::expanded::{
+    EncodingContext, ExpandedStreamItem, ExpandedValueRef, LazyExpandedValue, LazyExpandingReader,
+};
+use crate::lazy::r#struct::LazyStruct;
+use crate::lazy::system_stream_item::SystemStreamItem;
+use crate::lazy::text::raw::v1_1::reader::LazyRawTextReader_1_1;
+use crate::lazy::value::LazyValue;
 use crate::result::IonFailure;
 use crate::{IonResult, IonType, RawSymbolTokenRef, SymbolTable};
-
-use crate::lazy::binary::raw::reader::LazyRawBinaryReader;
-use crate::lazy::decoder::{LazyRawField, LazyRawReader, LazyRawStruct, LazyRawValue};
-
-use crate::lazy::decoder::private::LazyContainerPrivate;
-use crate::lazy::decoder::LazyDecoder;
-use crate::lazy::decoder::LazyRawSequence;
-use crate::lazy::r#struct::LazyStruct;
-use crate::lazy::raw_stream_item::RawStreamItem;
-use crate::lazy::raw_value_ref::RawValueRef;
-use crate::lazy::system_stream_item::SystemStreamItem;
-use crate::lazy::value::LazyValue;
 
 // Symbol IDs used for processing symbol table structs
 const ION_SYMBOL_TABLE: RawSymbolTokenRef = RawSymbolTokenRef::SymbolId(3);
@@ -72,13 +77,21 @@ const SYMBOLS: RawSymbolTokenRef = RawSymbolTokenRef::SymbolId(7);
 ///# }
 /// ```
 pub struct LazySystemReader<'data, D: LazyDecoder<'data>> {
-    raw_reader: D::Reader,
+    // TODO: Remove this RefCell when the Polonius borrow checker is available.
+    //       See: https://github.com/rust-lang/rust/issues/70255
+    expanding_reader: RefCell<LazyExpandingReader<'data, D>>,
+    // TODO: Make the symbol and macro tables traits on `D` such that they can be configured
+    //       statically. Then 1.0 types can use `Never` for the macro table.
     symbol_table: SymbolTable,
+    macro_table: MacroTable,
+    allocator: BumpAllocator,
     pending_lst: PendingLst,
 }
 
 pub type LazySystemBinaryReader<'data> = LazySystemReader<'data, BinaryEncoding_1_0>;
-pub type LazySystemTextReader<'data> = LazySystemReader<'data, TextEncoding_1_0>;
+pub type LazySystemTextReader_1_0<'data> = LazySystemReader<'data, TextEncoding_1_0>;
+pub type LazySystemTextReader_1_1<'data> = LazySystemReader<'data, TextEncoding_1_1>;
+
 pub type LazySystemAnyReader<'data> = LazySystemReader<'data, AnyEncoding>;
 
 // If the reader encounters a symbol table in the stream, it will store all of the symbols that
@@ -91,9 +104,12 @@ struct PendingLst {
 impl<'data> LazySystemAnyReader<'data> {
     pub fn new(ion_data: &'data [u8]) -> LazySystemAnyReader<'data> {
         let raw_reader = LazyRawAnyReader::new(ion_data);
+        let expanding_reader = LazyExpandingReader::new(raw_reader);
         LazySystemReader {
-            raw_reader,
+            expanding_reader: RefCell::new(expanding_reader),
             symbol_table: SymbolTable::new(),
+            macro_table: MacroTable::new(),
+            allocator: BumpAllocator::new(),
             pending_lst: PendingLst {
                 is_lst_append: false,
                 symbols: Vec::new(),
@@ -105,9 +121,29 @@ impl<'data> LazySystemAnyReader<'data> {
 impl<'data> LazySystemBinaryReader<'data> {
     pub(crate) fn new(ion_data: &'data [u8]) -> LazySystemBinaryReader<'data> {
         let raw_reader = LazyRawBinaryReader::new(ion_data);
+        let expanding_reader = LazyExpandingReader::new(raw_reader);
         LazySystemReader {
-            raw_reader,
+            expanding_reader: RefCell::new(expanding_reader),
             symbol_table: SymbolTable::new(),
+            macro_table: MacroTable::new(),
+            allocator: BumpAllocator::new(),
+            pending_lst: PendingLst {
+                is_lst_append: false,
+                symbols: Vec::new(),
+            },
+        }
+    }
+}
+
+impl<'data> LazySystemTextReader_1_1<'data> {
+    pub(crate) fn new(ion_data: &'data [u8]) -> LazySystemTextReader_1_1<'data> {
+        let raw_reader = LazyRawTextReader_1_1::new(ion_data);
+        let expanding_reader = LazyExpandingReader::new(raw_reader);
+        LazySystemReader {
+            expanding_reader: RefCell::new(expanding_reader),
+            symbol_table: SymbolTable::new(),
+            macro_table: MacroTable::new(),
+            allocator: BumpAllocator::new(),
             pending_lst: PendingLst {
                 is_lst_append: false,
                 symbols: Vec::new(),
@@ -119,7 +155,7 @@ impl<'data> LazySystemBinaryReader<'data> {
 impl<'data, D: LazyDecoder<'data>> LazySystemReader<'data, D> {
     // Returns `true` if the provided [`LazyRawValue`] is a struct whose first annotation is
     // `$ion_symbol_table`.
-    fn is_symbol_table_struct(lazy_value: &D::Value) -> IonResult<bool> {
+    fn is_symbol_table_struct(lazy_value: &'_ LazyExpandedValue<'_, 'data, D>) -> IonResult<bool> {
         if lazy_value.ion_type() != IonType::Struct {
             return Ok(false);
         }
@@ -132,29 +168,36 @@ impl<'data, D: LazyDecoder<'data>> LazySystemReader<'data, D> {
     /// Returns the next top-level stream item (IVM, Symbol Table, Value, or Nothing) as a
     /// [`SystemStreamItem`].
     pub fn next_item<'top>(&'top mut self) -> IonResult<SystemStreamItem<'top, 'data, D>> {
+        // Deconstruct the reader to get simultaneous mutable references to multiple fields
         let LazySystemReader {
-            raw_reader,
-            symbol_table,
+            ref expanding_reader,
+            ref symbol_table,
+            macro_table,
+            allocator,
             pending_lst,
         } = self;
         Self::apply_pending_lst(symbol_table, pending_lst);
-        let lazy_raw_value = match raw_reader.next()? {
-            RawStreamItem::VersionMarker(major, minor) => {
+        let context = EncodingContext {
+            macro_table,
+            symbol_table,
+            allocator,
+        };
+        let lazy_expanded_value = match expanding_reader.borrow_mut().next(context)? {
+            ExpandedStreamItem::VersionMarker(major, minor) => {
                 return Ok(SystemStreamItem::VersionMarker(major, minor));
             }
-            RawStreamItem::Value(lazy_raw_value) => lazy_raw_value,
-            RawStreamItem::EndOfStream => return Ok(SystemStreamItem::EndOfStream),
-            RawStreamItem::MacroInvocation(_) => todo!("impl macro invocations"),
+            ExpandedStreamItem::Value(lazy_raw_value) => lazy_raw_value,
+            ExpandedStreamItem::EndOfStream => return Ok(SystemStreamItem::EndOfStream),
         };
-        if Self::is_symbol_table_struct(&lazy_raw_value)? {
-            Self::process_symbol_table(pending_lst, &lazy_raw_value)?;
+        if Self::is_symbol_table_struct(&lazy_expanded_value)? {
+            Self::process_symbol_table(pending_lst, &lazy_expanded_value)?;
             let lazy_struct = LazyStruct {
-                raw_struct: D::Struct::from_value(lazy_raw_value),
-                symbol_table,
+                expanded_struct: lazy_expanded_value.read()?.expect_struct()?,
+                symbol_table: context.symbol_table,
             };
             return Ok(SystemStreamItem::SymbolTable(lazy_struct));
         }
-        let lazy_value = LazyValue::new(symbol_table, lazy_raw_value);
+        let lazy_value = LazyValue::new(lazy_expanded_value);
         Ok(SystemStreamItem::Value(lazy_value))
     }
 
@@ -167,36 +210,68 @@ impl<'data, D: LazyDecoder<'data>> LazySystemReader<'data, D> {
     // Until Polonius is available, the method will live here instead.
     // [1]: https://github.com/rust-lang/rust/issues/70255
     pub fn next_value<'top>(&'top mut self) -> IonResult<Option<LazyValue<'top, 'data, D>>> {
+        // Deconstruct the reader to get simultaneous mutable references to multiple fields
         let LazySystemReader {
-            raw_reader,
-            symbol_table,
+            ref expanding_reader,
+            ref symbol_table,
+            macro_table,
+            allocator,
             pending_lst,
         } = self;
+
         loop {
             Self::apply_pending_lst(symbol_table, pending_lst);
-            let lazy_raw_value = match raw_reader.next()? {
-                RawStreamItem::VersionMarker(_, _) => continue,
-                RawStreamItem::Value(lazy_raw_value) => lazy_raw_value,
-                RawStreamItem::EndOfStream => return Ok(None),
-                RawStreamItem::MacroInvocation(_) => todo!("impl macro invocations"),
+            let context = EncodingContext {
+                symbol_table,
+                macro_table,
+                allocator,
             };
-            if Self::is_symbol_table_struct(&lazy_raw_value)? {
-                // process the symbol table, but do not surface it
-                Self::process_symbol_table(pending_lst, &lazy_raw_value)?;
-            } else {
-                return Ok(Some(LazyValue::new(symbol_table, lazy_raw_value)));
+            let lazy_expanded_value = match expanding_reader.borrow_mut().next(context)? {
+                ExpandedStreamItem::VersionMarker(_major, _minor) => {
+                    // TODO: For text, switch the underlying reader as needed
+                    continue;
+                }
+                ExpandedStreamItem::Value(lazy_raw_value) => lazy_raw_value,
+                ExpandedStreamItem::EndOfStream => return Ok(None),
+            };
+            if Self::is_symbol_table_struct(&lazy_expanded_value)? {
+                Self::process_symbol_table(pending_lst, &lazy_expanded_value)?;
+                drop(lazy_expanded_value);
+                continue;
             }
+            let lazy_value = LazyValue::new(lazy_expanded_value);
+            return Ok(Some(lazy_value));
         }
     }
 
     // If the last stream item the reader visited was a symbol table, its `PendingLst` will
     // contain new symbols that need to be added to the local symbol table.
-    fn apply_pending_lst(symbol_table: &mut SymbolTable, pending_lst: &mut PendingLst) {
+    fn apply_pending_lst(symbol_table: &SymbolTable, pending_lst: &mut PendingLst) {
+        let ptr = symbol_table as *const SymbolTable;
+
+        // XXX: This `unsafe` is a workaround for https://github.com/rust-lang/rust/issues/70255
+        //      There is a rustc fix for this limitation on the horizon. See:
+        //      https://smallcultfollowing.com/babysteps/blog/2023/09/22/polonius-part-1/
+        //      Indeed, using the experimental `-Zpolonius` flag on the nightly compiler allows the
+        //      version of this code without this `unsafe` hack to work. The alternative to the
+        //      hack is wrapping the SymbolTable in something like `RefCell`, which adds a small
+        //      amount of overhead to each access. Given that the `SymbolTable` is on the hot
+        //      path and that a fix is inbound, I think this use of `unsafe` is warranted.
+        // SAFETY: At this point, the only thing that's holding potentially holding references to
+        //         the symbol table is the lazy value that represented an LST directive. We've
+        //         already read through that value in full to populate the `PendingLst`. Updating
+        //         the symbol table will invalidate data in that lazy value, so we just have to take
+        //         care not to read from it after updating the symbol table.
+        let symbol_table = unsafe {
+            let mut_ptr = ptr as *mut SymbolTable;
+            &mut *mut_ptr
+        };
         // `is_empty()` will be true if the last item was not a symbol table OR if it was a symbol
         // table but did not define new symbols. In either case, there's nothing for us to do.
         if pending_lst.symbols.is_empty() {
             return;
         }
+
         // If the symbol table's `imports` field had a value of `$ion_symbol_table`, then we're
         // appending the symbols it defined to the end of our existing local symbol table.
         // Otherwise, we need to clear the existing table before appending the new symbols.
@@ -213,15 +288,13 @@ impl<'data, D: LazyDecoder<'data>> LazySystemReader<'data, D> {
 
     // Traverses a symbol table, processing the `symbols` and `imports` fields as needed to
     // populate the `PendingLst`.
-    fn process_symbol_table(
+    fn process_symbol_table<'top>(
         pending_lst: &mut PendingLst,
-        symbol_table: &D::Value,
+        symbol_table: &LazyExpandedValue<'top, 'data, D>,
     ) -> IonResult<()> {
         // We've already confirmed this is an annotated struct
         let symbol_table = symbol_table.read()?.expect_struct()?;
-        // Assume it's not an LST append unless we found `imports: $ion_symbol_table`
-        pending_lst.is_lst_append = false;
-        // let mut fields = symbol_table.iter();
+
         let mut found_symbols_field = false;
         let mut found_imports_field = false;
 
@@ -234,7 +307,7 @@ impl<'data, D: LazyDecoder<'data>> LazySystemReader<'data, D> {
                     );
                 }
                 found_symbols_field = true;
-                Self::process_symbols(pending_lst, &field.value())?;
+                Self::process_symbols(pending_lst, field.value())?;
             }
             if field.name().matches_sid_or_text(6, "imports") {
                 if found_imports_field {
@@ -243,7 +316,7 @@ impl<'data, D: LazyDecoder<'data>> LazySystemReader<'data, D> {
                     );
                 }
                 found_imports_field = true;
-                Self::process_imports(pending_lst, &field.value())?;
+                Self::process_imports(pending_lst, field.value())?;
             }
             // Ignore other fields
         }
@@ -251,10 +324,13 @@ impl<'data, D: LazyDecoder<'data>> LazySystemReader<'data, D> {
     }
 
     // Store any strings defined in the `symbols` field in the `PendingLst` for future application.
-    fn process_symbols(pending_lst: &mut PendingLst, symbols: &D::Value) -> IonResult<()> {
-        if let RawValueRef::List(list) = symbols.read()? {
-            for symbol_text in list.iter() {
-                if let RawValueRef::String(str_ref) = symbol_text?.read()? {
+    fn process_symbols<'top>(
+        pending_lst: &mut PendingLst,
+        symbols: &LazyExpandedValue<'top, 'data, D>,
+    ) -> IonResult<()> {
+        if let ExpandedValueRef::List(list) = symbols.read()? {
+            for symbol_text_result in list.iter() {
+                if let ExpandedValueRef::String(str_ref) = symbol_text_result?.read()? {
                     pending_lst.symbols.push(Some(str_ref.text().to_owned()))
                 } else {
                     pending_lst.symbols.push(None)
@@ -266,16 +342,19 @@ impl<'data, D: LazyDecoder<'data>> LazySystemReader<'data, D> {
     }
 
     // Check for `imports: $ion_symbol_table`.
-    fn process_imports(pending_lst: &mut PendingLst, imports: &D::Value) -> IonResult<()> {
+    fn process_imports<'top>(
+        pending_lst: &mut PendingLst,
+        imports: &LazyExpandedValue<'top, 'data, D>,
+    ) -> IonResult<()> {
         match imports.read()? {
-            RawValueRef::Symbol(symbol_ref) => {
+            ExpandedValueRef::Symbol(symbol_ref) => {
                 if symbol_ref.matches_sid_or_text(3, "$ion_symbol_table") {
                     pending_lst.is_lst_append = true;
                 }
                 // Any other symbol is ignored
             }
             // TODO: Implement shared symbol table imports
-            RawValueRef::List(_) => {
+            ExpandedValueRef::List(_) => {
                 return IonResult::decoding_error(
                     "This implementation does not yet support shared symbol table imports",
                 );
@@ -291,10 +370,11 @@ impl<'data, D: LazyDecoder<'data>> LazySystemReader<'data, D> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::lazy::binary::test_utilities::to_binary_ion;
     use crate::lazy::system_stream_item::SystemStreamItem;
     use crate::IonResult;
+
+    use super::*;
 
     #[test]
     fn try_it() -> IonResult<()> {

--- a/src/lazy/text/encoded_value.rs
+++ b/src/lazy/text/encoded_value.rs
@@ -7,7 +7,7 @@ use std::ops::Range;
 /// Represents the type, offset, and length metadata of the various components of an encoded value
 /// in a text input stream.
 ///
-/// Each [`LazyRawTextValue`](crate::lazy::text::value::LazyRawTextValue_1_0) contains an `EncodedValue`,
+/// Each [`LazyRawTextValue`](crate::lazy::text::value::MatchedRawTextValue) contains an `EncodedValue`,
 /// allowing a user to re-read (that is: parse) the body of the value as many times as necessary
 /// without re-parsing its header information each time.
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/src/lazy/value_ref.rs
+++ b/src/lazy/value_ref.rs
@@ -22,10 +22,10 @@ pub enum ValueRef<'top, 'data, D: LazyDecoder<'data>> {
     Float(f64),
     Decimal(Decimal),
     Timestamp(Timestamp),
-    String(StrRef<'data>),
+    String(StrRef<'top>),
     Symbol(SymbolRef<'top>),
-    Blob(BytesRef<'data>),
-    Clob(BytesRef<'data>),
+    Blob(BytesRef<'top>),
+    Clob(BytesRef<'top>),
     SExp(LazySExp<'top, 'data, D>),
     List(LazyList<'top, 'data, D>),
     Struct(LazyStruct<'top, 'data, D>),
@@ -163,7 +163,7 @@ impl<'top, 'data, D: LazyDecoder<'data>> ValueRef<'top, 'data, D> {
         }
     }
 
-    pub fn expect_string(self) -> IonResult<StrRef<'data>> {
+    pub fn expect_string(self) -> IonResult<StrRef<'top>> {
         if let ValueRef::String(s) = self {
             Ok(s)
         } else {
@@ -179,7 +179,7 @@ impl<'top, 'data, D: LazyDecoder<'data>> ValueRef<'top, 'data, D> {
         }
     }
 
-    pub fn expect_blob(self) -> IonResult<BytesRef<'data>> {
+    pub fn expect_blob(self) -> IonResult<BytesRef<'top>> {
         if let ValueRef::Blob(b) = self {
             Ok(b)
         } else {
@@ -187,7 +187,7 @@ impl<'top, 'data, D: LazyDecoder<'data>> ValueRef<'top, 'data, D> {
         }
     }
 
-    pub fn expect_clob(self) -> IonResult<BytesRef<'data>> {
+    pub fn expect_clob(self) -> IonResult<BytesRef<'top>> {
         if let ValueRef::Clob(c) = self {
             Ok(c)
         } else {
@@ -216,6 +216,24 @@ impl<'top, 'data, D: LazyDecoder<'data>> ValueRef<'top, 'data, D> {
             Ok(s)
         } else {
             IonResult::decoding_error("expected a struct")
+        }
+    }
+
+    pub fn ion_type(&self) -> IonType {
+        match self {
+            ValueRef::Null(ion_type) => *ion_type,
+            ValueRef::Bool(_) => IonType::Bool,
+            ValueRef::Int(_) => IonType::Int,
+            ValueRef::Float(_) => IonType::Float,
+            ValueRef::Decimal(_) => IonType::Decimal,
+            ValueRef::Timestamp(_) => IonType::Timestamp,
+            ValueRef::String(_) => IonType::String,
+            ValueRef::Symbol(_) => IonType::Symbol,
+            ValueRef::Blob(_) => IonType::Blob,
+            ValueRef::Clob(_) => IonType::Clob,
+            ValueRef::SExp(_) => IonType::SExp,
+            ValueRef::List(_) => IonType::List,
+            ValueRef::Struct(_) => IonType::Struct,
         }
     }
 }

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -76,7 +76,6 @@ impl From<fmt::Error> for IonError {
     }
 }
 
-
 impl From<IonError> for fmt::Error {
     fn from(_ion_error: IonError) -> Self {
         // This no-op transformation allows `?` to be used in `Debug` implementations wherever

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -73,6 +73,14 @@ impl From<fmt::Error> for IonError {
     }
 }
 
+impl From<IonError> for fmt::Error {
+    fn from(_ion_error: IonError) -> Self {
+        // This no-op transformation allows `?` to be used in `Debug` implementations wherever
+        // an IonError could surface.
+        fmt::Error
+    }
+}
+
 // Crate-visible convenience methods for constructing error variants and wrapping them in the
 // appropriate type: IonResult<T> or IonError. This is a trait so these methods can be added to
 // `IonResult<T>`, which is just a type alias for `Result<T, IonError>`, whose implementation

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -7,6 +7,7 @@ use crate::{Symbol, SymbolId};
 /// Stores mappings from Symbol IDs to text and vice-versa.
 // SymbolTable instances always have at least system symbols; they are never empty.
 #[allow(clippy::len_without_is_empty)]
+#[derive(Debug)]
 pub struct SymbolTable {
     symbols_by_id: Vec<Symbol>,
     ids_by_text: HashMap<Symbol, SymbolId>,

--- a/src/types/struct.rs
+++ b/src/types/struct.rs
@@ -233,6 +233,13 @@ impl Struct {
     pub fn get_all<A: AsSymbolRef>(&self, field_name: A) -> impl Iterator<Item = &Element> {
         self.fields.get_all(field_name)
     }
+
+    pub fn get_index(&self, field_index: usize) -> Option<(&Symbol, &Element)> {
+        self.fields
+            .by_index
+            .get(field_index)
+            .map(|(name, value)| (name, value))
+    }
 }
 
 // Allows `for (name, value) in &my_struct {...}` syntax


### PR DESCRIPTION
### Syntax changes

Ion 1.1 only introduces a single text syntactic element: _encoding expressions_. Encoding expressions (e-expressions for short) represent a macro invocation in the data stream, and look like this:

```
(:macro_id arg1 arg2 arg3 ... argN)
```

Apart from the leading smiley (`(:`) and `macro_id`, they follow s-expression syntax rules.

E-expressions can appear anywhere that an Ion value can appear, including:
* In a sequence:
   * Top level: `$ion_1_1 (:foo)`
   * S-expression: `(1 2 (:foo) 4)`
   * List: `[1, 2, (:foo), 4]`
* In a struct:
   * In field value position: `{ a: 1, foo: (:bar), c: 3 }`
   * In field name position with no associated value: `{ a: 1, (:bar), c: 3 }`
* As an argument to another e-expression: `(:foo 1 2 (:bar) 4)`

To support this change to the grammar, the `LazyDecoder` trait has been modified to accommodate the possibility of an e-expression in these locations. In addition to the associated type `Value`, each `LazyDecoder` implementation `D` (for example: `TextEncoding_1_1`, `BinaryEncoding_1_0`, etc) now has to declare an associated type `MacroInvocation` that represents that encoding's syntactic representation of an e-expression. Rather than `D::Reader::next()` returning a `D::Value`, it now returns a `LazyRawValueExpr<D>`, an enum that could be either a value or an e-expression:

```rust
pub enum LazyRawValueExpr<'data, D: LazyDecoder<'data>> {
    /// A text Ion value literal. For example: `5`, `foo`, or `"hello"`
    ValueLiteral(D::Value),
    /// A text Ion 1.1+ macro invocation. For example: `(:employee 12345 "Sarah" "Gonzalez")`
    MacroInvocation(D::MacroInvocation),
}
```

Similarly, rather than returning a `D::Field`, a `D::Struct`'s iterator will return a `LazyRawFieldExpr<D>`:

```rust
/// An item found in field position within a struct.
/// This item may be:
///   * a name/value pair (as it is in Ion 1.0)
///   * a name/e-expression pair
///   * an e-expression
#[derive(Debug)]
pub enum LazyRawFieldExpr<'data, D: LazyDecoder<'data>> {
    NameValuePair(RawSymbolTokenRef<'data>, LazyRawValueExpr<'data, D>),
    MacroInvocation(D::MacroInvocation),
}
```

Because Ion 1.0 will never use these new enum variants, a special type called `Never` has been introduced that allows the compiler to recognize code paths related to macros in Ion 1.0 as dead branches that can be optimized out:

```rust
/// An uninhabited type that signals to the compiler that related code paths are not reachable.
#[derive(Debug, Copy, Clone)]
pub enum Never {
    // Has no variants, cannot be instantiated.
}
```

This should result in Ion 1.0 maintaining the same performance even though `ion-rust`'s data model is now more complex.

------

### Expansion behavior

Upon evaluation, an e-expression expands to zero or more Ion _values_ -- they cannot produce version markers, `NOP`s, or other e-expressions. This PR implements a limited set of macros:
* `(:values arg1 arg2 ... argN)`: always expands to its arguments.
* `(:void)`: always expands to 0 values. (This is equivalent to `(:values /* no args */)`).
* `(:make_string arg1 arg2 ... argN)`: builds a string by evaluating each of its arguments to produce a stream of text values which are then concatenated.

When an e-expression appears in a sequence, the values in its expansion are considered part of that sequence.

```ion_1_1
// Top level
$ion_1_1 1 2 (:values 3 4) 5 6    // 1 2 3 4 5 6

// List
[1, 2, (:values 3 4), 5, 6]       // [1, 2, 3, 4, 5, 6]

// S-expression
(1 2 (:values 3 4) 5 6)           // (1 2 3 4 5 6)
```

When an e-expression appears in a struct, its expansion behavior depends on whether it was in field value or field name position.

In field value position, each value in its expansion is treated as a field value with the same field name as preceded the e-expression.

```ion_1_1
// Field value position
{
    foo: (:values 1 2 3),
    bar: (:values 4),
    baz: (:void)
}                       
// Expands to:
{
    foo: 1,
    foo: 2,
    foo: 3,
    bar: 4
}
```

In field name position, the macro must evaluate to a single struct. That struct's fields will then be merged into the host struct.

```ion_1_1
// Field name position
{
    foo: 1,
    (:values {bar: 2, baz: 3}),
    quux: 4,
}                       
// Expands to:
{
    foo: 1,
    bar: 2,
    baz: 3,
    quux: 4
}
```

To enable this behavior, this patch introduces a fourth layer of abstraction into the lazy reader model:

1. `Raw`: where bits on the wire are turned into syntax tokens (IVMs, values, symbol ID tokens, e-expressions)
2. **--> new <--** `Expanded`: e-expressions encountered in the raw level are fully expanded. The reader API hands out `LazyExpandedValue`s, each of which may be backed either by an as-of-yet-unread value literal from the input stream or by the result of a macro's evaluation.
3. `System`: which filters out and processes encoding directives (symbol tables, module declarations) from the values surfaced by lower levels of abstraction.
4. `Application`: only data relevant to the application's data model is visible.

-----

### Macro evaluation

This PR introduces a new type, `MacroEvaluator`, which can evaluate a macro incrementally; it only calculates the next value in the expansion upon request. This enables e-expressions to be evaluated lazily, making skip-scanning even more powerful and preventing the unexpected spikes in memory usage that might come from eagerly evaluating expressions that may or may not be needed.

#### Incremental argument evaluation

The `MacroEvaluator` achieves this by maintaining a stack of macros that are in the process of being evaluated. Each time the next value is requested, the macro at the top of the stack is given the opportunity to either:
* yield another value
* push another macro onto the stack
* indicate that its evaluation is complete

Some macros like `(:values ...)` need to partially evaluate their arguments until they find another value. Consider:
```ion_1_1
(:values
  1
  (:values 2 3)
  4)
```
When evaluating this expression, the evaluator will follow these steps:
1. Push the entire expression onto the stack. Yield `1`.
1. Push `(:values 2 3)` onto the stack, yield `2`.
1. Yield `3`.
1. Pop `(:values 2 3)` off of the stack, yield `4`.
2. Pop the entire expression off of the stack. yield `None`.

#### Eager argument evaluation

Other macros like `(:make_string)` need access to the expanded form of all of their arguments to yield their next value. In this case, the macro can construct a transient (short-lived) evaluator of its own.

```ion_1_1
(:make_string
  foo_
  (:values bar_ baz_)
  quux_)
```

The evaluation steps for this are:

1. Push the entire expression onto the primary stack; construct an empty string buffer and a transient evaluator.
   a. Push the text content `foo_` onto the buffer.
   b. We cannot push `(:values bar_ baz_)` onto the primary evaluator without yielding flow control. Instead, we push `(:values bar_ baz_)` onto the secondary, transient evaluator's stack.
   c. Ask the secondary evaluator for the next value, get `bar_`, push its text onto the buffer.
   d. Ask the secondary evaluator for the next value, get `baz_`, push its text onto the buffer.
   e. Pop `(:values bar_ baz_)` off the secondary evaluator's stack. Get `quux_`, push its text onto the buffer.
   f. Pop the entire expression off of the stack, yield `"foo_bar_baz_quux"`.

From the caller's perspective, they called `next()` and received `"foo_bar_baz_quux"`. However, internally the same incremental evaluation logic was being used in a smaller scope. Note that this means each substring was evaluated one at a time; we did not need to collect them or hold them all in memory at the same time (modulo the buffer's contents).

#### Bump allocation

In the description of `(:make_string)` above, perceptive readers may have noticed some possible sources of allocations; in particular, constructing a string buffer and constructing a transient evaluator.

This PR leverages [`bumpalo`](https://docs.rs/bumpalo/latest/bumpalo/) to be able to trivially allocate and deallocate structures using a preallocated block of heap memory. Values created in this way (including string buffers, and the `Vec`s backing our transient evaluators) cannot live beyond the current top level value, but happily that's exactly how long we need them! As a result, we get to allocate and deallocate by simply bumping an offset within our preallocated memory.

-----

### TODO
* Benchmarking (particularly of Ion 1.0 code)
* Wiring up the `LazyReader` to switch between underlying readers when a different IVM is encountered.
* Template macros (including variable expansion)
* Encoding directives (module definition)
* Other built-in macros (`make_timestamp`, `if_void`, etc)
* Binary encoding

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
