### PR TITLE
Removes kludge import in integration test

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -149,8 +149,6 @@ pub mod integration_testing {
     use crate::raw_reader::RawReader;
     use crate::reader::{Reader, UserReader};
 
-    pub use crate::binary::constants::v1_0::IVM;
-
     pub fn new_reader<'a, R: 'a + RawReader>(raw_reader: R) -> Reader<'a> {
         UserReader::new(Box::new(raw_reader))
     }

--- a/tests/non_blocking_element_tests.rs
+++ b/tests/non_blocking_element_tests.rs
@@ -16,11 +16,11 @@ impl ElementApi for NonBlockingNativeElementApi {
     type ElementReader<'a> = Reader<'a>;
 
     fn make_reader(data: &[u8]) -> IonResult<Self::ElementReader<'_>> {
-        // These imports are visible as a temporary workaround.
+        // This import is visible as a temporary workaround.
         // See: https://github.com/amazon-ion/ion-rust/issues/484
-        use ion_rs::integration_testing::{new_reader, IVM};
+        use ion_rs::integration_testing::new_reader;
         // If the data is binary, create a non-blocking binary reader.
-        if data.starts_with(&IVM) {
+        if data.starts_with(&[0xE0u8, 0x01, 0x00, 0xEA]) {
             let raw_reader = RawBinaryReader::new(data);
             Ok(new_reader(raw_reader))
         } else {


### PR DESCRIPTION
One of our integration tests imported a `const` definition of the Ion 1.0 version marker. This would lead to clippy complaining in non-test contexts (when the usage conditionally not compiled) that there was an unused import in the source.

This change eliminates the conditional import and just inlines the definition of `IVM`. Slightly repetitive, but better than a compile warning.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
