### PR TITLE
Update CodeBuild Runner integration to include the run id and attempt

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,6 +54,9 @@ jobs:
         run: |
           echo '${{ toJSON(matrix) }}'
           echo '${{ env.runner-labels}}'
+          
+          echo '${{ fromJSON(needs.setup.outputs.runner-labels)["macos"] }}'
+
       - id: set-matrix
         run: echo "runner-labels={\"include\":[{\"project\":\"foo\",\"config\":\"Debug\"},{\"project\":\"bar\",\"config\":\"Release\"}]}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,7 @@ jobs:
           echo '${{ toJSON(matrix) }}'
           echo '${{ env.runner-labels}}'
           
-          echo '${{ fromJSON(needs.setup.outputs.runner-labels)["macos"] }}'
+          echo '${{ fromJSON(needs.setup.outputs.runner-labels)['macos'] }}'
 
       - id: set-matrix
         run: echo "runner-labels={\"include\":[{\"project\":\"foo\",\"config\":\"Debug\"},{\"project\":\"bar\",\"config\":\"Release\"}]}" >> $GITHUB_OUTPUT

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -130,7 +130,6 @@ jobs:
     # This job is just a "join" on all parallel strategies for the `build` job so that we can require it in our branch protection rules.
     needs: build
     name: Build and Test Confirmation
-    if: always()
     runs-on: ubuntu-latest
     steps:
       - run: echo ${{ needs.build.outputs.result }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   build:
     name: Build and Test
-    runs-on: ${{ format(matrix.os, "codebuild-ion-rust-${{ github.run_id }}-${{ github.run_attempt }}") }}
+    runs-on: ${{ format(matrix.os, format('codebuild-ion-rust-{0}-{1}', github.run_id, github.run_attempt)) }}
     # We want to run on external PRs, but not on internal ones as push automatically builds
     # H/T: https://github.com/Dart-Code/Dart-Code/commit/612732d5879730608baa9622bf7f5e5b7b51ae65
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-rust'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,8 +35,8 @@ jobs:
               al2-intel: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}-al2-5.0-large"
               al2-arm: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large"
     outputs:
-      runners: ${{ matrix.use-codebuild && matrix.runs-on-names-cb || matrix.runs-on-names }}
-      runs-on-versions: ${{ matrix.runs-on-versions }}
+      runners: ${{ matrix.use-codebuild && toJSON(matrix.runs-on-names-cb) || toJSON(matrix.runs-on-names) }}
+      runs-on-versions: ${{ toJSON(matrix.runs-on-versions) }}
     steps:
       - run: (:)
         if: false
@@ -52,14 +52,14 @@ jobs:
   build:
     name: Build and Test
     needs: setup
-    runs-on: ${{ needs.setup.outputs.runner-versions[matrix.runner] }}
+    runs-on: ${{ fromJSON(needs.setup.outputs.runner-versions)[matrix.runner] }}
     # runs-on: ${{ format(matrix.os, format('codebuild-ion-rust-{0}-{1}', github.run_id, github.run_attempt)) }}
     # We want to run on external PRs, but not on internal ones as push automatically builds
     # H/T: https://github.com/Dart-Code/Dart-Code/commit/612732d5879730608baa9622bf7f5e5b7b51ae65
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-rust'
     strategy:
       matrix:
-        runner: ${{ needs.setup.outputs.runners }}
+        runner: ${{ fromJSON(needs.setup.outputs.runners) }}
         # os: ${{ vars.USE_CODEBUILD_RUNNERS && fromJSON(env.os_with_codebuild) || fromJSON(env.os_without_codebuild) }}
         # build and test for different and interesting crate features
         features: ['default', 'all', 'experimental-ion-hash', 'experimental']

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,15 +28,15 @@ jobs:
           - use-codebuild: ${{ vars.CODEBUILD_PROJECT_NAME == '' }}
             runs-on-names-cb: [ windows, macos, ubuntu, al2-intel, al2-arm ]
             runs-on-names: [ windows, macos, ubuntu ]
-            runs-on-versions:
-              windows: windows-latest
-              macos: macos-latest
-              ubuntu: ubuntu-latest
-              al2-intel: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}-al2-5.0-large"
-              al2-arm: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large"
+            # runs-on-versions:
     outputs:
       runners: ${{ matrix.use-codebuild && toJSON(matrix.runs-on-names-cb) || toJSON(matrix.runs-on-names) }}
-      runs-on-versions: ${{ toJSON(matrix.runs-on-versions) }}
+      windows: windows-latest
+      macos: macos-latest
+      ubuntu: ubuntu-latest
+      al2-intel: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}-al2-5.0-large"
+      al2-arm: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large"
+      # runs-on-versions: ${{ toJSON(matrix.runs-on-versions) }}
     steps:
       - run: (:)
         if: false
@@ -52,17 +52,17 @@ jobs:
   build:
     name: Build and Test
     needs: setup
-    runs-on: ${{ fromJSON(needs.setup.outputs.runner-versions)[matrix.runner] }}
-    # runs-on: ${{ format(matrix.os, format('codebuild-ion-rust-{0}-{1}', github.run_id, github.run_attempt)) }}
-    # We want to run on external PRs, but not on internal ones as push automatically builds
-    # H/T: https://github.com/Dart-Code/Dart-Code/commit/612732d5879730608baa9622bf7f5e5b7b51ae65
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-rust'
     strategy:
       matrix:
         runner: ${{ fromJSON(needs.setup.outputs.runners) }}
         # os: ${{ vars.USE_CODEBUILD_RUNNERS && fromJSON(env.os_with_codebuild) || fromJSON(env.os_without_codebuild) }}
         # build and test for different and interesting crate features
-        features: ['default', 'all', 'experimental-ion-hash', 'experimental']
+        features: [ 'default', 'all', 'experimental-ion-hash', 'experimental' ]
+    runs-on: ${{ needs.setup.outputs[matrix.runner] }}
+    # runs-on: ${{ format(matrix.os, format('codebuild-ion-rust-{0}-{1}', github.run_id, github.run_attempt)) }}
+    # We want to run on external PRs, but not on internal ones as push automatically builds
+    # H/T: https://github.com/Dart-Code/Dart-Code/commit/612732d5879730608baa9622bf7f5e5b7b51ae65
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-rust'
     permissions:
       checks: write
 
@@ -115,10 +115,10 @@ jobs:
         # The clippy check depends on setup steps defined above, but we don't want it to run
         # for every OS because it posts its comments to the PR. These `if` checks limit clippy to
         # only running on the Linux test. (The choice of OS was arbitrary.)
-        if: matrix.os == 'ubuntu-latest' && matrix.features == 'all'
+        if: matrix.runner == 'ubuntu' && matrix.features == 'all'
         run: rustup component add clippy
       - name: Run Clippy 
-        if: matrix.os == 'ubuntu-latest' && matrix.features == 'all'
+        if: matrix.runner == 'ubuntu' && matrix.features == 'all'
         uses: actions-rs/clippy-check@v1
         with:
           # Adding comments to the PR requires the GITHUB_TOKEN secret.
@@ -128,7 +128,7 @@ jobs:
           args: --workspace --all-features --tests -- -Dwarnings
       - name: Rustdoc on Everything
         # We really only need to run this once--ubuntu/all features mode is as good as any
-        if: matrix.os == 'ubuntu-latest' && matrix.features == 'all'
+        if: matrix.runner == 'ubuntu' && matrix.features == 'all'
         uses: actions-rs/cargo@v1
         with:
           command: doc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
           echo '${{ toJSON(matrix) }}'
           echo '${{ env.runner-labels}}'
           
-          echo '${{ fromJSON(env.runner-labels).macos }}'
+          echo '${{ (fromJSON(env.runner-labels)).macos }}'
           echo '{{ fromJSON(needs.setup.outputs).runner-labels['windows'] }}'
           echo '{{ fromJSON(needs.setup.outputs.runner-labels).${{ env.os }} }}'
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,12 +25,15 @@ jobs:
         # We're using a matrix with a single entry so that we can define some config as YAML rather than
         # having to write escaped json in a string
         include:
-          - use-codebuild: ${{ vars.CODEBUILD_PROJECT_NAME != '' }}
+          - use-codebuild: ${{ github.repository_owner != 'amazon-ion' }}
+            # ${{ vars.CODEBUILD_PROJECT_NAME != '' }}
             runs-on-names-cb: [ windows, macos, ubuntu, al2-intel, al2-arm ]
             runs-on-names: [ windows, macos, ubuntu ]
             # runs-on-versions:
+    env:
+      use-codebuild: ${{ vars.CODEBUILD_PROJECT_NAME != '' }}
     outputs:
-      runners: ${{ matrix.use-codebuild && toJSON(matrix.runs-on-names-cb) || toJSON(matrix.runs-on-names) }}
+      available-runners: ${{ matrix.use-codebuild && toJSON(matrix.runs-on-names-cb) || toJSON(matrix.runs-on-names) }}
       windows: windows-latest
       macos: macos-latest
       ubuntu: ubuntu-latest
@@ -54,7 +57,7 @@ jobs:
     needs: setup
     strategy:
       matrix:
-        runner: ${{ fromJSON(needs.setup.outputs.runners) }}
+        runner: ${{ fromJSON(needs.setup.outputs.available-runners) }}
         # os: ${{ vars.USE_CODEBUILD_RUNNERS && fromJSON(env.os_with_codebuild) || fromJSON(env.os_without_codebuild) }}
         # build and test for different and interesting crate features
         features: [ 'default', 'all', 'experimental-ion-hash', 'experimental' ]
@@ -136,10 +139,10 @@ jobs:
   confirm-build:
     # This job is just a "join" on all parallel strategies for the `build` job so that we can require it in our branch protection rules.
     needs: build
-    name: Build and Test (all) Success
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-rust'
+    name: Build and Test Confirmation
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Pass
-        run: echo "ok"
+      - if: needs.build.output.result != 'success'
+        run: exit 1
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,7 +45,7 @@ jobs:
         {
           "windows": "windows-latest",
           "macos": "macos-latest",
-          "ubuntu": "ubuntu-latest,
+          "ubuntu": "ubuntu-latest",
           "al2-intel": "${{ matrix.al2-intel }}",
           "al2-arm": "${{ matrix.al2-arm }}"
         }
@@ -54,11 +54,11 @@ jobs:
       - name: Dump Config
         run: |
           echo '${{ toJSON(matrix) }}'
-          echo '${{ env.runner-labels}}'
+          echo '${{ env.runner-labels }}'
           
           echo '${{ (fromJSON(env.runner-labels)).macos }}'
-          echo '{{ fromJSON(needs.setup.outputs).runner-labels['windows'] }}'
-          echo '{{ fromJSON(needs.setup.outputs.runner-labels).${{ env.os }} }}'
+          echo '${{ fromJSON(env.runner-labels)['windows'] }}'
+          echo '${{ fromJSON(env.runner-labels).${{ env.os }} }}'
 
   build:
     name: Build and Test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,10 +55,8 @@ jobs:
           echo '${{ toJSON(matrix) }}'
           echo '${{ env.runner-labels}}'
           
-          echo '${{ fromJSON(needs.setup.outputs.runner-labels)['macos'] }}'
-
-      - id: set-matrix
-        run: echo "runner-labels={\"include\":[{\"project\":\"foo\",\"config\":\"Debug\"},{\"project\":\"bar\",\"config\":\"Release\"}]}" >> $GITHUB_OUTPUT
+          echo '${{ fromJSON(needs.setup.outputs.runner-labels).macos }}'
+          echo '${{ fromJSON(needs.setup.outputs).runner-labels['windows'] }}'
 
   build:
     name: Build and Test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,7 +67,7 @@ jobs:
         # build and test for different and interesting crate features
         features: [ 'default', 'all', 'experimental-ion-hash', 'experimental' ]
     # Map the friendly names from `available-runners` to the actual runner labels.
-    runs-on: ${{ needs.setup.outputs[matrix.os] }}
+    runs-on: ${{ fromJSON(needs.setup.outputs.runner-labels)[matrix.os] }}
     # We want to run on external PRs, but not on internal ones as push automatically builds
     # H/T: https://github.com/Dart-Code/Dart-Code/commit/612732d5879730608baa9622bf7f5e5b7b51ae65
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-rust'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,8 @@ jobs:
           echo '${{ env.runner-labels}}'
           
           echo '${{ fromJSON(needs.setup.outputs.runner-labels).macos }}'
-          echo '${{ fromJSON(needs.setup.outputs).runner-labels['windows'] }}'
+          echo '{{ fromJSON(needs.setup.outputs).runner-labels['windows'] }}'
+          echo '{{ fromJSON(needs.setup.outputs.runner-labels).${{ format("{0}", "ubuntu") }} }}'
 
   build:
     name: Build and Test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,6 +49,7 @@ jobs:
           "al2-intel": "${{ matrix.al2-intel }}",
           "al2-arm": "${{ matrix.al2-arm }}"
         }
+      os: ubuntu
     steps:
       - name: Dump Config
         run: |
@@ -57,7 +58,7 @@ jobs:
           
           echo '${{ fromJSON(needs.setup.outputs.runner-labels).macos }}'
           echo '{{ fromJSON(needs.setup.outputs).runner-labels['windows'] }}'
-          echo '{{ fromJSON(needs.setup.outputs.runner-labels).${{ format("{0}", "ubuntu") }} }}'
+          echo '{{ fromJSON(needs.setup.outputs.runner-labels).${{ env.os }} }}'
 
   build:
     name: Build and Test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,20 +2,65 @@ name: CI Build
 
 on: [push, pull_request]
 
-env:
-  os_with_codebuild: '["ubuntu-latest", "windows-latest", "macos-latest", "{0}-arm-3.0-large", "{0}-al2-5.0-large"]'
-  os_without_codebuild: '["ubuntu-latest", "windows-latest", "macos-latest"]'
-
 jobs:
+  # TODO: See if this job can be turned into a reusable component
+  setup:
+    name: Setup Build Matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+#        runs-on-names:
+#          - ${{
+#              vars.CODEBUILD_PROJECT_NAME && [ windows, macos, ubuntu, al2-intel, al2-arm ] || [ windows, macos, ubuntu ]
+#            }}
+#        value:
+#          - use-codebuild-runners: true
+#            runs-on-names: [ windows, macos, ubuntu, al2-intel, al2-arm ]
+#          - use-codebuild-runners: false
+#            runs-on-names: [ windows, macos, ubuntu ]
+#        exclude:
+#          - value:
+#              use-codebuild-runners: ${{ vars.CODEBUILD_PROJECT_NAME == '' }}
+
+        # We're using a matrix with a single entry so that we can define some config as YAML rather than
+        # having to write escaped json in a string
+        include:
+          - use-codebuild: ${{ vars.CODEBUILD_PROJECT_NAME == '' }}
+            runs-on-names-cb: [ windows, macos, ubuntu, al2-intel, al2-arm ]
+            runs-on-names: [ windows, macos, ubuntu ]
+            runs-on-versions:
+              windows: windows-latest
+              macos: macos-latest
+              ubuntu: ubuntu-latest
+              al2-intel: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}-al2-5.0-large"
+              al2-arm: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large"
+    outputs:
+      runners: ${{ matrix.use-codebuild && matrix.runs-on-names-cb || matrix.runs-on-names }}
+      runs-on-versions: ${{ matrix.runs-on-versions }}
+    steps:
+      - run: (:)
+        if: false
+#    steps:
+#      - name: Pass
+#        id: setup-runners
+#        env:
+#          USE_CODEBUILD_RUNNERS: ${{ vars.CODEBUILD_PROJECT_NAME }}
+#          CODEBUILD_PREFIX: ${{format('codebuild-{0}-{1}-{2}', vars.CODEBUILD_PROJECT_NAME, github.run_id, github.run_attempt)}}
+#        run: |
+#          echo "matrix={\"include\":[{\"project\":\"foo\",\"config\":\"Debug\"},{\"project\":\"bar\",\"config\":\"Release\"}]}" >> $GITHUB_OUTPUT
+
   build:
     name: Build and Test
-    runs-on: ${{ format(matrix.os, format('codebuild-ion-rust-{0}-{1}', github.run_id, github.run_attempt)) }}
+    needs: setup
+    runs-on: ${{ needs.setup.outputs.runner-versions[matrix.runner] }}
+    # runs-on: ${{ format(matrix.os, format('codebuild-ion-rust-{0}-{1}', github.run_id, github.run_attempt)) }}
     # We want to run on external PRs, but not on internal ones as push automatically builds
     # H/T: https://github.com/Dart-Code/Dart-Code/commit/612732d5879730608baa9622bf7f5e5b7b51ae65
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-rust'
     strategy:
       matrix:
-        os: ${{ vars.USE_CODEBUILD_RUNNERS && fromJSON(env.os_with_codebuild) || fromJSON(env.os_without_codebuild) }}
+        runner: ${{ needs.setup.outputs.runners }}
+        # os: ${{ vars.USE_CODEBUILD_RUNNERS && fromJSON(env.os_with_codebuild) || fromJSON(env.os_without_codebuild) }}
         # build and test for different and interesting crate features
         features: ['default', 'all', 'experimental-ion-hash', 'experimental']
     permissions:
@@ -88,7 +133,7 @@ jobs:
         with:
           command: doc
           args: --document-private-items --all-features
-  confirm_build:
+  confirm-build:
     # This job is just a "join" on all parallel strategies for the `build` job so that we can require it in our branch protection rules.
     needs: build
     name: Build and Test (all) Success

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,8 +36,8 @@ jobs:
       windows: windows-latest
       macos: macos-latest
       ubuntu: ubuntu-latest
-      al2-intel: matrix.al2-intel
-      al2-arm: matrix.al2-arm
+      al2-intel: ${{ matrix.al2-intel }}
+      al2-arm: ${{ matrix.al2-arm }}
     steps:
       - name: Dump Config
         run: echo '${{ toJSON(matrix) }}'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,14 @@ jobs:
               al2-arm: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME != '' && vars.CODEBUILD_PROJECT_NAME || 'ion-rust' }}-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large"
     outputs:
       available-runners: ${{ matrix.use-codebuild && toJSON(matrix.runs-on-names-cb) || toJSON(matrix.runs-on-names) }}
-      runner-labels: ${{ env.runner-labels }}
+      runner-labels: |
+        {
+          "windows": "windows-latest",
+          "macos": "macos-latest",
+          "ubuntu": "ubuntu-latest",
+          "al2-intel": "${{ matrix.al2-intel }}",
+          "al2-arm": "${{ matrix.al2-arm }}"
+        }
       windows: windows-latest
       macos: macos-latest
       ubuntu: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,8 +29,12 @@ jobs:
             codebuild-project-name: ${{ vars.CODEBUILD_PROJECT_NAME != '' && vars.CODEBUILD_PROJECT_NAME || 'ion-rust' }}
             runs-on-names-cb: [ windows, macos, ubuntu, al2-intel, al2-arm ]
             runs-on-names: [ windows, macos, ubuntu ]
-            al2-intel: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME != '' && vars.CODEBUILD_PROJECT_NAME || 'ion-rust' }}-${{ github.run_id }}-${{ github.run_attempt }}-al2-5.0-large"
-            al2-arm: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME != '' && vars.CODEBUILD_PROJECT_NAME || 'ion-rust' }}-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large"
+            runner-labels:
+              windows: windows-latest
+              ubuntu: ubuntu-latest
+              macos: macos-latest
+              al2-intel: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME != '' && vars.CODEBUILD_PROJECT_NAME || 'ion-rust' }}-${{ github.run_id }}-${{ github.run_attempt }}-al2-5.0-large"
+              al2-arm: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME != '' && vars.CODEBUILD_PROJECT_NAME || 'ion-rust' }}-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large"
     outputs:
       available-runners: ${{ matrix.use-codebuild && toJSON(matrix.runs-on-names-cb) || toJSON(matrix.runs-on-names) }}
       runner-labels: ${{ env.runner-labels }}
@@ -57,8 +61,7 @@ jobs:
           echo '${{ env.runner-labels }}'
           
           echo '${{ (fromJSON(env.runner-labels)).macos }}'
-          echo '${{ fromJSON(env.runner-labels)['windows'] }}'
-          echo '${{ fromJSON(env.runner-labels).${{ env.os }} }}'
+          echo '${{ fromJSON(env.runner-labels)[env.os] }}'
 
   build:
     name: Build and Test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -131,6 +131,7 @@ jobs:
     needs: build
     name: Build and Test Confirmation
     runs-on: ubuntu-latest
+    if: always()
     steps:
       - run: echo ${{ needs.build.outputs.result }}
       - if: needs.build.outputs.result != 'success'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         # use the available runner types that were determined by the setup step
-        runner: ${{ fromJSON(needs.setup.outputs.available-runners) }}
+        os: ${{ fromJSON(needs.setup.outputs.available-runners) }}
         # build and test for different and interesting crate features
         features: [ 'default', 'all', 'experimental-ion-hash', 'experimental' ]
     # Map the friendly names from `available-runners` to the actual runner labels.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,10 +43,10 @@ jobs:
       codebuild-project-name: ${{ vars.CODEBUILD_PROJECT_NAME != '' && vars.CODEBUILD_PROJECT_NAME || 'ion-rust' }}
       runner-labels: |
         {
-          "windows": "windows-latest"
-          "macos": "macos-latest"
-          "ubuntu": "ubuntu-latest
-          "al2-intel": "${{ matrix.al2-intel }}"
+          "windows": "windows-latest",
+          "macos": "macos-latest",
+          "ubuntu": "ubuntu-latest,
+          "al2-intel": "${{ matrix.al2-intel }}",
           "al2-arm": "${{ matrix.al2-arm }}"
         }
     steps:
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - run: echo ${{ needs.build.outputs.result }}
-      - if: needs.build.outputs.result != 'success'
+      - run: echo ${{ needs.build.result }}
+      - if: needs.build.result != 'success'
         run: exit 1
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ jobs:
             # Repository vars are not available for fork->source pull requests, so if we want to use codebuild runners
             # for PRs, we need a fallback to check the repository owner.
           - use-codebuild: ${{ vars.CODEBUILD_PROJECT_NAME != '' || github.repository_owner == 'amazon-ion' }}
-            codebuild-project-name: ${{ vars.CODEBUILD_PROJECT_NAME || 'ion-rust' }}
+            codebuild-project-name: ${{ vars.CODEBUILD_PROJECT_NAME != '' && vars.CODEBUILD_PROJECT_NAME || 'ion-rust' }}
             runs-on-names-cb: [ windows, macos, ubuntu, al2-intel, al2-arm ]
             runs-on-names: [ windows, macos, ubuntu ]
             al2-intel: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}-al2-5.0-large"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,10 @@ name: CI Build
 
 on: [push, pull_request]
 
+env:
+  os_with_codebuild: [ ubuntu-latest, windows-latest, macos-latest, "codebuild-ion-rust-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large", "codebuild-ion-rust-${{ github.run_id }}-${{ github.run_attempt }}-al2-5.0-large" ]
+  os_without_codebuild: [ ubuntu-latest, windows-latest, macos-latest ]
+
 jobs:
   build:
     name: Build and Test
@@ -11,17 +15,9 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-rust'
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest, "codebuild-ion-rust-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large", "codebuild-ion-rust-${{ github.run_id }}-${{ github.run_attempt }}-al2-5.0-large" ]
+        os: ${{ env.USE_CODEBUILD_RUNNERS && env.os_with_codebuild || env.os_without_codebuild }}
         # build and test for different and interesting crate features
         features: ['default', 'all', 'experimental-ion-hash', 'experimental']
-        # Forks cannot use the codebuild runners. The job will hang indefinitely waiting to be picked up by a worker.
-        isFork:
-          - ${{ github.repository_owner != 'amazon-ion' }}
-        exclude:
-          - isFork: true
-            os: "codebuild-ion-rust-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large"
-          - isFork: true
-            os: "codebuild-ion-rust-${{ github.run_id }}-${{ github.run_attempt }}-al2-5.0-large"
     permissions:
       checks: write
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,18 +29,33 @@ jobs:
             codebuild-project-name: ${{ vars.CODEBUILD_PROJECT_NAME != '' && vars.CODEBUILD_PROJECT_NAME || 'ion-rust' }}
             runs-on-names-cb: [ windows, macos, ubuntu, al2-intel, al2-arm ]
             runs-on-names: [ windows, macos, ubuntu ]
-            al2-intel: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}-al2-5.0-large"
-            al2-arm: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large"
+            al2-intel: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME != '' && vars.CODEBUILD_PROJECT_NAME || 'ion-rust' }}-${{ github.run_id }}-${{ github.run_attempt }}-al2-5.0-large"
+            al2-arm: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME != '' && vars.CODEBUILD_PROJECT_NAME || 'ion-rust' }}-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large"
     outputs:
       available-runners: ${{ matrix.use-codebuild && toJSON(matrix.runs-on-names-cb) || toJSON(matrix.runs-on-names) }}
+      runner-labels: ${{ env.runner-labels }}
       windows: windows-latest
       macos: macos-latest
       ubuntu: ubuntu-latest
       al2-intel: ${{ matrix.al2-intel }}
       al2-arm: ${{ matrix.al2-arm }}
+    env:
+      codebuild-project-name: ${{ vars.CODEBUILD_PROJECT_NAME != '' && vars.CODEBUILD_PROJECT_NAME || 'ion-rust' }}
+      runner-labels: |
+        {
+          "windows": "windows-latest"
+          "macos": "macos-latest"
+          "ubuntu": "ubuntu-latest
+          "al2-intel": "${{ matrix.al2-intel }}"
+          "al2-arm": "${{ matrix.al2-arm }}"
+        }
     steps:
       - name: Dump Config
-        run: echo '${{ toJSON(matrix) }}'
+        run: |
+          echo '${{ toJSON(matrix) }}'
+          echo '${{ env.runner-labels}}'
+      - id: set-matrix
+        run: echo "runner-labels={\"include\":[{\"project\":\"foo\",\"config\":\"Debug\"},{\"project\":\"bar\",\"config\":\"Release\"}]}" >> $GITHUB_OUTPUT
 
   build:
     name: Build and Test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
           echo '${{ toJSON(matrix) }}'
           echo '${{ env.runner-labels}}'
           
-          echo '${{ fromJSON(needs.setup.outputs.runner-labels).macos }}'
+          echo '${{ fromJSON(toJSON(env.runner-labels)).macos }}'
           echo '{{ fromJSON(needs.setup.outputs).runner-labels['windows'] }}'
           echo '{{ fromJSON(needs.setup.outputs.runner-labels).${{ env.os }} }}'
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,13 +3,13 @@ name: CI Build
 on: [push, pull_request]
 
 env:
-  os_with_codebuild: [ ubuntu-latest, windows-latest, macos-latest, "codebuild-ion-rust-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large", "codebuild-ion-rust-${{ github.run_id }}-${{ github.run_attempt }}-al2-5.0-large" ]
-  os_without_codebuild: [ ubuntu-latest, windows-latest, macos-latest ]
+  os_with_codebuild: '["ubuntu-latest", "windows-latest", "macos-latest", "{0}-arm-3.0-large", "{0}-al2-5.0-large"]'
+  os_without_codebuild: '["ubuntu-latest", "windows-latest", "macos-latest"]'
 
 jobs:
   build:
     name: Build and Test
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ format(matrix.os, "codebuild-ion-rust-${{ github.run_id }}-${{ github.run_attempt }}") }}
     # We want to run on external PRs, but not on internal ones as push automatically builds
     # H/T: https://github.com/Dart-Code/Dart-Code/commit/612732d5879730608baa9622bf7f5e5b7b51ae65
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-rust'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
           echo '${{ toJSON(matrix) }}'
           echo '${{ env.runner-labels}}'
           
-          echo '${{ fromJSON(toJSON(env.runner-labels)).macos }}'
+          echo '${{ fromJSON(env.runner-labels).macos }}'
           echo '{{ fromJSON(needs.setup.outputs).runner-labels['windows'] }}'
           echo '{{ fromJSON(needs.setup.outputs.runner-labels).${{ env.os }} }}'
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,72 +3,56 @@ name: CI Build
 on: [push, pull_request]
 
 jobs:
-  # TODO: See if this job can be turned into a reusable component
   setup:
+    # This job sets up the runners to be used in the matrix for the build workflow.
+    # It provides a list of available runners with stable, human-friendly names and a mapping
+    # from those names to the actual `runs-on` value for each runner type. This allows us to
+    # use codebuild-hosted runners for amazon-ion/ion-rust without requiring forks to also
+    # have codebuild-hosted runners.
+    #
+    # If you want to use codebuild runners for your personal fork, follow the instructions to set
+    # up a codebuild project. https://docs.aws.amazon.com/codebuild/latest/userguide/action-runner.html
+    # Then, create a repository variable for your fork named `CODEBUILD_PROJECT_NAME` with the name
+    # of the project you created.
+    #
+    # TODO: See if this job can be turned into a reusable component
     name: Setup Build Matrix
     runs-on: ubuntu-latest
     strategy:
       matrix:
-#        runs-on-names:
-#          - ${{
-#              vars.CODEBUILD_PROJECT_NAME && [ windows, macos, ubuntu, al2-intel, al2-arm ] || [ windows, macos, ubuntu ]
-#            }}
-#        value:
-#          - use-codebuild-runners: true
-#            runs-on-names: [ windows, macos, ubuntu, al2-intel, al2-arm ]
-#          - use-codebuild-runners: false
-#            runs-on-names: [ windows, macos, ubuntu ]
-#        exclude:
-#          - value:
-#              use-codebuild-runners: ${{ vars.CODEBUILD_PROJECT_NAME == '' }}
-
         # We're using a matrix with a single entry so that we can define some config as YAML rather than
-        # having to write escaped json in a string
+        # having to write escaped json in a string.
         include:
-          - use-codebuild: ${{ github.repository_owner == 'amazon-ion' }}
-            # ${{ vars.CODEBUILD_PROJECT_NAME != '' }}
+            # Repository vars are not available for fork->source pull requests, so if we want to use codebuild runners
+            # for PRs, we need a fallback to check the repository owner.
+          - use-codebuild: ${{ vars.CODEBUILD_PROJECT_NAME != '' || github.repository_owner == 'amazon-ion' }}
+            codebuild-project-name: ${{ vars.CODEBUILD_PROJECT_NAME || 'ion-rust' }}
             runs-on-names-cb: [ windows, macos, ubuntu, al2-intel, al2-arm ]
             runs-on-names: [ windows, macos, ubuntu ]
-            # runs-on-versions:
-    env:
-      use-codebuild: ${{ vars.CODEBUILD_PROJECT_NAME != '' }}
-      codebuild-project-name: ${{ vars.CODEBUILD_PROJECT_NAME }}
+            al2-intel: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}-al2-5.0-large"
+            al2-arm: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large"
     outputs:
       available-runners: ${{ matrix.use-codebuild && toJSON(matrix.runs-on-names-cb) || toJSON(matrix.runs-on-names) }}
       windows: windows-latest
       macos: macos-latest
       ubuntu: ubuntu-latest
-      al2-intel: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}-al2-5.0-large"
-      al2-arm: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large"
-      # runs-on-versions: ${{ toJSON(matrix.runs-on-versions) }}
+      al2-intel: matrix.al2-intel
+      al2-arm: matrix.al2-arm
     steps:
       - name: Dump Config
-        run: |
-          echo '---- Matrix ----'
-          echo '${{ toJSON(matrix) }}'
-          echo 'vars.CODEBUILD_PROJECT_NAME = ${{vars.CODEBUILD_PROJECT_NAME}}'
-          env
-
-#    steps:
-#      - name: Pass
-#        id: setup-runners
-#        env:
-#          USE_CODEBUILD_RUNNERS: ${{ vars.CODEBUILD_PROJECT_NAME }}
-#          CODEBUILD_PREFIX: ${{format('codebuild-{0}-{1}-{2}', vars.CODEBUILD_PROJECT_NAME, github.run_id, github.run_attempt)}}
-#        run: |
-#          echo "matrix={\"include\":[{\"project\":\"foo\",\"config\":\"Debug\"},{\"project\":\"bar\",\"config\":\"Release\"}]}" >> $GITHUB_OUTPUT
+        run: echo '${{ toJSON(matrix) }}'
 
   build:
     name: Build and Test
     needs: setup
     strategy:
       matrix:
+        # use the available runner types that were determined by the setup step
         runner: ${{ fromJSON(needs.setup.outputs.available-runners) }}
-        # os: ${{ vars.USE_CODEBUILD_RUNNERS && fromJSON(env.os_with_codebuild) || fromJSON(env.os_without_codebuild) }}
         # build and test for different and interesting crate features
         features: [ 'default', 'all', 'experimental-ion-hash', 'experimental' ]
-    runs-on: ${{ needs.setup.outputs[matrix.runner] }}
-    # runs-on: ${{ format(matrix.os, format('codebuild-ion-rust-{0}-{1}', github.run_id, github.run_attempt)) }}
+    # Map the friendly names from `available-runners` to the actual runner labels.
+    runs-on: ${{ needs.setup.outputs[matrix.os] }}
     # We want to run on external PRs, but not on internal ones as push automatically builds
     # H/T: https://github.com/Dart-Code/Dart-Code/commit/612732d5879730608baa9622bf7f5e5b7b51ae65
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-rust'
@@ -124,10 +108,10 @@ jobs:
         # The clippy check depends on setup steps defined above, but we don't want it to run
         # for every OS because it posts its comments to the PR. These `if` checks limit clippy to
         # only running on the Linux test. (The choice of OS was arbitrary.)
-        if: matrix.runner == 'ubuntu' && matrix.features == 'all'
+        if: matrix.os == 'ubuntu' && matrix.features == 'all'
         run: rustup component add clippy
       - name: Run Clippy 
-        if: matrix.runner == 'ubuntu' && matrix.features == 'all'
+        if: matrix.os == 'ubuntu' && matrix.features == 'all'
         uses: actions-rs/clippy-check@v1
         with:
           # Adding comments to the PR requires the GITHUB_TOKEN secret.
@@ -137,7 +121,7 @@ jobs:
           args: --workspace --all-features --tests -- -Dwarnings
       - name: Rustdoc on Everything
         # We really only need to run this once--ubuntu/all features mode is as good as any
-        if: matrix.runner == 'ubuntu' && matrix.features == 'all'
+        if: matrix.os == 'ubuntu' && matrix.features == 'all'
         uses: actions-rs/cargo@v1
         with:
           command: doc
@@ -149,6 +133,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - if: needs.build.output.result != 'success'
+      - run: echo ${{ needs.build.outputs.result }}
+      - if: needs.build.outputs.result != 'success'
         run: exit 1
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,38 +37,10 @@ jobs:
               al2-arm: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME != '' && vars.CODEBUILD_PROJECT_NAME || 'ion-rust' }}-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large"
     outputs:
       available-runners: ${{ matrix.use-codebuild && toJSON(matrix.runs-on-names-cb) || toJSON(matrix.runs-on-names) }}
-      runner-labels: |
-        {
-          "windows": "windows-latest",
-          "macos": "macos-latest",
-          "ubuntu": "ubuntu-latest",
-          "al2-intel": "${{ matrix.al2-intel }}",
-          "al2-arm": "${{ matrix.al2-arm }}"
-        }
-      windows: windows-latest
-      macos: macos-latest
-      ubuntu: ubuntu-latest
-      al2-intel: ${{ matrix.al2-intel }}
-      al2-arm: ${{ matrix.al2-arm }}
-    env:
-      codebuild-project-name: ${{ vars.CODEBUILD_PROJECT_NAME != '' && vars.CODEBUILD_PROJECT_NAME || 'ion-rust' }}
-      runner-labels: |
-        {
-          "windows": "windows-latest",
-          "macos": "macos-latest",
-          "ubuntu": "ubuntu-latest",
-          "al2-intel": "${{ matrix.al2-intel }}",
-          "al2-arm": "${{ matrix.al2-arm }}"
-        }
-      os: ubuntu
+      runner-labels: ${{ toJSON(matrix.runner-labels) }}
     steps:
       - name: Dump Config
-        run: |
-          echo '${{ toJSON(matrix) }}'
-          echo '${{ env.runner-labels }}'
-          
-          echo '${{ (fromJSON(env.runner-labels)).macos }}'
-          echo '${{ fromJSON(env.runner-labels)[env.os] }}'
+        run: echo '${{ toJSON(matrix) }}'
 
   build:
     name: Build and Test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,13 +25,14 @@ jobs:
         # We're using a matrix with a single entry so that we can define some config as YAML rather than
         # having to write escaped json in a string
         include:
-          - use-codebuild: ${{ github.repository_owner != 'amazon-ion' }}
+          - use-codebuild: ${{ github.repository_owner == 'amazon-ion' }}
             # ${{ vars.CODEBUILD_PROJECT_NAME != '' }}
             runs-on-names-cb: [ windows, macos, ubuntu, al2-intel, al2-arm ]
             runs-on-names: [ windows, macos, ubuntu ]
             # runs-on-versions:
     env:
       use-codebuild: ${{ vars.CODEBUILD_PROJECT_NAME != '' }}
+      codebuild-project-name: ${{ vars.CODEBUILD_PROJECT_NAME }}
     outputs:
       available-runners: ${{ matrix.use-codebuild && toJSON(matrix.runs-on-names-cb) || toJSON(matrix.runs-on-names) }}
       windows: windows-latest
@@ -41,8 +42,13 @@ jobs:
       al2-arm: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large"
       # runs-on-versions: ${{ toJSON(matrix.runs-on-versions) }}
     steps:
-      - run: (:)
-        if: false
+      - name: Dump Config
+        run: |
+          echo '---- Matrix ----'
+          echo '${{ toJSON(matrix) }}'
+          echo 'vars.CODEBUILD_PROJECT_NAME = ${{vars.CODEBUILD_PROJECT_NAME}}'
+          env
+
 #    steps:
 #      - name: Pass
 #        id: setup-runners

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
         # We're using a matrix with a single entry so that we can define some config as YAML rather than
         # having to write escaped json in a string
         include:
-          - use-codebuild: ${{ vars.CODEBUILD_PROJECT_NAME == '' }}
+          - use-codebuild: ${{ vars.CODEBUILD_PROJECT_NAME != '' }}
             runs-on-names-cb: [ windows, macos, ubuntu, al2-intel, al2-arm ]
             runs-on-names: [ windows, macos, ubuntu ]
             # runs-on-versions:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-rust'
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, codebuild-ion-rust-arm-3.0-large, codebuild-ion-rust-al2-5.0-large ]
+        os: [ ubuntu-latest, windows-latest, macos-latest, "codebuild-ion-rust-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large", "codebuild-ion-rust-${{ github.run_id }}-${{ github.run_attempt }}-al2-5.0-large" ]
         # build and test for different and interesting crate features
         features: ['default', 'all', 'experimental-ion-hash', 'experimental']
         # Forks cannot use the codebuild runners. The job will hang indefinitely waiting to be picked up by a worker.
@@ -19,9 +19,9 @@ jobs:
           - ${{ github.repository_owner != 'amazon-ion' }}
         exclude:
           - isFork: true
-            os: codebuild-ion-rust-arm-3.0-large
+            os: "codebuild-ion-rust-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large"
           - isFork: true
-            os: codebuild-ion-rust-al2-5.0-large
+            os: "codebuild-ion-rust-${{ github.run_id }}-${{ github.run_attempt }}-al2-5.0-large"
     permissions:
       checks: write
 
@@ -92,3 +92,13 @@ jobs:
         with:
           command: doc
           args: --document-private-items --all-features
+  confirm_build:
+    # This job is just a "join" on all parallel strategies for the `build` job so that we can require it in our branch protection rules.
+    needs: build
+    name: Build and Test (all) Success
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-rust'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pass
+        run: echo "ok"
+

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-rust'
     strategy:
       matrix:
-        os: ${{ env.USE_CODEBUILD_RUNNERS && fromJSON(env.os_with_codebuild) || fromJSON(env.os_without_codebuild) }}
+        os: ${{ vars.USE_CODEBUILD_RUNNERS && fromJSON(env.os_with_codebuild) || fromJSON(env.os_without_codebuild) }}
         # build and test for different and interesting crate features
         features: ['default', 'all', 'experimental-ion-hash', 'experimental']
     permissions:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-rust'
     strategy:
       matrix:
-        os: ${{ env.USE_CODEBUILD_RUNNERS && env.os_with_codebuild || env.os_without_codebuild }}
+        os: ${{ env.USE_CODEBUILD_RUNNERS && fromJSON(env.os_with_codebuild) || fromJSON(env.os_without_codebuild) }}
         # build and test for different and interesting crate features
         features: ['default', 'all', 'experimental-ion-hash', 'experimental']
     permissions:


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

According to https://docs.aws.amazon.com/codebuild/latest/userguide/action-runner.html, we need to start including the run id and run attempt in the "runs on" configuration for CodeBuild-hosted runners.
This will also make it impossible to create a branch protection rule on those particular tasks because we don't have a stable job name now that the run id, etc. are now part of the strategy matrix and therefore part of the parameterized task name, so I've created a job that functions as a "join" operation for all of the build strategies.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
