### PR TITLE
Implements writing v1.1 timestamps

### DIFF
--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -231,8 +231,156 @@ impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
         Ok(())
     }
 
-    pub fn write_timestamp(self, _value: &Timestamp) -> IonResult<()> {
-        todo!()
+    pub fn write_timestamp(mut self, value: &Timestamp) -> IonResult<()> {
+        use crate::TimestampPrecision::*;
+
+        const MIN_OFFSET: i32 = -14 * 60; // Western hemisphere, 14:00
+        const MAX_OFFSET: i32 = 14 * 60; // Eastern hemisphere, -14:00
+        const SHORT_FORM_OFFSET_RANGE: std::ops::RangeInclusive<i32> = MIN_OFFSET..=MAX_OFFSET;
+
+        let precision = value.precision();
+        let scale = value.fractional_seconds_scale().unwrap_or(0);
+
+        // Before encoding begins, see if this timestamp is one that can be written using the compact and easy-to-parse
+        // short form. To be short-form eligible, we must confirm that...
+        let is_short_form_eligible =
+            // ...the year can be represented as a 7 bit offset from the epoch (1970)...
+            (1970..2098).contains(&value.year())
+                // ...the offset is either unknown or is a quarter-hour between -14:00 and 14:00...
+                && value.offset().map(|offset| {
+                SHORT_FORM_OFFSET_RANGE.contains(&offset) && offset % 15 == 0
+            }).unwrap_or(true)
+                // ...and if present, the subsecond precision is either milliseconds, microseconds, or nanoseconds.
+                && match scale {
+                // TODO: Is this faster than `scale <= 9 && scale % 3 == 0`?
+                0 | 3 | 6 | 9 => true,
+                _ => false,
+            };
+
+        // If the timestamp does not meet the above criteria, we must instead encode it as a long-form timestamp.
+        if !is_short_form_eligible {
+            return self.write_long_form_timestamp(value);
+        }
+
+        // The number of bits dedicated to each time unit in a short-form timestamp
+        const NUM_YEAR_BITS: u32 = 7;
+        const NUM_MONTH_BITS: u32 = 4;
+        const NUM_DAY_BITS: u32 = 5;
+        const NUM_HOUR_BITS: u32 = 5;
+        const NUM_MINUTE_BITS: u32 = 6;
+        const NUM_SECOND_BITS: u32 = 6;
+        // The number of bits dedicated to representing the offset (known or unknown/UTC) in a short-form timestamp
+        const NUM_UNKNOWN_OR_UTC_BITS: u32 = 1;
+        const NUM_KNOWN_OFFSET_BITS: u32 = 7;
+
+        // The bit offsets of each time unit within the encoding
+        const YEAR_BIT_OFFSET: u32 = 0;
+        const MONTH_BIT_OFFSET: u32 = NUM_YEAR_BITS;
+        const DAY_BIT_OFFSET: u32 = MONTH_BIT_OFFSET + NUM_MONTH_BITS;
+        const HOUR_BIT_OFFSET: u32 = DAY_BIT_OFFSET + NUM_DAY_BITS;
+        const MINUTE_BIT_OFFSET: u32 = HOUR_BIT_OFFSET + NUM_HOUR_BITS;
+        const OFFSET_BIT_OFFSET: u32 = MINUTE_BIT_OFFSET + NUM_MINUTE_BITS;
+
+        // We encode all of the time unit fields regardless of the precision. This step is cheap, as it involves only
+        // left shifting and bitwise ORs. Branching to avoid these operations would be more expensive than just doing
+        // them.
+        let mut encoding: u64 = value.year() as u64 - 1970u64;
+        encoding |= (value.month() as u64) << MONTH_BIT_OFFSET;
+        encoding |= (value.day() as u64) << DAY_BIT_OFFSET;
+        encoding |= (value.hour() as u64) << HOUR_BIT_OFFSET;
+        encoding |= (value.minute() as u64) << MINUTE_BIT_OFFSET;
+
+        // Compute the offset, its width in bits, and how that will affect the opcode and encoded length.
+        let (num_offset_bits, offset_value, opcode_adjustment, length_adjustment) =
+            match value.offset() {
+                None => (1, 1, 0, 0), // Unknown offset uses a single bit (1); opcode and length stay the same.
+                Some(0) => (1, 0, 0, 0), // UTC uses a single bit (0); opcode and length stay the same.
+                Some(offset_minutes) => {
+                    // Bump the opcode to the one the corresponds to the same precision/scale but with a known offset
+                    let opcode_adjustment = 5;
+                    // `Seconds` is the only timestamp precision that does not change lengths when the offset is known.
+                    let length_adjustment = if precision == Second && scale == 0 {
+                        0
+                    } else {
+                        1
+                    };
+                    // The offset is encoded as the number of quarter-hours from offset -14:00.
+                    let quarter_hours = ((offset_minutes - MIN_OFFSET) / 15) as u64;
+                    // A known offset uses 7 bits; opcode increases by 5, length (often) increases by 1.
+                    (7, quarter_hours, opcode_adjustment, length_adjustment)
+                }
+            };
+
+        // These opcodes assume UTC or unknown offset--we adjust for known offsets afterwards.
+        let (mut opcode, bits_populated, mut encoded_body_length, subseconds) =
+            match (precision, scale) {
+                (Year, _) => (0x70, 7, 1, 0),
+                (Month, _) => (0x71, 11, 2, 0),
+                (Day, _) => (0x72, 16, 2, 0),
+                (HourAndMinute, _) => (0x73, 27 + num_offset_bits, 4, 0),
+                // Seconds
+                (Second, 0) => (0x74, 33 + num_offset_bits, 5, 0),
+                // Milliseconds
+                (Second, 3) => (0x75, 43 + num_offset_bits, 6, value.milliseconds()),
+                // Microseconds
+                (Second, 6) => (0x76, 53 + num_offset_bits, 7, value.microseconds()),
+                // Nanoseconds
+                (Second, 9) => (0x77, 63 + num_offset_bits, 8, value.nanoseconds()),
+                _ => {
+                    unreachable!("illegal precision / fractional second seconds scale encountered")
+                }
+            };
+
+        // If the timestamp has a known offset, its opcode and encoded length must be adjusted.
+        // If it is unknown or UTC, the adjustment values will be zero making these steps into no-ops.
+        opcode += opcode_adjustment;
+        encoded_body_length += length_adjustment;
+
+        // Encode the offset
+        encoding |= offset_value << OFFSET_BIT_OFFSET;
+
+        // Because the seconds and subseconds follow the offset (which can be 1 bit or 7 bits) we need to dynamically
+        // calculate their respective bit offsets.
+        let seconds_bit_offset = OFFSET_BIT_OFFSET + num_offset_bits;
+        encoding |= (value.second() as u64) << seconds_bit_offset;
+
+        let subseconds_bit_offset = seconds_bit_offset + NUM_SECOND_BITS;
+        encoding |= (subseconds as u64) << subseconds_bit_offset;
+
+        // Because we eagerly (and branchless-ly) encoded all of the time units, we may have populated bits that are
+        // irrelevant to the final encoding. To simplify unit testing (and in the current absence of a binary 1.1
+        // reader, we calculate a mask of which bits are relevant to the current opcode and set any bits not in use to `0`.
+        // TODO: Remove this logic pending resolution of https://github.com/amazon-ion/ion-docs/issues/295, which
+        //       suggests requiring readers to ignore bits not used by the specified opcode
+        let mask = 1u64
+            .checked_shl(bits_populated)
+            .unwrap_or(0)
+            .checked_sub(1)
+            .unwrap_or(u64::MAX);
+        encoding &= mask;
+
+        self.push_byte(opcode);
+
+        // If the timestamp is at a known offset and uses nanosecond precision...
+        if opcode == 0x7C {
+            // ...then its encoding requires 70 bits. We've been using a u64 to hold the encoding, so the most
+            // significant 6 bits have been lost at this point. We need to get the most significant 6 bits of the
+            // nanoseconds field and write them out as a final byte. Because `subseconds` represents a number of
+            // nanoseconds between 0 and 999,999,999, its most significant 2 bits are guaranteed to be `00`. We can
+            // isolate the most significant 6 bits of the magnitude by isolating the most significant 8 bits of
+            // `subseconds`, which is a u32.
+            let high_six = (subseconds >> 24) as u8;
+            self.push_bytes(&encoding.to_le_bytes()[..]);
+            self.push_byte(high_six);
+        } else {
+            self.push_bytes(&encoding.to_le_bytes()[..encoded_body_length]);
+        }
+
+        Ok(())
+    }
+
+    fn write_long_form_timestamp(self, _value: &Timestamp) -> IonResult<()> {
+        todo!("long-form timestamp encoding is not yet implemented");
     }
 
     pub fn write_string<A: AsRef<str>>(mut self, value: A) -> IonResult<()> {
@@ -605,11 +753,13 @@ impl<'value, 'top: 'value> ValueWriter for BinaryAnnotatedValueWriter_1_1<'value
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
+    use num_bigint::BigInt;
+
     use crate::lazy::encoder::binary::v1_1::writer::LazyRawBinaryWriter_1_1;
     use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
-    use crate::{Decimal, Int, IonResult, IonType, Null, SymbolId};
-    use num_bigint::BigInt;
-    use std::str::FromStr;
+    use crate::{Decimal, Element, Int, IonResult, IonType, Null, SymbolId, Timestamp};
 
     fn encoding_test(
         mut test: impl FnMut(&mut LazyRawBinaryWriter_1_1<&mut Vec<u8>>) -> IonResult<()>,
@@ -877,6 +1027,623 @@ mod tests {
             encoding_test(
                 |writer: &mut LazyRawBinaryWriter_1_1<&mut Vec<u8>>| {
                     writer.write(value)?;
+                    Ok(())
+                },
+                expected_encoding,
+            )?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn write_timestamps() -> IonResult<()> {
+        let test_cases: &[(&str, &[u8])] = &[
+            // === Year ===
+            //                  .YYY_YYYY
+            ("1970T", &[0x70, 0b0000_0000]),
+            ("2097T", &[0x70, 0b0111_1111]),
+            ("2024T", &[0x70, 0b0011_0110]),
+            //
+            // === Month ===
+            //                     MYYY_YYYY    ...._.MMM
+            ("2024-01T", &[0x71, 0b1011_0110, 0b0000_0000]),
+            ("2024-10T", &[0x71, 0b0011_0110, 0b0000_0101]),
+            ("2024-11T", &[0x71, 0b1011_0110, 0b0000_0101]),
+            ("2024-12T", &[0x71, 0b0011_0110, 0b0000_0110]),
+            //
+            // === Day ===
+            //                       MYYY_YYYY    DDDD_DMMM
+            ("2024-06-01", &[0x72, 0b0011_0110, 0b0000_1011]),
+            ("2024-06-15", &[0x72, 0b0011_0110, 0b0111_1011]),
+            ("2024-06-30", &[0x72, 0b0011_0110, 0b1111_0011]),
+            //
+            // === Hour & Minute @ UTC ===
+            //
+            (
+                "2024-06-01T08:00Z",
+                //        MYYY_YYYY    DDDD_DMMM    mmmH_HHHH    ...._Ummm
+                &[0x73, 0b0011_0110, 0b0000_1011, 0b0000_1000, 0b0000_0000],
+            ),
+            (
+                "2024-06-15T12:30Z",
+                //        MYYY_YYYY    DDDD_DMMM    mmmH_HHHH    ...._Ummm
+                &[0x73, 0b0011_0110, 0b0111_1011, 0b1100_1100, 0b0000_0011],
+            ),
+            (
+                "2024-06-30T16:45Z",
+                //        MYYY_YYYY    DDDD_DMMM    mmmH_HHHH    ...._Ummm
+                &[0x73, 0b0011_0110, 0b1111_0011, 0b1011_0000, 0b0000_0101],
+            ),
+            //
+            // === Hour & Minute @ Unknown Offset ===
+            //
+            (
+                "2024-06-01T08:00-00:00",
+                //        MYYY_YYYY    DDDD_DMMM    mmmH_HHHH    ...._Ummm
+                &[0x73, 0b0011_0110, 0b0000_1011, 0b0000_1000, 0b0000_1000],
+            ),
+            (
+                "2024-06-15T12:30-00:00",
+                //        MYYY_YYYY    DDDD_DMMM    mmmH_HHHH    ...._Ummm
+                &[0x73, 0b0011_0110, 0b0111_1011, 0b1100_1100, 0b0000_1011],
+            ),
+            (
+                "2024-06-30T16:45-00:00",
+                //        MYYY_YYYY    DDDD_DMMM    mmmH_HHHH    ...._Ummm
+                &[0x73, 0b0011_0110, 0b1111_0011, 0b1011_0000, 0b0000_1101],
+            ),
+            //
+            // === Second @ UTC ===
+            //
+            (
+                "2024-06-01T08:00:00Z",
+                &[
+                    0x74,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0000_1011, // DDDD_DMMM
+                    0b0000_1000, // mmmH_HHHH
+                    0b0000_0000, // ssss_Ummm
+                    0b0000_0000, // ...._..ss
+                ],
+            ),
+            (
+                "2024-06-15T12:30:30Z",
+                &[
+                    0x74,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0111_1011, // DDDD_DMMM
+                    0b1100_1100, // mmmH_HHHH
+                    0b1110_0011, // ssss_Ummm
+                    0b0000_0001, // ...._..ss
+                ],
+            ),
+            (
+                "2024-06-30T16:45:45Z",
+                &[
+                    0x74,
+                    0b0011_0110, // MYYY_YYYY
+                    0b1111_0011, // DDDD_DMMM
+                    0b1011_0000, // mmmH_HHHH
+                    0b1101_0101, // ssss_Ummm
+                    0b0000_0010, // ...._..ss
+                ],
+            ),
+            //
+            // === Second @ Unknown Offset ===
+            //
+            (
+                "2024-06-01T08:00:00-00:00",
+                &[
+                    0x74,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0000_1011, // DDDD_DMMM
+                    0b0000_1000, // mmmH_HHHH
+                    0b0000_1000, // ssss_Ummm
+                    0b0000_0000, // ...._..ss
+                ],
+            ),
+            (
+                "2024-06-15T12:30:30-00:00",
+                &[
+                    0x74,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0111_1011, // DDDD_DMMM
+                    0b1100_1100, // mmmH_HHHH
+                    0b1110_1011, // ssss_Ummm
+                    0b0000_0001, // ...._..ss
+                ],
+            ),
+            (
+                "2024-06-30T16:45:45-00:00",
+                &[
+                    0x74,
+                    0b0011_0110, // MYYY_YYYY
+                    0b1111_0011, // DDDD_DMMM
+                    0b1011_0000, // mmmH_HHHH
+                    0b1101_1101, // ssss_Ummm
+                    0b0000_0010, // ...._..ss
+                ],
+            ),
+            //
+            // === Milliseconds @ UTC ===
+            //
+            (
+                "2024-06-01T08:00:00.000Z",
+                &[
+                    0x75,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0000_1011, // DDDD_DMMM
+                    0b0000_1000, // mmmH_HHHH
+                    0b0000_0000, // ssss_Ummm
+                    0b0000_0000, // ffff_ffss
+                    0b0000_0000, // ...._ffff
+                ],
+            ),
+            (
+                "2024-06-15T12:30:30.030Z",
+                &[
+                    0x75,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0111_1011, // DDDD_DMMM
+                    0b1100_1100, // mmmH_HHHH
+                    0b1110_0011, // ssss_Ummm
+                    0b0111_1001, // ffff_ffss
+                    0b0000_0000, // ...._ffff
+                ],
+            ),
+            (
+                "2024-06-30T16:45:45.045Z",
+                &[
+                    0x75,
+                    0b0011_0110, // MYYY_YYYY
+                    0b1111_0011, // DDDD_DMMM
+                    0b1011_0000, // mmmH_HHHH
+                    0b1101_0101, // ssss_Ummm
+                    0b1011_0110, // ffff_ffss
+                    0b0000_0000, // ...._ffff
+                ],
+            ),
+            //
+            // === Milliseconds @ Unknown Offset ===
+            //
+            (
+                "2024-06-01T08:00:00.000-00:00",
+                &[
+                    0x75,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0000_1011, // DDDD_DMMM
+                    0b0000_1000, // mmmH_HHHH
+                    0b0000_1000, // ssss_Ummm
+                    0b0000_0000, // ffff_ffss
+                    0b0000_0000, // ...._ffff
+                ],
+            ),
+            (
+                "2024-06-15T12:30:30.030-00:00",
+                &[
+                    0x75,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0111_1011, // DDDD_DMMM
+                    0b1100_1100, // mmmH_HHHH
+                    0b1110_1011, // ssss_Ummm
+                    0b0111_1001, // ffff_ffss
+                    0b0000_0000, // ...._ffff
+                ],
+            ),
+            (
+                "2024-06-30T16:45:45.045-00:00",
+                &[
+                    0x75,
+                    0b0011_0110, // MYYY_YYYY
+                    0b1111_0011, // DDDD_DMMM
+                    0b1011_0000, // mmmH_HHHH
+                    0b1101_1101, // ssss_Ummm
+                    0b1011_0110, // ffff_ffss
+                    0b0000_0000, // ...._ffff
+                ],
+            ),
+            //
+            // === Microseconds @ UTC ===
+            //
+            (
+                "2024-06-01T08:00:00.000000Z",
+                &[
+                    0x76,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0000_1011, // DDDD_DMMM
+                    0b0000_1000, // mmmH_HHHH
+                    0b0000_0000, // ssss_Ummm
+                    0b0000_0000, // ffff_ffss
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ..ff_ffff
+                ],
+            ),
+            (
+                "2024-06-15T12:30:30.000030Z",
+                &[
+                    0x76,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0111_1011, // DDDD_DMMM
+                    0b1100_1100, // mmmH_HHHH
+                    0b1110_0011, // ssss_Ummm
+                    0b0111_1001, // ffff_ffss
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ..ff_ffff
+                ],
+            ),
+            (
+                "2024-06-30T16:45:45.000045Z",
+                &[
+                    0x76,
+                    0b0011_0110, // MYYY_YYYY
+                    0b1111_0011, // DDDD_DMMM
+                    0b1011_0000, // mmmH_HHHH
+                    0b1101_0101, // ssss_Ummm
+                    0b1011_0110, // ffff_ffss
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ..ff_ffff
+                ],
+            ),
+            //
+            // === Microseconds @ Unknown Offset ===
+            //
+            (
+                "2024-06-01T08:00:00.000000-00:00",
+                &[
+                    0x76,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0000_1011, // DDDD_DMMM
+                    0b0000_1000, // mmmH_HHHH
+                    0b0000_1000, // ssss_Ummm
+                    0b0000_0000, // ffff_ffss
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ..ff_ffff
+                ],
+            ),
+            (
+                "2024-06-15T12:30:30.000030-00:00",
+                &[
+                    0x76,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0111_1011, // DDDD_DMMM
+                    0b1100_1100, // mmmH_HHHH
+                    0b1110_1011, // ssss_Ummm
+                    0b0111_1001, // ffff_ffss
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ..ff_ffff
+                ],
+            ),
+            (
+                "2024-06-30T16:45:45.000045-00:00",
+                &[
+                    0x76,
+                    0b0011_0110, // MYYY_YYYY
+                    0b1111_0011, // DDDD_DMMM
+                    0b1011_0000, // mmmH_HHHH
+                    0b1101_1101, // ssss_Ummm
+                    0b1011_0110, // ffff_ffss
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ..ff_ffff
+                ],
+            ),
+            //
+            // === Nanoseconds @ UTC ===
+            //
+            (
+                "2024-06-01T08:00:00.000000000Z",
+                &[
+                    0x77,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0000_1011, // DDDD_DMMM
+                    0b0000_1000, // mmmH_HHHH
+                    0b0000_0000, // ssss_Ummm
+                    0b0000_0000, // ffff_ffss
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                ],
+            ),
+            (
+                "2024-06-15T12:30:30.000000030Z",
+                &[
+                    0x77,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0111_1011, // DDDD_DMMM
+                    0b1100_1100, // mmmH_HHHH
+                    0b1110_0011, // ssss_Ummm
+                    0b0111_1001, // ffff_ffss
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                ],
+            ),
+            (
+                "2024-06-30T16:45:45.000000045Z",
+                &[
+                    0x77,
+                    0b0011_0110, // MYYY_YYYY
+                    0b1111_0011, // DDDD_DMMM
+                    0b1011_0000, // mmmH_HHHH
+                    0b1101_0101, // ssss_Ummm
+                    0b1011_0110, // ffff_ffss
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                ],
+            ),
+            //
+            // === Nanoseconds @ Unknown Offset ===
+            //
+            (
+                "2024-06-01T08:00:00.000000000-00:00",
+                &[
+                    0x77,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0000_1011, // DDDD_DMMM
+                    0b0000_1000, // mmmH_HHHH
+                    0b0000_1000, // ssss_Ummm
+                    0b0000_0000, // ffff_ffss
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                ],
+            ),
+            (
+                "2024-06-15T12:30:30.000000030-00:00",
+                &[
+                    0x77,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0111_1011, // DDDD_DMMM
+                    0b1100_1100, // mmmH_HHHH
+                    0b1110_1011, // ssss_Ummm
+                    0b0111_1001, // ffff_ffss
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                ],
+            ),
+            (
+                "2024-06-30T16:45:45.000000045-00:00",
+                &[
+                    0x77,
+                    0b0011_0110, // MYYY_YYYY
+                    0b1111_0011, // DDDD_DMMM
+                    0b1011_0000, // mmmH_HHHH
+                    0b1101_1101, // ssss_Ummm
+                    0b1011_0110, // ffff_ffss
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                ],
+            ),
+            //
+            // === Hour & Minute @ Known offset ===
+            //
+            // Offset `-05:00` is 36 quarter-hours beyond the short form's minimum `-14:00` offset.
+            (
+                "2024-06-01T08:00-05:00",
+                &[
+                    0x78,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0000_1011, // DDDD_DMMM
+                    0b0000_1000, // mmmH_HHHH
+                    0b0010_0000, // oooo_ommm
+                    0b0000_0001, // ...._..oo
+                ],
+            ),
+            (
+                "2024-06-15T12:30-05:00",
+                &[
+                    0x78,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0111_1011, // DDDD_DMMM
+                    0b1100_1100, // mmmH_HHHH
+                    0b0010_0011, // oooo_ommm
+                    0b0000_0001, // ...._..oo
+                ],
+            ),
+            (
+                "2024-06-30T16:45-05:00",
+                &[
+                    0x78,
+                    0b0011_0110, // MYYY_YYYY
+                    0b1111_0011, // DDDD_DMMM
+                    0b1011_0000, // mmmH_HHHH
+                    0b0010_0101, // oooo_ommm
+                    0b0000_0001, // ...._..oo
+                ],
+            ),
+            //
+            // === Second @ Known offset ===
+            //
+            (
+                "2024-06-01T08:00:00-05:00",
+                &[
+                    0x79,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0000_1011, // DDDD_DMMM
+                    0b0000_1000, // mmmH_HHHH
+                    0b0010_0000, // oooo_ommm
+                    0b0000_0001, // ssss_ssoo
+                ],
+            ),
+            (
+                "2024-06-15T12:30:30-05:00",
+                &[
+                    0x79,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0111_1011, // DDDD_DMMM
+                    0b1100_1100, // mmmH_HHHH
+                    0b0010_0011, // oooo_ommm
+                    0b0111_1001, // ssss_ssoo
+                ],
+            ),
+            (
+                "2024-06-30T16:45:45-05:00",
+                &[
+                    0x79,
+                    0b0011_0110, // MYYY_YYYY
+                    0b1111_0011, // DDDD_DMMM
+                    0b1011_0000, // mmmH_HHHH
+                    0b0010_0101, // oooo_ommm
+                    0b1011_0101, // ssss_ssoo
+                ],
+            ),
+            //
+            // === Milliseconds @ Known offset ===
+            //
+            (
+                "2024-06-01T08:00:00.000-05:00",
+                &[
+                    0x7A,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0000_1011, // DDDD_DMMM
+                    0b0000_1000, // mmmH_HHHH
+                    0b0010_0000, // oooo_ommm
+                    0b0000_0001, // ssss_ssoo
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ...._..ff
+                ],
+            ),
+            (
+                "2024-06-15T12:30:30.030-05:00",
+                &[
+                    0x7A,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0111_1011, // DDDD_DMMM
+                    0b1100_1100, // mmmH_HHHH
+                    0b0010_0011, // oooo_ommm
+                    0b0111_1001, // ssss_ssoo
+                    0b0001_1110, // ffff_ffff
+                    0b0000_0000, // ...._..ff
+                ],
+            ),
+            (
+                "2024-06-30T16:45:45.045-05:00",
+                &[
+                    0x7A,
+                    0b0011_0110, // MYYY_YYYY
+                    0b1111_0011, // DDDD_DMMM
+                    0b1011_0000, // mmmH_HHHH
+                    0b0010_0101, // oooo_ommm
+                    0b1011_0101, // ssss_ssoo
+                    0b0010_1101, // ffff_ffff
+                    0b0000_0000, // ...._..ff
+                ],
+            ),
+            //
+            // === Microseconds @ Known offset ===
+            //
+            (
+                "2024-06-01T08:00:00.000000-05:00",
+                &[
+                    0x7B,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0000_1011, // DDDD_DMMM
+                    0b0000_1000, // mmmH_HHHH
+                    0b0010_0000, // oooo_ommm
+                    0b0000_0001, // ssss_ssoo
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ...._ffff
+                ],
+            ),
+            (
+                "2024-06-15T12:30:30.000030-05:00",
+                &[
+                    0x7B,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0111_1011, // DDDD_DMMM
+                    0b1100_1100, // mmmH_HHHH
+                    0b0010_0011, // oooo_ommm
+                    0b0111_1001, // ssss_ssoo
+                    0b0001_1110, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ...._ffff
+                ],
+            ),
+            (
+                "2024-06-30T16:45:45.000045-05:00",
+                &[
+                    0x7B,
+                    0b0011_0110, // MYYY_YYYY
+                    0b1111_0011, // DDDD_DMMM
+                    0b1011_0000, // mmmH_HHHH
+                    0b0010_0101, // oooo_ommm
+                    0b1011_0101, // ssss_ssoo
+                    0b0010_1101, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ...._ffff
+                ],
+            ),
+            //
+            // === Nanoseconds @ Known offset ===
+            //
+            (
+                "2024-06-01T08:00:00.000000000-05:00",
+                &[
+                    0x7C,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0000_1011, // DDDD_DMMM
+                    0b0000_1000, // mmmH_HHHH
+                    0b0010_0000, // oooo_ommm
+                    0b0000_0001, // ssss_ssoo
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ..ff_ffff
+                ],
+            ),
+            (
+                "2024-06-15T12:30:30.000000030-05:00",
+                &[
+                    0x7C,
+                    0b0011_0110, // MYYY_YYYY
+                    0b0111_1011, // DDDD_DMMM
+                    0b1100_1100, // mmmH_HHHH
+                    0b0010_0011, // oooo_ommm
+                    0b0111_1001, // ssss_ssoo
+                    0b0001_1110, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ..ff_ffff
+                ],
+            ),
+            (
+                "2024-06-30T16:45:45.000000045-05:00",
+                &[
+                    0x7C,
+                    0b0011_0110, // MYYY_YYYY
+                    0b1111_0011, // DDDD_DMMM
+                    0b1011_0000, // mmmH_HHHH
+                    0b0010_0101, // oooo_ommm
+                    0b1011_0101, // ssss_ssoo
+                    0b0010_1101, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ffff_ffff
+                    0b0000_0000, // ..ff_ffff
+                ],
+            ),
+        ];
+        // Turn the &str timestamps into instances of Timestamp
+        let test_cases: Vec<(Timestamp, &[u8])> = test_cases
+            .iter()
+            .map(|(text, expected_encoding)| {
+                (
+                    Element::read_one(text)
+                        .unwrap()
+                        .expect_timestamp()
+                        .unwrap()
+                        .clone(),
+                    *expected_encoding,
+                )
+            })
+            .collect();
+
+        for (value, expected_encoding) in test_cases {
+            encoding_test(
+                |writer: &mut LazyRawBinaryWriter_1_1<&mut Vec<u8>>| {
+                    writer.write(&value)?;
                     Ok(())
                 },
                 expected_encoding,

--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -349,7 +349,8 @@ impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
 
         // Because we eagerly (and branchless-ly) encoded all of the time units, we may have populated bits that are
         // irrelevant to the final encoding. To simplify unit testing (and in the current absence of a binary 1.1
-        // reader, we calculate a mask of which bits are relevant to the current opcode and set any bits not in use to `0`.
+        // reader), we calculate a mask of which bits are relevant to the current opcode and set any bits not in use
+        // to `0`.
         // TODO: Remove this logic pending resolution of https://github.com/amazon-ion/ion-docs/issues/295, which
         //       suggests requiring readers to ignore bits not used by the specified opcode
         let mask = 1u64

--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -1,3 +1,4 @@
+use arrayvec::ArrayVec;
 use bumpalo::collections::Vec as BumpVec;
 use bumpalo::Bump as BumpAllocator;
 use delegate::delegate;
@@ -9,11 +10,15 @@ use crate::lazy::encoder::binary::v1_1::container_writers::{
     BinarySExpValuesWriter_1_1, BinarySExpWriter_1_1, BinaryStructFieldsWriter_1_1,
     BinaryStructWriter_1_1,
 };
+use crate::lazy::encoder::binary::v1_1::fixed_int::FixedInt;
 use crate::lazy::encoder::private::Sealed;
 use crate::lazy::encoder::value_writer::{AnnotatableValueWriter, ValueWriter};
 use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
+use crate::result::IonFailure;
 use crate::types::integer::IntData;
-use crate::{Decimal, FlexUInt, Int, IonResult, IonType, RawSymbolTokenRef, SymbolId, Timestamp};
+use crate::{
+    Decimal, FlexInt, FlexUInt, Int, IonResult, IonType, RawSymbolTokenRef, SymbolId, Timestamp,
+};
 
 pub struct BinaryValueWriter_1_1<'value, 'top> {
     allocator: &'top BumpAllocator,
@@ -161,8 +166,66 @@ impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
         Ok(())
     }
 
-    pub fn write_decimal(self, _value: &Decimal) -> IonResult<()> {
-        todo!()
+    pub fn write_decimal(mut self, value: &Decimal) -> IonResult<()> {
+        // Insert a placeholder opcode; we'll overwrite the length nibble with the appropriate value when the encoding
+        // is complete.
+        let opcode_index = self.encoding_buffer.len();
+        self.push_byte(0x60);
+
+        // A positive zero coefficient, unspecified exponent
+        let is_positive_zero = value.coefficient().is_positive_zero();
+
+        if value.exponent() == 0 && is_positive_zero {
+            // The 0x60 opcode is the complete encoding.
+            return Ok(());
+        }
+
+        let encoded_exponent_size = FlexInt::write_i64(self.encoding_buffer, value.exponent())?;
+        let encoded_coefficient_size = if is_positive_zero {
+            // Write nothing; an implicit zero coefficient is positive.
+            0
+        } else if value.coefficient.is_negative_zero() {
+            // Write a zero byte; an explicit zero is negative.
+            self.push_byte(0x00);
+            1
+        } else {
+            // This `TryInto` impl will only fail if the coefficient is negative zero, which we've already ruled out.
+            let coefficient: Int = value.coefficient().try_into().unwrap();
+            FixedInt::write(self.encoding_buffer, &coefficient)?
+        };
+
+        let Some(encoded_body_size) = encoded_exponent_size.checked_add(encoded_coefficient_size)
+        else {
+            // If the decimal's *length* cannot be stored in a `usize`, report an error.
+            return IonResult::encoding_error(format!(
+                "decimal {value} exceeds the currently supported maximum encoding size"
+            ));
+        };
+
+        match encoded_body_size {
+            0..=15 => {
+                // In the common case, the body of a decimal will require fewer than 16 bytes to encode.
+                // In this case, we can write the encoded body length in the low nibble of the opcode we already wrote.
+                self.encoding_buffer[opcode_index] |= encoded_body_size as u8;
+            }
+            16.. => {
+                // If the encoded size ends up being unusually large, we will splice in a corrected header.
+                // Start by overwriting our original opcode with 0xF6, which indicates a Decimal with a FlexUInt length.
+                self.encoding_buffer[opcode_index] = 0xF6;
+                // We'll use an `ArrayVec` as our encoding buffer because it's stack-allocated and implements `io::Write`.
+                // It has a capacity of 16 bytes because it's the smallest power of two that is still large enough to
+                // hold a FlexUInt encoding of usize::MAX on a 64-bit platform.
+                let mut buffer: ArrayVec<u8, 16> = ArrayVec::new();
+                FlexUInt::write_u64(&mut buffer, encoded_body_size as u64)?;
+                let encoded_length_start = opcode_index + 1;
+                // `splice` allows you to overwrite Vec elements as well as insert them.
+                // This is an empty range at the desired location, indicating that we're only inserting.
+                let splice_range = encoded_length_start..encoded_length_start;
+                self.encoding_buffer
+                    .splice(splice_range, buffer.as_slice().iter().copied());
+            }
+        }
+        Ok(())
     }
 
     pub fn write_timestamp(self, _value: &Timestamp) -> IonResult<()> {
@@ -541,7 +604,9 @@ impl<'value, 'top: 'value> ValueWriter for BinaryAnnotatedValueWriter_1_1<'value
 mod tests {
     use crate::lazy::encoder::binary::v1_1::writer::LazyRawBinaryWriter_1_1;
     use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
-    use crate::{IonResult, IonType, Null, SymbolId};
+    use crate::{Decimal, Int, IonResult, IonType, Null, SymbolId};
+    use num_bigint::BigInt;
+    use std::str::FromStr;
 
     fn encoding_test(
         mut test: impl FnMut(&mut LazyRawBinaryWriter_1_1<&mut Vec<u8>>) -> IonResult<()>,
@@ -766,6 +831,49 @@ mod tests {
             encoding_test(
                 |writer: &mut LazyRawBinaryWriter_1_1<&mut Vec<u8>>| {
                     writer.write(value.as_raw_symbol_token_ref())?;
+                    Ok(())
+                },
+                expected_encoding,
+            )?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn write_decimals() -> IonResult<()> {
+        let test_cases: &[(Decimal, &[u8])] = &[
+            (Decimal::new(0, 0), &[0x60]),
+            (Decimal::new(0, 3), &[0x61, 0x07]),
+            (Decimal::negative_zero(), &[0x62, 0x01, 0x00]),
+            (Decimal::negative_zero_with_exponent(3), &[0x62, 0x07, 0x00]),
+            (
+                Decimal::negative_zero_with_exponent(-3),
+                &[0x62, 0xFB, 0x00],
+            ),
+            (Decimal::new(7, 4), &[0x62, 0x09, 0x07]),
+            (
+                // ~PI
+                Decimal::new(3_1415926535i64, -10),
+                &[0x66, 0xED, 0x07, 0xFF, 0x88, 0x50, 0x07],
+            ),
+            (
+                // ~e
+                Decimal::new(
+                    Int::from(
+                        BigInt::from_str("27182818284590452353602874713526624977572").unwrap(),
+                    ),
+                    -40,
+                ),
+                &[
+                    0xF6, 0x25, 0xB1, 0xA4, 0x2, 0x7E, 0xFA, 0x42, 0x46, 0x53, 0x50, 0xEF, 0x56,
+                    0x73, 0xB, 0xE7, 0x5E, 0x14, 0xE2, 0x4F,
+                ],
+            ),
+        ];
+        for (value, expected_encoding) in test_cases {
+            encoding_test(
+                |writer: &mut LazyRawBinaryWriter_1_1<&mut Vec<u8>>| {
+                    writer.write(value)?;
                     Ok(())
                 },
                 expected_encoding,

--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -356,8 +356,7 @@ impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
         let mask = 1u64
             .checked_shl(bits_populated)
             .unwrap_or(0)
-            .checked_sub(1)
-            .unwrap_or(u64::MAX);
+            .wrapping_sub(1);
         encoding &= mask;
 
         self.push_byte(opcode);
@@ -443,8 +442,7 @@ impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
         let mask = 1u64
             .checked_shl(num_bits_in_use)
             .unwrap_or(0)
-            .checked_sub(1)
-            .unwrap_or(u64::MAX);
+            .wrapping_sub(1);
         encoding &= mask;
 
         // Push 0xF7 (the opcode for a Timestamp w/FlexUInt length) and 0x01 (a placeholder 0 FlexUInt that we'll

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -604,19 +604,30 @@ impl Timestamp {
     ///
     /// NOTE: This is a potentially lossy operation. A Timestamp with picoseconds would return a
     /// number of nanoseconds, losing precision. If it loses precision then truncation is preformed.
-    /// (e.g. a timestamp with fractional seconds of `0.000000000999` would be returned as `0`)
+    /// (e.g. a timestamp with fractional seconds of `0.000000000999` would return `0`)
     pub fn nanoseconds(&self) -> u32 {
         self.fractional_seconds_as_nanoseconds().unwrap_or_default()
+    }
+
+    /// Returns this Timestamp's fractional seconds in microseconds
+    ///
+    /// NOTE: This is a potentially lossy operation. A Timestamp with picoseconds would return a
+    /// number of microseconds, losing precision. If it loses precision then truncation is preformed.
+    /// (e.g. a timestamp with fractional seconds of `0.000000999` would return `0`)
+    pub fn microseconds(&self) -> u32 {
+        self.fractional_seconds_as_nanoseconds()
+            .map(|s| s / 1_000)
+            .unwrap_or_default()
     }
 
     /// Returns this Timestamp's fractional seconds in milliseconds
     ///
     /// NOTE: This is a potentially lossy operation. A Timestamp with picoseconds would return a
     /// number of milliseconds, losing precision. If it loses precision then truncation is preformed.
-    /// (e.g. a timestamp with fractional seconds of `0.000999` would be returned as `0`)
+    /// (e.g. a timestamp with fractional seconds of `0.000999` would return `0`)
     pub fn milliseconds(&self) -> u32 {
         self.fractional_seconds_as_nanoseconds()
-            .map(|s| s / 1000000)
+            .map(|s| s / 1_000_000)
             .unwrap_or_default()
     }
 }

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -603,7 +603,7 @@ impl Timestamp {
     /// Returns this Timestamp's fractional seconds in nanoseconds
     ///
     /// NOTE: This is a potentially lossy operation. A Timestamp with picoseconds would return a
-    /// number of nanoseconds, losing precision. If it loses precision then truncation is preformed.
+    /// number of nanoseconds, losing precision. If it loses precision then truncation is performed.
     /// (e.g. a timestamp with fractional seconds of `0.000000000999` would return `0`)
     pub fn nanoseconds(&self) -> u32 {
         self.fractional_seconds_as_nanoseconds().unwrap_or_default()
@@ -612,7 +612,7 @@ impl Timestamp {
     /// Returns this Timestamp's fractional seconds in microseconds
     ///
     /// NOTE: This is a potentially lossy operation. A Timestamp with picoseconds would return a
-    /// number of microseconds, losing precision. If it loses precision then truncation is preformed.
+    /// number of microseconds, losing precision. If it loses precision then truncation is performed.
     /// (e.g. a timestamp with fractional seconds of `0.000000999` would return `0`)
     pub fn microseconds(&self) -> u32 {
         self.fractional_seconds_as_nanoseconds()
@@ -623,7 +623,7 @@ impl Timestamp {
     /// Returns this Timestamp's fractional seconds in milliseconds
     ///
     /// NOTE: This is a potentially lossy operation. A Timestamp with picoseconds would return a
-    /// number of milliseconds, losing precision. If it loses precision then truncation is preformed.
+    /// number of milliseconds, losing precision. If it loses precision then truncation is performed.
     /// (e.g. a timestamp with fractional seconds of `0.000999` would return `0`)
     pub fn milliseconds(&self) -> u32 {
         self.fractional_seconds_as_nanoseconds()


### PR DESCRIPTION
While this diff looks big, some ~900 of the ~1,200 lines are just generously spaced/commented unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
