### PR TITLE
Adds integration testing for Ion 1.1

### DIFF
--- a/src/ion_data/mod.rs
+++ b/src/ion_data/mod.rs
@@ -78,7 +78,7 @@ impl<T: Display> Display for IonData<T> {
 
 impl<T: IonEq + IonOrd> PartialOrd for IonData<T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(IonOrd::ion_cmp(&self.0, &other.0))
+        Some(self.cmp(other))
     }
 }
 

--- a/src/types/struct.rs
+++ b/src/types/struct.rs
@@ -267,7 +267,7 @@ where
 
             by_name
                 .entry(field_name.clone())
-                .or_insert_with(IndexVec::new)
+                .or_default()
                 .push(by_index.len());
             by_index.push((field_name, field_value));
         }

--- a/tests/ion_data_consistency.rs
+++ b/tests/ion_data_consistency.rs
@@ -20,13 +20,13 @@ fn contains_path(paths: &[&str], file_name: &str) -> bool {
 }
 
 const SKIP_LIST: &[&str] = &[
-    "ion-tests/iontestdata/good/equivs/localSymbolTableAppend.ion",
-    "ion-tests/iontestdata/good/equivs/localSymbolTableNullSlots.ion",
-    "ion-tests/iontestdata/good/equivs/nonIVMNoOps.ion",
+    "ion-tests/iontestdata_1_0/good/equivs/localSymbolTableAppend.ion",
+    "ion-tests/iontestdata_1_0/good/equivs/localSymbolTableNullSlots.ion",
+    "ion-tests/iontestdata_1_0/good/equivs/nonIVMNoOps.ion",
 ];
 
-#[test_resources("ion-tests/iontestdata/good/equivs/**/*.ion")]
-#[test_resources("ion-tests/iontestdata/good/equivs/**/*.10n")]
+#[test_resources("ion-tests/iontestdata_1_0/good/equivs/**/*.ion")]
+#[test_resources("ion-tests/iontestdata_1_0/good/equivs/**/*.10n")]
 fn ion_data_eq_ord_consistency(file_name: &str) {
     // Best-effort tests to check that Eq and Ord are consistent.
 


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

* There are a few clippy changes because a new version of rust was released.
* A large portion of the diff is `iontestdata` -> `iontestdata_1_0`.
* Adds an `ion_1_1` module to `element_test_vectors.rs` integration testing for the Ion 1.1 reader.
* Adds support for reading equivs and non-equivs test cases that are defined as a struct, and for reading embedded documents that are a blob.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
