### PR TITLE
Adds TextSExpWriter_1_0 implementation

### DIFF
--- a/src/lazy/encoder/mod.rs
+++ b/src/lazy/encoder/mod.rs
@@ -559,7 +559,6 @@ impl<'a, W: Write, E: LazyEncoder<W>> SequenceWriter<'a, W, E> for TextSExpWrite
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use crate::lazy::encoder::annotate::Annotate;


### PR DESCRIPTION
Adds a text s-expression writer to the `LazyTextWriter_1_0` implementation of `LazyEncoder`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
