### PR TITLE
Implements writing e-expressions in binary 1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,9 @@ num-integer = "0.1.44"
 num-traits = "0.2"
 arrayvec = "0.7"
 smallvec = {version ="1.9.0", features = ["const_generics"]}
-bumpalo = {version = "3.14.0", features = ["collections", "std"]}
+bumpalo = {version = "3.15.3", features = ["collections", "std"]}
 digest = { version = "0.9", optional = true }
+ice_code = "0.1.4"
 sha2 = { version = "0.9", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_with = { version = "2.0", optional = true }
@@ -86,9 +87,14 @@ test-generator = "0.3"
 memmap = "0.7.0"
 criterion = "0.5.1"
 rand = "0.8.5"
+tempfile = "3.10.0"
 
 [[bench]]
 name = "read_many_structs"
+harness = false
+
+[[bench]]
+name = "write_many_structs"
 harness = false
 
 [[bench]]

--- a/benches/encoding_primitives.rs
+++ b/benches/encoding_primitives.rs
@@ -142,7 +142,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 }
 
 fn roundtrip_var_uint_test(unsigned_values: &[u64]) -> IonResult<Vec<u8>> {
-    println!("Roundtripping unsigned values as VarUInts to check for correctness.");
     let mut encoded_values_buffer = Vec::new();
     for value in unsigned_values {
         VarUInt::write_u64(&mut encoded_values_buffer, *value)?;
@@ -159,7 +158,6 @@ fn roundtrip_var_uint_test(unsigned_values: &[u64]) -> IonResult<Vec<u8>> {
 }
 
 fn roundtrip_var_int_test(signed_values: &[i64]) -> IonResult<Vec<u8>> {
-    println!("Roundtripping signed values as VarInts to check for correctness.");
     let mut encoded_values_buffer = Vec::new();
     for value in signed_values {
         VarInt::write_i64(&mut encoded_values_buffer, *value)?;
@@ -176,7 +174,6 @@ fn roundtrip_var_int_test(signed_values: &[i64]) -> IonResult<Vec<u8>> {
 }
 
 fn roundtrip_flex_uint_test(unsigned_values: &[u64]) -> IonResult<Vec<u8>> {
-    println!("Roundtripping unsigned values as FlexUInts to check for correctness.");
     let mut encoded_values_buffer = Vec::new();
     for value in unsigned_values {
         FlexUInt::write_u64(&mut encoded_values_buffer, *value)?;
@@ -193,7 +190,6 @@ fn roundtrip_flex_uint_test(unsigned_values: &[u64]) -> IonResult<Vec<u8>> {
 }
 
 fn roundtrip_flex_int_test(signed_values: &[i64]) -> IonResult<Vec<u8>> {
-    println!("Roundtripping signed values as FlexInts to check for correctness.");
     let mut encoded_values_buffer = Vec::new();
     for value in signed_values {
         FlexInt::write_i64(&mut encoded_values_buffer, *value)?;

--- a/benches/write_many_structs.rs
+++ b/benches/write_many_structs.rs
@@ -1,0 +1,273 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use ion_rs::lazy::encoder::binary::v1_0::writer::LazyRawBinaryWriter_1_0;
+use nom::AsBytes;
+
+use ion_rs::lazy::encoder::binary::v1_1::writer::LazyRawBinaryWriter_1_1;
+use ion_rs::lazy::encoder::value_writer::{AnnotatableValueWriter, SequenceWriter};
+use ion_rs::lazy::encoder::value_writer::{StructWriter, ValueWriter};
+use ion_rs::RawSymbolTokenRef;
+
+fn write_struct_with_string_values(value_writer: impl ValueWriter) {
+    value_writer
+        .write_struct(|fields| {
+            fields
+                // $10 = timestamp
+                .write(10, black_box(1670446800245i64))?
+                // $11 = threadId
+                .write(11, black_box(418))?
+                // $12 = threadName
+                .write(12, black_box("scheduler-thread-6"))?
+                // $13 = loggerName
+                .write(13, black_box("com.example.organization.product.component.ClassName"))?
+                // $14 = logLevel
+                .write(14, black_box("INFO"))?
+                // $15 = format
+                .write(15, black_box("Request status: {} Client ID: {} Client Host: {} Client Region: {} Timestamp: {}"))?
+                // $16 = parameters
+                .write(16, &[
+                    black_box("SUCCESS"),
+                    black_box("example-client-1"),
+                    black_box("aws-us-east-5f-18b4fa"),
+                    black_box("region 4"),
+                    black_box("2022-12-07T20:59:59.744000Z"),
+                ])?;
+            Ok(())
+        }).unwrap();
+}
+
+fn write_struct_with_symbol_values(value_writer: impl ValueWriter) {
+    value_writer
+        .write_struct(|fields| {
+            fields
+                // $10 = timestamp
+                .write(10, black_box(1670446800245i64))?
+                // $11 = threadId
+                .write(11, black_box(418))?
+                // $12 = threadName, $17 = scheduler-thread-6
+                .write(12, symbol_id(black_box(17)))?
+                // $13 = loggerName, $18 = com.example.organization.product.component.ClassName
+                .write(13, symbol_id(black_box(18)))?
+                // $14 = logLevel, $19 = INFO
+                .write(14, symbol_id(black_box(19)))?
+                // $15 = format, $20 = Request status: {} Client ID: {} Client Host: {} Client Region: {} Timestamp: {}
+                .write(15, symbol_id(black_box(20)))?
+                // $16 = parameters
+                .write(
+                    16,
+                    &[
+                        // $21 = SUCCESS
+                        symbol_id(black_box(21)),
+                        // $22 = example-client-1
+                        symbol_id(black_box(22)),
+                        // $23 = aws-us-east-5f-18b4fa
+                        symbol_id(black_box(23)),
+                        // $24 = region 4
+                        symbol_id(black_box(24)),
+                        // $25 = 2022-12-07T20:59:59.744000Z (string, not timestamp)
+                        symbol_id(black_box(25)),
+                    ],
+                )?;
+            Ok(())
+        })
+        .unwrap();
+}
+
+fn write_eexp_with_symbol_values(value_writer: impl ValueWriter) {
+    value_writer
+        .write_eexp(0, |args| {
+            args.write(black_box(1670446800245i64))? // timestamp
+                .write(black_box(418))? // thread_id
+                // These are still strings because they're so short that using symbols to represent
+                // them wouldn't be beneficial.
+                .write(black_box("6"))? // thread_name
+                .write(black_box("1"))? // client_num
+                .write(symbol_id(black_box(10)))? // host_id: "18b4fa" ($10)
+                .value_writer()
+                .without_annotations()
+                .write_eexp(1, |args| {
+                    args
+                        // $11 = region 4
+                        .write(symbol_id(black_box(11)))?
+                        // $12 = "2022-12-07T20:59:59.744000Z" (string, not timestamp)
+                        .write(symbol_id(black_box(12)))?;
+                    Ok(())
+                })
+                .unwrap();
+            Ok(())
+        })
+        .unwrap();
+}
+
+fn write_eexp_with_string_values(value_writer: impl ValueWriter) {
+    value_writer
+        .write_eexp(0, |args| {
+            args.write(black_box(1670446800245i64))? // timestamp
+                .write(black_box(418))? // thread_id
+                .write(black_box("6"))? // thread_name
+                .write(black_box("1"))? // client_num
+                .write(black_box("18b4fa"))? // host_id
+                .value_writer()
+                .without_annotations()
+                .write_eexp(1, |args| {
+                    args.write(black_box("region 4"))?
+                        .write(black_box("2022-12-07T20:59:59.744000Z"))?;
+                    Ok(())
+                })?;
+            Ok(())
+        })
+        .unwrap();
+}
+
+fn symbol_id(sid: usize) -> RawSymbolTokenRef<'static> {
+    RawSymbolTokenRef::SymbolId(sid)
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let mut buffer = Vec::with_capacity(1024 * 1024);
+
+    let mut binary_1_0_group = c.benchmark_group("binary 1.0");
+    binary_1_0_group.bench_function("write structs with string values", |b| {
+        b.iter(|| {
+            buffer.clear();
+            let mut writer = LazyRawBinaryWriter_1_0::new(&mut buffer).unwrap();
+            write_struct_with_string_values(writer.value_writer().without_annotations());
+            writer.flush().unwrap();
+            black_box(buffer.as_bytes());
+        });
+    });
+    // The runner allows the user to specify which benchmarks to run. If the benchmark above ran,
+    // then the buffer will not be empty.
+    // This print statement cannot live within the benchmark itself, as both `bench_function` and
+    // `iter` are called several times.
+    if !buffer.is_empty() {
+        println!("\nencoded 1.0 size with string values: {}\n", buffer.len());
+        buffer.clear();
+    }
+
+    binary_1_0_group.bench_function("write structs with symbol values", |b| {
+        b.iter(|| {
+            buffer.clear();
+            let mut writer = LazyRawBinaryWriter_1_0::new(&mut buffer).unwrap();
+            write_struct_with_symbol_values(writer.value_writer().without_annotations());
+            writer.flush().unwrap();
+
+            black_box(buffer.as_bytes());
+        });
+    });
+    if !buffer.is_empty() {
+        println!("\nencoded 1.0 size with symbol values: {}\n", buffer.len());
+        buffer.clear()
+    }
+    binary_1_0_group.finish();
+
+    let mut binary_1_1_group = c.benchmark_group("binary 1.1");
+    binary_1_1_group.bench_function("write structs with string values", |b| {
+        b.iter(|| {
+            buffer.clear();
+            let mut writer = LazyRawBinaryWriter_1_1::new(&mut buffer).unwrap();
+            write_struct_with_string_values(writer.value_writer().without_annotations());
+            writer.flush().unwrap();
+            black_box(buffer.as_bytes());
+        });
+    });
+    if !buffer.is_empty() {
+        println!("\nencoded 1.1 size with string values: {}\n", buffer.len());
+        buffer.clear()
+    }
+
+    binary_1_1_group.bench_function("write structs with symbol values", |b| {
+        b.iter(|| {
+            buffer.clear();
+            let mut writer = LazyRawBinaryWriter_1_1::new(&mut buffer).unwrap();
+            write_struct_with_symbol_values(writer.value_writer().without_annotations());
+            writer.flush().unwrap();
+
+            black_box(buffer.as_bytes());
+        });
+    });
+    if !buffer.is_empty() {
+        println!("\nencoded 1.1 size with symbol values: {}\n", buffer.len());
+        buffer.clear()
+    }
+
+    binary_1_1_group.bench_function("write delimited structs with string values", |b| {
+        b.iter(|| {
+            buffer.clear();
+            let mut writer = LazyRawBinaryWriter_1_1::new(&mut buffer).unwrap();
+            write_struct_with_string_values(
+                writer
+                    .value_writer()
+                    .with_delimited_containers()
+                    .without_annotations(),
+            );
+            writer.flush().unwrap();
+            black_box(buffer.as_bytes());
+        });
+    });
+    if !buffer.is_empty() {
+        println!(
+            "\nencoded 1.1 size, delimited structs with string values: {}\n",
+            buffer.len()
+        );
+        buffer.clear()
+    }
+
+    binary_1_1_group.bench_function("write delimited structs with symbol values", |b| {
+        b.iter(|| {
+            buffer.clear();
+            let mut writer = LazyRawBinaryWriter_1_1::new(&mut buffer).unwrap();
+            write_struct_with_symbol_values(
+                writer
+                    .value_writer()
+                    .with_delimited_containers()
+                    .without_annotations(),
+            );
+            writer.flush().unwrap();
+
+            black_box(buffer.as_bytes());
+        });
+    });
+    if !buffer.is_empty() {
+        println!("\nencoded 1.1 size with symbol values: {}\n", buffer.len());
+        buffer.clear()
+    }
+
+    binary_1_1_group.bench_function("write structs with string values using macros", |b| {
+        b.iter(|| {
+            buffer.clear();
+            let mut writer = LazyRawBinaryWriter_1_1::new(&mut buffer).unwrap();
+            write_eexp_with_string_values(writer.value_writer().without_annotations());
+            writer.flush().unwrap();
+            black_box(buffer.as_bytes());
+        });
+    });
+    if !buffer.is_empty() {
+        println!(
+            "\nencoded 1.1 size with string values using macros: {}\n",
+            buffer.len()
+        );
+        buffer.clear()
+    }
+
+    binary_1_1_group.bench_function("write structs with symbol values using macros", |b| {
+        b.iter(|| {
+            buffer.clear();
+            let mut writer = LazyRawBinaryWriter_1_1::new(&mut buffer).unwrap();
+            write_eexp_with_symbol_values(writer.value_writer().without_annotations());
+            writer.flush().unwrap();
+            black_box(buffer.as_bytes());
+        });
+    });
+    if !buffer.is_empty() {
+        println!(
+            "\nencoded 1.1 size with symbol values using macros: {}\n",
+            buffer.len()
+        );
+        buffer.clear()
+    }
+
+    binary_1_1_group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/examples/write_log_events.rs
+++ b/examples/write_log_events.rs
@@ -1,0 +1,336 @@
+//! This program demonstrates implementing WriteAsIon using Ion 1.1's e-expressions for a more
+//! compact encoding. It uses raw-level writer APIs that end users are unlikely to leverage.
+//! Ion 1.1 is not yet finalized; the encoding produced by this example and the APIs it uses
+//! are very likely to change.
+
+use ion_rs::*;
+
+fn main() -> IonResult<()> {
+    #[cfg(not(feature = "experimental-lazy-reader"))]
+    panic!("This example requires the 'experimental-lazy-reader' feature to work.");
+
+    #[cfg(feature = "experimental-lazy-reader")]
+    example::write_log_events()
+}
+
+#[cfg(feature = "experimental-lazy-reader")]
+mod example {
+    use chrono::{DateTime, FixedOffset, NaiveDateTime};
+    use ion_rs::lazy::encoder::binary::v1_0::writer::LazyRawBinaryWriter_1_0;
+    use ion_rs::lazy::encoder::binary::v1_1::writer::LazyRawBinaryWriter_1_1;
+    use ion_rs::lazy::encoder::value_writer::{SequenceWriter, StructWriter, ValueWriter};
+    use ion_rs::lazy::encoder::write_as_ion::WriteAsIonValue;
+    use ion_rs::*;
+    use std::env::args;
+
+    use rand::rngs::StdRng;
+    use rand::seq::SliceRandom;
+    use rand::{Rng, SeedableRng};
+    use std::io::BufWriter;
+    use std::ops::Range;
+    use tempfile::NamedTempFile;
+
+    pub fn write_log_events() -> IonResult<()> {
+        // By default, this program deletes the encoded output before it ends. To keep the files
+        // for further review, you can pass a `--keep-files`/`-k` flag.
+        let args: Vec<String> = args().collect();
+        let keep_files_flag = match args.get(1).map(|a| a.as_str()) {
+            Some("--keep-files") | Some("-k") => true,
+            _ => false,
+        };
+
+        // Create a set of Log4J-style statements that might appear in a typical program. These statements
+        // have a fixed combination of (logger name, log level, format string) fields.
+        let log_statements = log_statements();
+
+        // Create a set of `NUM_EVENTS` log events. Each event comes from a log statement (described above)
+        // and provides additional one-off information like a timestamp, thread ID, thread name, and
+        // parameters to populate the format string.
+        const NUM_EVENTS: usize = 1_000_000;
+        const RNG_SEED: u64 = 1024;
+        let events = generate_events(RNG_SEED, &log_statements, NUM_EVENTS);
+
+        // Make some files in the OS' temp directory to hold our encoded output.
+        let ion_1_0_file = NamedTempFile::new().expect("failed to create a temp file");
+        let ion_1_1_file = NamedTempFile::new().expect("failed to create a temp file");
+
+        println!(
+            "Output files:\nIon 1.0: {}\nIon 1.1: {}",
+            ion_1_0_file.path().to_string_lossy(),
+            ion_1_1_file.path().to_string_lossy(),
+        );
+
+        // Encode the log events as Ion 1.0 data
+        let buf_writer = BufWriter::new(ion_1_0_file.as_file());
+        let mut ion_writer = LazyRawBinaryWriter_1_0::new(buf_writer)?;
+        for event in &events {
+            ion_writer.write(SerializeWithoutMacros(event))?;
+        }
+        ion_writer.flush()?;
+        drop(ion_writer);
+
+        // Encode the log events as Ion 1.1 data
+        let buf_writer = BufWriter::new(ion_1_1_file.as_file());
+        let mut ion_writer = LazyRawBinaryWriter_1_1::new(buf_writer)?;
+        for event in &events {
+            ion_writer.write(SerializeWithMacros(event))?;
+        }
+        ion_writer.flush()?;
+        drop(ion_writer);
+
+        let size_in_1_0 = ion_1_0_file
+            .as_file()
+            .metadata()
+            .expect("failed to read Ion 1.0 file length")
+            .len();
+        let size_in_1_1 = ion_1_1_file
+            .as_file()
+            .metadata()
+            .expect("failed to read Ion 1.1 file length")
+            .len();
+
+        let percentage_smaller = ((size_in_1_0 - size_in_1_1) as f64 / size_in_1_0 as f64) * 100.0;
+        println!("1.0 size: {size_in_1_0}");
+        println!("1.1 size: {size_in_1_1} ({percentage_smaller:.2}% smaller)");
+
+        if keep_files_flag {
+            ion_1_0_file.keep().expect("failed to persist Ion 1.0 file");
+            ion_1_1_file.keep().expect("failed to persist Ion 1.1 file");
+        }
+
+        Ok(())
+    }
+
+    // ===== Data types representing elements of a log file =====
+
+    // A log statement in the fictional codebase
+    #[derive(Debug)]
+    // This struct has several fields that get populated but which are not (yet) used: `logger_name`
+    // `log_level`, and `format`. Currently, the encoded output for Ion 1.0 writes these as symbol
+    // IDs and Ion 1.1 refers to them as part of a macro. In both cases, however, the encoding
+    // context is not written out in the resulting Ion stream.
+    // TODO: Include the symbol/macro table definitions in the resulting output stream.
+    #[allow(dead_code)]
+    struct LogStatement {
+        index: usize,
+        logger_name: String,
+        log_level: String,
+        format: String,
+        parameter_types: Vec<ParameterType>,
+    }
+
+    impl LogStatement {
+        pub fn new(
+            index: usize,
+            class_name: &str,
+            log_level: &str,
+            format: impl Into<String>,
+            parameter_types: impl Into<Vec<ParameterType>>,
+        ) -> Self {
+            Self {
+                index,
+                logger_name: format!("{PACKAGE_NAME}.{class_name}"),
+                log_level: log_level.to_string(),
+                format: format.into(),
+                parameter_types: parameter_types.into(),
+            }
+        }
+    }
+
+    // Each log statement expects a series of parameters to populate the format string. While the
+    // log statement doesn't care about their type, we configure an expected type for each
+    // parameter to generate log event text that makes sense.
+    #[derive(PartialEq, Copy, Clone, Debug)]
+    enum ParameterType {
+        Int,
+        String,
+    }
+
+    // A Log4J-ish log event
+    #[derive(Debug)]
+    struct LogEvent<'a> {
+        timestamp: Timestamp,
+        thread_id: usize,
+        thread_name: String,
+        statement: &'a LogStatement,
+        parameters: Vec<Parameter>,
+    }
+
+    // Randomly selected int or string values that will be passed as parameters to our log events
+    #[derive(Clone, Debug)]
+    enum Parameter {
+        Int(i64),
+        String(String),
+    }
+
+    // ===== Serialization logic for the above types =====
+
+    impl WriteAsIonValue for Parameter {
+        fn write_as_ion_value<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
+            match self {
+                Parameter::Int(i) => i.write_as_ion_value(writer),
+                Parameter::String(s) => s.as_str().write_as_ion_value(writer),
+            }
+        }
+    }
+
+    // Wrapper types to explicitly opt into or out of macro usage. These will not be necessary in
+    // the future, as types will be able to define both a macro-ized serialization and a no-macros
+    // serialization, allowing the writer to choose whichever is more appropriate.
+    struct SerializeWithoutMacros<'a, 'b>(&'a LogEvent<'b>);
+    struct SerializeWithMacros<'a, 'b>(&'a LogEvent<'b>);
+
+    // When serializing without macros (usually in Ion 1.0), we write out a struct with each
+    // field name/value pair. In the case of recurring strings, we take the liberty of writing
+    // out symbol IDs instead of the full text; this silent type coercion from string to symbol
+    // is technically data loss, but results in a much more compact encoding.
+    impl<'a, 'b> WriteAsIonValue for SerializeWithoutMacros<'a, 'b> {
+        fn write_as_ion_value<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
+            let event = self.0;
+            writer.write_struct(|fields| {
+                fields
+                    //            v--- Each field name is a symbol ID
+                    .write(10, &event.timestamp)?
+                    .write(11, event.thread_id)?
+                    .write(12, &event.thread_name)?
+                    //                 v--- The fixed strings from the log statement are also SIDs
+                    .write(13, RawSymbolToken::SymbolId(17))? // logger name
+                    .write(14, RawSymbolToken::SymbolId(18))? // log level
+                    .write(15, RawSymbolToken::SymbolId(19))? // format
+                    .write(16, &event.parameters)?;
+                Ok(())
+            })
+        }
+    }
+
+    // When leveraging macros, the thread name's recurring prefix can be elided from the output.
+    // This wrapper type is used by the `SerializeWithMacros` type to change to serialization
+    // behavior for the thread name.
+    struct ThreadName<'a>(&'a str);
+
+    impl<'a> WriteAsIonValue for ThreadName<'a> {
+        fn write_as_ion_value<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
+            // ID 12 chosen arbitrarily, but aligns with Ion 1.0 encoding above
+            writer.write_eexp(12, |args| {
+                // Ignore the part of the thread name that starts with the recurring prefix.
+                args.write(&self.0[THREAD_NAME_PREFIX.len()..])?;
+                Ok(())
+            })
+        }
+    }
+
+    impl<'a, 'b> WriteAsIonValue for SerializeWithMacros<'a, 'b> {
+        fn write_as_ion_value<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
+            let event = self.0;
+            writer.write_eexp(event.statement.index, |args| {
+                args.write(&event.timestamp)?
+                    .write(event.thread_id)?
+                    // Wrap the thread name in the `ThreadName` wrapper to change its serialization.
+                    .write(ThreadName(&event.thread_name))?
+                    .write(&event.parameters)?;
+                Ok(())
+            })
+        }
+    }
+
+    // ===== Random generation of sample data =====
+
+    const INT_PARAMETER_RANGE: Range<i64> = 0..5_000;
+    fn generate_int_parameter(rng: &mut StdRng) -> Parameter {
+        Parameter::Int(rng.gen_range(INT_PARAMETER_RANGE))
+    }
+
+    fn generate_string_parameter(rng: &mut StdRng) -> Parameter {
+        const WORDS: &[&str] = &["users", "transactions", "accounts", "customers", "waffles"];
+        Parameter::String(WORDS.choose(rng).unwrap().to_string())
+    }
+
+    fn log_statements() -> Vec<LogStatement> {
+        use ParameterType::*;
+        vec![
+            LogStatement::new(
+                0,
+                "Foo",
+                "DEBUG",
+                "Database heartbeat received after {} ms",
+                &[Int]
+            ),
+            LogStatement::new(
+                1,
+                "Bar",
+                "INFO",
+                "Retrieved {} results from the '{}' table in {} ms",
+                &[Int, String, Int],
+            ),
+            LogStatement::new(
+                2,
+                "Baz",
+                "WARN",
+                "Query to the '{}' table took {} ms to execute, which is higher than the configured threshold",
+                &[String, Int],
+            ),
+            LogStatement::new(
+                3,
+                "Quux",
+                "ERROR",
+                "Connection to database lost",
+                &[]
+            ),
+        ]
+    }
+
+    const INITIAL_EPOCH_MILLIS: i64 = 1708617898 * 1_000; // Feb 22, 2024
+    const THREAD_NAME_PREFIX: &str = "worker-thread-";
+    const PACKAGE_NAME: &str = "com.example.organization.product.component";
+
+    fn generate_events(
+        seed: u64,
+        log_statements: &[LogStatement],
+        num_events: usize,
+    ) -> Vec<LogEvent<'_>> {
+        let mut rng = StdRng::seed_from_u64(seed);
+        (0..num_events)
+            .map(|i| generate_event(&mut rng, log_statements, i))
+            .collect()
+    }
+
+    fn generate_event<'rng, 'statements>(
+        rng: &'rng mut StdRng,
+        log_statements: &'statements [LogStatement],
+        event_index: usize,
+    ) -> LogEvent<'statements> {
+        // Each event is 1 second after the previous event
+        let event_epoch_millis = INITIAL_EPOCH_MILLIS + (event_index as i64 * 1000);
+        let naive_datetime = NaiveDateTime::from_timestamp_millis(event_epoch_millis)
+            .unwrap()
+            .into();
+
+        // Timestamps have an offset of UTC-5:00
+        let timestamp: Timestamp = DateTime::<FixedOffset>::from_naive_utc_and_offset(
+            naive_datetime,
+            FixedOffset::east_opt(5 * 60 * 60).unwrap(),
+        )
+        .into();
+
+        let thread_id = rng.gen_range(1..=128);
+        let thread_name = format!("{THREAD_NAME_PREFIX}{}", rng.gen_range(1..=8));
+        let statement = log_statements.choose(rng).unwrap();
+
+        let parameters: Vec<Parameter> = statement
+            .parameter_types
+            .iter()
+            .map(|pt| match pt {
+                ParameterType::Int => generate_int_parameter(rng),
+                ParameterType::String => generate_string_parameter(rng),
+            })
+            .collect();
+
+        LogEvent {
+            timestamp,
+            thread_id,
+            thread_name,
+            statement,
+            parameters,
+        }
+    }
+}

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -316,7 +316,7 @@ impl From<crate::tokens::ScalarValue> for Value {
 /// // and then into an `Element`...
 /// let mut boolean_element: Element = boolean_value.into();
 /// // and then adding annotations to the `Element`.
-/// boolean_element = boolean_element.with_annotations(["foo", "bar"]);
+/// let boolean_element = boolean_element.with_annotations(["foo", "bar"]);
 ///
 /// // Much more concise equivalent leveraging the `IntoAnnotatedElement` trait.
 /// let boolean_element = true.with_annotations(["foo", "bar"]);

--- a/src/lazy/encoder/binary/v1_0/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_0/value_writer.rs
@@ -541,7 +541,7 @@ impl<'value, 'top: 'value> ValueWriter for BinaryAnnotatedValueWriter_1_0<'value
     // Ion 1.0 does not support macros
     type MacroArgsWriter<'a> = Never;
 
-    delegate_value_writer_to!(closure(|self_: Self| self_.value_writer()));
+    delegate_value_writer_to!(closure |self_: Self| self_.value_writer());
 }
 #[cfg(test)]
 mod tests {

--- a/src/lazy/encoder/binary/v1_0/writer.rs
+++ b/src/lazy/encoder/binary/v1_0/writer.rs
@@ -34,6 +34,10 @@ pub struct LazyRawBinaryWriter_1_0<W: Write> {
     encoding_buffer_ptr: Option<*mut ()>,
 }
 
+/// The initial size of the backing array for the writer's bump allocator.
+// This value was chosen somewhat arbitrarily and can be changed as needed.
+const DEFAULT_BUMP_SIZE: usize = 16 * 1024;
+
 impl<W: Write> LazyRawBinaryWriter_1_0<W> {
     /// Constructs a new binary writer and writes an Ion 1.0 Version Marker to output.
     pub fn new(mut output: W) -> IonResult<Self> {
@@ -42,7 +46,7 @@ impl<W: Write> LazyRawBinaryWriter_1_0<W> {
         // Construct the writer
         Ok(Self {
             output,
-            allocator: BumpAllocator::with_capacity(16 * 1024),
+            allocator: BumpAllocator::with_capacity(DEFAULT_BUMP_SIZE),
             encoding_buffer_ptr: None,
         })
     }

--- a/src/lazy/encoder/binary/v1_0/writer.rs
+++ b/src/lazy/encoder/binary/v1_0/writer.rs
@@ -42,7 +42,7 @@ impl<W: Write> LazyRawBinaryWriter_1_0<W> {
         // Construct the writer
         Ok(Self {
             output,
-            allocator: BumpAllocator::new(),
+            allocator: BumpAllocator::with_capacity(16 * 1024),
             encoding_buffer_ptr: None,
         })
     }
@@ -128,10 +128,8 @@ impl<W: Write> LazyRawWriter<W> for LazyRawBinaryWriter_1_0<W> {
 impl<W: Write> MakeValueWriter for LazyRawBinaryWriter_1_0<W> {
     type ValueWriter<'a> = BinaryAnnotatableValueWriter_1_0<'a, 'a> where Self: 'a;
 
-    delegate! {
-        to self {
-            fn value_writer(&mut self) -> Self::ValueWriter<'_>;
-        }
+    fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
+        self.value_writer()
     }
 }
 

--- a/src/lazy/encoder/binary/v1_1/container_writers.rs
+++ b/src/lazy/encoder/binary/v1_1/container_writers.rs
@@ -1,13 +1,14 @@
 use bumpalo::collections::Vec as BumpVec;
 use bumpalo::Bump as BumpAllocator;
 use delegate::delegate;
+use ice_code::ice as cold_path;
 
 use crate::lazy::encoder::binary::v1_1::value_writer::BinaryAnnotatableValueWriter_1_1;
 use crate::lazy::encoder::value_writer::internal::MakeValueWriter;
-use crate::lazy::encoder::value_writer::{SequenceWriter, StructWriter};
+use crate::lazy::encoder::value_writer::{MacroArgsWriter, SequenceWriter, StructWriter};
 use crate::lazy::encoder::write_as_ion::WriteAsIon;
 use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
-use crate::{FlexInt, FlexUInt, IonResult, RawSymbolTokenRef};
+use crate::{FlexInt, FlexUInt, IonResult, RawSymbolTokenRef, SymbolId};
 
 /// A helper type that holds fields and logic that is common to [`BinaryListWriter_1_1`],
 /// [`BinarySExpWriter_1_1`], and [`BinaryStructWriter_1_1`].
@@ -41,6 +42,7 @@ impl<'value, 'top> BinaryContainerWriter_1_1<'value, 'top> {
     }
 
     /// Encodes the provided `value` to the [`BinaryContainerWriter_1_1`]'s buffer.
+    #[inline]
     pub fn write<V: WriteAsIon>(&mut self, value: V) -> IonResult<&mut Self> {
         let annotated_value_writer = self.value_writer();
         value.write_as_ion(annotated_value_writer)?;
@@ -67,7 +69,7 @@ impl<'value, 'top> BinaryListWriter_1_1<'value, 'top> {
 impl<'value, 'top> MakeValueWriter for BinaryListWriter_1_1<'value, 'top> {
     type ValueWriter<'a> = BinaryAnnotatableValueWriter_1_1<'a, 'top> where Self: 'a;
 
-    fn value_writer(&mut self) -> Self::ValueWriter<'_> {
+    fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
         self.container_writer.value_writer()
     }
 }
@@ -94,7 +96,7 @@ impl<'value, 'top> BinarySExpWriter_1_1<'value, 'top> {
 impl<'value, 'top> MakeValueWriter for BinarySExpWriter_1_1<'value, 'top> {
     type ValueWriter<'a> = BinaryAnnotatableValueWriter_1_1<'a, 'top> where Self: 'a;
 
-    fn value_writer(&mut self) -> Self::ValueWriter<'_> {
+    fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
         BinaryAnnotatableValueWriter_1_1::new(
             self.container_writer.allocator(),
             self.container_writer.buffer(),
@@ -120,20 +122,20 @@ pub struct BinaryStructWriter_1_1<'value, 'top> {
 }
 
 impl<'value, 'top> BinaryStructWriter_1_1<'value, 'top> {
-    pub(crate) fn new(container_writer: BinaryContainerWriter_1_1<'value, 'top>) -> Self {
+    pub(crate) fn new_length_prefixed(
+        container_writer: BinaryContainerWriter_1_1<'value, 'top>,
+    ) -> Self {
         Self {
             flex_uint_encoding: true,
             container_writer,
         }
     }
 
-    fn enable_flex_sym_encoding(&mut self) {
-        if self.flex_uint_encoding {
-            // Write a zero byte out to signal to future readers that we are switching from
-            // FlexUInt to FlexSym.
-            self.container_writer.buffer().push(0x00);
-            // Remember that we've already done this step.
-            self.flex_uint_encoding = false;
+    pub(crate) fn new_delimited(container_writer: BinaryContainerWriter_1_1<'value, 'top>) -> Self {
+        Self {
+            // Delimited structs always use FlexSym encoding.
+            flex_uint_encoding: false,
+            container_writer,
         }
     }
 
@@ -141,7 +143,55 @@ impl<'value, 'top> BinaryStructWriter_1_1<'value, 'top> {
         self.container_writer.buffer
     }
 
+    #[inline]
     pub fn write<A: AsRawSymbolTokenRef, V: WriteAsIon>(
+        &mut self,
+        name: A,
+        value: V,
+    ) -> IonResult<&mut Self> {
+        use RawSymbolTokenRef::*;
+
+        match (self.flex_uint_encoding, name.as_raw_symbol_token_ref()) {
+            // We're already in FlexSym encoding mode
+            (false, _) => self.write_flex_sym_field(name, value),
+            // We're still in FlexUInt encoding mode, but this value requires FlexSym encoding
+            (_, Text(_)) | (_, SymbolId(0)) =>
+            // This can only happen up to once inside a length-prefixed struct
+            {
+                self.enable_flex_sym_and_write_field(name, value)
+            }
+            // We're in FlexUInt encoding mode and can write this field without switching modes
+            (_, SymbolId(sid)) => self.write_flex_uint_field(sid, value),
+        }
+    }
+
+    #[inline]
+    fn write_flex_uint_field<V: WriteAsIon>(
+        &mut self,
+        name: SymbolId,
+        value: V,
+    ) -> IonResult<&mut Self> {
+        FlexUInt::encode_u64(self.buffer(), name as u64);
+        self.container_writer.write(value)?;
+        Ok(self)
+    }
+
+    #[inline(never)]
+    fn enable_flex_sym_and_write_field<A: AsRawSymbolTokenRef, V: WriteAsIon>(
+        &mut self,
+        name: A,
+        value: V,
+    ) -> IonResult<&mut Self> {
+        if self.flex_uint_encoding {
+            // This is the first time we're writing a FlexSym field. Emit a FlexUInt 0 to tell
+            // readers that we're switching from FlexUInt to FlexSym.
+            self.buffer().push(0x01);
+            self.flex_uint_encoding = false;
+        }
+        self.write_flex_sym_field(name, value)
+    }
+
+    pub fn write_flex_sym_field<A: AsRawSymbolTokenRef, V: WriteAsIon>(
         &mut self,
         name: A,
         value: V,
@@ -151,29 +201,28 @@ impl<'value, 'top> BinaryStructWriter_1_1<'value, 'top> {
         // Write the field name
         match name.as_raw_symbol_token_ref() {
             SymbolId(0) => {
-                self.enable_flex_sym_encoding();
                 // Encoding `$0` requires a zero byte to indicate an opcode follows,
-                // and then opcode 0x70, which indicates symbol ID 0.
-                self.buffer().extend_from_slice(&[0, 0x70]);
-            }
-            SymbolId(sid) if self.flex_uint_encoding => {
-                FlexUInt::write_u64(self.buffer(), sid as u64)?;
+                // and then opcode 0x90, which indicates symbol ID 0.
+                cold_path! {
+                    write_symbol_id_zero => self.buffer().extend_from_slice_copy(&[0, 0x90])
+                }
             }
             SymbolId(sid) => {
-                FlexInt::write_i64(self.buffer(), sid as i64)?;
+                FlexInt::encode_i64(self.buffer(), sid as i64);
             }
             Text(text_token) => {
-                self.enable_flex_sym_encoding();
                 let text = text_token.as_ref();
                 let num_bytes = text.len();
                 if num_bytes == 0 {
                     // Encoding the empty string requires a zero byte to indicate an opcode follows,
                     // and then opcode 0x80, which indicates a string of length 0.
-                    self.buffer().extend_from_slice(&[0, 0x80])
+                    cold_path! {
+                        write_empty_string => self.buffer().extend_from_slice_copy(&[0, 0x80])
+                    }
                 } else {
                     let negated_num_bytes = -(text.len() as i64);
-                    FlexInt::write_i64(self.buffer(), negated_num_bytes)?;
-                    self.buffer().extend_from_slice(text.as_bytes());
+                    FlexInt::encode_i64(self.buffer(), negated_num_bytes);
+                    self.buffer().extend_from_slice_copy(text.as_bytes());
                 }
             }
         };
@@ -194,3 +243,19 @@ impl<'value, 'top> StructWriter for BinaryStructWriter_1_1<'value, 'top> {
         }
     }
 }
+
+pub struct BinaryMacroArgsWriter_1_1<'value, 'top> {
+    pub(crate) container_writer: BinaryContainerWriter_1_1<'value, 'top>,
+}
+
+impl<'value, 'top> MakeValueWriter for BinaryMacroArgsWriter_1_1<'value, 'top> {
+    type ValueWriter<'a> = BinaryAnnotatableValueWriter_1_1<'a, 'top> where Self: 'a;
+
+    fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
+        self.container_writer.value_writer()
+    }
+}
+
+impl<'value, 'top> SequenceWriter for BinaryMacroArgsWriter_1_1<'value, 'top> {}
+
+impl<'value, 'top> MacroArgsWriter for BinaryMacroArgsWriter_1_1<'value, 'top> {}

--- a/src/lazy/encoder/binary/v1_1/container_writers.rs
+++ b/src/lazy/encoder/binary/v1_1/container_writers.rs
@@ -182,12 +182,10 @@ impl<'value, 'top> BinaryStructWriter_1_1<'value, 'top> {
         name: A,
         value: V,
     ) -> IonResult<&mut Self> {
-        if self.flex_uint_encoding {
-            // This is the first time we're writing a FlexSym field. Emit a FlexUInt 0 to tell
-            // readers that we're switching from FlexUInt to FlexSym.
-            self.buffer().push(0x01);
-            self.flex_uint_encoding = false;
-        }
+        // This is the first time we're writing a FlexSym field. Emit a FlexUInt 0 to tell
+        // readers that we're switching from FlexUInt to FlexSym.
+        self.buffer().push(0x01);
+        self.flex_uint_encoding = false;
         self.write_flex_sym_field(name, value)
     }
 

--- a/src/lazy/encoder/binary/v1_1/flex_sym.rs
+++ b/src/lazy/encoder/binary/v1_1/flex_sym.rs
@@ -1,0 +1,46 @@
+use bumpalo::collections::Vec as BumpVec;
+use ice_code::ice as cold_path;
+
+use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
+use crate::RawSymbolTokenRef::{SymbolId, Text};
+use crate::{FlexInt, RawSymbolTokenRef};
+
+/// An Ion 1.1 encoding primitive that can compactly represent a symbol ID or inline text.
+#[derive(Debug)]
+pub struct FlexSym {
+    // No fields yet; these may be added when we get to read support.
+}
+
+impl FlexSym {
+    /// A FlexSym-encoded logical zero: the byte `0x01u8`
+    pub const ZERO: u8 = 0x01;
+
+    /// Encode the provided `symbol` as a FlexSym and write it to the provided [`BumpVec`].
+    pub fn encode_symbol(output: &mut BumpVec<u8>, symbol: impl AsRawSymbolTokenRef) {
+        let symbol_token = symbol.as_raw_symbol_token_ref();
+        // Write the field name
+        match symbol_token {
+            SymbolId(sid) if sid != 0 => {
+                FlexInt::encode_i64(output, sid as i64);
+            }
+            Text(text) if !text.is_empty() => {
+                let negated_num_bytes = -(text.len() as i64);
+                FlexInt::encode_i64(output, negated_num_bytes);
+                output.extend_from_slice_copy(text.as_bytes());
+            }
+            _ => cold_path! {
+                Self::encode_special_case(output, symbol_token)
+            },
+        };
+    }
+
+    /// Encodes the empty string or symbol ID zero as a FlexSym. The caller is responsible for
+    /// confirming that `symbol` is one of those two cases before calling.
+    fn encode_special_case(output: &mut BumpVec<u8>, symbol: RawSymbolTokenRef) {
+        let encoding: &[u8] = match symbol {
+            SymbolId(_) => &[FlexSym::ZERO, 0xE1, 0x00],
+            Text(_) => &[FlexSym::ZERO, 0x80],
+        };
+        output.extend_from_slice_copy(encoding);
+    }
+}

--- a/src/lazy/encoder/binary/v1_1/mod.rs
+++ b/src/lazy/encoder/binary/v1_1/mod.rs
@@ -7,6 +7,7 @@ pub mod container_writers;
 pub mod fixed_int;
 pub mod fixed_uint;
 pub mod flex_int;
+pub mod flex_sym;
 pub mod flex_uint;
 pub mod value_writer;
 pub mod writer;

--- a/src/lazy/encoder/mod.rs
+++ b/src/lazy/encoder/mod.rs
@@ -143,7 +143,7 @@ mod tests {
             ]
         "#;
         let test = |writer: &mut LazyRawTextWriter_1_0<&mut Vec<u8>>| {
-            writer.value_writer().write_list(|list| {
+            writer.make_value_writer().write_list(|list| {
                 list.write(1)?
                     .write(false)?
                     .write(3f32)?
@@ -173,7 +173,7 @@ mod tests {
             )
         "#;
         let test = |writer: &mut LazyRawTextWriter_1_0<&mut Vec<u8>>| {
-            writer.value_writer().write_sexp(|sexp| {
+            writer.make_value_writer().write_sexp(|sexp| {
                 sexp.write(1)?
                     .write(false)?
                     .write(3f32)?
@@ -202,7 +202,7 @@ mod tests {
             }
         "#;
         let test = |writer: &mut LazyRawTextWriter_1_0<&mut Vec<u8>>| {
-            writer.value_writer().write_struct(|struct_| {
+            writer.make_value_writer().write_struct(|struct_| {
                 struct_
                     .write("a", 1)?
                     .write("b", false)?

--- a/src/lazy/encoder/text/mod.rs
+++ b/src/lazy/encoder/text/mod.rs
@@ -68,7 +68,7 @@ impl<W: Write> MakeValueWriter for LazyRawTextWriter_1_0<W> {
     where
         Self: 'a;
 
-    fn value_writer(&mut self) -> Self::ValueWriter<'_> {
+    fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
         let value_writer = TextValueWriter_1_0::new(self, 0);
         TextAnnotatableValueWriter_1_0::new(value_writer)
     }

--- a/src/lazy/encoder/value_writer.rs
+++ b/src/lazy/encoder/value_writer.rs
@@ -154,18 +154,21 @@ macro_rules! delegate_value_writer_to {
     //
     // If no arguments are passed, trait method calls are delegated to inherent impl methods on `self`.
     () => {
-        $crate::lazy::encoder::value_writer::delegate_value_writer_to!(closure (|self_: Self| {self_}));
+        $crate::lazy::encoder::value_writer::delegate_value_writer_to!(closure |self_: Self| self_);
     };
     // If an identifier is passed, it is treated as the name of a subfield of `self`.
     ($name:ident) => {
-       $crate::lazy::encoder::value_writer::delegate_value_writer_to!(closure (|self_: Self| self_.$name));
+       $crate::lazy::encoder::value_writer::delegate_value_writer_to!(closure |self_: Self| self_.$name);
     };
     // If a closure is provided, trait method calls are delegated to the closure's return value.
     (closure $f:expr) => {
         // In order to forward this call to the `fallible closure` pattern, the provided closure is
         // wrapped in another closure that wraps the closure's output in IonResult::Ok(_). The
         // compiler can eliminate the redundant closure call.
-        $crate::lazy::encoder::value_writer::delegate_value_writer_to!(fallible closure |self_: Self| {$crate::IonResult::Ok($f(self_))});
+        $crate::lazy::encoder::value_writer::delegate_value_writer_to!(fallible closure |self_: Self| {
+            let infallible_closure = $f;
+            $crate::IonResult::Ok(infallible_closure(self_))
+        });
     };
     // If a fallible closure is provided, it will be called. If it returns an `Err`, the method
     // will return. Otherwise, trait method calls are delegated to the `Ok(_)` value.

--- a/src/lazy/encoder/value_writer.rs
+++ b/src/lazy/encoder/value_writer.rs
@@ -133,9 +133,21 @@ pub trait ValueWriter: Sized {
 /// This macro takes an expression and calls the `delegate!` proc macro on it for all of the methods
 /// in the ValueWriter trait. For example:
 /// ```text
-///     delegate_value_writer_to!(foo) => delegate! { to self.foo { ...signatures ... } }
-///     delegate_value_writer_to!(0)   => delegate! { to self.0 { ...signatures ... } }
-///     delegate_value_writer_to!()    => delegate! { to self { ...signatures ... } }
+///     delegate_value_writer_to!()     => delegate! { to self { ...signatures ... } }
+///     delegate_value_writer_to!(foo)  => delegate! { to self.foo { ...signatures ... } }
+///     delegate_value_writer_to!(0)    => delegate! { to self.0 { ...signatures ... } }
+///     delegate_value_writer_to!(
+///         closure
+///         |self_: Self| {
+///             self_.value_writer()
+///         }
+///     )                               => delegate! { to self.value_writer() { ...signatures ... } }
+///     delegate_value_writer_to!(
+///         fallible closure
+///         |self_: Self| {
+///             self_.returns_result()
+///         }
+///     )                               => delegate! { to self.returns_result()? { ...signatures ... } }
 /// ```
 ///
 /// Notice that if no parameter expression is passed, it results in delegation to `self`, which is helpful if

--- a/src/lazy/encoder/write_as_ion.rs
+++ b/src/lazy/encoder/write_as_ion.rs
@@ -69,6 +69,7 @@ macro_rules! impl_write_as_ion_value {
     // The caller defined an expression to write other than `self` (e.g. `*self`, `*self.0`, etc)
     ($target_type:ty => $method:ident with $self:ident as $value:expr, $($rest:tt)*) => {
         impl WriteAsIonValue for $target_type {
+            #[inline]
             fn write_as_ion_value<V: ValueWriter>(&$self, writer: V) -> IonResult<()> {
                 writer.$method($value)
             }
@@ -78,6 +79,7 @@ macro_rules! impl_write_as_ion_value {
     // We're writing the expression `self`
     ($target_type:ty => $method:ident, $($rest:tt)*) => {
         impl WriteAsIonValue for $target_type {
+            #[inline]
             fn write_as_ion_value<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
                 writer.$method(self)
             }
@@ -106,12 +108,14 @@ impl_write_as_ion_value!(
 );
 
 impl<'b> WriteAsIonValue for RawSymbolTokenRef<'b> {
+    #[inline]
     fn write_as_ion_value<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
         writer.write_symbol(self)
     }
 }
 
 impl<'b> WriteAsIonValue for SymbolRef<'b> {
+    #[inline]
     fn write_as_ion_value<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
         writer.write_symbol(self)
     }
@@ -124,6 +128,7 @@ impl<const N: usize> WriteAsIonValue for [u8; N] {
 }
 
 impl<T: WriteAsIonValue> WriteAsIonValue for &T {
+    #[inline]
     fn write_as_ion_value<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
         (*self).write_as_ion_value(writer)
     }

--- a/src/lazy/never.rs
+++ b/src/lazy/never.rs
@@ -1,9 +1,15 @@
 use std::fmt::Debug;
 
 use crate::lazy::decoder::{LazyDecoder, LazyRawValueExpr};
+use crate::lazy::encoder::value_writer::internal::MakeValueWriter;
+use crate::lazy::encoder::value_writer::{
+    AnnotatableValueWriter, MacroArgsWriter, SequenceWriter, StructWriter, ValueWriter,
+};
+use crate::lazy::encoder::write_as_ion::WriteAsIon;
 use crate::lazy::expanded::macro_evaluator::{MacroExpr, RawEExpression};
 use crate::lazy::text::raw::v1_1::reader::MacroIdRef;
-use crate::IonResult;
+use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
+use crate::{Decimal, Int, IonResult, IonType, Timestamp};
 
 /// An uninhabited type that signals to the compiler that related code paths are not reachable.
 #[derive(Debug, Copy, Clone)]
@@ -29,5 +35,130 @@ impl<'top, D: LazyDecoder<EExpression<'top> = Self>> RawEExpression<'top, D> for
 impl<'top, D: LazyDecoder> From<Never> for MacroExpr<'top, D> {
     fn from(_value: Never) -> Self {
         unreachable!("macro in Ion 1.0 (method: into)")
+    }
+}
+
+impl AnnotatableValueWriter for Never {
+    type ValueWriter = Never;
+    type AnnotatedValueWriter<'a, SymbolType: AsRawSymbolTokenRef + 'a> = Never where Self: 'a;
+
+    fn with_annotations<'a, SymbolType: AsRawSymbolTokenRef>(
+        self,
+        _annotations: &'a [SymbolType],
+    ) -> Self::AnnotatedValueWriter<'a, SymbolType>
+    where
+        Self: 'a,
+    {
+        unreachable!("AnnotatableValueWriter::with_annotations in Never")
+    }
+
+    fn without_annotations(self) -> Self::ValueWriter {
+        unreachable!("AnnotatableValueWriter::without_annotations in Never")
+    }
+}
+
+impl SequenceWriter for Never {}
+
+impl StructWriter for Never {
+    fn write<A: AsRawSymbolTokenRef, V: WriteAsIon>(
+        &mut self,
+        _name: A,
+        _value: V,
+    ) -> IonResult<&mut Self> {
+        unreachable!("StructWriter::write in Never")
+    }
+}
+
+impl MakeValueWriter for Never {
+    type ValueWriter<'a> = Never where Self: 'a;
+
+    fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
+        unreachable!("MakeValueWriter::value_writer in Never")
+    }
+}
+
+impl MacroArgsWriter for Never {}
+
+impl ValueWriter for Never {
+    type ListWriter<'a> = Never;
+    type SExpWriter<'a> = Never;
+    type StructWriter<'a> = Never;
+    type MacroArgsWriter<'a> = Never;
+
+    fn write_null(self, _ion_type: IonType) -> IonResult<()> {
+        unreachable!("ValueWriter::write_null in Never")
+    }
+
+    fn write_bool(self, _value: bool) -> IonResult<()> {
+        unreachable!("ValueWriter::write_bool in Never")
+    }
+
+    fn write_i64(self, _value: i64) -> IonResult<()> {
+        unreachable!("ValueWriter::write_i64 in Never")
+    }
+
+    fn write_int(self, _value: &Int) -> IonResult<()> {
+        unreachable!("ValueWriter::write_int in Never")
+    }
+
+    fn write_f32(self, _value: f32) -> IonResult<()> {
+        unreachable!("ValueWriter::write_f32 in Never")
+    }
+
+    fn write_f64(self, _value: f64) -> IonResult<()> {
+        unreachable!("ValueWriter::write_f64 in Never")
+    }
+
+    fn write_decimal(self, _value: &Decimal) -> IonResult<()> {
+        unreachable!("ValueWriter::write_decimal in Never")
+    }
+
+    fn write_timestamp(self, _value: &Timestamp) -> IonResult<()> {
+        unreachable!("ValueWriter::write_timestamp in Never")
+    }
+
+    fn write_string(self, _value: impl AsRef<str>) -> IonResult<()> {
+        unreachable!("ValueWriter::write_string in Never")
+    }
+
+    fn write_symbol(self, _value: impl AsRawSymbolTokenRef) -> IonResult<()> {
+        unreachable!("ValueWriter::write_symbol in Never")
+    }
+
+    fn write_clob(self, _value: impl AsRef<[u8]>) -> IonResult<()> {
+        unreachable!("ValueWriter::write_clob in Never")
+    }
+
+    fn write_blob(self, _value: impl AsRef<[u8]>) -> IonResult<()> {
+        unreachable!("ValueWriter::write_blob in Never")
+    }
+
+    fn write_list<F: for<'a> FnOnce(&mut Self::ListWriter<'a>) -> IonResult<()>>(
+        self,
+        _list_fn: F,
+    ) -> IonResult<()> {
+        unreachable!("ValueWriter::write_list in Never")
+    }
+
+    fn write_sexp<F: for<'a> FnOnce(&mut Self::SExpWriter<'a>) -> IonResult<()>>(
+        self,
+        _sexp_fn: F,
+    ) -> IonResult<()> {
+        unreachable!("ValueWriter::write_sexp in Never")
+    }
+
+    fn write_struct<F: for<'a> FnOnce(&mut Self::StructWriter<'a>) -> IonResult<()>>(
+        self,
+        _struct_fn: F,
+    ) -> IonResult<()> {
+        unreachable!("ValueWriter::write_struct in Never")
+    }
+
+    fn write_eexp<'macro_id, F: for<'a> FnOnce(&mut Self::MacroArgsWriter<'a>) -> IonResult<()>>(
+        self,
+        _macro_id: impl Into<MacroIdRef<'macro_id>>,
+        _macro_fn: F,
+    ) -> IonResult<()> {
+        unreachable!("ValueWriter::write_eexp in Never")
     }
 }

--- a/src/lazy/text/raw/v1_1/reader.rs
+++ b/src/lazy/text/raw/v1_1/reader.rs
@@ -34,11 +34,24 @@ pub type MacroAddress = usize;
 
 /// The index at which a value expression can be found within a template's body.
 pub type TemplateBodyExprAddress = usize;
+
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum MacroIdRef<'data> {
     LocalName(&'data str),
     LocalAddress(usize),
     // TODO: Addresses and qualified names
+}
+
+impl<'data> From<usize> for MacroIdRef<'data> {
+    fn from(address: usize) -> Self {
+        MacroIdRef::LocalAddress(address)
+    }
+}
+
+impl<'data> From<&'data str> for MacroIdRef<'data> {
+    fn from(name: &'data str) -> Self {
+        MacroIdRef::LocalName(name)
+    }
 }
 
 #[derive(Copy, Clone)]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -22,8 +22,6 @@ use std::fmt::{Display, Formatter};
 use crate::types::Str;
 /// Configures and constructs new instances of [Reader].
 pub struct ReaderBuilder {
-    // This will be set to to `Some` catalog when the reader builder is created with catalog information.
-    // Default value for this field will be set to `None`.
     catalog: Box<dyn Catalog>,
 }
 
@@ -31,6 +29,8 @@ impl ReaderBuilder {
     /// Constructs a [ReaderBuilder] pre-populated with common default settings.
     pub fn new() -> ReaderBuilder {
         ReaderBuilder {
+            // `EmptyCatalog` is a zero-sized type; creating a Box<EmptyCatalog> does not actually
+            // cause a heap allocation.
             catalog: Box::<EmptyCatalog>::default(),
         }
     }

--- a/src/result/encoding_error.rs
+++ b/src/result/encoding_error.rs
@@ -1,3 +1,4 @@
+use ice_code::ice as cold_path;
 use std::borrow::Cow;
 use thiserror::Error;
 
@@ -11,7 +12,7 @@ pub struct EncodingError {
 impl EncodingError {
     pub(crate) fn new(description: impl Into<Cow<'static, str>>) -> Self {
         EncodingError {
-            description: description.into(),
+            description: cold_path! { encoding_error => description.into()},
         }
     }
 }

--- a/src/result/io_error.rs
+++ b/src/result/io_error.rs
@@ -1,12 +1,20 @@
 use std::io;
+use std::io::Error;
 use thiserror::Error;
 
 /// Indicates that a read or write operation failed due to an I/O error.
 #[derive(Debug, Error)]
 #[error("{source:?}")]
 pub struct IoError {
-    #[from]
     source: io::Error,
+}
+
+impl From<io::Error> for IoError {
+    #[cold]
+    #[inline(never)]
+    fn from(value: Error) -> Self {
+        IoError { source: value }
+    }
 }
 
 impl IoError {


### PR DESCRIPTION
Adds write support for e-expressions in the binary writer.

Additionally:
* Adds a `write_many_structs` benchmark that compares time to write structs in Ion 1.0, Ion 1.1 w/length prefixes, Ion 1.1 w/delimited containers, and Ion 1.1 w/macros.
* Adds an example program that generates a large number of Log4J-style event structs and serializes them in various forms.
* Amends some binary encoding details that were ambiguous in the spec.
* Adds [`ice_code`](https://github.com/zslayton/ice_code/) as a dependency to label cold code paths without having to construct new methods.
* Sets some default allocation sizes for encoding buffers and the bump allocator itself to reduce reallocations.
* Adds a `delegate_value_writer_to!` macro that cuts the number of places the `ValueWriter` trait method collection is written out, simplifying refactoring.

Related to #671.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
