### PR TITLE
Adds implementation of `finish` for `IonWriter`

### DIFF
--- a/src/binary/binary_writer.rs
+++ b/src/binary/binary_writer.rs
@@ -192,6 +192,7 @@ impl<W: Write> IonWriter for BinaryWriter<W> {
             fn parent_type(&self) -> Option<IonType>;
             fn depth(&self) -> usize;
             fn step_out(&mut self) -> IonResult<()>;
+            fn finish(self) -> IonResult<Self::Output>;
             fn output(&self) -> &Self::Output;
             fn output_mut(&mut self) -> &mut Self::Output;
         }
@@ -260,6 +261,23 @@ mod tests {
         assert_eq!(Value(IonType::Symbol), reader.next()?);
         assert_eq!("baz", reader.read_symbol()?);
 
+        Ok(())
+    }
+
+    #[test]
+    fn finish_test() -> IonResult<()> {
+        let buffer = Vec::new();
+        let mut binary_writer = BinaryWriterBuilder::new().build(buffer)?;
+        binary_writer.write_string("foo")?;
+        binary_writer.write_i64(5)?;
+        let output = binary_writer.finish()?;
+
+        let mut reader = ReaderBuilder::new().build(output)?;
+        assert_eq!(Value(IonType::String), reader.next()?);
+        assert_eq!("foo", reader.read_string()?);
+
+        assert_eq!(Value(IonType::Int), reader.next()?);
+        assert_eq!(5, reader.read_i64()?);
         Ok(())
     }
 }

--- a/src/binary/raw_binary_writer.rs
+++ b/src/binary/raw_binary_writer.rs
@@ -891,6 +891,11 @@ impl<W: Write> IonWriter for RawBinaryWriter<W> {
         Ok(())
     }
 
+    fn finish(mut self) -> IonResult<Self::Output> {
+        self.flush()?;
+        Ok(self.out)
+    }
+
     fn output(&self) -> &Self::Output {
         &self.out
     }

--- a/src/element/element_stream_writer.rs
+++ b/src/element/element_stream_writer.rs
@@ -284,6 +284,10 @@ where
         Ok(())
     }
 
+    fn finish(self) -> IonResult<Self::Output> {
+        Ok(self.output)
+    }
+
     fn output(&self) -> &Self::Output {
         &self.output
     }

--- a/src/ion_writer.rs
+++ b/src/ion_writer.rs
@@ -97,6 +97,10 @@ pub trait IonWriter {
     /// This method can only be called when the writer is at the top level.
     fn flush(&mut self) -> IonResult<()>;
 
+    /// Flushes any buffered data to be written to the underlying io::Write implementation,
+    /// and returns the writer's output.
+    fn finish(self) -> IonResult<Self::Output>;
+
     // This portion of the doc comment is always visible
     #[doc = r##"
 Returns a reference to the writer's output.

--- a/src/text/raw_text_writer.rs
+++ b/src/text/raw_text_writer.rs
@@ -726,6 +726,11 @@ impl<W: Write> IonWriter for RawTextWriter<W> {
         Ok(())
     }
 
+    fn finish(mut self) -> IonResult<W> {
+        self.output.flush()?;
+        Ok(self.output.into_inner().map_err(|e| e.into_error())?)
+    }
+
     fn output(&self) -> &W {
         self.output.get_ref()
     }

--- a/src/text/text_writer.rs
+++ b/src/text/text_writer.rs
@@ -181,6 +181,7 @@ impl<W: Write> IonWriter for TextWriter<W> {
             fn depth(&self) -> usize;
             fn step_out(&mut self) -> IonResult<()>;
             fn flush(&mut self) -> IonResult<()>;
+            fn finish(self) -> IonResult<Self::Output>;
             fn output(&self) -> &Self::Output;
             fn output_mut(&mut self) -> &mut Self::Output;
         }
@@ -219,6 +220,23 @@ mod tests {
         assert_eq!("name", reader.field_name()?);
         assert_eq!("version", reader.read_symbol()?);
 
+        Ok(())
+    }
+
+    #[test]
+    fn finish_test() -> IonResult<()> {
+        let buffer = Vec::new();
+        let mut text_writer = TextWriterBuilder::default().build(buffer)?;
+        text_writer.write_string("foo")?;
+        text_writer.write_i64(5)?;
+        let output = text_writer.finish()?;
+
+        let mut reader = ReaderBuilder::new().build(output)?;
+        assert_eq!(Value(IonType::String), reader.next()?);
+        assert_eq!("foo", reader.read_string()?);
+
+        assert_eq!(Value(IonType::Int), reader.next()?);
+        assert_eq!(5, reader.read_i64()?);
         Ok(())
     }
 }


### PR DESCRIPTION
*Issue #713*

*Description of changes:*
This PR adds a `finish` API to `IonWriter` which flushes the buffered data and returns writer's output.

*Test:*
Added unit tests for `finish` API for binary and text writer. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
