### PR TITLE
Adds test for `PartialEq` of `Symbol` for `&str`

### DIFF
--- a/src/types/symbol.rs
+++ b/src/types/symbol.rs
@@ -233,4 +233,17 @@ mod symbol_tests {
         ];
         assert_eq!(symbols, expected)
     }
+
+    #[test]
+    fn partial_eq_str() {
+        let symbols = vec![
+            Symbol::shared(Arc::from("bar")),
+            Symbol::shared(Arc::from("baz")),
+            Symbol::owned("foo"),
+            Symbol::owned("quux"),
+        ];
+        // Equality testing for a rust str with symbol
+        let expected = vec!["bar", "baz", "foo", "quux"];
+        assert_eq!(symbols, expected)
+    }
 }


### PR DESCRIPTION
*Issue #610*

*Description of changes:*
This PR adds test for`PartialEq` of `Symbol` for `&str`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
