### PR TITLE
Constant time struct field access

### DIFF
--- a/benches/read_many_structs.rs
+++ b/benches/read_many_structs.rs
@@ -117,6 +117,19 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             let _ = black_box(num_values);
         })
     });
+    c.bench_function("text 1.0: read 'format' field", |b| {
+        b.iter(|| {
+            let mut reader =
+                LazyApplicationReader::<'_, TextEncoding_1_1>::new(data_1_0.as_bytes()).unwrap();
+            let mut num_values = 0usize;
+            while let Some(value) = reader.next().unwrap() {
+                let s = value.read().unwrap().expect_struct().unwrap();
+                let parameters_list = s.find_expected("format").unwrap();
+                num_values += count_value_and_children(&parameters_list).unwrap();
+            }
+            let _ = black_box(num_values);
+        })
+    });
     c.bench_function("text 1.1: scan all", |b| {
         b.iter(|| {
             let mut reader = LazyTextReader_1_1::new(data_1_1.as_bytes()).unwrap();
@@ -133,6 +146,20 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             let mut num_values = 0usize;
             while let Some(item) = reader.next().unwrap() {
                 num_values += count_value_and_children(&item).unwrap();
+            }
+            let _ = black_box(num_values);
+        })
+    });
+    c.bench_function("text 1.1: read 'format' field", |b| {
+        b.iter(|| {
+            let mut reader =
+                LazyApplicationReader::<'_, TextEncoding_1_1>::new(data_1_1.as_bytes()).unwrap();
+            reader.register_template(template_text).unwrap();
+            let mut num_values = 0usize;
+            while let Some(value) = reader.next().unwrap() {
+                let s = value.read().unwrap().expect_struct().unwrap();
+                let parameters_list = s.find_expected("format").unwrap();
+                num_values += count_value_and_children(&parameters_list).unwrap();
             }
             let _ = black_box(num_values);
         })

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -454,9 +454,7 @@ impl TemplateCompiler {
                 match fields.get_mut(text) {
                     Some(value_expr_addresses) => value_expr_addresses.push(value_expr_address),
                     None => {
-                        let mut value_expr_addresses = Vec::new();
-                        value_expr_addresses.push(value_expr_address);
-                        fields.insert(name.clone(), value_expr_addresses);
+                        let _ = fields.insert(name.clone(), vec![value_expr_address]);
                     }
                 }
             }

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -687,7 +687,7 @@ impl<'top> TemplateExpansion<'top> {
                 match e.value() {
                     TemplateValue::List(range)
                     | TemplateValue::SExp(range)
-                    | TemplateValue::Struct(range) => self.step_index += range.len(),
+                    | TemplateValue::Struct(range, _) => self.step_index += range.len(),
                     _ => {}
                 }
                 ValueExpr::ValueLiteral(LazyExpandedValue::from_template(

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -271,9 +271,7 @@ impl<'top, D: LazyDecoder> MacroEvaluator<'top, D> {
             context,
         }
     }
-}
 
-impl<'top, D: LazyDecoder> MacroEvaluator<'top, D> {
     /// Returns the number of macros that are currently being evaluated.
     pub fn macro_stack_depth(&self) -> usize {
         self.macro_stack.len()
@@ -353,6 +351,8 @@ impl<'top, D: LazyDecoder> MacroEvaluator<'top, D> {
     ///
     /// This is equivalent to calling [`next_at_or_above_depth`](Self::next_at_or_above_depth)
     /// with a `depth_to_exhaust` of `0`; see that method's documentation for more details.
+    // Clippy complains that `next` will be confused for the iterator method of the same name.
+    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> IonResult<Option<LazyExpandedValue<'top, D>>> {
         self.next_at_or_above_depth(0)
     }

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -859,12 +859,13 @@ impl<'top, D: LazyDecoder> ExpandedValueRef<'top, D> {
                 element.annotations_range(),
                 *s,
             )),
-            Struct(s) => ExpandedValueRef::Struct(LazyExpandedStruct::from_template(
+            Struct(s, index) => ExpandedValueRef::Struct(LazyExpandedStruct::from_template(
                 context,
                 environment,
                 element.template(),
                 element.annotations_range(),
                 *s,
+                index,
             )),
         }
     }

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -387,7 +387,7 @@ impl<'data, D: LazyDecoder> LazyExpandingReader<'data, D> {
                             .alloc_with(move || MacroEvaluator::new(context, Environment::empty())),
                     };
                     // Push the invocation onto the evaluation stack.
-                    evaluator.push(context, resolved_e_exp)?;
+                    evaluator.push(resolved_e_exp)?;
                     self.evaluator_ptr
                         .set(Some(Self::evaluator_to_ptr(evaluator)));
 
@@ -419,7 +419,7 @@ impl<'data, D: LazyDecoder> LazyExpandingReader<'data, D> {
         };
         let evaluator = Self::ptr_to_evaluator(evaluator_ptr);
 
-        match evaluator.next(self.context()) {
+        match evaluator.next() {
             Ok(Some(value)) => {
                 // See if this value was a symbol table that needs interpretation.
                 self.interpret_value(value).map(Some)

--- a/src/lazy/expanded/sequence.rs
+++ b/src/lazy/expanded/sequence.rs
@@ -314,7 +314,7 @@ fn expand_next_sequence_value<'top, D: LazyDecoder>(
     loop {
         // If the evaluator's stack is not empty, it's still expanding a macro.
         if evaluator.macro_stack_depth() > 0 {
-            let value = evaluator.next(context).transpose();
+            let value = evaluator.next().transpose();
             if value.is_some() {
                 // The `Some` may contain a value or an error; either way, that's the next return value.
                 return value;
@@ -336,7 +336,7 @@ fn expand_next_sequence_value<'top, D: LazyDecoder>(
                     Ok(resolved) => resolved,
                     Err(e) => return Some(Err(e)),
                 };
-                let begin_expansion_result = evaluator.push(context, resolved_invocation);
+                let begin_expansion_result = evaluator.push(resolved_invocation);
                 if let Err(e) = begin_expansion_result {
                     return Some(Err(e));
                 }

--- a/src/lazy/expanded/struct.rs
+++ b/src/lazy/expanded/struct.rs
@@ -9,14 +9,13 @@ use crate::lazy::expanded::macro_evaluator::{
 };
 use crate::lazy::expanded::sequence::Environment;
 use crate::lazy::expanded::template::{
-    AnnotationsRange, ExprRange, TemplateBodyValueExpr, TemplateElement, TemplateMacroInvocation,
-    TemplateMacroRef, TemplateStructIndex, TemplateStructRawFieldsIterator,
+    AnnotationsRange, ExprRange, TemplateBodyValueExpr, TemplateElement, TemplateMacroRef,
+    TemplateStructIndex, TemplateStructRawFieldsIterator,
 };
 use crate::lazy::expanded::{
     EncodingContext, ExpandedAnnotationsIterator, ExpandedAnnotationsSource, ExpandedValueRef,
     ExpandedValueSource, LazyExpandedValue,
 };
-use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
 use crate::result::IonFailure;
 use crate::{IonError, IonResult, RawSymbolTokenRef, SymbolRef};
 

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -174,7 +174,7 @@ impl<'top, D: LazyDecoder> Iterator for TemplateSequenceIterator<'top, D> {
         loop {
             // If the evaluator's stack is not empty, give it the opportunity to yield a value.
             if self.evaluator.macro_stack_depth() > 0 {
-                match self.evaluator.next(self.context).transpose() {
+                match self.evaluator.next().transpose() {
                     Some(value) => return Some(value),
                     None => {
                         // The stack did not produce values and is empty, pull
@@ -215,7 +215,7 @@ impl<'top, D: LazyDecoder> Iterator for TemplateSequenceIterator<'top, D> {
                             .unwrap(),
                     );
                     self.index += invocation.arg_expressions.len();
-                    match self.evaluator.push(self.context, invocation) {
+                    match self.evaluator.push(invocation) {
                         Ok(_) => continue,
                         Err(e) => Some(Err(e)),
                     }
@@ -230,7 +230,7 @@ impl<'top, D: LazyDecoder> Iterator for TemplateSequenceIterator<'top, D> {
                     match arg_expr {
                         ValueExpr::ValueLiteral(value) => Some(Ok(*value)),
                         ValueExpr::MacroInvocation(invocation) => {
-                            match self.evaluator.push(self.context, *invocation) {
+                            match self.evaluator.push(*invocation) {
                                 Ok(_) => continue,
                                 Err(e) => Some(Err(e)),
                             }

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -188,7 +188,7 @@ impl<'data, D: LazyDecoder> LazySystemReader<'data, D> {
 
         for field_result in symbol_table.iter() {
             let field = field_result?;
-            if field.name().matches_sid_or_text(7, "symbols") {
+            if field.raw_name().matches_sid_or_text(7, "symbols") {
                 if found_symbols_field {
                     return IonResult::decoding_error(
                         "found symbol table with multiple 'symbols' fields",
@@ -197,7 +197,7 @@ impl<'data, D: LazyDecoder> LazySystemReader<'data, D> {
                 found_symbols_field = true;
                 Self::process_symbols(pending_lst, field.value())?;
             }
-            if field.name().matches_sid_or_text(6, "imports") {
+            if field.raw_name().matches_sid_or_text(6, "imports") {
                 if found_imports_field {
                     return IonResult::decoding_error(
                         "found symbol table with multiple 'imports' fields",


### PR DESCRIPTION
*Issue #, if available:*
#672 

*Description of changes:*

This PR modifies the `TemplateCompiler` to maintain a `field_name` => `field_value_addresses` index for each template struct that it encounters. This allows `LazyStruct::find(name: &str)` to perform a single `HashMap` lookup any time its backing data is a template. If its backing data is a value literal, it will still need to perform a linear scan.

Commit guide:
* f986c14183f8b3948a58912abef5c9358af16374 contains the meat of the change
* 576fb0b984cf99e7a26f2081149efc7938150423 removes a now-superflous `context` parameter from a few `MacroEvaluator` methods; `MacroEvaluator` stores its own `context` that can be used instead as needed.
* 91f2d25871190a73f6e2fa4409c1685af10d435c Incorporates clippy suggestions

Here are some timings from of the included benchmark from my 2019 Intel MBP:

| Data Version | Scan all fields | Read single field | Read all fields |
| ----------- | --------:| ----------------:| --------------:|
| Ion 1.0        | 118ms    | 123ms                 | 138ms             |
| Ion 1.1        | 40ms      | 42ms                  |  67ms             | 

The same benchmarks, this time running on an `m5.4xlarge`:

| Data Version | Scan all fields | Read single field | Read all fields |
| ----------- | --------:| ----------------:| --------------:|
| Ion 1.0        | 133ms    | 139ms                 | 157ms             |
| Ion 1.1        | 46ms      | 48ms                  |  75ms             | 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
