### PR TITLE
Fixes parsing of macro invocations in Lists and SExps and some cases …

### DIFF
--- a/src/lazy/text/buffer.rs
+++ b/src/lazy/text/buffer.rs
@@ -117,7 +117,6 @@ pub(crate) struct TextBufferView<'a> {
     //                          offset: 6
     data: &'a [u8],
     offset: usize,
-    // encoding: AnyTextEncoding,
 }
 
 impl<'data> TextBufferView<'data> {


### PR DESCRIPTION
…in Structs

**Issue #, if available:**

None

**Description of changes:**

As I was starting to write test cases in `ion-tests` for macros, I discovered that macros were working when they appeared at the top level of an Ion stream, or when they were nested no more than one layer deep. I've fixed that, though some issues still remain with macros in structs (see #653).

See specific notes in 🗺️ comments.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
