### PR TITLE
Adds a `StreamingRawReader`, switches `Element` to the `LazyReader`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [features]
-default = []
+default = ["experimental"]
 experimental-ion-hash = ["digest"]
 
 # Feature for indicating particularly bleeding edge APIs or functionality in the library.

--- a/benches/read_many_structs.rs
+++ b/benches/read_many_structs.rs
@@ -87,7 +87,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     // As a sanity check, materialize the data from both the Ion 1.0 and 1.1 streams and make sure
     // that they are equivalent before we start measuring the time needed to read them.
-    let seq_1_0 = LazyTextReader_1_1::new(&text_1_0_data)
+    let seq_1_0 = LazyTextReader_1_1::new(text_1_0_data.as_slice())
         .unwrap()
         .read_all_elements()
         .unwrap();
@@ -102,7 +102,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let mut binary_1_0_group = c.benchmark_group("binary 1.0");
     binary_1_0_group.bench_function("scan all", |b| {
         b.iter(|| {
-            let mut reader = LazyBinaryReader::new(&binary_1_0_data).unwrap();
+            let mut reader = LazyBinaryReader::new(binary_1_0_data.as_slice()).unwrap();
             while let Some(item) = reader.next().unwrap() {
                 black_box(item);
             }
@@ -110,7 +110,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     });
     binary_1_0_group.bench_function("read all", |b| {
         b.iter(|| {
-            let mut reader = LazyBinaryReader::new(&binary_1_0_data).unwrap();
+            let mut reader = LazyBinaryReader::new(binary_1_0_data.as_slice()).unwrap();
             let mut num_values = 0usize;
             while let Some(item) = reader.next().unwrap() {
                 num_values += count_value_and_children(&item).unwrap();
@@ -124,7 +124,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     text_1_0_group.bench_function("scan all", |b| {
         b.iter(|| {
             let mut reader =
-                LazyApplicationReader::<'_, TextEncoding_1_1>::new(&text_1_0_data).unwrap();
+                LazyApplicationReader::<TextEncoding_1_1, _>::new(text_1_0_data.as_slice())
+                    .unwrap();
             while let Some(item) = reader.next().unwrap() {
                 black_box(item);
             }
@@ -133,7 +134,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     text_1_0_group.bench_function("read all", |b| {
         b.iter(|| {
             let mut reader =
-                LazyApplicationReader::<'_, TextEncoding_1_1>::new(&text_1_0_data).unwrap();
+                LazyApplicationReader::<TextEncoding_1_1, _>::new(text_1_0_data.as_slice())
+                    .unwrap();
             let mut num_values = 0usize;
             while let Some(item) = reader.next().unwrap() {
                 num_values += count_value_and_children(&item).unwrap();
@@ -144,7 +146,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     text_1_0_group.bench_function("read 'format' field", |b| {
         b.iter(|| {
             let mut reader =
-                LazyApplicationReader::<'_, TextEncoding_1_1>::new(&text_1_0_data).unwrap();
+                LazyApplicationReader::<TextEncoding_1_1, _>::new(text_1_0_data.as_slice())
+                    .unwrap();
             let mut num_values = 0usize;
             while let Some(value) = reader.next().unwrap() {
                 let s = value.read().unwrap().expect_struct().unwrap();
@@ -180,7 +183,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     text_1_1_group.bench_function("read 'format' field", |b| {
         b.iter(|| {
             let mut reader =
-                LazyApplicationReader::<'_, TextEncoding_1_1>::new(text_1_1_data.as_bytes())
+                LazyApplicationReader::<TextEncoding_1_1, _>::new(text_1_1_data.as_bytes())
                     .unwrap();
             reader.register_template(template_text).unwrap();
             let mut num_values = 0usize;

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::io;
 use std::io::{BufReader, Read, StdinLock};
 
-/// Types that implement this trait can be converted into an implementation of [BufRead], allowing
+/// Types that implement this trait can be converted into an implementation of [Read], allowing
 /// users to deserialize Ion from a variety of types that might not define I/O operations on their own.
 pub trait IonDataSource {
     type DataSource: Read;

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -1,11 +1,11 @@
 use std::fs::File;
 use std::io;
-use std::io::{BufRead, BufReader, Read, StdinLock};
+use std::io::{BufReader, Read, StdinLock};
 
 /// Types that implement this trait can be converted into an implementation of [BufRead], allowing
 /// users to deserialize Ion from a variety of types that might not define I/O operations on their own.
 pub trait IonDataSource {
-    type DataSource: BufRead;
+    type DataSource: Read;
     fn to_ion_data_source(self) -> Self::DataSource;
 }
 
@@ -49,7 +49,7 @@ impl IonDataSource for Vec<u8> {
     }
 }
 
-impl<T: BufRead, U: BufRead> IonDataSource for io::Chain<T, U> {
+impl<T: Read, U: Read> IonDataSource for io::Chain<T, U> {
     type DataSource = Self;
 
     fn to_ion_data_source(self) -> Self::DataSource {

--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -1,9 +1,11 @@
 #![allow(non_camel_case_types)]
 
 use std::fmt::Debug;
+use std::ops::Range;
 
 use bumpalo::Bump as BumpAllocator;
 
+use crate::lazy::any_encoding::RawReaderKind::{Binary_1_0, Text_1_0};
 use crate::lazy::binary::raw::annotations_iterator::RawBinaryAnnotationsIterator;
 use crate::lazy::binary::raw::r#struct::{LazyRawBinaryStruct, RawBinaryStructIterator};
 use crate::lazy::binary::raw::reader::LazyRawBinaryReader;
@@ -44,6 +46,7 @@ pub struct AnyEncoding;
 // underlying type.
 impl LazyDecoder for AnyEncoding {
     type Reader<'data> = LazyRawAnyReader<'data>;
+    type ReaderSavedState = RawReaderType;
     type Value<'top> = LazyRawAnyValue<'top>;
     type SExp<'top> = LazyRawAnySExp<'top>;
     type List<'top> = LazyRawAnyList<'top>;
@@ -141,10 +144,20 @@ pub enum RawReaderKind<'data> {
     Binary_1_0(LazyRawBinaryReader<'data>),
 }
 
+#[derive(Default, Copy, Clone)]
+pub enum RawReaderType {
+    // In the absence of a binary IVM, readers must assume Ion 1.0 text data until a
+    // text Ion 1.1 version marker is found.
+    #[default]
+    Text_1_0,
+    Binary_1_0,
+    // TODO: v1.1
+}
+
 impl<'data> From<LazyRawTextReader_1_0<'data>> for LazyRawAnyReader<'data> {
     fn from(reader: LazyRawTextReader_1_0<'data>) -> Self {
         LazyRawAnyReader {
-            encoding: RawReaderKind::Text_1_0(reader),
+            encoding: Text_1_0(reader),
         }
     }
 }
@@ -152,17 +165,32 @@ impl<'data> From<LazyRawTextReader_1_0<'data>> for LazyRawAnyReader<'data> {
 impl<'data> From<LazyRawBinaryReader<'data>> for LazyRawAnyReader<'data> {
     fn from(reader: LazyRawBinaryReader<'data>) -> Self {
         LazyRawAnyReader {
-            encoding: RawReaderKind::Binary_1_0(reader),
+            encoding: Binary_1_0(reader),
         }
     }
 }
 
 impl<'data> LazyRawReader<'data, AnyEncoding> for LazyRawAnyReader<'data> {
     fn new(data: &'data [u8]) -> Self {
-        if data.starts_with(&[0xE0u8, 0x01, 0x00, 0xEA]) {
-            LazyRawBinaryReader::new(data).into()
-        } else {
-            LazyRawTextReader_1_0::new(data).into()
+        const BINARY_1_0_IVM: &[u8] = &[0xEA, 0x01, 0x00, 0xE0];
+
+        let reader_type = match data {
+            &[0xE0, 0x01, 0x00, 0xEA, ..] => RawReaderType::Binary_1_0,
+            // TODO: Binary Ion 1.1
+            _ => RawReaderType::Text_1_0,
+        };
+
+        Self::resume_at_offset(data, 0, reader_type)
+    }
+
+    fn resume_at_offset(data: &'data [u8], offset: usize, raw_reader_type: RawReaderType) -> Self {
+        match raw_reader_type {
+            RawReaderType::Text_1_0 => {
+                LazyRawTextReader_1_0::resume_at_offset(data, offset, ()).into()
+            }
+            RawReaderType::Binary_1_0 => {
+                LazyRawBinaryReader::resume_at_offset(data, offset, ()).into()
+            }
         }
     }
 
@@ -174,8 +202,24 @@ impl<'data> LazyRawReader<'data, AnyEncoding> for LazyRawAnyReader<'data> {
         'data: 'top,
     {
         match &mut self.encoding {
-            RawReaderKind::Text_1_0(r) => Ok(r.next(allocator)?.into()),
-            RawReaderKind::Binary_1_0(r) => Ok(r.next()?.into()),
+            Text_1_0(r) => Ok(r.next(allocator)?.into()),
+            Binary_1_0(r) => Ok(r.next()?.into()),
+        }
+    }
+
+    #[inline]
+    fn save_state(&self) -> <AnyEncoding as LazyDecoder>::ReaderSavedState {
+        use RawReaderKind::*;
+        match &self.encoding {
+            Text_1_0(_) => RawReaderType::Text_1_0,
+            Binary_1_0(_) => RawReaderType::Binary_1_0,
+        }
+    }
+
+    fn position(&self) -> usize {
+        match &self.encoding {
+            Text_1_0(r) => r.position(),
+            Binary_1_0(r) => r.position(),
         }
     }
 }
@@ -392,50 +436,73 @@ impl<'top> From<LazyRawStreamItem<'top, TextEncoding_1_1>>
 
 impl<'top> LazyRawValuePrivate<'top> for LazyRawAnyValue<'top> {
     fn field_name(&self) -> IonResult<RawSymbolTokenRef<'top>> {
+        use LazyRawValueKind::*;
         match &self.encoding {
-            LazyRawValueKind::Text_1_0(v) => v.field_name(),
-            LazyRawValueKind::Binary_1_0(v) => v.field_name(),
-            LazyRawValueKind::Text_1_1(v) => v.field_name(),
+            Text_1_0(v) => v.field_name(),
+            Binary_1_0(v) => v.field_name(),
+            Text_1_1(v) => v.field_name(),
         }
     }
 }
 
 impl<'top> LazyRawValue<'top, AnyEncoding> for LazyRawAnyValue<'top> {
     fn ion_type(&self) -> IonType {
+        use LazyRawValueKind::*;
         match &self.encoding {
-            LazyRawValueKind::Text_1_0(v) => v.ion_type(),
-            LazyRawValueKind::Binary_1_0(v) => v.ion_type(),
-            LazyRawValueKind::Text_1_1(v) => v.ion_type(),
+            Text_1_0(v) => v.ion_type(),
+            Binary_1_0(v) => v.ion_type(),
+            Text_1_1(v) => v.ion_type(),
         }
     }
 
     fn is_null(&self) -> bool {
+        use LazyRawValueKind::*;
         match &self.encoding {
-            LazyRawValueKind::Text_1_0(v) => v.is_null(),
-            LazyRawValueKind::Binary_1_0(v) => v.is_null(),
-            LazyRawValueKind::Text_1_1(v) => v.is_null(),
+            Text_1_0(v) => v.is_null(),
+            Binary_1_0(v) => v.is_null(),
+            Text_1_1(v) => v.is_null(),
         }
     }
 
     fn annotations(&self) -> RawAnyAnnotationsIterator<'top> {
+        use LazyRawValueKind::*;
         match &self.encoding {
-            LazyRawValueKind::Text_1_0(v) => RawAnyAnnotationsIterator {
+            Text_1_0(v) => RawAnyAnnotationsIterator {
                 encoding: RawAnnotationsIteratorKind::Text_1_0(v.annotations()),
             },
-            LazyRawValueKind::Binary_1_0(v) => RawAnyAnnotationsIterator {
+            Binary_1_0(v) => RawAnyAnnotationsIterator {
                 encoding: RawAnnotationsIteratorKind::Binary_1_0(v.annotations()),
             },
-            LazyRawValueKind::Text_1_1(v) => RawAnyAnnotationsIterator {
+            Text_1_1(v) => RawAnyAnnotationsIterator {
                 encoding: RawAnnotationsIteratorKind::Text_1_1(v.annotations()),
             },
         }
     }
 
     fn read(&self) -> IonResult<RawValueRef<'top, AnyEncoding>> {
+        use LazyRawValueKind::*;
         match &self.encoding {
-            LazyRawValueKind::Text_1_0(v) => Ok(v.read()?.into()),
-            LazyRawValueKind::Binary_1_0(v) => Ok(v.read()?.into()),
-            LazyRawValueKind::Text_1_1(v) => Ok(v.read()?.into()),
+            Text_1_0(v) => Ok(v.read()?.into()),
+            Binary_1_0(v) => Ok(v.read()?.into()),
+            Text_1_1(v) => Ok(v.read()?.into()),
+        }
+    }
+
+    fn range(&self) -> Range<usize> {
+        use LazyRawValueKind::*;
+        match &self.encoding {
+            Text_1_0(v) => v.range(),
+            Binary_1_0(v) => v.range(),
+            Text_1_1(v) => v.range(),
+        }
+    }
+
+    fn span(&self) -> &[u8] {
+        use LazyRawValueKind::*;
+        match &self.encoding {
+            Text_1_0(v) => v.span(),
+            Binary_1_0(v) => v.span(),
+            Text_1_1(v) => v.span(),
         }
     }
 }

--- a/src/lazy/binary/encoded_value.rs
+++ b/src/lazy/binary/encoded_value.rs
@@ -211,6 +211,16 @@ impl EncodedValue {
         self.total_length
     }
 
+    /// The offset Range (starting from the beginning of the stream) that contains this value's
+    /// complete encoding, including annotations. (It does not include the leading field ID, if
+    /// any.)
+    pub fn annotated_value_range(&self) -> Range<usize> {
+        // [ field_id? | annotations? | header (type descriptor) | header_length? | value ]
+        let start = self.header_offset - self.annotations_header_length as usize;
+        let end = start - self.field_id_length as usize + self.total_length;
+        start..end
+    }
+
     pub fn ion_type(&self) -> IonType {
         self.header.ion_type
     }

--- a/src/lazy/binary/immutable_buffer.rs
+++ b/src/lazy/binary/immutable_buffer.rs
@@ -738,6 +738,13 @@ impl<'a> ImmutableBuffer<'a> {
                 + length_length as usize
                 + value_length;
 
+        if total_length > input.len() {
+            return IonResult::incomplete(
+                "the stream ended unexpectedly in the middle of a value",
+                header_offset,
+            );
+        }
+
         let encoded_value = EncodedValue {
             header,
             // If applicable, these are populated by the caller: `peek_field()`

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -17,6 +17,7 @@ use crate::types::SymbolId;
 use crate::{Decimal, Int, IonError, IonResult, IonType, RawSymbolTokenRef, Timestamp};
 use bytes::{BigEndian, ByteOrder};
 use std::fmt::{Debug, Formatter};
+use std::ops::Range;
 use std::{fmt, mem};
 
 /// A value that has been identified in the input stream but whose data has not yet been read.
@@ -73,6 +74,17 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_0> for LazyRawBinaryValue<'top> {
 
     fn read(&self) -> IonResult<RawValueRef<'top, BinaryEncoding_1_0>> {
         self.read()
+    }
+
+    fn range(&self) -> Range<usize> {
+        self.encoded_value.annotated_value_range()
+    }
+
+    fn span(&self) -> &[u8] {
+        let range = self.range();
+        // Subtract the `offset()` of the ImmutableBuffer to get the local indexes for start/end
+        let local_range = (range.start - self.input.offset())..(range.end - self.input.offset());
+        &self.input.bytes()[local_range]
     }
 }
 

--- a/src/lazy/encoding.rs
+++ b/src/lazy/encoding.rs
@@ -101,6 +101,7 @@ impl EncodingWithMacroSupport for TextEncoding_1_1 {}
 
 impl LazyDecoder for BinaryEncoding_1_0 {
     type Reader<'data> = LazyRawBinaryReader<'data>;
+    type ReaderSavedState = ();
     type Value<'top> = LazyRawBinaryValue<'top>;
     type SExp<'top> = LazyRawBinarySExp<'top>;
     type List<'top> = LazyRawBinaryList<'top>;
@@ -112,6 +113,7 @@ impl LazyDecoder for BinaryEncoding_1_0 {
 
 impl LazyDecoder for TextEncoding_1_0 {
     type Reader<'data> = LazyRawTextReader_1_0<'data>;
+    type ReaderSavedState = ();
     type Value<'top> = LazyRawTextValue_1_0<'top>;
     type SExp<'top> = LazyRawTextSExp_1_0<'top>;
     type List<'top> = LazyRawTextList_1_0<'top>;
@@ -123,6 +125,7 @@ impl LazyDecoder for TextEncoding_1_0 {
 
 impl LazyDecoder for TextEncoding_1_1 {
     type Reader<'data> = LazyRawTextReader_1_1<'data>;
+    type ReaderSavedState = ();
     type Value<'top> = LazyRawTextValue_1_1<'top>;
     type SExp<'top> = LazyRawTextSExp_1_1<'top>;
     type List<'top> = LazyRawTextList_1_1<'top>;

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -42,7 +42,7 @@ use sequence::{LazyExpandedList, LazyExpandedSExp};
 
 use crate::element::iterators::SymbolsIterator;
 use crate::lazy::bytes_ref::BytesRef;
-use crate::lazy::decoder::{LazyDecoder, LazyRawReader, LazyRawValue};
+use crate::lazy::decoder::{LazyDecoder, LazyRawValue};
 use crate::lazy::encoding::RawValueLiteral;
 use crate::lazy::expanded::compiler::TemplateCompiler;
 use crate::lazy::expanded::macro_evaluator::{MacroEvaluator, RawEExpression};
@@ -54,6 +54,7 @@ use crate::lazy::r#struct::LazyStruct;
 use crate::lazy::raw_value_ref::RawValueRef;
 use crate::lazy::sequence::{LazyList, LazySExp};
 use crate::lazy::str_ref::StrRef;
+use crate::lazy::streaming_raw_reader::{IntoIonInput, StreamingRawReader};
 use crate::lazy::system_reader::{LazySystemReader, PendingLst};
 use crate::lazy::system_stream_item::SystemStreamItem;
 use crate::lazy::text::raw::v1_1::reader::MacroAddress;
@@ -132,8 +133,8 @@ impl<'top, D: LazyDecoder> ExpandedStreamItem<'top, D> {
 
 /// A reader that evaluates macro invocations in the data stream and surfaces the resulting
 /// raw values to the caller.
-pub struct LazyExpandingReader<'data, D: LazyDecoder> {
-    raw_reader: UnsafeCell<D::Reader<'data>>,
+pub struct LazyExpandingReader<Encoding: LazyDecoder, Input: IntoIonInput> {
+    raw_reader: UnsafeCell<StreamingRawReader<Encoding, Input>>,
     // The expanding raw reader needs to be able to return multiple values from a single expression.
     // For example, if the raw reader encounters this e-expression:
     //
@@ -187,14 +188,14 @@ pub struct LazyExpandingReader<'data, D: LazyDecoder> {
     pending_lst: UnsafeCell<PendingLst>,
     // A bump allocator that is cleared between top-level expressions.
     allocator: UnsafeCell<BumpAllocator>,
-    // TODO: Make the symbol and macro tables traits on `D` such that they can be configured
+    // TODO: Make the symbol and macro tables traits on `Encoding` such that they can be configured
     //       statically. Then 1.0 types can use `Never` for the macro table.
     symbol_table: UnsafeCell<SymbolTable>,
     macro_table: UnsafeCell<MacroTable>,
 }
 
-impl<'data, D: LazyDecoder> LazyExpandingReader<'data, D> {
-    pub(crate) fn new(raw_reader: D::Reader<'data>) -> Self {
+impl<Encoding: LazyDecoder, Input: IntoIonInput> LazyExpandingReader<Encoding, Input> {
+    pub(crate) fn new(raw_reader: StreamingRawReader<Encoding, Input>) -> Self {
         Self {
             raw_reader: raw_reader.into(),
             evaluator_ptr: None.into(),
@@ -235,7 +236,7 @@ impl<'data, D: LazyDecoder> LazyExpandingReader<'data, D> {
     }
 
     /// Dereferences a raw pointer storing the address of the active MacroEvaluator.
-    fn ptr_to_evaluator<'top>(evaluator_ptr: *mut ()) -> &'top mut MacroEvaluator<'top, D> {
+    fn ptr_to_evaluator<'top>(evaluator_ptr: *mut ()) -> &'top mut MacroEvaluator<'top, Encoding> {
         Self::ptr_to_mut_ref(evaluator_ptr)
     }
 
@@ -246,7 +247,7 @@ impl<'data, D: LazyDecoder> LazyExpandingReader<'data, D> {
     }
 
     /// Converts a mutable reference to the active MacroEvaluator into a raw, untyped pointer.
-    fn evaluator_to_ptr(evaluator: &mut MacroEvaluator<'_, D>) -> *mut () {
+    fn evaluator_to_ptr(evaluator: &mut MacroEvaluator<'_, Encoding>) -> *mut () {
         Self::ref_as_ptr(evaluator)
     }
 
@@ -272,13 +273,13 @@ impl<'data, D: LazyDecoder> LazyExpandingReader<'data, D> {
     /// application-level value. Returns it as the appropriate variant of `SystemStreamItem`.
     fn interpret_value<'top>(
         &self,
-        value: LazyExpandedValue<'top, D>,
-    ) -> IonResult<SystemStreamItem<'top, D>> {
+        value: LazyExpandedValue<'top, Encoding>,
+    ) -> IonResult<SystemStreamItem<'top, Encoding>> {
         // If this value is a symbol table...
-        if LazySystemReader::is_symbol_table_struct(&value)? {
+        if LazySystemReader::<_, Input>::is_symbol_table_struct(&value)? {
             // ...traverse it and record any new symbols in our `pending_lst`.
             let pending_lst = unsafe { &mut *self.pending_lst.get() };
-            LazySystemReader::process_symbol_table(pending_lst, &value)?;
+            LazySystemReader::<_, Input>::process_symbol_table(pending_lst, &value)?;
             pending_lst.has_changes = true;
             let lazy_struct = LazyStruct {
                 expanded_struct: value.read()?.expect_struct().unwrap(),
@@ -319,7 +320,7 @@ impl<'data, D: LazyDecoder> LazyExpandingReader<'data, D> {
     ///
     /// This method will consume and process as many system-level values as possible until it
     /// encounters an application-level value or the end of the stream.
-    pub fn next_value(&mut self) -> IonResult<Option<LazyValue<D>>> {
+    pub fn next_value(&mut self) -> IonResult<Option<LazyValue<Encoding>>> {
         loop {
             match self.next_item()? {
                 SystemStreamItem::VersionMarker(_, _) => {
@@ -337,10 +338,7 @@ impl<'data, D: LazyDecoder> LazyExpandingReader<'data, D> {
 
     /// Returns the next [`SystemStreamItem`] either by continuing to evaluate a macro invocation
     /// in progress or by pulling another expression from the input stream.
-    pub fn next_item<'top>(&'top self) -> IonResult<SystemStreamItem<'top, D>>
-    where
-        'data: 'top,
-    {
+    pub fn next_item<'top>(&'top self) -> IonResult<SystemStreamItem<'top, Encoding>> {
         // If there's already an active macro evaluator, that means the reader is still in the process
         // of expanding a macro invocation it previously encountered. See if it has a value to give us.
         if let Some(stream_item) = self.next_from_evaluator()? {
@@ -410,7 +408,7 @@ impl<'data, D: LazyDecoder> LazyExpandingReader<'data, D> {
     /// If there is an evaluation in process but it does not yield another value, returns `Ok(None)`.
     /// If there is an evaluation in process and it yields another value, returns `Ok(Some(value))`.
     /// Otherwise, returns `Err`.
-    fn next_from_evaluator(&self) -> IonResult<Option<SystemStreamItem<D>>> {
+    fn next_from_evaluator(&self) -> IonResult<Option<SystemStreamItem<Encoding>>> {
         let evaluator_ptr = match self.evaluator_ptr.get() {
             // There's not currently an evaluator.
             None => return Ok(None),
@@ -452,7 +450,7 @@ pub enum ExpandedValueSource<'top, D: LazyDecoder> {
     ),
 }
 
-impl<'top, D: LazyDecoder> Debug for ExpandedValueSource<'top, D> {
+impl<'top, Encoding: LazyDecoder> Debug for ExpandedValueSource<'top, Encoding> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match &self {
             ExpandedValueSource::ValueLiteral(v) => write!(f, "{v:?}"),
@@ -466,8 +464,8 @@ impl<'top, D: LazyDecoder> Debug for ExpandedValueSource<'top, D> {
 
 // Converts the raw value literal types associated with each format decoder (e.g. LazyRawTextValue_1_1)
 // into an ExpandedValueSource.
-impl<'top, V: RawValueLiteral, D: LazyDecoder<Value<'top> = V>> From<V>
-    for ExpandedValueSource<'top, D>
+impl<'top, V: RawValueLiteral, Encoding: LazyDecoder<Value<'top> = V>> From<V>
+    for ExpandedValueSource<'top, Encoding>
 {
     fn from(value: V) -> Self {
         ExpandedValueSource::ValueLiteral(value)
@@ -476,19 +474,19 @@ impl<'top, V: RawValueLiteral, D: LazyDecoder<Value<'top> = V>> From<V>
 
 /// A value produced by expanding the 'raw' view of the input data.
 #[derive(Copy, Clone)]
-pub struct LazyExpandedValue<'top, D: LazyDecoder> {
+pub struct LazyExpandedValue<'top, Encoding: LazyDecoder> {
     pub(crate) context: EncodingContext<'top>,
-    pub(crate) source: ExpandedValueSource<'top, D>,
+    pub(crate) source: ExpandedValueSource<'top, Encoding>,
 }
 
-impl<'top, D: LazyDecoder> Debug for LazyExpandedValue<'top, D> {
+impl<'top, Encoding: LazyDecoder> Debug for LazyExpandedValue<'top, Encoding> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.source)
     }
 }
 
-impl<'top, D: LazyDecoder> LazyExpandedValue<'top, D> {
-    pub(crate) fn from_value(context: EncodingContext<'top>, value: D::Value<'top>) -> Self {
+impl<'top, Encoding: LazyDecoder> LazyExpandedValue<'top, Encoding> {
+    pub(crate) fn from_value(context: EncodingContext<'top>, value: Encoding::Value<'top>) -> Self {
         Self {
             context,
             source: ExpandedValueSource::ValueLiteral(value),
@@ -497,7 +495,7 @@ impl<'top, D: LazyDecoder> LazyExpandedValue<'top, D> {
 
     pub(crate) fn from_template(
         context: EncodingContext<'top>,
-        environment: Environment<'top, D>,
+        environment: Environment<'top, Encoding>,
         element: TemplateElement<'top>,
     ) -> Self {
         Self {
@@ -526,7 +524,7 @@ impl<'top, D: LazyDecoder> LazyExpandedValue<'top, D> {
         }
     }
 
-    pub fn annotations(&self) -> ExpandedAnnotationsIterator<'top, D> {
+    pub fn annotations(&self) -> ExpandedAnnotationsIterator<'top, Encoding> {
         use ExpandedValueSource::*;
         match &self.source {
             ValueLiteral(value) => ExpandedAnnotationsIterator::new(
@@ -545,7 +543,7 @@ impl<'top, D: LazyDecoder> LazyExpandedValue<'top, D> {
         }
     }
 
-    pub fn read(&self) -> IonResult<ExpandedValueRef<'top, D>> {
+    pub fn read(&self) -> IonResult<ExpandedValueRef<'top, Encoding>> {
         use ExpandedValueSource::*;
         match &self.source {
             ValueLiteral(value) => Ok(ExpandedValueRef::from_raw(self.context, value.read()?)),
@@ -563,48 +561,56 @@ impl<'top, D: LazyDecoder> LazyExpandedValue<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> From<LazyExpandedValue<'top, D>> for LazyValue<'top, D> {
-    fn from(expanded_value: LazyExpandedValue<'top, D>) -> Self {
+impl<'top, Encoding: LazyDecoder> From<LazyExpandedValue<'top, Encoding>>
+    for LazyValue<'top, Encoding>
+{
+    fn from(expanded_value: LazyExpandedValue<'top, Encoding>) -> Self {
         LazyValue { expanded_value }
     }
 }
 
-impl<'top, D: LazyDecoder> From<LazyExpandedStruct<'top, D>> for LazyStruct<'top, D> {
-    fn from(expanded_struct: LazyExpandedStruct<'top, D>) -> Self {
+impl<'top, Encoding: LazyDecoder> From<LazyExpandedStruct<'top, Encoding>>
+    for LazyStruct<'top, Encoding>
+{
+    fn from(expanded_struct: LazyExpandedStruct<'top, Encoding>) -> Self {
         LazyStruct { expanded_struct }
     }
 }
 
-impl<'top, D: LazyDecoder> From<LazyExpandedSExp<'top, D>> for LazySExp<'top, D> {
-    fn from(expanded_sexp: LazyExpandedSExp<'top, D>) -> Self {
+impl<'top, Encoding: LazyDecoder> From<LazyExpandedSExp<'top, Encoding>>
+    for LazySExp<'top, Encoding>
+{
+    fn from(expanded_sexp: LazyExpandedSExp<'top, Encoding>) -> Self {
         LazySExp { expanded_sexp }
     }
 }
 
-impl<'top, D: LazyDecoder> From<LazyExpandedList<'top, D>> for LazyList<'top, D> {
-    fn from(expanded_list: LazyExpandedList<'top, D>) -> Self {
+impl<'top, Encoding: LazyDecoder> From<LazyExpandedList<'top, Encoding>>
+    for LazyList<'top, Encoding>
+{
+    fn from(expanded_list: LazyExpandedList<'top, Encoding>) -> Self {
         LazyList { expanded_list }
     }
 }
 
-pub enum ExpandedAnnotationsSource<'top, D: LazyDecoder> {
-    ValueLiteral(D::AnnotationsIterator<'top>),
+pub enum ExpandedAnnotationsSource<'top, Encoding: LazyDecoder> {
+    ValueLiteral(Encoding::AnnotationsIterator<'top>),
     Template(SymbolsIterator<'top>),
     // TODO: This is a placeholder impl and always returns an empty iterator
     Constructed(Box<dyn Iterator<Item = IonResult<RawSymbolTokenRef<'top>>> + 'top>),
 }
 
-pub struct ExpandedAnnotationsIterator<'top, D: LazyDecoder> {
-    source: ExpandedAnnotationsSource<'top, D>,
+pub struct ExpandedAnnotationsIterator<'top, Encoding: LazyDecoder> {
+    source: ExpandedAnnotationsSource<'top, Encoding>,
 }
 
-impl<'top, D: LazyDecoder> ExpandedAnnotationsIterator<'top, D> {
-    pub fn new(source: ExpandedAnnotationsSource<'top, D>) -> Self {
+impl<'top, Encoding: LazyDecoder> ExpandedAnnotationsIterator<'top, Encoding> {
+    pub fn new(source: ExpandedAnnotationsSource<'top, Encoding>) -> Self {
         Self { source }
     }
 }
 
-impl<'top, D: LazyDecoder> Iterator for ExpandedAnnotationsIterator<'top, D> {
+impl<'top, Encoding: LazyDecoder> Iterator for ExpandedAnnotationsIterator<'top, Encoding> {
     type Item = IonResult<RawSymbolTokenRef<'top>>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -620,12 +626,12 @@ impl<'top, D: LazyDecoder> Iterator for ExpandedAnnotationsIterator<'top, D> {
 }
 
 // TODO: This type does not implement `Copy` because some of its variants can own heap resources.
-//       (Specifically: Int, Decimal, String, Symbol, Blob, Clob.) If plumb the bump allocator all
+//       (Specifically: Int, Decimal, String, Symbol, Blob, Clob.) If we plumb the bump allocator all
 //       the way down to the raw readers, then the situations that require allocation can
 //       hold a 'top reference to a bump allocation instead of a static reference to a heap allocation.
 //       This will enable us to remove several calls to `clone()`, which can be much slower than copies.
 #[derive(Clone)]
-pub enum ExpandedValueRef<'top, D: LazyDecoder> {
+pub enum ExpandedValueRef<'top, Encoding: LazyDecoder> {
     Null(IonType),
     Bool(bool),
     Int(Int),
@@ -636,12 +642,12 @@ pub enum ExpandedValueRef<'top, D: LazyDecoder> {
     Symbol(RawSymbolTokenRef<'top>),
     Blob(BytesRef<'top>),
     Clob(BytesRef<'top>),
-    SExp(LazyExpandedSExp<'top, D>),
-    List(LazyExpandedList<'top, D>),
-    Struct(LazyExpandedStruct<'top, D>),
+    SExp(LazyExpandedSExp<'top, Encoding>),
+    List(LazyExpandedList<'top, Encoding>),
+    Struct(LazyExpandedStruct<'top, Encoding>),
 }
 
-impl<'top, D: LazyDecoder> PartialEq for ExpandedValueRef<'top, D> {
+impl<'top, Encoding: LazyDecoder> PartialEq for ExpandedValueRef<'top, Encoding> {
     fn eq(&self, other: &Self) -> bool {
         use ExpandedValueRef::*;
         match (self, other) {
@@ -665,7 +671,7 @@ impl<'top, D: LazyDecoder> PartialEq for ExpandedValueRef<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> ExpandedValueRef<'top, D> {
+impl<'top, Encoding: LazyDecoder> ExpandedValueRef<'top, Encoding> {
     fn expected<T>(self, expected_name: &str) -> IonResult<T> {
         IonResult::decoding_error(format!(
             "expected a(n) {} but found a {:?}",
@@ -761,7 +767,7 @@ impl<'top, D: LazyDecoder> ExpandedValueRef<'top, D> {
         }
     }
 
-    pub fn expect_list(self) -> IonResult<LazyExpandedList<'top, D>> {
+    pub fn expect_list(self) -> IonResult<LazyExpandedList<'top, Encoding>> {
         if let ExpandedValueRef::List(s) = self {
             Ok(s)
         } else {
@@ -769,7 +775,7 @@ impl<'top, D: LazyDecoder> ExpandedValueRef<'top, D> {
         }
     }
 
-    pub fn expect_sexp(self) -> IonResult<LazyExpandedSExp<'top, D>> {
+    pub fn expect_sexp(self) -> IonResult<LazyExpandedSExp<'top, Encoding>> {
         if let ExpandedValueRef::SExp(s) = self {
             Ok(s)
         } else {
@@ -777,7 +783,7 @@ impl<'top, D: LazyDecoder> ExpandedValueRef<'top, D> {
         }
     }
 
-    pub fn expect_struct(self) -> IonResult<LazyExpandedStruct<'top, D>> {
+    pub fn expect_struct(self) -> IonResult<LazyExpandedStruct<'top, Encoding>> {
         if let ExpandedValueRef::Struct(s) = self {
             Ok(s)
         } else {
@@ -785,7 +791,7 @@ impl<'top, D: LazyDecoder> ExpandedValueRef<'top, D> {
         }
     }
 
-    fn from_raw(context: EncodingContext<'top>, value: RawValueRef<'top, D>) -> Self {
+    fn from_raw(context: EncodingContext<'top>, value: RawValueRef<'top, Encoding>) -> Self {
         use RawValueRef::*;
         match value {
             Null(ion_type) => ExpandedValueRef::Null(ion_type),
@@ -827,10 +833,10 @@ impl<'top, D: LazyDecoder> Debug for ExpandedValueRef<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> ExpandedValueRef<'top, D> {
+impl<'top, Encoding: LazyDecoder> ExpandedValueRef<'top, Encoding> {
     fn from_template(
         context: EncodingContext<'top>,
-        environment: Environment<'top, D>,
+        environment: Environment<'top, Encoding>,
         element: &TemplateElement<'top>,
     ) -> Self {
         use TemplateValue::*;

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -54,7 +54,7 @@ use crate::lazy::r#struct::LazyStruct;
 use crate::lazy::raw_value_ref::RawValueRef;
 use crate::lazy::sequence::{LazyList, LazySExp};
 use crate::lazy::str_ref::StrRef;
-use crate::lazy::streaming_raw_reader::{IntoIonInput, StreamingRawReader};
+use crate::lazy::streaming_raw_reader::{IonInput, StreamingRawReader};
 use crate::lazy::system_reader::{LazySystemReader, PendingLst};
 use crate::lazy::system_stream_item::SystemStreamItem;
 use crate::lazy::text::raw::v1_1::reader::MacroAddress;
@@ -133,7 +133,7 @@ impl<'top, D: LazyDecoder> ExpandedStreamItem<'top, D> {
 
 /// A reader that evaluates macro invocations in the data stream and surfaces the resulting
 /// raw values to the caller.
-pub struct LazyExpandingReader<Encoding: LazyDecoder, Input: IntoIonInput> {
+pub struct LazyExpandingReader<Encoding: LazyDecoder, Input: IonInput> {
     raw_reader: UnsafeCell<StreamingRawReader<Encoding, Input>>,
     // The expanding raw reader needs to be able to return multiple values from a single expression.
     // For example, if the raw reader encounters this e-expression:
@@ -194,7 +194,7 @@ pub struct LazyExpandingReader<Encoding: LazyDecoder, Input: IntoIonInput> {
     macro_table: UnsafeCell<MacroTable>,
 }
 
-impl<Encoding: LazyDecoder, Input: IntoIonInput> LazyExpandingReader<Encoding, Input> {
+impl<Encoding: LazyDecoder, Input: IonInput> LazyExpandingReader<Encoding, Input> {
     pub(crate) fn new(raw_reader: StreamingRawReader<Encoding, Input>) -> Self {
         Self {
             raw_reader: raw_reader.into(),

--- a/src/lazy/mod.rs
+++ b/src/lazy/mod.rs
@@ -15,7 +15,7 @@ pub mod raw_value_ref;
 pub mod reader;
 pub mod sequence;
 pub mod str_ref;
-mod streaming_raw_reader;
+pub mod streaming_raw_reader;
 pub mod r#struct;
 pub mod system_reader;
 pub mod system_stream_item;

--- a/src/lazy/mod.rs
+++ b/src/lazy/mod.rs
@@ -15,6 +15,7 @@ pub mod raw_value_ref;
 pub mod reader;
 pub mod sequence;
 pub mod str_ref;
+mod streaming_raw_reader;
 pub mod r#struct;
 pub mod system_reader;
 pub mod system_stream_item;

--- a/src/lazy/reader.rs
+++ b/src/lazy/reader.rs
@@ -97,13 +97,12 @@ impl<Encoding: LazyDecoder, Input: IonInput> LazyApplicationReader<Encoding, Inp
     /// | `null`                          | `.struct`                           |
     /// | `$ion`                          | `_1_0`                              |
     /// | `2024-03-14T`                   | `12:00:30.000Z`                     |
-    /// | `// Discarded start of comment` | `words treated as symbols`          |
+    /// | `// Discarded start of comment` | ` with words treated as symbols`    |
     ///
     /// This is not an issue in binary Ion as incomplete items can always be detected. When following
-    /// a text Ion data source, it is recommended to only trust values returned after an `Ok(None)`
-    /// (i.e. an end-of-stream, indicating an empty buffer) or an `Ok(container_value)` as incomplete
-    /// containers can be detected reliably. This should only be attempted when you have control over
-    /// the format of the data being read.
+    /// a text Ion data source, it is recommended that you only trust values returned after an
+    /// `Ok(container_value)`, as incomplete containers can be detected reliably. This should only
+    /// be attempted when you have control over the format of the data being read.
     #[allow(clippy::should_implement_trait)]
     // ^-- Clippy objects that the method name `next` will be confused for `Iterator::next()`
     pub fn next(&mut self) -> IonResult<Option<LazyValue<Encoding>>> {

--- a/src/lazy/reader.rs
+++ b/src/lazy/reader.rs
@@ -76,12 +76,14 @@ impl<Encoding: LazyDecoder, Input: IntoIonInput> LazyApplicationReader<Encoding,
     /// If there are no more top-level values in the stream, returns `Ok(None)`.
     /// If the next value is incomplete (that is: only part of it is in the input buffer) or if the
     /// input buffer contains invalid data, returns `Err(ion_error)`.
-    pub fn next<'top>(&'top mut self) -> IonResult<Option<LazyValue<'top, Encoding>>> {
+    #[allow(clippy::should_implement_trait)]
+    // ^-- Clippy objects that the method name `next` will be confused for `Iterator::next()`
+    pub fn next(&mut self) -> IonResult<Option<LazyValue<Encoding>>> {
         self.system_reader.next_value()
     }
 
     /// Like [`Self::next`], but returns an `IonError` if there are no more values in the stream.
-    pub fn expect_next<'top>(&'top mut self) -> IonResult<LazyValue<'top, Encoding>> {
+    pub fn expect_next(&mut self) -> IonResult<LazyValue<Encoding>> {
         self.next()?
             .ok_or_else(|| IonError::decoding_error("expected another top-level value"))
     }

--- a/src/lazy/reader.rs
+++ b/src/lazy/reader.rs
@@ -1,11 +1,11 @@
 #![allow(non_camel_case_types)]
 
-use crate::binary::constants::v1_0::IVM;
 use crate::element::reader::ElementReader;
 use crate::element::Element;
 use crate::lazy::any_encoding::AnyEncoding;
 use crate::lazy::decoder::LazyDecoder;
 use crate::lazy::encoding::{BinaryEncoding_1_0, TextEncoding_1_0, TextEncoding_1_1};
+use crate::lazy::streaming_raw_reader::IntoIonInput;
 use crate::lazy::system_reader::{
     LazySystemAnyReader, LazySystemBinaryReader, LazySystemReader, LazySystemTextReader_1_1,
 };
@@ -38,7 +38,7 @@ use crate::{IonError, IonResult};
 /// let element: Element = ion_list! [10, 20, 30].into();
 /// let binary_ion = element.to_binary()?;
 ///
-/// let mut lazy_reader = LazyBinaryReader::new(&binary_ion)?;
+/// let mut lazy_reader = LazyBinaryReader::new(binary_ion)?;
 ///
 /// // Get the first value from the stream and confirm that it's a list.
 /// let lazy_list = lazy_reader.expect_next()?.read()?.expect_list()?;
@@ -61,8 +61,8 @@ use crate::{IonError, IonResult};
 ///# Ok(())
 ///# }
 /// ```
-pub struct LazyApplicationReader<'data, D: LazyDecoder> {
-    system_reader: LazySystemReader<'data, D>,
+pub struct LazyApplicationReader<Encoding: LazyDecoder, Input: IntoIonInput> {
+    system_reader: LazySystemReader<Encoding, Input>,
 }
 
 pub(crate) enum NextApplicationValue<'top, D: LazyDecoder> {
@@ -71,55 +71,43 @@ pub(crate) enum NextApplicationValue<'top, D: LazyDecoder> {
     EndOfStream,
 }
 
-impl<'data, D: LazyDecoder> LazyApplicationReader<'data, D> {
+impl<Encoding: LazyDecoder, Input: IntoIonInput> LazyApplicationReader<Encoding, Input> {
     /// Returns the next top-level value in the input stream as `Ok(Some(lazy_value))`.
     /// If there are no more top-level values in the stream, returns `Ok(None)`.
     /// If the next value is incomplete (that is: only part of it is in the input buffer) or if the
     /// input buffer contains invalid data, returns `Err(ion_error)`.
-    pub fn next<'top>(&'top mut self) -> IonResult<Option<LazyValue<'top, D>>>
-    where
-        'data: 'top,
-    {
+    pub fn next<'top>(&'top mut self) -> IonResult<Option<LazyValue<'top, Encoding>>> {
         self.system_reader.next_value()
     }
 
     /// Like [`Self::next`], but returns an `IonError` if there are no more values in the stream.
-    pub fn expect_next<'top>(&'top mut self) -> IonResult<LazyValue<'top, D>>
-    where
-        'data: 'top,
-    {
+    pub fn expect_next<'top>(&'top mut self) -> IonResult<LazyValue<'top, Encoding>> {
         self.next()?
             .ok_or_else(|| IonError::decoding_error("expected another top-level value"))
     }
 }
 
-pub type LazyBinaryReader<'data> = LazyApplicationReader<'data, BinaryEncoding_1_0>;
-pub type LazyTextReader_1_0<'data> = LazyApplicationReader<'data, TextEncoding_1_0>;
-pub type LazyTextReader_1_1<'data> = LazyApplicationReader<'data, TextEncoding_1_1>;
-pub type LazyReader<'data> = LazyApplicationReader<'data, AnyEncoding>;
+pub type LazyBinaryReader<Input> = LazyApplicationReader<BinaryEncoding_1_0, Input>;
+pub type LazyTextReader_1_0<Input> = LazyApplicationReader<TextEncoding_1_0, Input>;
+pub type LazyTextReader_1_1<Input> = LazyApplicationReader<TextEncoding_1_1, Input>;
+pub type LazyReader<Input> = LazyApplicationReader<AnyEncoding, Input>;
 
-impl<'data> LazyReader<'data> {
-    pub fn new(ion_data: &'data [u8]) -> LazyReader<'data> {
+impl<Input: IntoIonInput> LazyReader<Input> {
+    pub fn new(ion_data: Input) -> LazyReader<Input> {
         let system_reader = LazySystemAnyReader::new(ion_data);
         LazyApplicationReader { system_reader }
     }
 }
 
-impl<'data> LazyBinaryReader<'data> {
-    pub fn new(ion_data: &'data [u8]) -> IonResult<LazyBinaryReader<'data>> {
-        if ion_data.len() < IVM.len() {
-            return IonResult::decoding_error("input is too short to be recognized as Ion");
-        } else if ion_data[..IVM.len()] != IVM {
-            return IonResult::decoding_error("input does not begin with an Ion version marker");
-        }
-
+impl<Input: IntoIonInput> LazyBinaryReader<Input> {
+    pub fn new(ion_data: Input) -> IonResult<LazyBinaryReader<Input>> {
         let system_reader = LazySystemBinaryReader::new(ion_data);
         Ok(LazyApplicationReader { system_reader })
     }
 }
 
-impl<'data> LazyTextReader_1_1<'data> {
-    pub fn new(ion_data: &'data [u8]) -> IonResult<LazyTextReader_1_1<'data>> {
+impl<Input: IntoIonInput> LazyTextReader_1_1<Input> {
+    pub fn new(ion_data: Input) -> IonResult<LazyTextReader_1_1<Input>> {
         let system_reader = LazySystemTextReader_1_1::new(ion_data);
         Ok(LazyApplicationReader { system_reader })
     }
@@ -133,11 +121,13 @@ impl<'data> LazyTextReader_1_1<'data> {
     }
 }
 
-pub struct LazyElementIterator<'iter, 'data, D: LazyDecoder> {
-    lazy_reader: &'iter mut LazyApplicationReader<'data, D>,
+pub struct LazyElementIterator<'iter, Encoding: LazyDecoder, Input: IntoIonInput> {
+    lazy_reader: &'iter mut LazyApplicationReader<Encoding, Input>,
 }
 
-impl<'iter, 'data, D: LazyDecoder> Iterator for LazyElementIterator<'iter, 'data, D> {
+impl<'iter, Encoding: LazyDecoder, Input: IntoIonInput> Iterator
+    for LazyElementIterator<'iter, Encoding, Input>
+{
     type Item = IonResult<Element>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -149,8 +139,10 @@ impl<'iter, 'data, D: LazyDecoder> Iterator for LazyElementIterator<'iter, 'data
     }
 }
 
-impl<'data, D: LazyDecoder> ElementReader for LazyApplicationReader<'data, D> {
-    type ElementIterator<'a> = LazyElementIterator<'a, 'data, D> where Self: 'a,;
+impl<Encoding: LazyDecoder, Input: IntoIonInput> ElementReader
+    for LazyApplicationReader<Encoding, Input>
+{
+    type ElementIterator<'a> = LazyElementIterator<'a, Encoding, Input> where Self: 'a,;
 
     fn read_next_element(&mut self) -> IonResult<Option<Element>> {
         let lazy_value = match self.next()? {
@@ -196,7 +188,7 @@ mod tests {
                 (a b c)
         "#,
         )?;
-        let mut reader = LazyBinaryReader::new(&ion_data)?;
+        let mut reader = LazyBinaryReader::new(ion_data)?;
         // For each top-level value...
         while let Some(top_level_value) = reader.next()? {
             // ...see if it's an S-expression...
@@ -212,7 +204,7 @@ mod tests {
 
     #[test]
     fn test_rewind() -> IonResult<()> {
-        let data = &to_binary_ion(
+        let data = to_binary_ion(
             r#"
             [
                 "yo",
@@ -235,7 +227,7 @@ mod tests {
 
     #[test]
     fn materialize() -> IonResult<()> {
-        let data = &to_binary_ion(
+        let data = to_binary_ion(
             r#"
             [
                 "yo",

--- a/src/lazy/reader.rs
+++ b/src/lazy/reader.rs
@@ -5,7 +5,7 @@ use crate::element::Element;
 use crate::lazy::any_encoding::AnyEncoding;
 use crate::lazy::decoder::LazyDecoder;
 use crate::lazy::encoding::{BinaryEncoding_1_0, TextEncoding_1_0, TextEncoding_1_1};
-use crate::lazy::streaming_raw_reader::IntoIonInput;
+use crate::lazy::streaming_raw_reader::IonInput;
 use crate::lazy::system_reader::{
     LazySystemAnyReader, LazySystemBinaryReader, LazySystemReader, LazySystemTextReader_1_1,
 };
@@ -61,7 +61,7 @@ use crate::{IonError, IonResult};
 ///# Ok(())
 ///# }
 /// ```
-pub struct LazyApplicationReader<Encoding: LazyDecoder, Input: IntoIonInput> {
+pub struct LazyApplicationReader<Encoding: LazyDecoder, Input: IonInput> {
     system_reader: LazySystemReader<Encoding, Input>,
 }
 
@@ -71,7 +71,7 @@ pub(crate) enum NextApplicationValue<'top, D: LazyDecoder> {
     EndOfStream,
 }
 
-impl<Encoding: LazyDecoder, Input: IntoIonInput> LazyApplicationReader<Encoding, Input> {
+impl<Encoding: LazyDecoder, Input: IonInput> LazyApplicationReader<Encoding, Input> {
     /// Returns the next top-level value in the input stream as `Ok(Some(lazy_value))`.
     /// If there are no more top-level values in the stream, returns `Ok(None)`.
     /// If the next value is incomplete (that is: only part of it is in the input buffer) or if the
@@ -94,21 +94,21 @@ pub type LazyTextReader_1_0<Input> = LazyApplicationReader<TextEncoding_1_0, Inp
 pub type LazyTextReader_1_1<Input> = LazyApplicationReader<TextEncoding_1_1, Input>;
 pub type LazyReader<Input> = LazyApplicationReader<AnyEncoding, Input>;
 
-impl<Input: IntoIonInput> LazyReader<Input> {
+impl<Input: IonInput> LazyReader<Input> {
     pub fn new(ion_data: Input) -> LazyReader<Input> {
         let system_reader = LazySystemAnyReader::new(ion_data);
         LazyApplicationReader { system_reader }
     }
 }
 
-impl<Input: IntoIonInput> LazyBinaryReader<Input> {
+impl<Input: IonInput> LazyBinaryReader<Input> {
     pub fn new(ion_data: Input) -> IonResult<LazyBinaryReader<Input>> {
         let system_reader = LazySystemBinaryReader::new(ion_data);
         Ok(LazyApplicationReader { system_reader })
     }
 }
 
-impl<Input: IntoIonInput> LazyTextReader_1_1<Input> {
+impl<Input: IonInput> LazyTextReader_1_1<Input> {
     pub fn new(ion_data: Input) -> IonResult<LazyTextReader_1_1<Input>> {
         let system_reader = LazySystemTextReader_1_1::new(ion_data);
         Ok(LazyApplicationReader { system_reader })
@@ -123,11 +123,11 @@ impl<Input: IntoIonInput> LazyTextReader_1_1<Input> {
     }
 }
 
-pub struct LazyElementIterator<'iter, Encoding: LazyDecoder, Input: IntoIonInput> {
+pub struct LazyElementIterator<'iter, Encoding: LazyDecoder, Input: IonInput> {
     lazy_reader: &'iter mut LazyApplicationReader<Encoding, Input>,
 }
 
-impl<'iter, Encoding: LazyDecoder, Input: IntoIonInput> Iterator
+impl<'iter, Encoding: LazyDecoder, Input: IonInput> Iterator
     for LazyElementIterator<'iter, Encoding, Input>
 {
     type Item = IonResult<Element>;
@@ -141,7 +141,7 @@ impl<'iter, Encoding: LazyDecoder, Input: IntoIonInput> Iterator
     }
 }
 
-impl<Encoding: LazyDecoder, Input: IntoIonInput> ElementReader
+impl<Encoding: LazyDecoder, Input: IonInput> ElementReader
     for LazyApplicationReader<Encoding, Input>
 {
     type ElementIterator<'a> = LazyElementIterator<'a, Encoding, Input> where Self: 'a,;

--- a/src/lazy/sequence.rs
+++ b/src/lazy/sequence.rs
@@ -25,7 +25,7 @@ use crate::{IonError, IonResult};
 /// let element: Element = ion_list! [10, 20, 30].into();
 /// let binary_ion = element.to_binary()?;
 ///
-/// let mut lazy_reader = LazyBinaryReader::new(&binary_ion)?;
+/// let mut lazy_reader = LazyBinaryReader::new(binary_ion)?;
 ///
 /// // Get the first value from the stream and confirm that it's a list.
 /// let lazy_list = lazy_reader.expect_next()?.read()?.expect_list()?;
@@ -76,7 +76,7 @@ impl<'top, D: LazyDecoder> LazyList<'top, D> {
     /// let element: Element = ion_sexp!(true false).with_annotations(["foo", "bar", "baz"]);
     /// let binary_ion = element.to_binary()?;
     ///
-    /// let mut lazy_reader = LazyBinaryReader::new(&binary_ion)?;
+    /// let mut lazy_reader = LazyBinaryReader::new(binary_ion)?;
     ///
     /// // Get the first lazy value from the stream.
     /// let lazy_sexp = lazy_reader.expect_next()?.read()?.expect_sexp()?;
@@ -202,7 +202,7 @@ impl<'top, D: LazyDecoder> LazySExp<'top, D> {
     /// let element: Element = ion_sexp!(true false).with_annotations(["foo", "bar", "baz"]);
     /// let binary_ion = element.to_binary()?;
     ///
-    /// let mut lazy_reader = LazyBinaryReader::new(&binary_ion)?;
+    /// let mut lazy_reader = LazyBinaryReader::new(binary_ion)?;
     ///
     /// // Get the first lazy value from the stream.
     /// let lazy_sexp = lazy_reader.expect_next()?.read()?.expect_sexp()?;
@@ -286,7 +286,7 @@ mod tests {
     #[test]
     fn annotations() -> IonResult<()> {
         let binary_ion = to_binary_ion("foo::bar::baz::[1, 2, 3]")?;
-        let mut reader = LazyBinaryReader::new(&binary_ion)?;
+        let mut reader = LazyBinaryReader::new(binary_ion)?;
         let list = reader.expect_next()?.read()?.expect_list()?;
         assert!(list.annotations().are(["foo", "bar", "baz"])?);
         list.annotations().expect(["foo", "bar", "baz"])?;
@@ -297,23 +297,11 @@ mod tests {
     fn try_into_element() -> IonResult<()> {
         let ion_text = "foo::baz::baz::[1, 2, 3]";
         let binary_ion = to_binary_ion(ion_text)?;
-        let mut reader = LazyBinaryReader::new(&binary_ion)?;
+        let mut reader = LazyBinaryReader::new(binary_ion)?;
         let list = reader.expect_next()?.read()?.expect_list()?;
         let result: IonResult<Element> = list.try_into();
         assert!(result.is_ok());
         assert_eq!(result?, Element::read_one(ion_text)?);
-        Ok(())
-    }
-
-    #[test]
-    fn try_into_element_error() -> IonResult<()> {
-        let mut binary_ion = to_binary_ion("foo::baz::baz::[1, 2, 3]")?;
-        let _oops_i_lost_a_byte = binary_ion.pop().unwrap();
-        let mut reader = LazyBinaryReader::new(&binary_ion)?;
-        let list = reader.expect_next()?.read()?.expect_list()?;
-        // Conversion will fail because the reader will encounter an unexpected end of input
-        let result: IonResult<Element> = list.try_into();
-        assert!(result.is_err());
         Ok(())
     }
 }

--- a/src/lazy/streaming_raw_reader.rs
+++ b/src/lazy/streaming_raw_reader.rs
@@ -1,0 +1,426 @@
+use std::cell::UnsafeCell;
+use std::fs::File;
+use std::io::{BufReader, Read, StdinLock};
+
+use bumpalo::Bump as BumpAllocator;
+
+use crate::lazy::decoder::{LazyDecoder, LazyRawReader};
+use crate::lazy::raw_stream_item::LazyRawStreamItem;
+use crate::IonResult;
+
+struct StreamingRawReader<Encoding: LazyDecoder, Input: IonInput> {
+    encoding: Encoding,
+    saved_state: Encoding::ReaderSavedState,
+    stream_position: usize,
+    // XXX: The `UnsafeCell` wrappers around the field below is a workaround for a limitation in
+    //      rustc's borrow checker that prevents mutable references from being conditionally
+    //      returned in a loop.
+    //
+    //      See: https://github.com/rust-lang/rust/issues/70255
+    //
+    //      There is a rustc fix for this limitation on the horizon.
+    //
+    //      See: https://smallcultfollowing.com/babysteps/blog/2023/09/22/polonius-part-1/
+    //
+    //      Indeed, using the experimental `-Zpolonius` flag on the nightly compiler allows the
+    //      version of this code without `unsafe` types to work. The alternative to the
+    //      hack is wrapping each field in something like `RefCell`, which adds a small amount of
+    //      overhead to each access. Given that this is the hottest path in the code and that a
+    //      fix is inbound, I think this use of `unsafe` is warranted for now.
+    //
+    input: UnsafeCell<Input>,
+}
+
+const DEFAULT_IO_BUFFER_SIZE: usize = 4 * 1024;
+
+impl<Encoding: LazyDecoder, Input: IonInput> StreamingRawReader<Encoding, Input> {
+    pub fn new<I: IntoIonInput<IonInput = Input>>(
+        encoding: Encoding,
+        input: I,
+    ) -> StreamingRawReader<Encoding, I::IonInput> {
+        StreamingRawReader {
+            encoding,
+            input: input.into_ion_input().into(),
+            saved_state: Default::default(),
+            stream_position: 0,
+        }
+    }
+
+    pub fn next<'top>(
+        &'top mut self,
+        allocator: &'top BumpAllocator,
+    ) -> IonResult<LazyRawStreamItem<'top, Encoding>> {
+        loop {
+            let available_bytes = unsafe { &*self.input.get() }.buffer();
+            let unsafe_cell_reader = UnsafeCell::new(<Encoding::Reader<'top> as LazyRawReader<
+                'top,
+                Encoding,
+            >>::resume_at_offset(
+                available_bytes,
+                self.stream_position,
+                self.saved_state,
+            ));
+            let slice_reader = unsafe { &mut *unsafe_cell_reader.get() };
+            let starting_position = slice_reader.position();
+            let result = slice_reader.next(allocator);
+            // We're done modifying `slice_reader`, but we need to access its `position` field
+            // We have to circumvent the borrow checker's limitation (described in a comment on the
+            // StreamingRawReader type) by getting a second (read-only) reference to the reader.
+            let slice_reader_ref = unsafe { &*unsafe_cell_reader.get() };
+            let end_position = slice_reader_ref.position();
+
+            let bytes_read = end_position - starting_position;
+            let input = unsafe { &mut *self.input.get() };
+            // If we've exhausted the buffer but not the data source...
+            if bytes_read == available_bytes.len() && !input.stream_has_ended() {
+                // ...we need to pull more data from the source and try again to make sure that the
+                // buffer didn't contain incomplete data.
+                input.fill_buffer()?;
+                continue;
+            }
+            // Mark those input bytes as having been consumed so they are not read again.
+            input.consume(bytes_read);
+            // Update the streaming reader's position to reflect the number of bytes we
+            // just read.
+            self.stream_position = end_position;
+
+            return result;
+            // let result = match slice_reader.next(allocator) {
+            //     incomplete @ Err(IonError::Incomplete(_)) => {
+            //         let input = unsafe { &mut *self.input.get() };
+            //         if input.stream_has_ended() {
+            //             incomplete
+            //         } else {
+            //             input.fill_buffer()?;
+            //             // Try decoding again on the next iteration.
+            //             continue;
+            //         }
+            //     }
+            //     // TODO: If it's incomplete OR we get EndOfStream, we try to read
+            //     result => result,
+            // };
+            // // We're done modifying `slice_reader`'s data, but we need to access its `position`
+            // // field. We have to circumvent the borrow checker's limitation (described in a comment
+            // // on the StreamingRawReader type) by getting a second (read-only) reference to the reader.
+            // let slice_reader_ref = unsafe { &*unsafe_cell_reader.get() };
+            // let end_position = slice_reader_ref.position();
+            // // Update the streaming reader's position to reflect the number of bytes we
+            // // just read.
+            // let bytes_read = end_position - starting_position;
+            // self.stream_position = end_position;
+            // // Mark those input bytes as having been consumed so they are not read again.
+            // let input = unsafe { &mut *self.input.get() };
+            // input.consume(bytes_read);
+            // return result;
+        }
+    }
+}
+
+pub trait IonInput {
+    /// Returns a slice of all bytes that are currently available.
+    fn buffer(&self) -> &[u8];
+    fn stream_has_ended(&self) -> bool;
+    fn fill_buffer(&mut self) -> IonResult<()>;
+    fn consume(&mut self, number_of_bytes: usize);
+}
+
+/// A fixed slice of Ion data that does not grow
+pub struct IonSlice<SliceType> {
+    source: SliceType,
+    // The offset of the first byte that hasn't yet been consumed.
+    position: usize,
+}
+
+impl<SliceType: AsRef<[u8]>> IonSlice<SliceType> {
+    pub fn new(bytes: SliceType) -> Self {
+        Self {
+            source: bytes,
+            position: 0,
+        }
+    }
+
+    #[inline]
+    fn stream_bytes(&self) -> &[u8] {
+        self.source.as_ref()
+    }
+}
+
+impl<SliceType: AsRef<[u8]>> IonInput for IonSlice<SliceType> {
+    #[inline]
+    fn buffer(&self) -> &[u8] {
+        &self.stream_bytes()[self.position..]
+    }
+
+    fn stream_has_ended(&self) -> bool {
+        true
+    }
+
+    fn fill_buffer(&mut self) -> IonResult<()> {
+        Ok(())
+    }
+
+    fn consume(&mut self, number_of_bytes: usize) {
+        self.position += number_of_bytes;
+        debug_assert!(
+            self.position <= self.stream_bytes().len(),
+            "Assert failed: {} <= {}, buffer: {:0x?}",
+            self.position,
+            self.stream_bytes().len(),
+            self.buffer()
+        );
+    }
+}
+
+/// A buffered reader for types that don't implement AsRef<[u8]>
+pub struct IonStream<R: Read> {
+    input: R,
+    buffer: Vec<u8>,
+    // The index of the first occupied byte in the buffer. If position==limit, no bytes
+    // are occupied.
+    position: usize,
+    // The index of the first unoccupied byte in the buffer *at or after* `position`.
+    limit: usize,
+    is_end_of_stream: bool,
+}
+
+impl<R: Read> IonStream<R> {
+    const DEFAULT_IO_BUFFER_SIZE: usize = 4 * 1024;
+
+    fn new(input: R) -> Self {
+        IonStream {
+            input,
+            buffer: vec![0u8; Self::DEFAULT_IO_BUFFER_SIZE],
+            // The index of the first occupied byte in the buffer
+            position: 0,
+            // The index of the first unoccupied byte in the buffer *at or after* `position`.
+            limit: 0,
+            // Whether `input` has returned EOF yet
+            is_end_of_stream: false,
+        }
+    }
+}
+
+impl<R: Read> IonStream<R> {
+    /// Moves all of the bytes from `self.position` to `self.limit` to the beginning of the buffer,
+    /// reclaiming space that was previously occupied by bytes that have been consumed.
+    fn shift_remaining_bytes_to_index_zero(&mut self) {
+        // Shift everything after `remaining_data_start_index` to the beginning of the Vec and
+        // update the limit.
+        let remaining_data_range = self.position..self.limit;
+        self.limit = remaining_data_range.len();
+        self.position = 0;
+        self.buffer.copy_within(remaining_data_range, 0);
+        debug_assert!(self.buffer().len() == self.limit - self.position);
+    }
+}
+
+impl<R: Read> IonInput for IonStream<R> {
+    fn buffer(&self) -> &[u8] {
+        &self.buffer[self.position..self.limit]
+    }
+
+    fn stream_has_ended(&self) -> bool {
+        self.is_end_of_stream
+    }
+
+    fn fill_buffer(&mut self) -> IonResult<()> {
+        // If
+        if self.position > 0 {
+            // We've consumed bytes (advancing `position`) and can therefore reclaim some of the
+            // space at the beginning of our buffer.
+            self.shift_remaining_bytes_to_index_zero();
+        }
+        if self.buffer.len() == self.limit {
+            // If we're out of space, double the size of the buffer and fill it with zeros
+            // before proceeding. (The bytes must be set to a value to avoid undefined behavior;
+            // zero is a conventional choice. The value will never be used anyway.)
+            self.buffer.resize(self.buffer.len() * 2, 0);
+        }
+        // Attempt to read as many bytes as will fit in the currently allocated capacity beyond
+        // `limit`.
+        let bytes_read = self.input.read(&mut self.buffer[self.limit..])?;
+        // If the input source returns `Ok(0)`, there's no more data coming. We can mark the stream
+        // as complete.
+        if bytes_read == 0 {
+            self.is_end_of_stream = true;
+        }
+        // Update `self.limit` to mark the newly read in bytes as available.
+        self.limit += bytes_read;
+        Ok(())
+    }
+
+    fn consume(&mut self, number_of_bytes: usize) {
+        self.position += number_of_bytes;
+        debug_assert!(self.position <= self.limit);
+    }
+}
+
+pub trait IntoIonInput {
+    type IonInput: IonInput;
+
+    fn into_ion_input(self) -> Self::IonInput;
+}
+
+/// Implements `IntoIonInput` for types that represent a complete Ion stream (i.e. that do not and
+/// cannot read more data from another source once exhausted).
+macro_rules! impl_into_ion_input_for_slice_types {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl <'a> IntoIonInput for $ty {
+                type IonInput = IonSlice<$ty>;
+
+                fn into_ion_input(self) -> Self::IonInput {
+                    IonSlice::new(self)
+                }
+            }
+        )*
+    };
+}
+
+impl_into_ion_input_for_slice_types!(&'a [u8], &'a str, String, Vec<u8>,);
+
+impl IntoIonInput for File {
+    type IonInput = IonStream<BufReader<Self>>;
+
+    fn into_ion_input(self) -> Self::IonInput {
+        IonStream::new(BufReader::new(self))
+    }
+}
+
+impl<R: Read> IntoIonInput for BufReader<R> {
+    type IonInput = IonStream<Self>;
+
+    fn into_ion_input(self) -> Self::IonInput {
+        IonStream::new(self)
+    }
+}
+
+impl<'a> IntoIonInput for StdinLock<'a> {
+    type IonInput = IonStream<Self>;
+
+    fn into_ion_input(self) -> Self::IonInput {
+        IonStream::new(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{BufReader, Cursor};
+
+    use bumpalo::Bump as BumpAllocator;
+
+    use crate::lazy::any_encoding::AnyEncoding;
+    use crate::lazy::decoder::{LazyDecoder, LazyRawValue};
+    use crate::lazy::raw_stream_item::LazyRawStreamItem;
+    use crate::lazy::raw_value_ref::RawValueRef;
+    use crate::lazy::streaming_raw_reader::{IntoIonInput, StreamingRawReader};
+    use crate::{IonError, IonResult};
+
+    fn expect_value<'a, D: LazyDecoder>(
+        actual: LazyRawStreamItem<'a, D>,
+        expected: RawValueRef<'a, D>,
+    ) -> IonResult<()> {
+        assert_eq!(actual.expect_value()?.read()?, expected);
+        Ok(())
+    }
+
+    fn expect_string<'a, 'b: 'a>(
+        actual: LazyRawStreamItem<'a, AnyEncoding>,
+        text: &'b str,
+    ) -> IonResult<()> {
+        expect_value(actual, RawValueRef::<AnyEncoding>::String(text.into()))
+    }
+
+    fn expect_end_of_stream(actual: LazyRawStreamItem<AnyEncoding>) -> IonResult<()> {
+        assert!(matches!(
+            actual,
+            LazyRawStreamItem::<AnyEncoding>::EndOfStream
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn read_empty_slice() -> IonResult<()> {
+        let bump = BumpAllocator::new();
+        let ion = "";
+        let mut reader = StreamingRawReader::new(AnyEncoding, ion.as_bytes());
+        // We expect `Ok(EndOfStream)`, not `Err(Incomplete)`.
+        expect_end_of_stream(reader.next(&bump)?)?;
+        Ok(())
+    }
+
+    fn read_example_stream(input: impl IntoIonInput) -> IonResult<()> {
+        let bump = BumpAllocator::new();
+        let mut reader = StreamingRawReader::new(AnyEncoding, input);
+        expect_string(reader.next(&bump)?, "foo")?;
+        expect_string(reader.next(&bump)?, "bar")?;
+        expect_string(reader.next(&bump)?, "baz")?;
+        expect_string(reader.next(&bump)?, "quux")?;
+        expect_string(reader.next(&bump)?, "quuz")?;
+        expect_end_of_stream(reader.next(&bump)?)
+    }
+
+    // This stream is 104 bytes long
+    const EXAMPLE_STREAM: &str = r#"
+        "foo" // comment 1
+        "bar"
+        "baz"
+        "quux" /* comment 2 
+     */ "quuz"
+    "#;
+
+    #[test]
+    fn read_slice() -> IonResult<()> {
+        let str_ = EXAMPLE_STREAM;
+        let string = str_.to_string();
+        let slice = str_.as_bytes();
+        let vec = slice.to_vec();
+
+        read_example_stream(str_)?;
+        read_example_stream(string)?;
+        read_example_stream(slice)?;
+        read_example_stream(vec)
+    }
+
+    /// Returns an implementation of io::Read with a buffer small enough to encounter multiple
+    /// incomplete values.
+    fn tiny_buf_reader(input: &str) -> BufReader<Cursor<&str>> {
+        BufReader::with_capacity(1, Cursor::new(input))
+    }
+
+    #[test]
+    fn read_stream() -> IonResult<()> {
+        let input = tiny_buf_reader(EXAMPLE_STREAM);
+        read_example_stream(input)
+    }
+
+    const INVALID_EXAMPLE_STREAM: &str = "2024-03-12T16:33.000-05:"; // Missing offset minutes
+
+    fn read_invalid_example_stream(input: impl IntoIonInput) -> IonResult<()> {
+        let bump = BumpAllocator::new();
+        let mut reader = StreamingRawReader::new(AnyEncoding, input);
+        let result = reader.next(&bump);
+        // Because the input stream is exhausted, the incomplete value is illegal data and raises
+        // a decoding error.
+        assert!(matches!(result, Err(IonError::Decoding(_))), "{:?}", result);
+        Ok(())
+    }
+
+    #[test]
+    fn read_invalid_stream() -> IonResult<()> {
+        read_invalid_example_stream(tiny_buf_reader(INVALID_EXAMPLE_STREAM))
+    }
+
+    #[test]
+    fn read_invalid_slice() -> IonResult<()> {
+        let str_ = INVALID_EXAMPLE_STREAM;
+        let string = str_.to_string();
+        let slice = str_.as_bytes();
+        let vec = slice.to_vec();
+
+        read_invalid_example_stream(str_)?;
+        read_invalid_example_stream(string)?;
+        read_invalid_example_stream(slice)?;
+        read_invalid_example_stream(vec)
+    }
+}

--- a/src/lazy/streaming_raw_reader.rs
+++ b/src/lazy/streaming_raw_reader.rs
@@ -83,14 +83,10 @@ impl<Encoding: LazyDecoder, Input: IonInput> StreamingRawReader<Encoding, Input>
 
             let bytes_read = end_position - starting_position;
             let input = unsafe { &mut *self.input.get() };
-            // If we've exhausted the buffer but not the data source...
             // If we've exhausted the buffer...
             if bytes_read >= available_bytes.len() {
-                // && !input.stream_has_ended() {
-                // ...we need to pull more data from the source and try again to make sure that the
-                // buffer didn't contain incomplete data.
-                // ...try to pull more data from the buffer. If there's nothing available, return
-                // the result we got.
+                // ...try to pull more data from the data source. If there's nothing available,
+                // return the result we got.
                 if input.fill_buffer()? > 0 {
                     continue;
                 }
@@ -226,7 +222,6 @@ impl<R: Read> IonDataSource for IonStream<R> {
     }
 
     fn fill_buffer(&mut self) -> IonResult<usize> {
-        // If
         if self.position > 0 {
             // We've consumed bytes (advancing `position`) and can therefore reclaim some of the
             // space at the beginning of our buffer.

--- a/src/lazy/streaming_raw_reader.rs
+++ b/src/lazy/streaming_raw_reader.rs
@@ -194,7 +194,7 @@ pub struct IonStream<R: Read> {
 impl<R: Read> IonStream<R> {
     const DEFAULT_IO_BUFFER_SIZE: usize = 4 * 1024;
 
-    fn new(input: R) -> Self {
+    pub(crate) fn new(input: R) -> Self {
         IonStream {
             input,
             buffer: vec![0u8; Self::DEFAULT_IO_BUFFER_SIZE],
@@ -263,6 +263,22 @@ pub trait IonInput {
     type DataSource: IonDataSource;
 
     fn into_data_source(self) -> Self::DataSource;
+}
+
+impl<SliceType: AsRef<[u8]>> IonInput for IonSlice<SliceType> {
+    type DataSource = Self;
+
+    fn into_data_source(self) -> Self::DataSource {
+        self
+    }
+}
+
+impl<Input: Read> IonInput for IonStream<Input> {
+    type DataSource = Self;
+
+    fn into_data_source(self) -> Self::DataSource {
+        self
+    }
 }
 
 /// Implements `IonInput` for types that represent a complete Ion stream (i.e. that do not and

--- a/src/lazy/streaming_raw_reader.rs
+++ b/src/lazy/streaming_raw_reader.rs
@@ -10,6 +10,7 @@ use crate::IonResult;
 
 pub struct StreamingRawReader<Encoding: LazyDecoder, Input: IntoIonInput> {
     encoding: Encoding,
+    // TODO: Explain
     saved_state: Encoding::ReaderSavedState,
     stream_position: usize,
     // XXX: The `UnsafeCell` wrappers around the field below is a workaround for a limitation in

--- a/src/lazy/struct.rs
+++ b/src/lazy/struct.rs
@@ -26,7 +26,7 @@ use crate::{
 ///
 /// let ion_data = r#"{foo: 1, bar: 2, foo: 3, bar: 4}"#;
 /// let ion_bytes: Vec<u8> = Element::read_one(ion_data)?.to_binary()?;
-/// let mut reader = LazyBinaryReader::new(&ion_bytes)?;
+/// let mut reader = LazyBinaryReader::new(ion_bytes)?;
 ///
 /// // Advance the reader to the first value and confirm it's a struct
 /// let lazy_struct = reader.expect_next()?.read()?.expect_struct()?;
@@ -91,7 +91,7 @@ impl<'top, D: LazyDecoder> LazyStruct<'top, D> {
     ///
     /// let ion_data = r#"{foo: "hello", bar: quux::5, baz: null, bar: false}"#;
     /// let ion_bytes: Vec<u8> = Element::read_one(ion_data)?.to_binary()?;
-    /// let mut reader = LazyBinaryReader::new(&ion_bytes)?;
+    /// let mut reader = LazyBinaryReader::new(ion_bytes)?;
     ///
     /// let lazy_struct = reader.expect_next()?.read()?.expect_struct()?;
     ///
@@ -125,7 +125,7 @@ impl<'top, D: LazyDecoder> LazyStruct<'top, D> {
     ///
     /// let ion_data = r#"{foo: "hello", bar: quux::5, baz: null, bar: false}"#;
     /// let ion_bytes: Vec<u8> = Element::read_one(ion_data)?.to_binary()?;
-    /// let mut reader = LazyBinaryReader::new(&ion_bytes)?;
+    /// let mut reader = LazyBinaryReader::new(ion_bytes)?;
     ///
     /// let lazy_struct = reader.expect_next()?.read()?.expect_struct()?;
     ///
@@ -151,7 +151,7 @@ impl<'top, D: LazyDecoder> LazyStruct<'top, D> {
     ///
     /// let ion_data = r#"{foo: "hello", bar: null.list, baz: 3, bar: 4}"#;
     /// let ion_bytes = Element::read_one(ion_data)?.to_binary()?;
-    /// let mut reader = LazyBinaryReader::new(&ion_bytes)?;
+    /// let mut reader = LazyBinaryReader::new(ion_bytes)?;
     ///
     /// let lazy_struct = reader.expect_next()?.read()?.expect_struct()?;
     ///
@@ -176,7 +176,7 @@ impl<'top, D: LazyDecoder> LazyStruct<'top, D> {
     ///
     /// let ion_data = r#"{foo: "hello", bar: null.list, baz: 3, bar: 4}"#;
     /// let ion_bytes = Element::read_one(ion_data)?.to_binary()?;
-    /// let mut reader = LazyBinaryReader::new(&ion_bytes)?;
+    /// let mut reader = LazyBinaryReader::new(ion_bytes)?;
     ///
     /// let lazy_struct = reader.expect_next()?.read()?.expect_struct()?;
     ///
@@ -206,7 +206,7 @@ impl<'top, D: LazyDecoder> LazyStruct<'top, D> {
     /// let element: Element = ion_struct! {"foo": 1, "bar": 2}.with_annotations(["foo", "bar", "baz"]);
     /// let binary_ion = element.to_binary()?;
     ///
-    /// let mut lazy_reader = LazyBinaryReader::new(&binary_ion)?;
+    /// let mut lazy_reader = LazyBinaryReader::new(binary_ion)?;
     ///
     /// // Get the first lazy value from the stream.
     /// let lazy_struct = lazy_reader.expect_next()?.read()?.expect_struct()?;
@@ -338,7 +338,7 @@ mod tests {
     #[test]
     fn find() -> IonResult<()> {
         let ion_data = to_binary_ion("{foo: 1, bar: 2, baz: 3}")?;
-        let mut reader = LazyBinaryReader::new(&ion_data)?;
+        let mut reader = LazyBinaryReader::new(ion_data)?;
         let struct_ = reader.expect_next()?.read()?.expect_struct()?;
         let baz = struct_.find("baz")?;
         assert!(baz.is_some());
@@ -351,7 +351,7 @@ mod tests {
     #[test]
     fn find_expected() -> IonResult<()> {
         let ion_data = to_binary_ion("{foo: 1, bar: 2, baz: 3}")?;
-        let mut reader = LazyBinaryReader::new(&ion_data)?;
+        let mut reader = LazyBinaryReader::new(ion_data)?;
         let struct_ = reader.expect_next()?.read()?.expect_struct()?;
         let baz = struct_.find_expected("baz");
         assert!(baz.is_ok());
@@ -364,7 +364,7 @@ mod tests {
     #[test]
     fn get() -> IonResult<()> {
         let ion_data = to_binary_ion("{foo: 1, bar: 2, baz: 3}")?;
-        let mut reader = LazyBinaryReader::new(&ion_data)?;
+        let mut reader = LazyBinaryReader::new(ion_data)?;
         let struct_ = reader.expect_next()?.read()?.expect_struct()?;
         let baz = struct_.get("baz")?;
         assert_eq!(baz, Some(ValueRef::Int(3.into())));
@@ -376,7 +376,7 @@ mod tests {
     #[test]
     fn get_expected() -> IonResult<()> {
         let ion_data = to_binary_ion("{foo: 1, bar: 2, baz: 3}")?;
-        let mut reader = LazyBinaryReader::new(&ion_data)?;
+        let mut reader = LazyBinaryReader::new(ion_data)?;
         let struct_ = reader.expect_next()?.read()?.expect_struct()?;
         let baz = struct_.get_expected("baz");
         assert_eq!(baz, Ok(ValueRef::Int(3.into())));
@@ -388,7 +388,7 @@ mod tests {
     #[test]
     fn annotations() -> IonResult<()> {
         let ion_data = to_binary_ion("a::b::c::{foo: 1, bar: 2, baz: quux::quuz::3}")?;
-        let mut reader = LazyBinaryReader::new(&ion_data)?;
+        let mut reader = LazyBinaryReader::new(ion_data)?;
         let struct_ = reader.expect_next()?.read()?.expect_struct()?;
         assert!(struct_.annotations().are(["a", "b", "c"])?);
         let baz = struct_.find_expected("baz")?;
@@ -400,23 +400,11 @@ mod tests {
     fn try_into_element() -> IonResult<()> {
         let ion_text = "foo::baz::baz::{a: 1, b: 2, c: 3}";
         let binary_ion = to_binary_ion(ion_text)?;
-        let mut reader = LazyBinaryReader::new(&binary_ion)?;
+        let mut reader = LazyBinaryReader::new(binary_ion)?;
         let struct_ = reader.expect_next()?.read()?.expect_struct()?;
         let result: IonResult<Element> = struct_.try_into();
         assert!(result.is_ok());
         assert_eq!(result?, Element::read_one(ion_text)?);
-        Ok(())
-    }
-
-    #[test]
-    fn try_into_element_error() -> IonResult<()> {
-        let mut binary_ion = to_binary_ion("foo::baz::baz::{a: 1, b: 2, c: 3}")?;
-        let _oops_i_lost_a_byte = binary_ion.pop().unwrap();
-        let mut reader = LazyBinaryReader::new(&binary_ion)?;
-        let struct_ = reader.expect_next()?.read()?.expect_struct()?;
-        // Conversion will fail because the reader will encounter an unexpected end of input
-        let result: IonResult<Element> = struct_.try_into();
-        assert!(result.is_err());
         Ok(())
     }
 }

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -1,13 +1,11 @@
 #![allow(non_camel_case_types)]
 
-use crate::lazy::any_encoding::{AnyEncoding, LazyRawAnyReader};
-use crate::lazy::binary::raw::reader::LazyRawBinaryReader;
+use crate::lazy::any_encoding::AnyEncoding;
 use crate::lazy::decoder::LazyDecoder;
-use crate::lazy::decoder::LazyRawReader;
 use crate::lazy::encoding::{BinaryEncoding_1_0, TextEncoding_1_0, TextEncoding_1_1};
 use crate::lazy::expanded::{ExpandedValueRef, LazyExpandedValue, LazyExpandingReader};
+use crate::lazy::streaming_raw_reader::{IntoIonInput, StreamingRawReader};
 use crate::lazy::system_stream_item::SystemStreamItem;
-use crate::lazy::text::raw::v1_1::reader::LazyRawTextReader_1_1;
 use crate::lazy::value::LazyValue;
 use crate::result::IonFailure;
 use crate::{IonResult, IonType, RawSymbolTokenRef, SymbolTable};
@@ -46,7 +44,7 @@ const SYMBOLS: RawSymbolTokenRef = RawSymbolTokenRef::SymbolId(7);
 /// let element: Element = ion_list! [10, 20, 30].into();
 /// let binary_ion = element.to_binary()?;
 ///
-/// let mut lazy_reader = LazyBinaryReader::new(&binary_ion)?;
+/// let mut lazy_reader = LazyBinaryReader::new(binary_ion)?;
 ///
 /// // Get the first value from the stream and confirm that it's a list.
 /// let lazy_list = lazy_reader.expect_next()?.read()?.expect_list()?;
@@ -69,15 +67,15 @@ const SYMBOLS: RawSymbolTokenRef = RawSymbolTokenRef::SymbolId(7);
 ///# Ok(())
 ///# }
 /// ```
-pub struct LazySystemReader<'data, D: LazyDecoder> {
-    pub(crate) expanding_reader: LazyExpandingReader<'data, D>,
+pub struct LazySystemReader<Encoding: LazyDecoder, Input: IntoIonInput> {
+    pub(crate) expanding_reader: LazyExpandingReader<Encoding, Input>,
 }
 
-pub type LazySystemBinaryReader<'data> = LazySystemReader<'data, BinaryEncoding_1_0>;
-pub type LazySystemTextReader_1_0<'data> = LazySystemReader<'data, TextEncoding_1_0>;
-pub type LazySystemTextReader_1_1<'data> = LazySystemReader<'data, TextEncoding_1_1>;
+pub type LazySystemBinaryReader<Input> = LazySystemReader<BinaryEncoding_1_0, Input>;
+pub type LazySystemTextReader_1_0<Input> = LazySystemReader<TextEncoding_1_0, Input>;
+pub type LazySystemTextReader_1_1<Input> = LazySystemReader<TextEncoding_1_1, Input>;
 
-pub type LazySystemAnyReader<'data> = LazySystemReader<'data, AnyEncoding>;
+pub type LazySystemAnyReader<Input> = LazySystemReader<AnyEncoding, Input>;
 
 // If the reader encounters a symbol table in the stream, it will store all of the symbols that
 // the table defines in this structure so that they may be applied when the reader next advances.
@@ -98,34 +96,36 @@ impl PendingLst {
     }
 }
 
-impl<'data> LazySystemAnyReader<'data> {
-    pub fn new(ion_data: &'data [u8]) -> LazySystemAnyReader<'data> {
-        let raw_reader = LazyRawAnyReader::new(ion_data);
+impl<Input: IntoIonInput> LazySystemAnyReader<Input> {
+    pub(crate) fn new(ion_data: Input) -> LazySystemAnyReader<Input> {
+        let raw_reader = StreamingRawReader::new(AnyEncoding, ion_data);
         let expanding_reader = LazyExpandingReader::new(raw_reader);
         LazySystemReader { expanding_reader }
     }
 }
 
-impl<'data> LazySystemBinaryReader<'data> {
-    pub(crate) fn new(ion_data: &'data [u8]) -> LazySystemBinaryReader<'data> {
-        let raw_reader = LazyRawBinaryReader::new(ion_data);
+impl<Input: IntoIonInput> LazySystemBinaryReader<Input> {
+    pub(crate) fn new(ion_data: Input) -> LazySystemBinaryReader<Input> {
+        let raw_reader = StreamingRawReader::new(BinaryEncoding_1_0, ion_data);
         let expanding_reader = LazyExpandingReader::new(raw_reader);
         LazySystemReader { expanding_reader }
     }
 }
 
-impl<'data> LazySystemTextReader_1_1<'data> {
-    pub(crate) fn new(ion_data: &'data [u8]) -> LazySystemTextReader_1_1<'data> {
-        let raw_reader = LazyRawTextReader_1_1::new(ion_data);
+impl<Input: IntoIonInput> LazySystemTextReader_1_1<Input> {
+    pub(crate) fn new(ion_data: Input) -> LazySystemTextReader_1_1<Input> {
+        let raw_reader = StreamingRawReader::new(TextEncoding_1_1, ion_data);
         let expanding_reader = LazyExpandingReader::new(raw_reader);
         LazySystemReader { expanding_reader }
     }
 }
 
-impl<'data, D: LazyDecoder> LazySystemReader<'data, D> {
+impl<Encoding: LazyDecoder, Input: IntoIonInput> LazySystemReader<Encoding, Input> {
     // Returns `true` if the provided [`LazyRawValue`] is a struct whose first annotation is
     // `$ion_symbol_table`.
-    pub fn is_symbol_table_struct(lazy_value: &'_ LazyExpandedValue<'_, D>) -> IonResult<bool> {
+    pub fn is_symbol_table_struct(
+        lazy_value: &'_ LazyExpandedValue<'_, Encoding>,
+    ) -> IonResult<bool> {
         if lazy_value.ion_type() != IonType::Struct {
             return Ok(false);
         }
@@ -137,19 +137,13 @@ impl<'data, D: LazyDecoder> LazySystemReader<'data, D> {
 
     /// Returns the next top-level stream item (IVM, Symbol Table, Value, or Nothing) as a
     /// [`SystemStreamItem`].
-    pub fn next_item<'top>(&'top mut self) -> IonResult<SystemStreamItem<'top, D>>
-    where
-        'data: 'top,
-    {
+    pub fn next_item<'top>(&'top mut self) -> IonResult<SystemStreamItem<'top, Encoding>> {
         self.expanding_reader.next_item()
     }
 
     /// Returns the next value that is part of the application data model, bypassing all encoding
     /// artifacts (IVMs, symbol tables).
-    pub fn next_value<'top>(&'top mut self) -> IonResult<Option<LazyValue<'top, D>>>
-    where
-        'data: 'top,
-    {
+    pub fn next_value<'top>(&'top mut self) -> IonResult<Option<LazyValue<'top, Encoding>>> {
         self.expanding_reader.next_value()
     }
 
@@ -178,7 +172,7 @@ impl<'data, D: LazyDecoder> LazySystemReader<'data, D> {
     // populate the `PendingLst`.
     pub(crate) fn process_symbol_table(
         pending_lst: &mut PendingLst,
-        symbol_table: &LazyExpandedValue<'_, D>,
+        symbol_table: &LazyExpandedValue<'_, Encoding>,
     ) -> IonResult<()> {
         // We've already confirmed this is an annotated struct
         let symbol_table = symbol_table.read()?.expect_struct()?;
@@ -214,7 +208,7 @@ impl<'data, D: LazyDecoder> LazySystemReader<'data, D> {
     // Store any strings defined in the `symbols` field in the `PendingLst` for future application.
     fn process_symbols(
         pending_lst: &mut PendingLst,
-        symbols: &LazyExpandedValue<'_, D>,
+        symbols: &LazyExpandedValue<'_, Encoding>,
     ) -> IonResult<()> {
         if let ExpandedValueRef::List(list) = symbols.read()? {
             for symbol_text_result in list.iter() {
@@ -232,7 +226,7 @@ impl<'data, D: LazyDecoder> LazySystemReader<'data, D> {
     // Check for `imports: $ion_symbol_table`.
     fn process_imports(
         pending_lst: &mut PendingLst,
-        imports: &LazyExpandedValue<'_, D>,
+        imports: &LazyExpandedValue<'_, Encoding>,
     ) -> IonResult<()> {
         match imports.read()? {
             ExpandedValueRef::Symbol(symbol_ref) => {
@@ -278,7 +272,7 @@ mod tests {
         hello
         "#,
         )?;
-        let mut system_reader = LazySystemBinaryReader::new(&ion_data);
+        let mut system_reader = LazySystemBinaryReader::new(ion_data);
         loop {
             match system_reader.next_item()? {
                 SystemStreamItem::VersionMarker(major, minor) => {
@@ -303,7 +297,7 @@ mod tests {
         )
         "#,
         )?;
-        let mut system_reader = LazySystemBinaryReader::new(&ion_data);
+        let mut system_reader = LazySystemBinaryReader::new(ion_data);
         loop {
             match system_reader.next_item()? {
                 SystemStreamItem::Value(value) => {
@@ -330,7 +324,7 @@ mod tests {
         }
         "#,
         )?;
-        let mut system_reader = LazySystemBinaryReader::new(&ion_data);
+        let mut system_reader = LazySystemBinaryReader::new(ion_data);
         loop {
             match system_reader.next_item()? {
                 SystemStreamItem::Value(value) => {

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -137,13 +137,13 @@ impl<Encoding: LazyDecoder, Input: IntoIonInput> LazySystemReader<Encoding, Inpu
 
     /// Returns the next top-level stream item (IVM, Symbol Table, Value, or Nothing) as a
     /// [`SystemStreamItem`].
-    pub fn next_item<'top>(&'top mut self) -> IonResult<SystemStreamItem<'top, Encoding>> {
+    pub fn next_item(&mut self) -> IonResult<SystemStreamItem<'_, Encoding>> {
         self.expanding_reader.next_item()
     }
 
     /// Returns the next value that is part of the application data model, bypassing all encoding
     /// artifacts (IVMs, symbol tables).
-    pub fn next_value<'top>(&'top mut self) -> IonResult<Option<LazyValue<'top, Encoding>>> {
+    pub fn next_value(&mut self) -> IonResult<Option<LazyValue<Encoding>>> {
         self.expanding_reader.next_value()
     }
 

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -4,7 +4,7 @@ use crate::lazy::any_encoding::AnyEncoding;
 use crate::lazy::decoder::LazyDecoder;
 use crate::lazy::encoding::{BinaryEncoding_1_0, TextEncoding_1_0, TextEncoding_1_1};
 use crate::lazy::expanded::{ExpandedValueRef, LazyExpandedValue, LazyExpandingReader};
-use crate::lazy::streaming_raw_reader::{IntoIonInput, StreamingRawReader};
+use crate::lazy::streaming_raw_reader::{IonInput, StreamingRawReader};
 use crate::lazy::system_stream_item::SystemStreamItem;
 use crate::lazy::value::LazyValue;
 use crate::result::IonFailure;
@@ -67,7 +67,7 @@ const SYMBOLS: RawSymbolTokenRef = RawSymbolTokenRef::SymbolId(7);
 ///# Ok(())
 ///# }
 /// ```
-pub struct LazySystemReader<Encoding: LazyDecoder, Input: IntoIonInput> {
+pub struct LazySystemReader<Encoding: LazyDecoder, Input: IonInput> {
     pub(crate) expanding_reader: LazyExpandingReader<Encoding, Input>,
 }
 
@@ -96,7 +96,7 @@ impl PendingLst {
     }
 }
 
-impl<Input: IntoIonInput> LazySystemAnyReader<Input> {
+impl<Input: IonInput> LazySystemAnyReader<Input> {
     pub(crate) fn new(ion_data: Input) -> LazySystemAnyReader<Input> {
         let raw_reader = StreamingRawReader::new(AnyEncoding, ion_data);
         let expanding_reader = LazyExpandingReader::new(raw_reader);
@@ -104,7 +104,7 @@ impl<Input: IntoIonInput> LazySystemAnyReader<Input> {
     }
 }
 
-impl<Input: IntoIonInput> LazySystemBinaryReader<Input> {
+impl<Input: IonInput> LazySystemBinaryReader<Input> {
     pub(crate) fn new(ion_data: Input) -> LazySystemBinaryReader<Input> {
         let raw_reader = StreamingRawReader::new(BinaryEncoding_1_0, ion_data);
         let expanding_reader = LazyExpandingReader::new(raw_reader);
@@ -112,7 +112,7 @@ impl<Input: IntoIonInput> LazySystemBinaryReader<Input> {
     }
 }
 
-impl<Input: IntoIonInput> LazySystemTextReader_1_1<Input> {
+impl<Input: IonInput> LazySystemTextReader_1_1<Input> {
     pub(crate) fn new(ion_data: Input) -> LazySystemTextReader_1_1<Input> {
         let raw_reader = StreamingRawReader::new(TextEncoding_1_1, ion_data);
         let expanding_reader = LazyExpandingReader::new(raw_reader);
@@ -120,7 +120,7 @@ impl<Input: IntoIonInput> LazySystemTextReader_1_1<Input> {
     }
 }
 
-impl<Encoding: LazyDecoder, Input: IntoIonInput> LazySystemReader<Encoding, Input> {
+impl<Encoding: LazyDecoder, Input: IonInput> LazySystemReader<Encoding, Input> {
     // Returns `true` if the provided [`LazyRawValue`] is a struct whose first annotation is
     // `$ion_symbol_table`.
     pub fn is_symbol_table_struct(

--- a/src/lazy/text/encoded_value.rs
+++ b/src/lazy/text/encoded_value.rs
@@ -207,6 +207,12 @@ impl<'top, E: TextEncoding<'top>> EncodedTextValue<'top, E> {
         self.data_length + u32::max(self.annotations_offset, self.field_name_offset) as usize
     }
 
+    pub fn annotated_value_range(&self) -> Range<usize> {
+        let start = self.data_offset - self.annotations_length as usize;
+        let end = self.data_offset + self.data_length;
+        start..end
+    }
+
     pub fn field_name_syntax(&self) -> Option<MatchedFieldNameSyntax> {
         self.field_name_syntax
     }

--- a/src/lazy/text/raw/reader.rs
+++ b/src/lazy/text/raw/reader.rs
@@ -1,5 +1,5 @@
 #![allow(non_camel_case_types)]
-use crate::lazy::decoder::LazyRawReader;
+use crate::lazy::decoder::{LazyDecoder, LazyRawReader};
 use crate::lazy::encoding::TextEncoding_1_0;
 use crate::lazy::never::Never;
 use crate::lazy::raw_stream_item::{LazyRawStreamItem, RawStreamItem};
@@ -14,7 +14,10 @@ use bumpalo::Bump as BumpAllocator;
 /// in the provided input stream.
 pub struct LazyRawTextReader_1_0<'data> {
     input: &'data [u8],
-    offset: usize,
+    // The offset from the beginning of the overall stream at which the `input` slice begins
+    stream_offset: usize,
+    // The offset from the beginning of `input` at which the reader is positioned
+    local_offset: usize,
 }
 
 impl<'data> LazyRawTextReader_1_0<'data> {
@@ -30,7 +33,11 @@ impl<'data> LazyRawTextReader_1_0<'data> {
     fn new_with_offset(data: &'data [u8], offset: usize) -> LazyRawTextReader_1_0<'data> {
         LazyRawTextReader_1_0 {
             input: data,
-            offset,
+            // `data` begins at position `offset` within some larger stream. If `data` contains
+            // the entire stream, this will be zero.
+            stream_offset: offset,
+            // Start reading from the beginning of the slice `data`
+            local_offset: 0,
         }
     }
 
@@ -41,8 +48,11 @@ impl<'data> LazyRawTextReader_1_0<'data> {
     where
         'data: 'top,
     {
-        let input =
-            TextBufferView::new_with_offset(allocator, &self.input[self.offset..], self.offset);
+        let input = TextBufferView::new_with_offset(
+            allocator,
+            &self.input[self.local_offset..],
+            self.stream_offset + self.local_offset,
+        );
         let (buffer_after_whitespace, _whitespace) = input
             .match_optional_comments_and_whitespace()
             .with_context("reading whitespace/comments at the top level", input)?;
@@ -68,14 +78,18 @@ impl<'data> LazyRawTextReader_1_0<'data> {
         }
         // Since we successfully matched the next value, we'll update the buffer
         // so a future call to `next()` will resume parsing the remaining input.
-        self.offset = remaining.offset();
+        self.local_offset = remaining.offset() - self.stream_offset;
         Ok(matched_item)
     }
 }
 
 impl<'data> LazyRawReader<'data, TextEncoding_1_0> for LazyRawTextReader_1_0<'data> {
-    fn new(data: &'data [u8]) -> Self {
-        LazyRawTextReader_1_0::new(data)
+    fn resume_at_offset(
+        data: &'data [u8],
+        offset: usize,
+        _config: <TextEncoding_1_0 as LazyDecoder>::ReaderSavedState,
+    ) -> Self {
+        LazyRawTextReader_1_0::new_with_offset(data, offset)
     }
 
     fn next<'top>(
@@ -86,6 +100,10 @@ impl<'data> LazyRawReader<'data, TextEncoding_1_0> for LazyRawTextReader_1_0<'da
         'data: 'top,
     {
         self.next(allocator)
+    }
+
+    fn position(&self) -> usize {
+        self.stream_offset + self.local_offset
     }
 }
 

--- a/src/lazy/text/raw/reader.rs
+++ b/src/lazy/text/raw/reader.rs
@@ -476,4 +476,44 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn ranges_and_spans() -> IonResult<()> {
+        let bump = bumpalo::Bump::new();
+        let data = b"foo 2024T bar::38 [1, 2, 3]";
+        let mut reader = LazyRawTextReader_1_0::new(data);
+
+        let foo = reader.next(&bump)?.expect_value()?;
+        assert_eq!(foo.span(), b"foo");
+        assert_eq!(foo.range(), 0..3);
+
+        let timestamp = reader.next(&bump)?.expect_value()?;
+        assert_eq!(timestamp.span(), b"2024T");
+        assert_eq!(timestamp.range(), 4..9);
+
+        let annotated_int = reader.next(&bump)?.expect_value()?;
+        assert_eq!(annotated_int.span(), b"bar::38");
+        assert_eq!(annotated_int.range(), 10..17);
+
+        let list_value = reader.next(&bump)?.expect_value()?;
+        assert_eq!(list_value.span(), b"[1, 2, 3]");
+        assert_eq!(list_value.range(), 18..27);
+
+        let list = list_value.read()?.expect_list()?;
+        let mut child_values = list.iter();
+
+        let value1 = child_values.next().unwrap()?.expect_value()?;
+        assert_eq!(value1.span(), b"1");
+        assert_eq!(value1.range(), 19..20);
+
+        let value2 = child_values.next().unwrap()?.expect_value()?;
+        assert_eq!(value2.span(), b"2");
+        assert_eq!(value2.range(), 22..23);
+
+        let value3 = child_values.next().unwrap()?.expect_value()?;
+        assert_eq!(value3.span(), b"3");
+        assert_eq!(value3.range(), 25..26);
+
+        Ok(())
+    }
 }

--- a/src/lazy/text/value.rs
+++ b/src/lazy/text/value.rs
@@ -2,6 +2,7 @@
 
 use std::fmt;
 use std::fmt::{Debug, Formatter};
+use std::ops::Range;
 
 use crate::lazy::decoder::private::{LazyContainerPrivate, LazyRawValuePrivate};
 use crate::lazy::decoder::{LazyDecoder, LazyRawValue};
@@ -136,6 +137,17 @@ impl<'top, E: TextEncoding<'top>> LazyRawValue<'top, E> for MatchedRawTextValue<
         };
         Ok(value_ref)
     }
+
+    fn range(&self) -> Range<usize> {
+        self.encoded_value.annotated_value_range()
+    }
+
+    fn span(&self) -> &[u8] {
+        let range = self.range();
+        let input_offset = self.input.offset();
+        let local_range = (range.start - input_offset)..(range.end - input_offset);
+        &self.input.bytes()[local_range]
+    }
 }
 
 impl<'top, E: TextEncoding<'top>> LazyRawValuePrivate<'top> for LazyRawTextValue<'top, E> {
@@ -159,6 +171,14 @@ impl<'top, E: TextEncoding<'top>> LazyRawValue<'top, E> for LazyRawTextValue<'to
 
     fn read(&self) -> IonResult<RawValueRef<'top, E>> {
         self.matched.read()
+    }
+
+    fn range(&self) -> Range<usize> {
+        self.matched.range()
+    }
+
+    fn span(&self) -> &[u8] {
+        self.matched.span()
     }
 }
 

--- a/src/lazy/value_ref.rs
+++ b/src/lazy/value_ref.rs
@@ -264,7 +264,7 @@ mod tests {
             {this: is, a: struct}
         "#,
         )?;
-        let mut reader = LazyBinaryReader::new(&ion_data)?;
+        let mut reader = LazyBinaryReader::new(ion_data)?;
         assert_eq!(reader.expect_next()?.read()?.expect_null()?, IonType::Null);
         assert!(reader.expect_next()?.read()?.expect_bool()?);
         assert_eq!(reader.expect_next()?.read()?.expect_i64()?, 1);
@@ -313,7 +313,7 @@ mod tests {
             {{"Clob"}}
         "#,
         )?;
-        let mut reader = LazyBinaryReader::new(&ion_data)?;
+        let mut reader = LazyBinaryReader::new(ion_data)?;
         let first_value = reader.expect_next()?.read()?;
         assert_ne!(first_value, ValueRef::String("it's not a string".into()));
         assert_eq!(first_value, ValueRef::Null(IonType::Null));

--- a/tests/ion_tests_1_1.rs
+++ b/tests/ion_tests_1_1.rs
@@ -11,7 +11,7 @@ use test_generator::test_resources;
 struct LazyReaderElementApi;
 
 impl ElementApi for LazyReaderElementApi {
-    type ElementReader<'a> = LazyTextReader_1_1<'a>;
+    type ElementReader<'a> = LazyTextReader_1_1<&'a [u8]>;
 
     fn make_reader(data: &[u8]) -> IonResult<Self::ElementReader<'_>> {
         Ok(LazyTextReader_1_1::new(data).unwrap())

--- a/tests/lazy_element_ion_tests.rs
+++ b/tests/lazy_element_ion_tests.rs
@@ -14,7 +14,7 @@ use test_generator::test_resources;
 struct LazyReaderElementApi;
 
 impl ElementApi for LazyReaderElementApi {
-    type ElementReader<'a> = LazyReader<'a>;
+    type ElementReader<'a> = LazyReader<&'a [u8]>;
 
     fn make_reader(data: &[u8]) -> IonResult<Self::ElementReader<'_>> {
         Ok(LazyReader::new(data))


### PR DESCRIPTION
This PR:
* Introduces an `IonDataSource` trait with two implementations:
   * `IonSlice<impl AsRef<[u8]>`, which reads from byte-array backed fixed streams with no overhead.
   * `IonStream<impl io::Read>`, which reads incrementally from a streaming input source with minimal overhead.
* Introduces an `IonInput` trait for types that can be converted to an `IonDataSource`, including `&[u8]`, `Vec<u8>`, `&str`, `File`, etc.
* Introduces a `StreamingRawReader` that wraps an `IonDataSource` and exposes one top-level value at a time as a `LazyValue`.
* Modifies the `Element::read*` and `Element::iter` APIs to use the LazyReader.
* Modifies the `ion-tests` to exercise the `LazyReader`.
* Adds `range()` and `span()` methods for viewing the input bytes that correspond to a given value. There's a lot more to do for this API, but I stopped because this PR was getting too big. I'll continue it in a separate PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
