### PR TITLE
Updates dep versions, remove deprecated method use from example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,12 @@ readme = "README.md"
 keywords = ["ion", "parser", "json", "format", "serde"]
 categories = ["encoding", "parser-implementations"]
 exclude = [
-  "**/.git/**",
-  "**/.github/**",
-  "**/.travis.yml",
-  "**/.appveyor.yml",
-  "**/ion-tests/iontestdata/**",
-  "*.pdf"
+    "**/.git/**",
+    "**/.github/**",
+    "**/.travis.yml",
+    "**/.appveyor.yml",
+    "**/ion-tests/iontestdata/**",
+    "*.pdf"
 ]
 version = "1.0.0-rc.3"
 edition = "2021"
@@ -30,10 +30,10 @@ experimental-ion-hash = ["digest"]
 # These are not guaranteed any sort of API stability and may also have non-standard
 # Ion behavior (e.g., draft Ion 1.1 capabilities).
 experimental = [
-  "experimental-lazy-reader",
-  "experimental-reader",
-  "experimental-writer",
-  "experimental-serde",
+    "experimental-lazy-reader",
+    "experimental-reader",
+    "experimental-writer",
+    "experimental-serde",
 ]
 
 # Access to the `IonReader` trait, its implementations, and the `ReaderBuilder`.
@@ -59,26 +59,26 @@ bytes = "0.4"
 # this makes it explicitly not do this as there is an advisory warning against this:
 # See: https://github.com/chronotope/chrono/issues/602
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "wasmbind"] }
-delegate = "0.10.0"
+delegate = "0.12.0"
 thiserror = "1.0"
 nom = "7.1.1"
 num-bigint = "0.4.3"
 num-integer = "0.1.44"
 num-traits = "0.2"
 arrayvec = "0.7"
-smallvec = {version ="1.9.0", features = ["const_generics"]}
-bumpalo = {version = "3.15.3", features = ["collections", "std"]}
+smallvec = { version = "1.9.0", features = ["const_generics"] }
+bumpalo = { version = "3.15.3", features = ["collections", "std"] }
 digest = { version = "0.9", optional = true }
 ice_code = "0.1.4"
 sha2 = { version = "0.9", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
-serde_with = { version = "2.0", optional = true }
+serde_with = { version = "3.7.0", optional = true }
 
 [dev-dependencies]
-rstest = "0.17.0"
-rstest_reuse = "0.5.0"
+rstest = "0.18.2"
+rstest_reuse = "0.6.0"
 # Used by ion-tests integration
-walkdir = "2.3"
+walkdir = "2.5.0"
 test-generator = "0.3"
 memmap = "0.7.0"
 criterion = "0.5.1"

--- a/examples/write_log_events.rs
+++ b/examples/write_log_events.rs
@@ -15,7 +15,7 @@ fn main() -> IonResult<()> {
 
 #[cfg(feature = "experimental-lazy-reader")]
 mod example {
-    use chrono::{DateTime, FixedOffset, NaiveDateTime};
+    use chrono::{DateTime, FixedOffset};
     use ion_rs::lazy::encoder::binary::v1_0::writer::LazyRawBinaryWriter_1_0;
     use ion_rs::lazy::encoder::binary::v1_1::writer::LazyRawBinaryWriter_1_1;
     use ion_rs::lazy::encoder::value_writer::{SequenceWriter, StructWriter, ValueWriter};
@@ -301,16 +301,10 @@ mod example {
     ) -> LogEvent<'statements> {
         // Each event is 1 second after the previous event
         let event_epoch_millis = INITIAL_EPOCH_MILLIS + (event_index as i64 * 1000);
-        let naive_datetime = NaiveDateTime::from_timestamp_millis(event_epoch_millis)
+        let datetime: DateTime<FixedOffset> = DateTime::from_timestamp_millis(event_epoch_millis)
             .unwrap()
             .into();
-
-        // Timestamps have an offset of UTC-5:00
-        let timestamp: Timestamp = DateTime::<FixedOffset>::from_naive_utc_and_offset(
-            naive_datetime,
-            FixedOffset::east_opt(5 * 60 * 60).unwrap(),
-        )
-        .into();
+        let timestamp: Timestamp = datetime.into();
 
         let thread_id = rng.gen_range(1..=128);
         let thread_name = format!("{THREAD_NAME_PREFIX}{}", rng.gen_range(1..=8));

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -1494,7 +1494,7 @@ mod value_tests {
         let list: Element = ion_list![1, 2, 3].into();
         thread::scope(|_| {
             // Move `list` into this scope, demonstrating `Send`
-            let elements = vec![list];
+            let elements = [list];
             // Trivial assertion to use `elements`
             assert_eq!(elements.len(), 1);
         });

--- a/src/lazy/encoder/mod.rs
+++ b/src/lazy/encoder/mod.rs
@@ -52,7 +52,7 @@ mod tests {
     use crate::lazy::encoder::annotate::Annotate;
     use crate::lazy::encoder::text::LazyRawTextWriter_1_0;
     use crate::lazy::encoder::value_writer::internal::MakeValueWriter;
-    use crate::lazy::encoder::value_writer::{AnnotatableValueWriter, StructWriter};
+    use crate::lazy::encoder::value_writer::{StructWriter, ValueWriter};
     use crate::symbol_ref::AsSymbolRef;
     use crate::{Element, IonData, IonResult, Timestamp};
 

--- a/src/lazy/encoder/write_as_ion.rs
+++ b/src/lazy/encoder/write_as_ion.rs
@@ -91,8 +91,13 @@ macro_rules! impl_write_as_ion_value {
 impl_write_as_ion_value!(
     Null => write_null with self as self.0,
     bool => write_bool with self as *self,
+    i16 => write_i64 with self as *self as i64,
     i32 => write_i64 with self as *self as i64,
     i64 => write_i64 with self as *self,
+    isize => write_i64 with self as *self as i64,
+    u16 => write_i64 with self as i64::from(*self),
+    u32 => write_i64 with self as i64::from(*self),
+    u64 => write_int with self as &Int::from(*self),
     usize => write_int with self as &Int::from(*self),
     f32 => write_f32 with self as *self,
     f64 => write_f64 with self as *self,

--- a/src/lazy/encoder/write_as_ion.rs
+++ b/src/lazy/encoder/write_as_ion.rs
@@ -88,6 +88,11 @@ macro_rules! impl_write_as_ion_value {
     };
 }
 
+// TODO: For the moment, `i8` and `u8` do not directly implement `WriteAsIon` because this causes
+//       the desired serialization for `&[u8]` and `&[i8]` to be ambiguous. They could be serialized
+//       either as blobs or as lists of integers. We should use the same trick that `SExpTypeHint`
+//       employs to make it possible for users to override the default blob serialization by writing:
+//           writer.write(&[1u8, 2, 3].as_list())
 impl_write_as_ion_value!(
     Null => write_null with self as self.0,
     bool => write_bool with self as *self,

--- a/src/lazy/never.rs
+++ b/src/lazy/never.rs
@@ -3,13 +3,13 @@ use std::fmt::Debug;
 use crate::lazy::decoder::{LazyDecoder, LazyRawValueExpr};
 use crate::lazy::encoder::value_writer::internal::MakeValueWriter;
 use crate::lazy::encoder::value_writer::{
-    AnnotatableValueWriter, MacroArgsWriter, SequenceWriter, StructWriter, ValueWriter,
+    AnnotatableValueWriter, MacroArgsWriter, SequenceWriter, StructWriter,
 };
 use crate::lazy::encoder::write_as_ion::WriteAsIon;
 use crate::lazy::expanded::macro_evaluator::{MacroExpr, RawEExpression};
 use crate::lazy::text::raw::v1_1::reader::MacroIdRef;
 use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
-use crate::{Decimal, Int, IonResult, IonType, Timestamp};
+use crate::IonResult;
 
 /// An uninhabited type that signals to the compiler that related code paths are not reachable.
 #[derive(Debug, Copy, Clone)]
@@ -78,87 +78,3 @@ impl MakeValueWriter for Never {
 }
 
 impl MacroArgsWriter for Never {}
-
-impl ValueWriter for Never {
-    type ListWriter<'a> = Never;
-    type SExpWriter<'a> = Never;
-    type StructWriter<'a> = Never;
-    type MacroArgsWriter<'a> = Never;
-
-    fn write_null(self, _ion_type: IonType) -> IonResult<()> {
-        unreachable!("ValueWriter::write_null in Never")
-    }
-
-    fn write_bool(self, _value: bool) -> IonResult<()> {
-        unreachable!("ValueWriter::write_bool in Never")
-    }
-
-    fn write_i64(self, _value: i64) -> IonResult<()> {
-        unreachable!("ValueWriter::write_i64 in Never")
-    }
-
-    fn write_int(self, _value: &Int) -> IonResult<()> {
-        unreachable!("ValueWriter::write_int in Never")
-    }
-
-    fn write_f32(self, _value: f32) -> IonResult<()> {
-        unreachable!("ValueWriter::write_f32 in Never")
-    }
-
-    fn write_f64(self, _value: f64) -> IonResult<()> {
-        unreachable!("ValueWriter::write_f64 in Never")
-    }
-
-    fn write_decimal(self, _value: &Decimal) -> IonResult<()> {
-        unreachable!("ValueWriter::write_decimal in Never")
-    }
-
-    fn write_timestamp(self, _value: &Timestamp) -> IonResult<()> {
-        unreachable!("ValueWriter::write_timestamp in Never")
-    }
-
-    fn write_string(self, _value: impl AsRef<str>) -> IonResult<()> {
-        unreachable!("ValueWriter::write_string in Never")
-    }
-
-    fn write_symbol(self, _value: impl AsRawSymbolTokenRef) -> IonResult<()> {
-        unreachable!("ValueWriter::write_symbol in Never")
-    }
-
-    fn write_clob(self, _value: impl AsRef<[u8]>) -> IonResult<()> {
-        unreachable!("ValueWriter::write_clob in Never")
-    }
-
-    fn write_blob(self, _value: impl AsRef<[u8]>) -> IonResult<()> {
-        unreachable!("ValueWriter::write_blob in Never")
-    }
-
-    fn write_list<F: for<'a> FnOnce(&mut Self::ListWriter<'a>) -> IonResult<()>>(
-        self,
-        _list_fn: F,
-    ) -> IonResult<()> {
-        unreachable!("ValueWriter::write_list in Never")
-    }
-
-    fn write_sexp<F: for<'a> FnOnce(&mut Self::SExpWriter<'a>) -> IonResult<()>>(
-        self,
-        _sexp_fn: F,
-    ) -> IonResult<()> {
-        unreachable!("ValueWriter::write_sexp in Never")
-    }
-
-    fn write_struct<F: for<'a> FnOnce(&mut Self::StructWriter<'a>) -> IonResult<()>>(
-        self,
-        _struct_fn: F,
-    ) -> IonResult<()> {
-        unreachable!("ValueWriter::write_struct in Never")
-    }
-
-    fn write_eexp<'macro_id, F: for<'a> FnOnce(&mut Self::MacroArgsWriter<'a>) -> IonResult<()>>(
-        self,
-        _macro_id: impl Into<MacroIdRef<'macro_id>>,
-        _macro_fn: F,
-    ) -> IonResult<()> {
-        unreachable!("ValueWriter::write_eexp in Never")
-    }
-}


### PR DESCRIPTION
Updates all of the dependencies that were outdated and which could also be upgraded without an invasive code change. Also updates usages of the now-deprecated `chrono::NaiveDateTime::from_timestamp_millis` in the `write_log_events` example.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
