### PR TITLE
Adds sexp and struct writers to the `LazyRawTextWriter_1_0`

### DIFF
--- a/src/lazy/encoder/mod.rs
+++ b/src/lazy/encoder/mod.rs
@@ -559,7 +559,6 @@ impl<'a, W: Write, E: LazyEncoder<W>> SequenceWriter<'a, W, E> for TextSExpWrite
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use crate::lazy::encoder::annotate::Annotate;


### PR DESCRIPTION
* Introduces a `TextContainerWriter_1_0` that houses information and behavior common to the container writer.
* Adds an s-expression writer, `TextSExpWriter_1_0`.
* Adds a struct writer, `TextStructWriter_1_0`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
