### PR TITLE
Simplifies the `ValueWriter` trait family

### DIFF
--- a/src/lazy/encoder/binary/mod.rs
+++ b/src/lazy/encoder/binary/mod.rs
@@ -1,3 +1,2 @@
 pub mod v1_0;
 pub mod v1_1;
-

--- a/src/lazy/encoder/binary/mod.rs
+++ b/src/lazy/encoder/binary/mod.rs
@@ -1,21 +1,3 @@
 pub mod v1_0;
 pub mod v1_1;
 
-/// Takes a series of `TYPE => METHOD` pairs, generating a function for each that calls the host
-/// type's `encode_annotated` method to encode an annotations sequence and then delegates encoding
-/// the value to the corresponding value writer method.
-// This macro is used in the v1_0 and v1_1 binary writer implementations, which both define an
-// `encode_annotated` method. That method is not codified (for example: in a trait); this relies
-// solely on convention between the two.
-macro_rules! annotate_and_delegate {
-    // End of iteration
-    () => {};
-    // Recurses one argument pair at a time
-    ($value_type:ty => $method:ident, $($rest:tt)*) => {
-        fn $method(self, value: $value_type) -> IonResult<()> {
-            self.encode_annotated(|value_writer| value_writer.$method(value))
-        }
-        annotate_and_delegate!($($rest)*);
-    };
-}
-pub(crate) use annotate_and_delegate;

--- a/src/lazy/encoder/binary/v1_0/container_writers.rs
+++ b/src/lazy/encoder/binary/v1_0/container_writers.rs
@@ -1,16 +1,14 @@
+use bumpalo::Bump as BumpAllocator;
+use bumpalo::collections::Vec as BumpVec;
+
+use crate::{IonError, IonResult, RawSymbolTokenRef};
 use crate::binary::var_uint::VarUInt;
-use crate::lazy::encoder::binary::v1_0::value_writer::{
-    BinaryAnnotatableValueWriter_1_0, MAX_INLINE_LENGTH,
-};
-use crate::lazy::encoder::value_writer::internal::MakeValueWriter;
+use crate::lazy::encoder::binary::v1_0::value_writer::BinaryAnnotatableValueWriter_1_0;
 use crate::lazy::encoder::value_writer::{SequenceWriter, StructWriter};
+use crate::lazy::encoder::value_writer::internal::MakeValueWriter;
 use crate::lazy::encoder::write_as_ion::WriteAsIon;
 use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
 use crate::result::EncodingError;
-use crate::{IonError, IonResult, RawSymbolTokenRef};
-use bumpalo::collections::Vec as BumpVec;
-use bumpalo::Bump as BumpAllocator;
-use delegate::delegate;
 
 /// A helper type that holds fields and logic that is common to [`BinaryListWriter_1_0`],
 /// [`BinarySExpWriter_1_0`], and [`BinaryStructWriter_1_0`].
@@ -22,43 +20,31 @@ pub struct BinaryContainerWriter_1_0<'value, 'top> {
     // The buffer containing the parent's encoded body. When this list writer is finished encoding
     // its own data, a header will be written to the parent and then the list body will be copied
     // over.
-    parent_buffer: &'value mut BumpVec<'top, u8>,
+    buffer: &'value mut BumpVec<'top, u8>,
 }
 
 impl<'value, 'top> BinaryContainerWriter_1_0<'value, 'top> {
     pub fn new(
         type_code: u8,
         allocator: &'top BumpAllocator,
-        parent_buffer: &'value mut BumpVec<'top, u8>,
+        buffer: &'value mut BumpVec<'top, u8>,
     ) -> Self {
         Self {
             type_code,
             allocator,
-            parent_buffer,
+            buffer,
         }
     }
 
-    pub fn write_values<'a, F>(mut self, write_fn: F) -> IonResult<()>
-    where
-        'top: 'a,
-        F: FnOnce(BinaryContainerValuesWriter_1_0<'a>) -> IonResult<BumpVec<'a, u8>>,
-    {
-        let container_values_writer = BinaryContainerValuesWriter_1_0::new(self.allocator);
-        let encoded_values = write_fn(container_values_writer)?;
-        self.write_header_and_encoded_body(encoded_values.as_slice())
+    pub fn write<V: WriteAsIon>(&mut self, value: V) -> IonResult<&mut Self> {
+        let annotated_value_writer =
+            BinaryAnnotatableValueWriter_1_0::new(self.allocator, self.buffer);
+        value.write_as_ion(annotated_value_writer)?;
+        Ok(self)
     }
 
-    fn write_header_and_encoded_body(&mut self, body: &[u8]) -> IonResult<()> {
-        let body_length = body.len();
-        if body_length <= MAX_INLINE_LENGTH {
-            let type_descriptor = self.type_code | (body_length as u8);
-            self.parent_buffer.push(type_descriptor);
-        } else {
-            self.parent_buffer.push(self.type_code | 0xE);
-            VarUInt::write_u64(&mut self.parent_buffer, body_length as u64)?;
-        }
-        self.parent_buffer.extend_from_slice_copy(body);
-        Ok(())
+    pub fn buffer(&self) -> &[u8] {
+        self.buffer.as_slice()
     }
 }
 
@@ -72,55 +58,8 @@ pub struct BinaryContainerValuesWriter_1_0<'value> {
 // reallocations/copies.
 const DEFAULT_CONTAINER_BUFFER_SIZE: usize = 512;
 
-impl<'value> BinaryContainerValuesWriter_1_0<'value> {
-    pub fn new(allocator: &'value BumpAllocator) -> Self {
-        let buffer = BumpVec::with_capacity_in(DEFAULT_CONTAINER_BUFFER_SIZE, allocator);
-        Self { allocator, buffer }
-    }
-
-    pub fn write<V: WriteAsIon>(&mut self, value: V) -> IonResult<&mut Self> {
-        let annotated_value_writer =
-            BinaryAnnotatableValueWriter_1_0::new(self.allocator, &mut self.buffer);
-        value.write_as_ion(annotated_value_writer)?;
-        Ok(self)
-    }
-}
-
-pub struct BinaryListValuesWriter_1_0<'value> {
-    values_writer: BinaryContainerValuesWriter_1_0<'value>,
-}
-
-impl<'value> BinaryListValuesWriter_1_0<'value> {
-    pub fn new(values_writer: BinaryContainerValuesWriter_1_0<'value>) -> Self {
-        Self { values_writer }
-    }
-    pub fn write<V: WriteAsIon>(&mut self, value: V) -> IonResult<&mut Self> {
-        self.values_writer.write(value)?;
-        Ok(self)
-    }
-}
-
-impl<'value> MakeValueWriter for BinaryListValuesWriter_1_0<'value> {
-    type ValueWriter<'a> = BinaryAnnotatableValueWriter_1_0<'a, 'value> where Self: 'a;
-
-    fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
-        BinaryAnnotatableValueWriter_1_0::new(
-            self.values_writer.allocator,
-            &mut self.values_writer.buffer,
-        )
-    }
-}
-
-impl<'value> SequenceWriter for BinaryListValuesWriter_1_0<'value> {
-    delegate! {
-        to self {
-            fn write<V: WriteAsIon>(&mut self, value: V) -> IonResult<&mut Self>;
-        }
-    }
-}
-
 pub struct BinaryListWriter_1_0<'value, 'top> {
-    container_writer: BinaryContainerWriter_1_0<'value, 'top>,
+    pub(crate) container_writer: BinaryContainerWriter_1_0<'value, 'top>,
 }
 
 impl<'value, 'top> BinaryListWriter_1_0<'value, 'top> {
@@ -128,52 +67,39 @@ impl<'value, 'top> BinaryListWriter_1_0<'value, 'top> {
         Self { container_writer }
     }
 
-    pub fn write_values<'a, F>(self, write_fn: F) -> IonResult<()>
-    where
-        'top: 'a,
-        F: FnOnce(&mut BinaryListValuesWriter_1_0<'a>) -> IonResult<()>,
-    {
-        self.container_writer
-            .write_values(|container_values_writer| {
-                let mut list_values_writer =
-                    BinaryListValuesWriter_1_0::new(container_values_writer);
-                write_fn(&mut list_values_writer)?;
-                Ok(list_values_writer.values_writer.buffer)
-            })
+    pub fn buffer(&self) -> &[u8] {
+        self.container_writer.buffer()
     }
 }
 
-pub struct BinarySExpValuesWriter_1_0<'value> {
-    values_writer: BinaryContainerValuesWriter_1_0<'value>,
-}
-
-impl<'value> BinarySExpValuesWriter_1_0<'value> {
-    pub fn new(values_writer: BinaryContainerValuesWriter_1_0<'value>) -> Self {
-        Self { values_writer }
-    }
-    pub fn write<V: WriteAsIon>(&mut self, value: V) -> IonResult<&mut Self> {
-        self.values_writer.write(value)?;
-        Ok(self)
-    }
-}
-
-impl<'value> MakeValueWriter for BinarySExpValuesWriter_1_0<'value> {
-    type ValueWriter<'a> = BinaryAnnotatableValueWriter_1_0<'a, 'value> where Self: 'a;
+impl<'value, 'top> MakeValueWriter for BinaryListWriter_1_0<'value, 'top> {
+    type ValueWriter<'a> = BinaryAnnotatableValueWriter_1_0<'a, 'top> where Self: 'a;
 
     fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
         BinaryAnnotatableValueWriter_1_0::new(
-            self.values_writer.allocator,
-            &mut self.values_writer.buffer,
+            self.container_writer.allocator,
+            self.container_writer.buffer,
         )
     }
 }
 
-impl<'value> SequenceWriter for BinarySExpValuesWriter_1_0<'value> {
-    delegate! {
-        to self {
-            fn write<V: WriteAsIon>(&mut self, value: V) -> IonResult<&mut Self>;
-        }
+impl<'value, 'top> SequenceWriter for BinaryListWriter_1_0<'value, 'top> {
+    // All default methods
+}
+
+impl<'value, 'top> MakeValueWriter for BinarySExpWriter_1_0<'value, 'top> {
+    type ValueWriter<'a> = BinaryAnnotatableValueWriter_1_0<'a, 'top> where Self: 'a;
+
+    fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
+        BinaryAnnotatableValueWriter_1_0::new(
+            self.container_writer.allocator,
+            self.container_writer.buffer,
+        )
     }
+}
+
+impl<'value, 'top> SequenceWriter for BinarySExpWriter_1_0<'value, 'top> {
+    // All default methods
 }
 
 pub struct BinarySExpWriter_1_0<'value, 'top> {
@@ -187,63 +113,8 @@ impl<'value, 'top> BinarySExpWriter_1_0<'value, 'top> {
         }
     }
 
-    pub fn write_values<'a, F>(self, write_fn: F) -> IonResult<()>
-    where
-        'top: 'a,
-        F: FnOnce(&mut BinarySExpValuesWriter_1_0<'a>) -> IonResult<()>,
-    {
-        self.container_writer
-            .write_values(|container_values_writer| {
-                let mut sexp_values_writer =
-                    BinarySExpValuesWriter_1_0::new(container_values_writer);
-                write_fn(&mut sexp_values_writer)?;
-                Ok(sexp_values_writer.values_writer.buffer)
-            })
-    }
-}
-
-pub struct BinaryStructFieldsWriter_1_0<'value> {
-    container_values_writer: BinaryContainerValuesWriter_1_0<'value>,
-}
-
-impl<'value> BinaryStructFieldsWriter_1_0<'value> {
-    pub fn new(container_values_writer: BinaryContainerValuesWriter_1_0<'value>) -> Self {
-        Self {
-            container_values_writer,
-        }
-    }
-
-    pub fn write<A: AsRawSymbolTokenRef, V: WriteAsIon>(
-        &mut self,
-        name: A,
-        value: V,
-    ) -> IonResult<&mut Self> {
-        // Write the field name
-        let sid = match name.as_raw_symbol_token_ref() {
-            RawSymbolTokenRef::SymbolId(sid) => sid,
-            RawSymbolTokenRef::Text(text) => {
-                return Err(IonError::Encoding(EncodingError::new(format!(
-                    "tried to write a text literal using the v1.0 raw binary writer: '{text}'"
-                ))));
-            }
-        };
-        VarUInt::write_u64(&mut self.container_values_writer.buffer, sid as u64)?;
-
-        // Write the field value
-        self.container_values_writer.write(value)?;
-        Ok(self)
-    }
-}
-
-impl<'value> StructWriter for BinaryStructFieldsWriter_1_0<'value> {
-    delegate! {
-        to self {
-            fn write<A: AsRawSymbolTokenRef, V: WriteAsIon>(
-                &mut self,
-                name: A,
-                value: V,
-            ) -> IonResult<&mut Self>;
-        }
+    pub fn buffer(&self) -> &[u8] {
+        self.container_writer.buffer()
     }
 }
 
@@ -258,17 +129,30 @@ impl<'value, 'top> BinaryStructWriter_1_0<'value, 'top> {
         }
     }
 
-    pub fn write_fields<'a, F>(self, write_fn: F) -> IonResult<()>
-    where
-        'top: 'a,
-        F: FnOnce(&mut BinaryStructFieldsWriter_1_0<'a>) -> IonResult<()>,
-    {
-        self.container_writer
-            .write_values(|container_values_writer| {
-                let mut struct_fields_writer =
-                    BinaryStructFieldsWriter_1_0::new(container_values_writer);
-                write_fn(&mut struct_fields_writer)?;
-                Ok(struct_fields_writer.container_values_writer.buffer)
-            })
+    pub fn buffer(&self) -> &[u8] {
+        self.container_writer.buffer()
+    }
+}
+
+impl<'value, 'top> StructWriter for BinaryStructWriter_1_0<'value, 'top> {
+    fn write<A: AsRawSymbolTokenRef, V: WriteAsIon>(
+        &mut self,
+        name: A,
+        value: V,
+    ) -> IonResult<&mut Self> {
+        // Write the field name
+        let sid = match name.as_raw_symbol_token_ref() {
+            RawSymbolTokenRef::SymbolId(sid) => sid,
+            RawSymbolTokenRef::Text(text) => {
+                return Err(IonError::Encoding(EncodingError::new(format!(
+                    "tried to write a text literal using the v1.0 raw binary writer: '{text}'"
+                ))));
+            }
+        };
+        VarUInt::write_u64(&mut self.container_writer.buffer, sid as u64)?;
+
+        // Write the field value
+        self.container_writer.write(value)?;
+        Ok(self)
     }
 }

--- a/src/lazy/encoder/binary/v1_0/container_writers.rs
+++ b/src/lazy/encoder/binary/v1_0/container_writers.rs
@@ -1,14 +1,14 @@
-use bumpalo::Bump as BumpAllocator;
 use bumpalo::collections::Vec as BumpVec;
+use bumpalo::Bump as BumpAllocator;
 
-use crate::{IonError, IonResult, RawSymbolTokenRef};
 use crate::binary::var_uint::VarUInt;
 use crate::lazy::encoder::binary::v1_0::value_writer::BinaryAnnotatableValueWriter_1_0;
-use crate::lazy::encoder::value_writer::{SequenceWriter, StructWriter};
 use crate::lazy::encoder::value_writer::internal::MakeValueWriter;
+use crate::lazy::encoder::value_writer::{SequenceWriter, StructWriter};
 use crate::lazy::encoder::write_as_ion::WriteAsIon;
 use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
 use crate::result::EncodingError;
+use crate::{IonError, IonResult, RawSymbolTokenRef};
 
 /// A helper type that holds fields and logic that is common to [`BinaryListWriter_1_0`],
 /// [`BinarySExpWriter_1_0`], and [`BinaryStructWriter_1_0`].

--- a/src/lazy/encoder/binary/v1_0/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_0/value_writer.rs
@@ -12,16 +12,12 @@ use crate::binary::timestamp::TimestampBinaryEncoder;
 use crate::binary::uint;
 use crate::binary::uint::DecodedUInt;
 use crate::binary::var_uint::VarUInt;
-use crate::lazy::encoder::binary::annotate_and_delegate;
 use crate::lazy::encoder::binary::v1_0::container_writers::{
-    BinaryContainerWriter_1_0, BinaryListValuesWriter_1_0, BinaryListWriter_1_0,
-    BinarySExpValuesWriter_1_0, BinarySExpWriter_1_0, BinaryStructFieldsWriter_1_0,
-    BinaryStructWriter_1_0,
+    BinaryContainerWriter_1_0, BinaryListWriter_1_0, BinarySExpWriter_1_0, BinaryStructWriter_1_0,
 };
+use crate::lazy::encoder::container_fn::{ListFn, MacroArgsFn, SExpFn, StructFn};
 use crate::lazy::encoder::private::Sealed;
-use crate::lazy::encoder::value_writer::{
-    delegate_value_writer_to, delegate_value_writer_to_self, AnnotatableValueWriter, ValueWriter,
-};
+use crate::lazy::encoder::value_writer::{delegate_value_writer_to, AnnotatableValueWriter, ValueWriter};
 use crate::lazy::never::Never;
 use crate::lazy::text::raw::v1_1::reader::MacroIdRef;
 use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
@@ -32,6 +28,12 @@ use crate::{Decimal, Int, IonError, IonResult, IonType, RawSymbolTokenRef, Symbo
 /// The largest possible 'L' (length) value that can be written directly in a type descriptor byte.
 /// Larger length values will need to be written as a VarUInt following the type descriptor.
 pub(crate) const MAX_INLINE_LENGTH: usize = 13;
+
+/// The initial size of the bump-allocated buffer created to hold a container's child elements.
+// This number was chosen somewhat arbitrarily and can be updated as needed.
+// TODO: Writers could track the largest container size they've seen and use that as their initial
+//       size to minimize reallocations.
+const DEFAULT_CONTAINER_BUFFER_SIZE: usize = 512;
 
 pub struct BinaryValueWriter_1_0<'value, 'top> {
     allocator: &'top BumpAllocator,
@@ -63,7 +65,7 @@ impl<'value, 'top> BinaryValueWriter_1_0<'value, 'top> {
         self.encoding_buffer.as_slice()
     }
 
-    pub fn write_symbol_id(mut self, symbol_id: SymbolId) -> IonResult<()> {
+    pub fn write_symbol_id(&mut self, symbol_id: SymbolId) -> IonResult<()> {
         const SYMBOL_BUFFER_SIZE: usize = mem::size_of::<u64>();
         let mut buffer = [0u8; SYMBOL_BUFFER_SIZE];
         let mut writer = std::io::Cursor::new(&mut buffer).writer();
@@ -83,7 +85,7 @@ impl<'value, 'top> BinaryValueWriter_1_0<'value, 'top> {
         Ok(())
     }
 
-    pub fn write_lob(mut self, value: &[u8], type_code: u8) -> IonResult<()> {
+    pub fn write_lob(&mut self, value: &[u8], type_code: u8) -> IonResult<()> {
         let encoded_length = value.len();
         let type_descriptor: u8;
         if encoded_length <= MAX_INLINE_LENGTH {
@@ -98,7 +100,7 @@ impl<'value, 'top> BinaryValueWriter_1_0<'value, 'top> {
         Ok(())
     }
 
-    pub fn write_null(mut self, ion_type: IonType) -> IonResult<()> {
+    pub fn write_null(&mut self, ion_type: IonType) -> IonResult<()> {
         let byte: u8 = match ion_type {
             IonType::Null => 0x0F,
             IonType::Bool => 0x1F,
@@ -118,13 +120,13 @@ impl<'value, 'top> BinaryValueWriter_1_0<'value, 'top> {
         Ok(())
     }
 
-    pub fn write_bool(mut self, value: bool) -> IonResult<()> {
+    pub fn write_bool(&mut self, value: bool) -> IonResult<()> {
         let byte: u8 = if value { 0x11 } else { 0x10 };
         self.push_byte(byte);
         Ok(())
     }
 
-    pub fn write_i64(mut self, value: i64) -> IonResult<()> {
+    pub fn write_i64(&mut self, value: i64) -> IonResult<()> {
         // Get the absolute value of the i64 and store it in a u64.
         let magnitude: u64 = value.unsigned_abs();
         let encoded = uint::encode_u64(magnitude);
@@ -144,7 +146,7 @@ impl<'value, 'top> BinaryValueWriter_1_0<'value, 'top> {
         Ok(())
     }
 
-    pub fn write_int(mut self, value: &Int) -> IonResult<()> {
+    pub fn write_int(&mut self, value: &Int) -> IonResult<()> {
         // If the `value` is an `i64`, use `write_i64` and return.
         let value = match &value.data {
             IntData::I64(i) => return self.write_i64(*i),
@@ -179,7 +181,7 @@ impl<'value, 'top> BinaryValueWriter_1_0<'value, 'top> {
         Ok(())
     }
 
-    pub fn write_f32(mut self, value: f32) -> IonResult<()> {
+    pub fn write_f32(&mut self, value: f32) -> IonResult<()> {
         if value == 0f32 && !value.is_sign_negative() {
             self.push_byte(0x40);
             return Ok(());
@@ -190,7 +192,7 @@ impl<'value, 'top> BinaryValueWriter_1_0<'value, 'top> {
         Ok(())
     }
 
-    pub fn write_f64(mut self, value: f64) -> IonResult<()> {
+    pub fn write_f64(&mut self, value: f64) -> IonResult<()> {
         if value == 0f64 && !value.is_sign_negative() {
             self.push_byte(0x40);
             return Ok(());
@@ -201,17 +203,17 @@ impl<'value, 'top> BinaryValueWriter_1_0<'value, 'top> {
         Ok(())
     }
 
-    pub fn write_decimal(self, value: &Decimal) -> IonResult<()> {
+    pub fn write_decimal(&mut self, value: &Decimal) -> IonResult<()> {
         let _encoded_size = self.encoding_buffer.encode_decimal_value(value)?;
         Ok(())
     }
 
-    pub fn write_timestamp(self, value: &Timestamp) -> IonResult<()> {
+    pub fn write_timestamp(&mut self, value: &Timestamp) -> IonResult<()> {
         let _ = self.encoding_buffer.encode_timestamp_value(value)?;
         Ok(())
     }
 
-    pub fn write_string<A: AsRef<str>>(mut self, value: A) -> IonResult<()> {
+    pub fn write_string<A: AsRef<str>>(&mut self, value: A) -> IonResult<()> {
         let text: &str = value.as_ref();
         let encoded_length = text.len(); // The number of utf8 bytes
 
@@ -228,7 +230,7 @@ impl<'value, 'top> BinaryValueWriter_1_0<'value, 'top> {
         Ok(())
     }
 
-    pub fn write_symbol<A: AsRawSymbolTokenRef>(self, value: A) -> IonResult<()> {
+    pub fn write_symbol<A: AsRawSymbolTokenRef>(&mut self, value: A) -> IonResult<()> {
         match value.as_raw_symbol_token_ref() {
             RawSymbolTokenRef::SymbolId(sid) => self.write_symbol_id(sid),
             RawSymbolTokenRef::Text(text) => IonResult::illegal_operation(format!(
@@ -237,25 +239,16 @@ impl<'value, 'top> BinaryValueWriter_1_0<'value, 'top> {
         }
     }
 
-    pub fn write_clob<A: AsRef<[u8]>>(self, value: A) -> IonResult<()> {
+    pub fn write_clob<A: AsRef<[u8]>>(&mut self, value: A) -> IonResult<()> {
         let bytes: &[u8] = value.as_ref();
         // The clob type descriptor's high nibble is type code 9
         self.write_lob(bytes, 0x90)
     }
 
-    pub fn write_blob<A: AsRef<[u8]>>(self, value: A) -> IonResult<()> {
+    pub fn write_blob<A: AsRef<[u8]>>(&mut self, value: A) -> IonResult<()> {
         let bytes: &[u8] = value.as_ref();
         // The blob type descriptor's high nibble is type code 10 (0xA)
         self.write_lob(bytes, 0xA0)
-    }
-
-    fn list_writer(&mut self) -> BinaryListWriter_1_0<'_, 'top> {
-        const LIST_TYPE_CODE: u8 = 0xB0;
-        BinaryListWriter_1_0::new(BinaryContainerWriter_1_0::new(
-            LIST_TYPE_CODE,
-            self.allocator,
-            self.encoding_buffer,
-        ))
     }
 
     fn sexp_writer(&mut self) -> BinarySExpWriter_1_0<'_, 'top> {
@@ -276,37 +269,97 @@ impl<'value, 'top> BinaryValueWriter_1_0<'value, 'top> {
         ))
     }
 
-    fn write_list<
-        F: for<'a> FnOnce(&mut <Self as ValueWriter>::ListWriter<'a>) -> IonResult<()>,
-    >(
-        mut self,
-        list_fn: F,
-    ) -> IonResult<()> {
-        self.list_writer().write_values(list_fn)
+    fn write_list(&mut self, list_fn: impl ListFn<Self>) -> IonResult<()> {
+        const LIST_TYPE_CODE: u8 = 0xB0;
+        let child_encoding_buffer = self.allocator.alloc_with(|| {
+            BumpVec::with_capacity_in(DEFAULT_CONTAINER_BUFFER_SIZE, self.allocator)
+        });
+        // Create a BinaryListWriter_1_0 to pass to the user's closure.
+        let mut list_writer = BinaryListWriter_1_0::new(BinaryContainerWriter_1_0::new(
+            LIST_TYPE_CODE,
+            self.allocator,
+            child_encoding_buffer,
+        ));
+        // Pass it to the closure, allowing the user to encode child values.
+        list_fn(&mut list_writer)?;
+        // Write the appropriate opcode for a list of this length.
+        let encoded_length = list_writer.buffer().len();
+        match encoded_length {
+            0..=15 => {
+                let opcode = 0xB0 | encoded_length as u8;
+                self.push_byte(opcode);
+            }
+            _ => {
+                let opcode = 0xBE; // List w/VarUInt length
+                self.push_byte(opcode);
+                VarUInt::write_u64(self.encoding_buffer, encoded_length as u64)?;
+            }
+        }
+        self.push_bytes(list_writer.buffer());
+        Ok(())
     }
-    fn write_sexp<
-        F: for<'a> FnOnce(&mut <Self as ValueWriter>::SExpWriter<'a>) -> IonResult<()>,
-    >(
-        mut self,
-        sexp_fn: F,
-    ) -> IonResult<()> {
-        self.sexp_writer().write_values(sexp_fn)
+    fn write_sexp(&mut self, sexp_fn: impl SExpFn<Self>) -> IonResult<()> {
+        const SEXP_TYPE_CODE: u8 = 0xC0;
+        let child_encoding_buffer = self.allocator.alloc_with(|| {
+            BumpVec::with_capacity_in(DEFAULT_CONTAINER_BUFFER_SIZE, self.allocator)
+        });
+        // Create a BinarySExpWriter_1_0 to pass to the user's closure.
+        let mut sexp_writer = BinarySExpWriter_1_0::new(BinaryContainerWriter_1_0::new(
+            SEXP_TYPE_CODE,
+            self.allocator,
+            child_encoding_buffer,
+        ));
+        // Pass it to the closure, allowing the user to encode child values.
+        sexp_fn(&mut sexp_writer)?;
+        // Write the appropriate opcode for a sexp of this length.
+        let encoded_length = sexp_writer.buffer().len();
+        match encoded_length {
+            0..=15 => {
+                let opcode = 0xC0 | encoded_length as u8;
+                self.push_byte(opcode);
+            }
+            _ => {
+                let opcode = 0xCE; // SExp w/VarUInt length
+                self.push_byte(opcode);
+                VarUInt::write_u64(self.encoding_buffer, encoded_length as u64)?;
+            }
+        }
+        self.push_bytes(sexp_writer.buffer());
+        Ok(())
     }
-    fn write_struct<
-        F: for<'a> FnOnce(&mut <Self as ValueWriter>::StructWriter<'a>) -> IonResult<()>,
-    >(
-        mut self,
-        struct_fn: F,
-    ) -> IonResult<()> {
-        self.struct_writer().write_fields(struct_fn)
+    fn write_struct(&mut self, struct_fn: impl StructFn<Self>) -> IonResult<()> {
+        const STRUCT_TYPE_CODE: u8 = 0xD0;
+        let child_encoding_buffer = self.allocator.alloc_with(|| {
+            BumpVec::with_capacity_in(DEFAULT_CONTAINER_BUFFER_SIZE, self.allocator)
+        });
+        // Create a BinarySExpWriter_1_0 to pass to the user's closure.
+        let mut struct_writer = BinaryStructWriter_1_0::new(BinaryContainerWriter_1_0::new(
+            STRUCT_TYPE_CODE,
+            self.allocator,
+            child_encoding_buffer,
+        ));
+        // Pass it to the closure, allowing the user to encode child values.
+        struct_fn(&mut struct_writer)?;
+        // Write the appropriate opcode for a struct of this length.
+        let encoded_length = struct_writer.buffer().len();
+        match encoded_length {
+            0..=15 => {
+                let opcode = 0xD0 | encoded_length as u8;
+                self.push_byte(opcode);
+            }
+            _ => {
+                let opcode = 0xDE; // Struct w/VarUInt length
+                self.push_byte(opcode);
+                VarUInt::write_u64(self.encoding_buffer, encoded_length as u64)?;
+            }
+        }
+        self.push_bytes(struct_writer.buffer());
+        Ok(())
     }
-    fn write_eexp<
-        'macro_id,
-        F: for<'a> FnOnce(&mut <Self as ValueWriter>::MacroArgsWriter<'a>) -> IonResult<()>,
-    >(
-        self,
+    fn write_eexp<'macro_id>(
+        &mut self,
         macro_id: impl Into<MacroIdRef<'macro_id>>,
-        _macro_fn: F,
+        _macro_fn: impl MacroArgsFn<Self>,
     ) -> IonResult<()> {
         let id = macro_id.into();
         IonResult::encoding_error(format!(
@@ -318,13 +371,27 @@ impl<'value, 'top> BinaryValueWriter_1_0<'value, 'top> {
 impl<'value, 'top> Sealed for BinaryValueWriter_1_0<'value, 'top> {}
 
 impl<'value, 'top> ValueWriter for BinaryValueWriter_1_0<'value, 'top> {
-    type ListWriter<'a> = BinaryListValuesWriter_1_0<'a>;
-    type SExpWriter<'a> = BinarySExpValuesWriter_1_0<'a>;
-    type StructWriter<'a> = BinaryStructFieldsWriter_1_0<'a>;
+    type ListWriter = BinaryListWriter_1_0<'value, 'top>;
+    type SExpWriter = BinarySExpWriter_1_0<'value, 'top>;
+    type StructWriter = BinaryStructWriter_1_0<'value, 'top>;
 
-    type MacroArgsWriter<'a> = Never;
+    type MacroArgsWriter = Never;
 
-    delegate_value_writer_to_self!();
+    delegate_value_writer_to!(closure |_self: Self| BinaryValueWriterRef_1_0(_self));
+}
+
+// TODO: Doc comment
+pub(crate) struct BinaryValueWriterRef_1_0<'value, 'top>(
+    pub(crate) BinaryValueWriter_1_0<'value, 'top>,
+);
+
+impl<'value, 'top> ValueWriter for &mut BinaryValueWriterRef_1_0<'value, 'top> {
+    type ListWriter = BinaryListWriter_1_0<'value, 'top>;
+    type SExpWriter = BinarySExpWriter_1_0<'value, 'top>;
+    type StructWriter = BinaryStructWriter_1_0<'value, 'top>;
+    type MacroArgsWriter = Never;
+
+    delegate_value_writer_to!(closure |self_: Self| &mut self_.0);
 }
 
 pub struct BinaryAnnotatableValueWriter_1_0<'value, 'top> {
@@ -388,24 +455,62 @@ impl<'value, 'top, SymbolType: AsRawSymbolTokenRef>
     }
 }
 
+/// Takes a series of `TYPE => METHOD` pairs, generating a function for each that encodes an
+/// annotations sequence and then delegates encoding the value to the corresponding value writer
+/// method.
+macro_rules! annotate_and_delegate_1_0 {
+    // End of iteration
+    () => {};
+    // Recurses one argument pair at a time
+    ($value_type:ty => $method:ident, $($rest:tt)*) => {
+        fn $method(self, value: $value_type) -> IonResult<()> {
+            let allocator = self.allocator;
+            let buffer = allocator.alloc_with(|| BumpVec::new_in(allocator));
+            let value_writer =
+                $crate::lazy::encoder::binary::v1_0::value_writer::BinaryValueWriter_1_0::new(
+                    self.allocator,
+                    buffer,
+                );
+            value_writer.$method(value)?;
+            self.annotate_encoded_value(buffer.as_slice())
+        }
+        annotate_and_delegate_1_0!($($rest)*);
+    };
+}
+
+trait EncodeValueFn<V>: FnOnce(&mut V) -> IonResult<()>
+where
+    for<'a> &'a mut V: ValueWriter,
+{
+    fn encode_value(self, value_writer: &mut V) -> IonResult<()>;
+}
+
+impl<V, F> EncodeValueFn<V> for F
+where
+    F: FnOnce(&mut V) -> IonResult<()>,
+    for<'a> &'a mut V: ValueWriter,
+{
+    fn encode_value(self, value_writer: &mut V) -> IonResult<()> {
+        self(value_writer)
+    }
+}
+
 impl<'value, 'top, SymbolType: AsRawSymbolTokenRef>
     BinaryAnnotationsWrapperWriter<'value, 'top, SymbolType>
 {
-    fn encode_annotated<F>(self, encode_value_fn: F) -> IonResult<()>
-    where
-        F: for<'a> FnOnce(BinaryAnnotatedValueWriter_1_0<'a, 'top>) -> IonResult<()>,
-    {
+    fn encode_annotated(
+        self,
+        encode_value_fn: impl EncodeValueFn<BinaryValueWriterRef_1_0<'value, 'top>>,
+    ) -> IonResult<()> {
         let allocator = self.allocator;
         let buffer = allocator.alloc_with(|| BumpVec::new_in(allocator));
-        {
-            let annotated_value_writer =
-                BinaryAnnotatedValueWriter_1_0::new(self.allocator, buffer);
-            encode_value_fn(annotated_value_writer)?;
-        }
-        self.annotate_encoded_value(buffer.as_slice())
+        let value_writer = BinaryValueWriter_1_0::new(self.allocator, buffer);
+        let vw_ref = &mut BinaryValueWriterRef_1_0(value_writer);
+        encode_value_fn.encode_value(vw_ref)?;
+        self.annotate_encoded_value(vw_ref.0.buffer())
     }
 
-    fn annotate_encoded_value(self, encoded_value: &[u8]) -> IonResult<()> {
+    pub(crate) fn annotate_encoded_value(self, encoded_value: &[u8]) -> IonResult<()> {
         let mut encoded_annotations_sequence = BumpVec::new_in(self.allocator);
         self.encode_annotations_sequence(&mut encoded_annotations_sequence)?;
 
@@ -457,15 +562,15 @@ impl<'value, 'top, SymbolType: AsRawSymbolTokenRef> Sealed
 impl<'value, 'top, SymbolType: AsRawSymbolTokenRef> ValueWriter
     for BinaryAnnotationsWrapperWriter<'value, 'top, SymbolType>
 {
-    type ListWriter<'a> = BinaryListValuesWriter_1_0<'a>;
-    type SExpWriter<'a> = BinarySExpValuesWriter_1_0<'a>;
+    type ListWriter = BinaryListWriter_1_0<'value, 'top>;
+    type SExpWriter = BinarySExpWriter_1_0<'value, 'top>;
 
-    type StructWriter<'a> = BinaryStructFieldsWriter_1_0<'a>;
+    type StructWriter = BinaryStructWriter_1_0<'value, 'top>;
 
     // Ion 1.0
-    type MacroArgsWriter<'a> = Never;
+    type MacroArgsWriter = Never;
 
-    annotate_and_delegate!(
+    annotate_and_delegate_1_0!(
         IonType => write_null,
         bool => write_bool,
         i64 => write_i64,
@@ -479,30 +584,20 @@ impl<'value, 'top, SymbolType: AsRawSymbolTokenRef> ValueWriter
         impl AsRef<[u8]> => write_clob,
         impl AsRef<[u8]> => write_blob,
     );
-
-    fn write_list<F: for<'a> FnOnce(&mut Self::ListWriter<'a>) -> IonResult<()>>(
-        self,
-        list_fn: F,
-    ) -> IonResult<()> {
+    fn write_list(self, list_fn: impl ListFn<Self>) -> IonResult<()> {
         self.encode_annotated(|value_writer| value_writer.write_list(list_fn))
     }
-    fn write_sexp<F: for<'a> FnOnce(&mut Self::SExpWriter<'a>) -> IonResult<()>>(
-        self,
-        sexp_fn: F,
-    ) -> IonResult<()> {
+    fn write_sexp(self, sexp_fn: impl SExpFn<Self>) -> IonResult<()> {
         self.encode_annotated(|value_writer| value_writer.write_sexp(sexp_fn))
     }
-    fn write_struct<F: for<'a> FnOnce(&mut Self::StructWriter<'a>) -> IonResult<()>>(
-        self,
-        struct_fn: F,
-    ) -> IonResult<()> {
+    fn write_struct(self, struct_fn: impl StructFn<Self>) -> IonResult<()> {
         self.encode_annotated(|value_writer| value_writer.write_struct(struct_fn))
     }
 
-    fn write_eexp<'macro_id, F: for<'a> FnOnce(&mut Self::MacroArgsWriter<'a>) -> IonResult<()>>(
+    fn write_eexp<'macro_id>(
         self,
         macro_id: impl Into<MacroIdRef<'macro_id>>,
-        _macro_fn: F,
+        _macro_fn: impl MacroArgsFn<Self>,
     ) -> IonResult<()> {
         let id = macro_id.into();
         IonResult::encoding_error(format!(
@@ -511,43 +606,13 @@ impl<'value, 'top, SymbolType: AsRawSymbolTokenRef> ValueWriter
     }
 }
 
-pub struct BinaryAnnotatedValueWriter_1_0<'value, 'top> {
-    allocator: &'top BumpAllocator,
-    // Note that unlike the BinaryValueWriter_1_0, the borrow and the BumpVec here have the same
-    // lifetime. This allows this type to be passed as a closure argument.
-    buffer: &'value mut BumpVec<'top, u8>,
-}
-
-impl<'value, 'top> BinaryAnnotatedValueWriter_1_0<'value, 'top> {
-    pub fn new(allocator: &'top BumpAllocator, buffer: &'value mut BumpVec<'top, u8>) -> Self {
-        Self { allocator, buffer }
-    }
-    pub(crate) fn value_writer(self) -> BinaryValueWriter_1_0<'value, 'top> {
-        BinaryValueWriter_1_0::new(self.allocator, self.buffer)
-    }
-
-    pub(crate) fn buffer(&self) -> &[u8] {
-        self.buffer.as_slice()
-    }
-}
-
-impl<'value, 'top> Sealed for BinaryAnnotatedValueWriter_1_0<'value, 'top> {}
-
-impl<'value, 'top: 'value> ValueWriter for BinaryAnnotatedValueWriter_1_0<'value, 'top> {
-    type ListWriter<'a> = BinaryListValuesWriter_1_0<'a>;
-    type SExpWriter<'a> = BinarySExpValuesWriter_1_0<'a>;
-    type StructWriter<'a> = BinaryStructFieldsWriter_1_0<'a>;
-
-    // Ion 1.0 does not support macros
-    type MacroArgsWriter<'a> = Never;
-
-    delegate_value_writer_to!(closure |self_: Self| self_.value_writer());
-}
 #[cfg(test)]
 mod tests {
     use crate::lazy::encoder::annotate::Annotate;
     use crate::lazy::encoder::binary::v1_0::writer::LazyRawBinaryWriter_1_0;
     use crate::lazy::encoder::value_writer::AnnotatableValueWriter;
+    use crate::lazy::encoder::value_writer::SequenceWriter;
+    use crate::lazy::encoder::value_writer::StructWriter;
     use crate::lazy::encoder::write_as_ion::WriteAsSExp;
     use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
     use crate::{Element, IonData, IonResult, RawSymbolTokenRef, Timestamp};

--- a/src/lazy/encoder/binary/v1_0/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_0/value_writer.rs
@@ -17,7 +17,9 @@ use crate::lazy::encoder::binary::v1_0::container_writers::{
 };
 use crate::lazy::encoder::container_fn::{ListFn, MacroArgsFn, SExpFn, StructFn};
 use crate::lazy::encoder::private::Sealed;
-use crate::lazy::encoder::value_writer::{delegate_value_writer_to, AnnotatableValueWriter, ValueWriter};
+use crate::lazy::encoder::value_writer::{
+    delegate_value_writer_to, AnnotatableValueWriter, ValueWriter,
+};
 use crate::lazy::never::Never;
 use crate::lazy::text::raw::v1_1::reader::MacroIdRef;
 use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;

--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -624,20 +624,14 @@ impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
         Ok(())
     }
 
-    fn write_sexp(
-        self,
-        sexp_fn: impl SExpFn<Self>,
-    ) -> IonResult<()> {
+    fn write_sexp(self, sexp_fn: impl SExpFn<Self>) -> IonResult<()> {
         if self.delimited_containers {
             return self.write_delimited_sexp(sexp_fn);
         }
         self.write_length_prefixed_sexp(sexp_fn)
     }
 
-    fn write_length_prefixed_sexp(
-        mut self,
-        sexp_fn: impl SExpFn<Self>,
-    ) -> IonResult<()> {
+    fn write_length_prefixed_sexp(mut self, sexp_fn: impl SExpFn<Self>) -> IonResult<()> {
         // We're writing a length-prefixed sexp, so we need to set up a space to encode the sexp's children.
         let child_encoding_buffer = self.allocator.alloc_with(|| {
             BumpVec::with_capacity_in(DEFAULT_CONTAINER_BUFFER_SIZE, self.allocator)
@@ -665,10 +659,7 @@ impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
         Ok(())
     }
 
-    fn write_delimited_sexp(
-        self,
-        sexp_fn: impl SExpFn<Self>,
-    ) -> IonResult<()> {
+    fn write_delimited_sexp(self, sexp_fn: impl SExpFn<Self>) -> IonResult<()> {
         let child_encoding_buffer = self.encoding_buffer;
         let container_writer =
             BinaryContainerWriter_1_1::new(self.allocator, child_encoding_buffer);

--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -6,7 +6,6 @@ use ice_code::ice as cold_path;
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 
-use crate::lazy::encoder::binary::annotate_and_delegate;
 use crate::lazy::encoder::binary::v1_1::container_writers::{
     BinaryContainerWriter_1_1, BinaryListWriter_1_1, BinaryMacroArgsWriter_1_1,
     BinarySExpWriter_1_1, BinaryStructWriter_1_1,
@@ -14,6 +13,7 @@ use crate::lazy::encoder::binary::v1_1::container_writers::{
 use crate::lazy::encoder::binary::v1_1::fixed_int::FixedInt;
 use crate::lazy::encoder::binary::v1_1::fixed_uint::FixedUInt;
 use crate::lazy::encoder::binary::v1_1::flex_sym::FlexSym;
+use crate::lazy::encoder::container_fn::{ListFn, MacroArgsFn, SExpFn, StructFn};
 use crate::lazy::encoder::private::Sealed;
 use crate::lazy::encoder::value_writer::{
     delegate_value_writer_to_self, AnnotatableValueWriter, ValueWriter,
@@ -578,24 +578,14 @@ impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
         Ok(())
     }
 
-    pub fn write_list<
-        F: for<'a> FnOnce(&mut <Self as ValueWriter>::ListWriter<'a>) -> IonResult<()>,
-    >(
-        self,
-        list_fn: F,
-    ) -> IonResult<()> {
+    fn write_list(self, list_fn: impl ListFn<Self>) -> IonResult<()> {
         if self.delimited_containers {
             return self.write_delimited_list(list_fn);
         }
         self.write_length_prefixed_list(list_fn)
     }
 
-    pub fn write_length_prefixed_list<
-        F: for<'a> FnOnce(&mut <Self as ValueWriter>::ListWriter<'a>) -> IonResult<()>,
-    >(
-        mut self,
-        list_fn: F,
-    ) -> IonResult<()> {
+    fn write_length_prefixed_list(mut self, list_fn: impl ListFn<Self>) -> IonResult<()> {
         // We're writing a length-prefixed list, so we need to set up a space to encode the list's children.
         let child_encoding_buffer = self.allocator.alloc_with(|| {
             BumpVec::with_capacity_in(DEFAULT_CONTAINER_BUFFER_SIZE, self.allocator)
@@ -623,12 +613,7 @@ impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
         Ok(())
     }
 
-    fn write_delimited_list<
-        F: for<'a> FnOnce(&mut <Self as ValueWriter>::ListWriter<'a>) -> IonResult<()>,
-    >(
-        self,
-        list_fn: F,
-    ) -> IonResult<()> {
+    fn write_delimited_list(self, list_fn: impl ListFn<Self>) -> IonResult<()> {
         let child_encoding_buffer = self.encoding_buffer;
         let container_writer =
             BinaryContainerWriter_1_1::new(self.allocator, child_encoding_buffer);
@@ -639,11 +624,9 @@ impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
         Ok(())
     }
 
-    fn write_sexp<
-        F: for<'a> FnOnce(&mut <Self as ValueWriter>::SExpWriter<'a>) -> IonResult<()>,
-    >(
+    fn write_sexp(
         self,
-        sexp_fn: F,
+        sexp_fn: impl SExpFn<Self>,
     ) -> IonResult<()> {
         if self.delimited_containers {
             return self.write_delimited_sexp(sexp_fn);
@@ -651,11 +634,9 @@ impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
         self.write_length_prefixed_sexp(sexp_fn)
     }
 
-    fn write_length_prefixed_sexp<
-        F: for<'a> FnOnce(&mut <Self as ValueWriter>::SExpWriter<'a>) -> IonResult<()>,
-    >(
+    fn write_length_prefixed_sexp(
         mut self,
-        sexp_fn: F,
+        sexp_fn: impl SExpFn<Self>,
     ) -> IonResult<()> {
         // We're writing a length-prefixed sexp, so we need to set up a space to encode the sexp's children.
         let child_encoding_buffer = self.allocator.alloc_with(|| {
@@ -684,11 +665,9 @@ impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
         Ok(())
     }
 
-    fn write_delimited_sexp<
-        F: for<'a> FnOnce(&mut <Self as ValueWriter>::SExpWriter<'a>) -> IonResult<()>,
-    >(
+    fn write_delimited_sexp(
         self,
-        sexp_fn: F,
+        sexp_fn: impl SExpFn<Self>,
     ) -> IonResult<()> {
         let child_encoding_buffer = self.encoding_buffer;
         let container_writer =
@@ -700,12 +679,7 @@ impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
         Ok(())
     }
 
-    fn write_struct<
-        F: for<'a> FnOnce(&mut <Self as ValueWriter>::StructWriter<'a>) -> IonResult<()>,
-    >(
-        self,
-        struct_fn: F,
-    ) -> IonResult<()> {
+    fn write_struct(self, struct_fn: impl StructFn<Self>) -> IonResult<()> {
         if self.delimited_containers {
             self.write_delimited_struct(struct_fn)
         } else {
@@ -713,12 +687,7 @@ impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
         }
     }
 
-    fn write_delimited_struct<
-        F: for<'a> FnOnce(&mut <Self as ValueWriter>::StructWriter<'a>) -> IonResult<()>,
-    >(
-        self,
-        struct_fn: F,
-    ) -> IonResult<()> {
+    fn write_delimited_struct(self, struct_fn: impl StructFn<Self>) -> IonResult<()> {
         let fields_encoding_buffer = self.encoding_buffer;
         let container_writer =
             BinaryContainerWriter_1_1::new(self.allocator, fields_encoding_buffer);
@@ -729,12 +698,7 @@ impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
         Ok(())
     }
 
-    fn write_length_prefixed_struct<
-        F: for<'a> FnOnce(&mut <Self as ValueWriter>::StructWriter<'a>) -> IonResult<()>,
-    >(
-        mut self,
-        struct_fn: F,
-    ) -> IonResult<()> {
+    fn write_length_prefixed_struct(mut self, struct_fn: impl StructFn<Self>) -> IonResult<()> {
         // We're writing a length-prefixed struct, so we need to set up a space to encode the struct's fields.
         let field_encoding_buffer = self.allocator.alloc_with(|| {
             BumpVec::with_capacity_in(DEFAULT_CONTAINER_BUFFER_SIZE, self.allocator)
@@ -762,13 +726,10 @@ impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
         Ok(())
     }
 
-    fn write_eexp<
-        'macro_id,
-        F: for<'a> FnOnce(&mut <Self as ValueWriter>::MacroArgsWriter<'a>) -> IonResult<()>,
-    >(
+    fn write_eexp<'macro_id>(
         self,
         macro_id: impl Into<MacroIdRef<'macro_id>>,
-        macro_fn: F,
+        macro_fn: impl MacroArgsFn<Self>,
     ) -> IonResult<()> {
         match macro_id.into() {
             MacroIdRef::LocalName(_name) => {
@@ -792,11 +753,11 @@ impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
 impl<'value, 'top> Sealed for BinaryValueWriter_1_1<'value, 'top> {}
 
 impl<'value, 'top> ValueWriter for BinaryValueWriter_1_1<'value, 'top> {
-    type ListWriter<'a> = BinaryListWriter_1_1<'value, 'top>;
-    type SExpWriter<'a> = BinarySExpWriter_1_1<'value, 'top>;
-    type StructWriter<'a> = BinaryStructWriter_1_1<'value, 'top>;
+    type ListWriter = BinaryListWriter_1_1<'value, 'top>;
+    type SExpWriter = BinarySExpWriter_1_1<'value, 'top>;
+    type StructWriter = BinaryStructWriter_1_1<'value, 'top>;
 
-    type MacroArgsWriter<'a> = BinaryMacroArgsWriter_1_1<'value, 'top>;
+    type MacroArgsWriter = BinaryMacroArgsWriter_1_1<'value, 'top>;
 
     delegate_value_writer_to_self!();
 }
@@ -848,6 +809,45 @@ impl<'value, 'top> AnnotatableValueWriter for BinaryAnnotatableValueWriter_1_1<'
         writer.delimited_containers = self.delimited_containers;
         writer
     }
+}
+
+/// Takes a series of `TYPE => METHOD` pairs, generating a function for each that encodes an
+/// annotations sequence and then delegates encoding the value to the corresponding value writer
+/// method.
+macro_rules! annotate_and_delegate_1_1 {
+    // End of iteration
+    () => {};
+    // Recurses one argument pair at a time
+    ($value_type:ty => $method:ident, $($rest:tt)*) => {
+        fn $method(mut self, value: $value_type) -> IonResult<()> {
+            match self.annotations {
+                [] => {
+                    // There are no annotations; nothing to do.
+                }
+                [a] => {
+                    // Opcode 0xE7: A single FlexSym annotation follows
+                    self.buffer.push(0xE7);
+                    FlexSym::encode_symbol(self.buffer, a);
+                }
+                [a1, a2] => {
+                    // Opcode 0xE8: Two FlexSym annotations follow
+                    self.buffer.push(0xE8);
+                    FlexSym::encode_symbol(self.buffer, a1);
+                    FlexSym::encode_symbol(self.buffer, a2);
+                }
+                _ => {
+                    self.write_length_prefixed_flex_sym_annotation_sequence();
+                }
+            }
+            // We've encoded the annotations, now create a no-annotations ValueWriter to encode the value itself.
+            let value_writer = $crate::lazy::encoder::binary::v1_1::value_writer::BinaryValueWriter_1_1::new(self.allocator, self.buffer);
+            value_writer.$method(value)
+            // encode_value_fn(value_writer)
+            // self.encode_annotated(|value_writer| value_writer.$method(value))
+            // <Self as AnnotateAndDelegate>::encode_annotated(self, |value_writer| value_writer.$method(value))
+        }
+        annotate_and_delegate_1_1!($($rest)*);
+    };
 }
 
 pub struct BinaryAnnotatedValueWriter_1_1<'value, 'top, SymbolType: AsRawSymbolTokenRef> {
@@ -922,12 +922,12 @@ impl<'value, 'top, SymbolType: AsRawSymbolTokenRef> Sealed
 impl<'value, 'top, SymbolType: AsRawSymbolTokenRef> ValueWriter
     for BinaryAnnotatedValueWriter_1_1<'value, 'top, SymbolType>
 {
-    type ListWriter<'a> = BinaryListWriter_1_1<'value, 'top>;
-    type SExpWriter<'a> = BinarySExpWriter_1_1<'value, 'top>;
-    type StructWriter<'a> = BinaryStructWriter_1_1<'value, 'top>;
-    type MacroArgsWriter<'a> = BinaryMacroArgsWriter_1_1<'value, 'top>;
+    type ListWriter = BinaryListWriter_1_1<'value, 'top>;
+    type SExpWriter = BinarySExpWriter_1_1<'value, 'top>;
+    type StructWriter = BinaryStructWriter_1_1<'value, 'top>;
+    type MacroArgsWriter = BinaryMacroArgsWriter_1_1<'value, 'top>;
 
-    annotate_and_delegate!(
+    annotate_and_delegate_1_1!(
         IonType => write_null,
         bool => write_bool,
         i64 => write_i64,
@@ -942,29 +942,22 @@ impl<'value, 'top, SymbolType: AsRawSymbolTokenRef> ValueWriter
         impl AsRef<[u8]> => write_blob,
     );
 
-    fn write_list<F: for<'a> FnOnce(&mut Self::ListWriter<'a>) -> IonResult<()>>(
-        self,
-        list_fn: F,
-    ) -> IonResult<()> {
+    fn write_list(self, list_fn: impl ListFn<Self>) -> IonResult<()> {
         self.encode_annotated(|value_writer| value_writer.write_list(list_fn))
     }
-    fn write_sexp<F: for<'a> FnOnce(&mut Self::SExpWriter<'a>) -> IonResult<()>>(
-        self,
-        sexp_fn: F,
-    ) -> IonResult<()> {
+
+    fn write_sexp(self, sexp_fn: impl SExpFn<Self>) -> IonResult<()> {
         self.encode_annotated(|value_writer| value_writer.write_sexp(sexp_fn))
     }
-    fn write_struct<F: for<'a> FnOnce(&mut Self::StructWriter<'a>) -> IonResult<()>>(
-        self,
-        struct_fn: F,
-    ) -> IonResult<()> {
+    fn write_struct(self, struct_fn: impl StructFn<Self>) -> IonResult<()> {
         self.encode_annotated(|value_writer| value_writer.write_struct(struct_fn))
     }
-    fn write_eexp<'macro_id, F: for<'a> FnOnce(&mut Self::MacroArgsWriter<'a>) -> IonResult<()>>(
+    fn write_eexp<'macro_id>(
         self,
         macro_id: impl Into<MacroIdRef<'macro_id>>,
-        macro_fn: F,
+        macro_fn: impl MacroArgsFn<Self>,
     ) -> IonResult<()> {
+        // todo!()
         self.encode_annotated(|value_writer| value_writer.write_eexp(macro_id, macro_fn))
     }
 }

--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -833,9 +833,6 @@ macro_rules! annotate_and_delegate_1_1 {
             // We've encoded the annotations, now create a no-annotations ValueWriter to encode the value itself.
             let value_writer = $crate::lazy::encoder::binary::v1_1::value_writer::BinaryValueWriter_1_1::new(self.allocator, self.buffer);
             value_writer.$method(value)
-            // encode_value_fn(value_writer)
-            // self.encode_annotated(|value_writer| value_writer.$method(value))
-            // <Self as AnnotateAndDelegate>::encode_annotated(self, |value_writer| value_writer.$method(value))
         }
         annotate_and_delegate_1_1!($($rest)*);
     };

--- a/src/lazy/encoder/container_fn.rs
+++ b/src/lazy/encoder/container_fn.rs
@@ -1,6 +1,6 @@
 //! Container population traits that allow closures to be used in places where the borrow checker
-//! would normally balk due to point-in-time limitations [1].
-//! [1] https://blog.rust-lang.org/2022/10/28/gats-stabilization.html#implied-static-requirement-from-higher-ranked-trait-bounds
+//! would normally balk due to point-in-time limitations.
+//! See: <https://blog.rust-lang.org/2022/10/28/gats-stabilization.html#implied-static-requirement-from-higher-ranked-trait-bounds>
 
 use crate::lazy::encoder::value_writer::ValueWriter;
 use crate::IonResult;

--- a/src/lazy/encoder/container_fn.rs
+++ b/src/lazy/encoder/container_fn.rs
@@ -1,0 +1,56 @@
+//! Container population traits that allow closures to be used in places where the borrow checker
+//! would normally balk due to point-in-time limitations [1].
+//! [1] https://blog.rust-lang.org/2022/10/28/gats-stabilization.html#implied-static-requirement-from-higher-ranked-trait-bounds
+
+use crate::lazy::encoder::value_writer::ValueWriter;
+use crate::IonResult;
+
+/// Generates a trait with a single method that takes one of [`ValueWriter`]'s associated types as
+/// an argument. The trait extends `FnOnce(TheAssociatedType) -> IonResult<()>`, allowing it to be
+/// invoked directly as a closure. The macro also generates a blanket implementation of the trait
+/// for any closures that also implement `FnOnce(TheAssociatedType) -> IonResult<()>`.
+///
+/// For example:
+///```text
+///     container_fn_trait!(ListFn => ListWriter);
+///```
+///
+/// generates a trait `ListFn` with a single method:
+///```text
+///     fn populate(self, writer: &mut V::ListWriter) -> IonResult<()>;
+///```
+///
+/// Types that implement this trait can be invoked as though they were closures.
+/// Closures with the signature `(&mut V::ListWriter) -> IonResult<()>` automatically implement
+/// the trait.
+///
+/// This circular arrangement allows the compiler to accept closures that would otherwise
+/// require explicit Higher-Rank Trait Bounds, a feature which currently has limitations.
+macro_rules! container_fn_trait {
+    // End of iteration
+    () => {};
+    // Recurses one argument pair at a time
+    ($trait_name:ident => $assoc_type_name:ident, $($rest:tt)*) => {
+        pub trait $trait_name<V: ValueWriter>: FnOnce(&mut V::$assoc_type_name) -> IonResult<()> {
+            fn populate(self, writer: &mut V::$assoc_type_name) -> IonResult<()>;
+        }
+
+        impl<F, V: ValueWriter> $trait_name<V> for F
+            where
+                F: FnOnce(&mut V::$assoc_type_name) -> IonResult<()>,
+        {
+            fn populate(self, writer: &mut V::$assoc_type_name) -> IonResult<()> {
+                self(writer)
+            }
+        }
+
+        container_fn_trait!($($rest)*);
+    };
+}
+
+container_fn_trait!(
+    ListFn => ListWriter,
+    SExpFn => SExpWriter,
+    StructFn => StructWriter,
+    MacroArgsFn => MacroArgsWriter,
+);

--- a/src/lazy/encoder/mod.rs
+++ b/src/lazy/encoder/mod.rs
@@ -10,6 +10,7 @@ use value_writer::SequenceWriter;
 
 pub mod annotate;
 pub mod binary;
+pub(crate) mod container_fn;
 pub mod text;
 pub mod value_writer;
 pub mod write_as_ion;

--- a/src/lazy/encoder/write_as_ion.rs
+++ b/src/lazy/encoder/write_as_ion.rs
@@ -151,7 +151,7 @@ macro_rules! impl_write_as_ion_value_for_iterable {
             for<'a> &'a $item: WriteAsIon,
         {
             fn write_as_ion_value<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
-                writer.write_list(|list| {
+                writer.write_list(|list: &mut V::ListWriter| {
                     for value in self.iter() {
                         list.write(value)?;
                     }

--- a/src/types/symbol.rs
+++ b/src/types/symbol.rs
@@ -201,6 +201,7 @@ impl PartialEq<Symbol> for &str {
 
 // Note that if the Symbol has no text, this will return the empty string. This is unfortunate,
 // but implementing this trait is necessary to allow `Symbol` to be used as a HashMap key.
+// See issue https://github.com/amazon-ion/ion-rust/issues/444 for more information.
 impl Borrow<str> for Symbol {
     fn borrow(&self) -> &str {
         // If the

--- a/src/types/symbol.rs
+++ b/src/types/symbol.rs
@@ -34,7 +34,7 @@ impl Hash for SymbolText {
         match self {
             SymbolText::Shared(text) => text.hash(state),
             SymbolText::Owned(text) => text.hash(state),
-            SymbolText::Unknown => 0.hash(state),
+            SymbolText::Unknown => "".hash(state),
         }
     }
 }
@@ -199,12 +199,12 @@ impl PartialEq<Symbol> for &str {
     }
 }
 
-// Note that this method panics if the Symbol has unknown text! This is unfortunate but is required
-// in order to allow a HashMap<Symbol, _> to do lookups with a &str instead of a &Symbol
+// Note that if the Symbol has no text, this will return the empty string. This is unfortunate,
+// but implementing this trait is necessary to allow `Symbol` to be used as a HashMap key.
 impl Borrow<str> for Symbol {
     fn borrow(&self) -> &str {
-        self.text()
-            .expect("cannot borrow a &str from a Symbol with unknown text")
+        // If the
+        self.text().unwrap_or("")
     }
 }
 


### PR DESCRIPTION
The `ValueWriter` trait's container-writing methods (`write_list`, `write_sexp`, etc) take a closure using [HRTB](https://doc.rust-lang.org/nomicon/hrtb.html), allowing the user to call whatever methods they want on the provided container writer.

Unfortunately, due to a limitation in the compiler's implementation of HRTB evaluation, HRTB lifetimes are over-conservatively [assumed to be `'static`](https://blog.rust-lang.org/2022/10/28/gats-stabilization.html#implied-static-requirement-from-higher-ranked-trait-bounds). This constraint led to a number of workaround warts in the `ValueWriter` trait family.

This PR replaces those closures with a collection of new traits.

*Old signatures*
```rust
fn write_list<F: for<'a> FnOnce(&mut Self::ListWriter<'a>) -> IonResult<()>>(
    self,
    list_fn: F,
) -> IonResult<()>;

fn write_sexp<F: for<'a> FnOnce(&mut Self::SExpWriter<'a>) -> IonResult<()>>(
    self,
    sexp_fn: F,
) -> IonResult<()>;

fn write_struct<F: for<'a> FnOnce(&mut Self::StructWriter<'a>) -> IonResult<()>>(
    self,
    struct_fn: F,
) -> IonResult<()>;

fn write_eexp<'macro_id, F: for<'a> FnOnce(&mut Self::MacroArgsWriter<'a>) -> IonResult<()>>(
    self,
    _macro_id: impl Into<MacroIdRef<'macro_id>>,
    _macro_fn: F,
) -> IonResult<()>;
```

*New signatures*
```rust
fn write_list(self, list_fn: impl ListFn<Self>) -> IonResult<()>;

fn write_sexp(self, sexp_fn: impl SExpFn<Self>) -> IonResult<()>;

fn write_struct(self, struct_fn: impl StructFn<Self>) -> IonResult<()>;

fn write_eexp<'macro_id>(
    self,
    _macro_id: impl Into<MacroIdRef<'macro_id>>,
    _macro_fn: impl MacroArgsFn<Self>,
) -> IonResult<()>;
```

These traits are intentionally very close in meaning to the closures they replace. However, introducing them simplifies things quite a bit; in particular:
* We are able to remove a lifetime from each of `ValueWriter`'s associated types. For example: `ValueWriter::ListWriter<'a>` is now `ValueWriter::ListWriter`.
* Because the traits' generics do not involve HRTB (`for <'a> ...`), the compiler is able to accept the traits anywhere we were already accepting closures.
* We can automatically implement the new traits for the old closures, so there's no change to user code needed.
* Passing around values that implement these types is much less likely to lead to lifetime errors.
* The method signatures are less likely to cause your eyes to bleed.

This patch also modifies the behavior of `Symbol`'s implementation of `Borrow`, which allows `Symbol`s to be used as keys in a `HashMap`. Previously, the `Symbol` would panic if it had no text and the user called `borrow()` to get a `&str`. (See #444 for a more detailed write-up.) This PR encountered a spot in our implementation of `Struct`/`Fields` that needs to look up fields which have unknown text, causing the tests to trigger the panic. For now, I've modified the `Borrow` impl to return the empty string if no text is available. This allows symbols with unknown text to be used as HashMap keys, but it could be surprising behavior on the off chance that someone finds another use case for `Symbol`'s `Borrow` implementation. #444 discusses some long-term options that are more robust.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
