### PR TITLE
Update CodeBuild Runner integration to include the run id and attempt

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,25 +3,59 @@ name: CI Build
 on: [push, pull_request]
 
 jobs:
+  setup:
+    # This job sets up the runners to be used in the matrix for the build workflow.
+    # It provides a list of available runners with stable, human-friendly names and a mapping
+    # from those names to the actual `runs-on` value for each runner type. This allows us to
+    # use codebuild-hosted runners for amazon-ion/ion-rust without requiring forks to also
+    # have codebuild-hosted runners.
+    #
+    # If you want to use codebuild runners for your personal fork, follow the instructions to set
+    # up a codebuild project. https://docs.aws.amazon.com/codebuild/latest/userguide/action-runner.html
+    # Then, create a repository variable for your fork named `CODEBUILD_PROJECT_NAME` with the name
+    # of the project you created.
+    #
+    # TODO: See if this job can be turned into a reusable component
+    name: Setup Build Matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # We're using a matrix with a single entry so that we can define some config as YAML rather than
+        # having to write escaped json in a string.
+        include:
+            # Repository vars are not available for fork->source pull requests, so if we want to use codebuild runners
+            # for PRs, we need a fallback to check the repository owner.
+          - use-codebuild: ${{ vars.CODEBUILD_PROJECT_NAME != '' || github.repository_owner == 'amazon-ion' }}
+            codebuild-project-name: ${{ vars.CODEBUILD_PROJECT_NAME != '' && vars.CODEBUILD_PROJECT_NAME || 'ion-rust' }}
+            runs-on-names-cb: [ windows, macos, ubuntu, al2-x86, al2-arm ]
+            runs-on-names: [ windows, macos, ubuntu ]
+            runner-labels:
+              windows: windows-latest
+              ubuntu: ubuntu-latest
+              macos: macos-latest
+              al2-x86: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME != '' && vars.CODEBUILD_PROJECT_NAME || 'ion-rust' }}-${{ github.run_id }}-${{ github.run_attempt }}-al2-5.0-large"
+              al2-arm: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME != '' && vars.CODEBUILD_PROJECT_NAME || 'ion-rust' }}-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large"
+    outputs:
+      available-runners: ${{ matrix.use-codebuild && toJSON(matrix.runs-on-names-cb) || toJSON(matrix.runs-on-names) }}
+      runner-labels: ${{ toJSON(matrix.runner-labels) }}
+    steps:
+      - name: Dump Config
+        run: echo '${{ toJSON(matrix) }}'
+
   build:
     name: Build and Test
-    runs-on: ${{ matrix.os }}
+    needs: setup
+    # Map the friendly names from `available-runners` to the actual runner labels.
+    runs-on: ${{ fromJSON(needs.setup.outputs.runner-labels)[matrix.os] }}
     # We want to run on external PRs, but not on internal ones as push automatically builds
     # H/T: https://github.com/Dart-Code/Dart-Code/commit/612732d5879730608baa9622bf7f5e5b7b51ae65
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-rust'
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, codebuild-ion-rust-arm-3.0-large, codebuild-ion-rust-al2-5.0-large ]
+        # use the available runner types that were determined by the setup step
+        os: ${{ fromJSON(needs.setup.outputs.available-runners) }}
         # build and test for different and interesting crate features
         features: ['default', 'all', 'experimental-ion-hash', 'experimental']
-        # Forks cannot use the codebuild runners. The job will hang indefinitely waiting to be picked up by a worker.
-        isFork:
-          - ${{ github.repository_owner != 'amazon-ion' }}
-        exclude:
-          - isFork: true
-            os: codebuild-ion-rust-arm-3.0-large
-          - isFork: true
-            os: codebuild-ion-rust-al2-5.0-large
     permissions:
       checks: write
 
@@ -74,10 +108,10 @@ jobs:
         # The clippy check depends on setup steps defined above, but we don't want it to run
         # for every OS because it posts its comments to the PR. These `if` checks limit clippy to
         # only running on the Linux test. (The choice of OS was arbitrary.)
-        if: matrix.os == 'ubuntu-latest' && matrix.features == 'all'
+        if: matrix.os == 'ubuntu' && matrix.features == 'all'
         run: rustup component add clippy
       - name: Run Clippy 
-        if: matrix.os == 'ubuntu-latest' && matrix.features == 'all'
+        if: matrix.os == 'ubuntu' && matrix.features == 'all'
         uses: actions-rs/clippy-check@v1
         with:
           # Adding comments to the PR requires the GITHUB_TOKEN secret.
@@ -87,8 +121,19 @@ jobs:
           args: --workspace --all-features --tests -- -Dwarnings
       - name: Rustdoc on Everything
         # We really only need to run this once--ubuntu/all features mode is as good as any
-        if: matrix.os == 'ubuntu-latest' && matrix.features == 'all'
+        if: matrix.os == 'ubuntu' && matrix.features == 'all'
         uses: actions-rs/cargo@v1
         with:
           command: doc
           args: --document-private-items --all-features
+  confirm-build:
+    # This job is just a "join" on all parallel strategies for the `build` job so that we can require it in our branch protection rules.
+    needs: build
+    name: Build and Test Confirmation
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - run: echo ${{ needs.build.result }}
+      - if: needs.build.result != 'success'
+        run: exit 1
+


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

According to https://docs.aws.amazon.com/codebuild/latest/userguide/action-runner.html, we need to start including the run id and run attempt in the "runs on" configuration for CodeBuild-hosted runners.

I've also created a job that functions as a "join" operation for all of the forks from the build matrix. We can use the build confirmation job as the required job for the branch protection rule since it has a stable name.

The codecov workflow is failing for this PR. It looks like it's related to [this issue](https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954), so in theory, it's to be expected for any fork->source PRs (since the workflows for the PR can't access GitHub secrets).

If this PR is approved, I will also update the branch protection rule accordingly.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
