### PR TITLE
Fixes bug in reading shared symbol table import

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ use rstest_reuse;
 // Private modules that serve to organize implementation details.
 mod binary;
 mod blocking_reader;
-pub mod catalog;
+mod catalog;
 mod constants;
 mod data_source;
 mod ion_data;
@@ -151,7 +151,7 @@ mod raw_reader;
 mod raw_symbol_token;
 mod raw_symbol_token_ref;
 mod reader;
-pub mod shared_symbol_table;
+mod shared_symbol_table;
 mod symbol_ref;
 mod symbol_table;
 mod system_reader;
@@ -177,12 +177,14 @@ pub mod thunk;
 pub mod tokens;
 pub(crate) mod unsafe_helpers;
 
+pub use catalog::{Catalog, MapCatalog};
 pub use element::builders::{SequenceBuilder, StructBuilder};
 pub use element::{
     reader::ElementReader, writer::ElementWriter, Annotations, Element, IntoAnnotatedElement,
     IntoAnnotations, Sequence, Value,
 };
 pub use ion_data::IonData;
+pub use shared_symbol_table::SharedSymbolTable;
 pub use symbol_ref::SymbolRef;
 #[doc(inline)]
 pub use types::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ use rstest_reuse;
 // Private modules that serve to organize implementation details.
 mod binary;
 mod blocking_reader;
-mod catalog;
+pub mod catalog;
 mod constants;
 mod data_source;
 mod ion_data;
@@ -151,7 +151,7 @@ mod raw_reader;
 mod raw_symbol_token;
 mod raw_symbol_token_ref;
 mod reader;
-mod shared_symbol_table;
+pub mod shared_symbol_table;
 mod symbol_ref;
 mod symbol_table;
 mod system_reader;

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -53,18 +53,12 @@ impl SymbolTable {
         }
 
         // Otherwise, intern it and return the new ID.
-        let id = self.symbols_by_id.len();
-        let arc: Arc<str> = Arc::from(text);
-        let symbol = Symbol::shared(arc);
-        self.symbols_by_id.push(symbol.clone());
-        self.ids_by_text.insert(symbol, id);
-        id
+        self.add_symbol(text)
     }
 
     /// adds `text` to the symbol table and returns the newly assigned [SymbolId].
     pub(crate) fn add_symbol<A: AsRef<str>>(&mut self, text: A) -> SymbolId {
         let text = text.as_ref();
-        // Otherwise, intern it and return the new ID.
         let id = self.symbols_by_id.len();
         let arc: Arc<str> = Arc::from(text);
         let symbol = Symbol::shared(arc);

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -61,12 +61,36 @@ impl SymbolTable {
         id
     }
 
+    /// adds `text` to the symbol table and returns the newly assigned [SymbolId].
+    pub(crate) fn add_symbol<A: AsRef<str>>(&mut self, text: A) -> SymbolId {
+        let text = text.as_ref();
+        // Otherwise, intern it and return the new ID.
+        let id = self.symbols_by_id.len();
+        let arc: Arc<str> = Arc::from(text);
+        let symbol = Symbol::shared(arc);
+        self.symbols_by_id.push(symbol.clone());
+        self.ids_by_text.insert(symbol, id);
+        id
+    }
+
     /// Assigns unknown text to the next available symbol ID. This is used when an Ion reader
     /// encounters null or non-string values in a stream's symbol table.
     pub(crate) fn add_placeholder(&mut self) -> SymbolId {
         let sid = self.symbols_by_id.len();
         self.symbols_by_id.push(Symbol::unknown_text());
         sid
+    }
+
+    /// If `maybe_text` is `Some(text)`, this method is equivalent to `add_symbol(text)`.
+    /// If `maybe_text` is `None`, this method is equivalent to `add_placeholder()`.
+    pub(crate) fn add_symbol_or_placeholder<A: AsRef<str>>(
+        &mut self,
+        maybe_text: Option<A>,
+    ) -> SymbolId {
+        match maybe_text {
+            Some(text) => self.add_symbol(text),
+            None => self.add_placeholder(),
+        }
     }
 
     /// If `maybe_text` is `Some(text)`, this method is equivalent to `intern(text)`.

--- a/src/system_reader.rs
+++ b/src/system_reader.rs
@@ -345,7 +345,7 @@ impl<R: RawReader> SystemReader<R> {
                     Ok(field_name_token) => {
                         let field_name = match field_name_token {
                             RawSymbolToken::SymbolId(sid) => self.symbol_table.text_for(sid),
-                            RawSymbolToken::Text(_) => field_name_token.text(),
+                            RawSymbolToken::Text(ref text) => Some(text.as_str()),
                         };
                         if let Some(field_name) = field_name {
                             match field_name {
@@ -1137,12 +1137,15 @@ mod tests {
                 0x88, // $8 `max_id`
                 0x21, 0x02, // INT 2
                 0x71, 0x04, // $4 `name`
+                0x71, 0x0a, // $10 `name`
                 0x71, 0x0b, // $11 `foo`
             ],
             Box::new(map_catalog),
         );
         assert_eq!(reader.next()?, VersionMarker(1, 0));
         assert_eq!(reader.next()?, SymbolTableValue(IonType::Struct));
+        assert_eq!(reader.next()?, Value(IonType::Symbol));
+        assert_eq!(reader.read_symbol()?, Symbol::shared(Arc::from("name")));
         assert_eq!(reader.next()?, Value(IonType::Symbol));
         assert_eq!(reader.read_symbol()?, Symbol::shared(Arc::from("name")));
         assert_eq!(reader.next()?, Value(IonType::Symbol));


### PR DESCRIPTION

*Issue:*
The issue is in importing shared symbol import. SST import used `RawSymbolToken#text()` method to get a field name of SST import which resulted in not loading the symbol table import properly. `RawSymbolToken#text()` returns `None` if the token is an SID. Instead it should look up in the symbol table to get that SID's text. 
Another issue was with importing a system symbol with a shared symbol table import. While reading Ion data it should add this system table again to current symbol table and but while writing it should return the smallest SID(the system SID). 

*Description of changes:*
This PR works on fixing a bug in shared symbol table import.

*List of changes:*
* Modified how SST import read symbol text so that in case of SID it
gets corresponding text first
* Modified adding symbols to current symbol table using
`add_symbol_or_placeholder` 

*Test:*
Added a test that verifies SST import in binary Ion data. It also adds a system symbol to make sure the reading works as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
