### PR TITLE
Introduces an application-level lazy writer

### DIFF
--- a/benches/write_many_structs.rs
+++ b/benches/write_many_structs.rs
@@ -41,7 +41,7 @@ fn write_struct_with_string_values(value_writer: impl ValueWriter) -> IonResult<
                 black_box("2022-12-07T20:59:59.744000Z"),
             ],
         )?;
-    struct_.end()
+    struct_.close()
 }
 
 fn write_struct_with_symbol_values(value_writer: impl ValueWriter) -> IonResult<()> {
@@ -75,7 +75,7 @@ fn write_struct_with_symbol_values(value_writer: impl ValueWriter) -> IonResult<
                 symbol_id(black_box(25)),
             ],
         )?;
-    struct_.end()
+    struct_.close()
 }
 
 fn write_eexp_with_symbol_values(value_writer: impl ValueWriter) -> IonResult<()> {

--- a/examples/write_log_events.rs
+++ b/examples/write_log_events.rs
@@ -198,7 +198,7 @@ mod example {
                 .write(14, RawSymbolToken::SymbolId(18))? // log level
                 .write(15, RawSymbolToken::SymbolId(19))? // format
                 .write(16, &event.parameters)?;
-            struct_.end()
+            struct_.close()
         }
     }
 

--- a/src/element/writer.rs
+++ b/src/element/writer.rs
@@ -7,6 +7,7 @@ use crate::ion_writer::IonWriter;
 use crate::result::IonResult;
 use crate::{Element, IonType, TextKind, Value};
 
+use crate::lazy::encoding::BinaryEncoding_1_1;
 #[cfg(feature = "experimental-lazy-reader")]
 use {
     crate::lazy::encoder::{LazyEncoder, LazyRawWriter},
@@ -18,6 +19,7 @@ use {
 /// Writer configuration to provide format and Ion version details to writer through encoding
 /// This will be used to create a writer without specifying which writer methods to use
 #[cfg(feature = "experimental-lazy-reader")]
+#[derive(Clone, Debug)]
 pub struct WriteConfig<E: Encoding> {
     pub(crate) kind: WriteConfigKind,
     phantom_data: PhantomData<E>,
@@ -52,6 +54,16 @@ impl WriteConfig<BinaryEncoding_1_0> {
 }
 
 #[cfg(feature = "experimental-lazy-reader")]
+impl WriteConfig<BinaryEncoding_1_1> {
+    pub fn new() -> Self {
+        Self {
+            kind: WriteConfigKind::Binary(BinaryWriteConfig),
+            phantom_data: Default::default(),
+        }
+    }
+}
+
+#[cfg(feature = "experimental-lazy-reader")]
 impl Default for WriteConfig<BinaryEncoding_1_0> {
     fn default() -> Self {
         Self::new()
@@ -59,18 +71,21 @@ impl Default for WriteConfig<BinaryEncoding_1_0> {
 }
 
 /// Writer configuration type enum for text and binary configuration
+#[derive(Clone, Debug)]
 pub(crate) enum WriteConfigKind {
     Text(TextWriteConfig),
     Binary(BinaryWriteConfig),
 }
 
 /// Text writer configuration with text kind to be used to create a writer
+#[derive(Clone, Debug)]
 pub(crate) struct TextWriteConfig {
     text_kind: TextKind,
 }
 
 /// Binary writer configuration to be used to create a writer
 // TODO: Add appropriate binary configuration if required for 1.1
+#[derive(Clone, Debug)]
 pub(crate) struct BinaryWriteConfig;
 
 /// Serializes [`Element`] instances into some kind of output sink.

--- a/src/lazy/encoder/annotate.rs
+++ b/src/lazy/encoder/annotate.rs
@@ -1,17 +1,17 @@
-use crate::lazy::encoder::value_writer::ValueWriter;
+use crate::lazy::encoder::annotation_seq::AnnotationSeq;
+use crate::lazy::encoder::value_writer::{AnnotatableWriter, ValueWriter};
 use crate::lazy::encoder::write_as_ion::WriteAsIon;
-use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
 use crate::IonResult;
 
 /// Associates a value to serialize with a sequence of annotations.
-pub struct Annotated<'a, T: ?Sized, A> {
+pub struct Annotated<'a, T: ?Sized, A: 'a> {
     value: &'a T,
-    annotations: &'a [A],
+    annotations: A,
 }
 
-/// Provides implementors with an extension method ([`annotate`](Annotate::annotated_with)) that allows
+/// Provides implementors with an extension method ([`annotate`](Annotatable::annotated_with)) that allows
 /// them to be serialized with an associated sequence of annotations.    
-pub trait Annotate {
+pub trait Annotatable {
     /// Pairs a reference to the provided value with a slice containing annotations.
     ///
     /// ```
@@ -19,12 +19,12 @@ pub trait Annotate {
     ///# fn main() -> IonResult<()> {
     /// use ion_rs::{Element, IonData};
     /// use ion_rs::lazy::encoder::text::LazyRawTextWriter_1_0;
-    /// use ion_rs::lazy::encoder::annotate::Annotate;
+    /// use ion_rs::lazy::encoder::annotate::Annotatable;
     ///
     /// let mut buffer = vec![];
     /// let mut writer = LazyRawTextWriter_1_0::new(&mut buffer);
     ///
-    /// writer.write(42_usize.annotated_with(&["foo", "bar", "baz"]))?.flush()?;
+    /// writer.write(42_usize.annotated_with(["foo", "bar", "baz"]))?.flush()?;
     ///
     /// let expected = Element::read_one("foo::bar::baz::42")?;
     /// let actual = Element::read_one(&buffer)?;
@@ -33,21 +33,20 @@ pub trait Annotate {
     ///# Ok(())
     ///# }
     /// ```
-    fn annotated_with<'a, A: AsRawSymbolTokenRef>(
-        &'a self,
-        annotations: &'a [A],
-    ) -> Annotated<'a, Self, A>;
+    fn annotated_with<'a, A: 'a>(&'a self, annotations: A) -> Annotated<'a, Self, A>
+    where
+        &'a A: AnnotationSeq<'a>;
 }
 
 // Any Rust value that can be serialized as an Ion value can call `annotate`.
-impl<T> Annotate for T
+impl<T> Annotatable for T
 where
     T: ?Sized + WriteAsIon,
 {
-    fn annotated_with<'a, A: AsRawSymbolTokenRef>(
-        &'a self,
-        annotations: &'a [A],
-    ) -> Annotated<'a, Self, A> {
+    fn annotated_with<'a, A: 'a>(&'a self, annotations: A) -> Annotated<'a, Self, A>
+    where
+        &'a A: AnnotationSeq<'a>,
+    {
         Annotated {
             value: self,
             annotations,
@@ -57,13 +56,13 @@ where
 
 // The `Annotated` struct implements `WriteAsIon` by serializing its sequence of annotations
 // and then invoking the inner value's implementation of `WriteAsIon`.
-impl<'annotations, T, A> WriteAsIon for Annotated<'annotations, T, A>
+impl<'annotations, T, A: 'annotations> WriteAsIon for Annotated<'annotations, T, A>
 where
+    for<'x> &'x A: AnnotationSeq<'x>,
     T: WriteAsIon,
-    A: AsRawSymbolTokenRef,
 {
     fn write_as_ion<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
-        let value_writer = <V as ValueWriter>::with_annotations(writer, self.annotations);
+        let value_writer = <V as AnnotatableWriter>::with_annotations(writer, &self.annotations)?;
         self.value.write_as_ion(value_writer)
     }
 }

--- a/src/lazy/encoder/annotation_seq.rs
+++ b/src/lazy/encoder/annotation_seq.rs
@@ -1,0 +1,106 @@
+use crate::{RawSymbolTokenRef, SymbolId};
+use smallvec::SmallVec;
+
+pub type AnnotationsVec<'a> = SmallVec<[RawSymbolTokenRef<'a>; 2]>;
+
+pub trait AnnotationSeq<'a> {
+    fn into_annotations_vec(self) -> AnnotationsVec<'a>;
+}
+
+impl<'a> AnnotationSeq<'a> for &'a str {
+    fn into_annotations_vec(self) -> AnnotationsVec<'a> {
+        let mut vec = AnnotationsVec::new();
+        vec.push(RawSymbolTokenRef::Text(self.into()));
+        vec
+    }
+}
+
+impl<'a> AnnotationSeq<'a> for &'a &str {
+    fn into_annotations_vec(self) -> AnnotationsVec<'a> {
+        let mut vec = AnnotationsVec::new();
+        vec.push(RawSymbolTokenRef::Text((*self).into()));
+        vec
+    }
+}
+
+impl<'a> AnnotationSeq<'a> for SymbolId {
+    fn into_annotations_vec(self) -> AnnotationsVec<'a> {
+        let mut vec = AnnotationsVec::new();
+        vec.push(RawSymbolTokenRef::SymbolId(self));
+        vec
+    }
+}
+
+impl<'a> AnnotationSeq<'a> for &'a SymbolId {
+    fn into_annotations_vec(self) -> AnnotationsVec<'a> {
+        let mut vec = AnnotationsVec::new();
+        vec.push(RawSymbolTokenRef::SymbolId(*self));
+        vec
+    }
+}
+
+impl<'a> AnnotationSeq<'a> for RawSymbolTokenRef<'a> {
+    fn into_annotations_vec(self) -> AnnotationsVec<'a> {
+        let mut vec = AnnotationsVec::new();
+        vec.push(self);
+        vec
+    }
+}
+
+impl<'a> AnnotationSeq<'a> for AnnotationsVec<'a> {
+    fn into_annotations_vec(self) -> AnnotationsVec<'a> {
+        self
+    }
+}
+
+impl<'a, T> AnnotationSeq<'a> for Vec<T>
+where
+    T: Into<RawSymbolTokenRef<'a>>,
+{
+    fn into_annotations_vec(self) -> AnnotationsVec<'a> {
+        let mut annotations = AnnotationsVec::new();
+        for token in self {
+            annotations.push(token.into());
+        }
+        annotations
+    }
+}
+
+impl<'a, T> AnnotationSeq<'a> for &'a [T]
+where
+    for<'b> &'b T: Into<RawSymbolTokenRef<'b>>,
+{
+    fn into_annotations_vec(self) -> AnnotationsVec<'a> {
+        let mut annotations = AnnotationsVec::new();
+        for token in self {
+            annotations.push(token.into());
+        }
+        annotations
+    }
+}
+
+impl<'a, T, const N: usize> AnnotationSeq<'a> for [T; N]
+where
+    T: Into<RawSymbolTokenRef<'a>>,
+{
+    fn into_annotations_vec(self) -> AnnotationsVec<'a> {
+        let mut annotations = AnnotationsVec::new();
+        for token in self {
+            annotations.push(token.into());
+        }
+        annotations
+    }
+}
+
+impl<'a, T, const N: usize> AnnotationSeq<'a> for &'a [T; N]
+where
+    for<'b> &'b T: Into<RawSymbolTokenRef<'b>>,
+{
+    fn into_annotations_vec(self) -> AnnotationsVec<'a> {
+        let mut annotations = AnnotationsVec::new();
+        for token in self {
+            annotations.push(token.into());
+        }
+        annotations
+    }
+}

--- a/src/lazy/encoder/annotation_seq.rs
+++ b/src/lazy/encoder/annotation_seq.rs
@@ -1,13 +1,20 @@
 use crate::{RawSymbolTokenRef, SymbolId};
 use smallvec::SmallVec;
 
+/// A sequence of annotations.
+///
+/// When the sequence is two or fewer annotations, it will not require a heap allocation.
 pub type AnnotationsVec<'a> = SmallVec<[RawSymbolTokenRef<'a>; 2]>;
 
+/// Types that can be viewed as an annotations sequence.
+///
+/// Examples include `SymbolId`, `&str`, and iterables of those types.
 pub trait AnnotationSeq<'a> {
     fn into_annotations_vec(self) -> AnnotationsVec<'a>;
 }
 
 impl<'a> AnnotationSeq<'a> for &'a str {
+    /// Converts the value into an `AnnotationsVec`.
     fn into_annotations_vec(self) -> AnnotationsVec<'a> {
         let mut vec = AnnotationsVec::new();
         vec.push(RawSymbolTokenRef::Text(self.into()));

--- a/src/lazy/encoder/binary/v1_0/container_writers.rs
+++ b/src/lazy/encoder/binary/v1_0/container_writers.rs
@@ -335,7 +335,7 @@ impl<'value, 'top> MakeValueWriter for BinaryStructWriter_1_0<'value, 'top> {
 }
 
 impl<'value, 'top> StructWriter for BinaryStructWriter_1_0<'value, 'top> {
-    fn end(self) -> IonResult<()> {
+    fn close(self) -> IonResult<()> {
         self.container_writer.end()
     }
 }

--- a/src/lazy/encoder/binary/v1_0/mod.rs
+++ b/src/lazy/encoder/binary/v1_0/mod.rs
@@ -1,6 +1,7 @@
 use crate::lazy::encoder::binary::v1_0::writer::LazyRawBinaryWriter_1_0;
-use crate::lazy::encoder::LazyEncoder;
+use crate::lazy::encoder::{LazyEncoder, SymbolCreationPolicy};
 use crate::lazy::encoding::BinaryEncoding_1_0;
+use crate::WriteConfig;
 use std::io::Write;
 
 mod container_writers;
@@ -8,5 +9,13 @@ pub mod value_writer;
 pub mod writer;
 
 impl LazyEncoder for BinaryEncoding_1_0 {
+    const SUPPORTS_TEXT_TOKENS: bool = false;
+    const DEFAULT_SYMBOL_CREATION_POLICY: SymbolCreationPolicy =
+        SymbolCreationPolicy::RequireSymbolId;
+
     type Writer<W: Write> = LazyRawBinaryWriter_1_0<W>;
+
+    fn default_write_config() -> WriteConfig<Self> {
+        WriteConfig::<Self>::new()
+    }
 }

--- a/src/lazy/encoder/binary/v1_0/writer.rs
+++ b/src/lazy/encoder/binary/v1_0/writer.rs
@@ -79,6 +79,8 @@ impl<W: Write> LazyRawBinaryWriter_1_0<W> {
         output.write_all(encoding_buffer)?;
         // Flush the output sink, which may have its own buffers.
         output.flush()?;
+        // Now that we've written the encoding buffer's contents to output, clear it.
+        self.encoding_buffer_ptr = None;
         // Clear the allocator. A new encoding buffer will be allocated on the next write.
         allocator.reset();
         Ok(())
@@ -125,6 +127,14 @@ impl<W: Write> LazyRawWriter<W> for LazyRawBinaryWriter_1_0<W> {
         to self {
             fn flush(&mut self) -> IonResult<()>;
         }
+    }
+
+    fn output(&self) -> &W {
+        &self.output
+    }
+
+    fn output_mut(&mut self) -> &mut W {
+        &mut self.output
     }
 }
 

--- a/src/lazy/encoder/binary/v1_1/container_writers.rs
+++ b/src/lazy/encoder/binary/v1_1/container_writers.rs
@@ -110,8 +110,8 @@ impl<'value, 'top> BinaryContainerWriter_1_1<'value, 'top> {
     /// Encodes the provided `value` to the [`BinaryContainerWriter_1_1`]'s buffer.
     #[inline]
     pub fn write<V: WriteAsIon>(&mut self, value: V) -> IonResult<&mut Self> {
-        let annotated_value_writer = self.value_writer();
-        value.write_as_ion(annotated_value_writer)?;
+        let value_writer = self.value_writer();
+        value.write_as_ion(value_writer)?;
         Ok(self)
     }
 
@@ -344,7 +344,7 @@ impl<'value, 'top> MakeValueWriter for BinaryStructWriter_1_1<'value, 'top> {
 }
 
 impl<'value, 'top> StructWriter for BinaryStructWriter_1_1<'value, 'top> {
-    fn end(mut self) -> IonResult<()> {
+    fn close(mut self) -> IonResult<()> {
         if let ContainerEncodingKind::Delimited(_) = &mut self.container_writer.encoder {
             // Write the FlexSym escape (FlexUInt 0). The container writer can emit the closing
             // delimited END opcode.

--- a/src/lazy/encoder/binary/v1_1/mod.rs
+++ b/src/lazy/encoder/binary/v1_1/mod.rs
@@ -1,6 +1,7 @@
-use crate::lazy::encoder::binary::v1_0::writer::LazyRawBinaryWriter_1_0;
-use crate::lazy::encoder::LazyEncoder;
+use crate::lazy::encoder::binary::v1_1::writer::LazyRawBinaryWriter_1_1;
+use crate::lazy::encoder::{LazyEncoder, SymbolCreationPolicy};
 use crate::lazy::encoding::BinaryEncoding_1_1;
+use crate::WriteConfig;
 use std::io::Write;
 
 pub mod container_writers;
@@ -13,6 +14,13 @@ pub mod value_writer;
 pub mod writer;
 
 impl LazyEncoder for BinaryEncoding_1_1 {
-    // TODO: Create 1.1 writer
-    type Writer<W: Write> = LazyRawBinaryWriter_1_0<W>;
+    const SUPPORTS_TEXT_TOKENS: bool = true;
+    const DEFAULT_SYMBOL_CREATION_POLICY: SymbolCreationPolicy =
+        SymbolCreationPolicy::RequireSymbolId;
+
+    type Writer<W: Write> = LazyRawBinaryWriter_1_1<W>;
+
+    fn default_write_config() -> WriteConfig<Self> {
+        WriteConfig::<Self>::new()
+    }
 }

--- a/src/lazy/encoder/binary/v1_1/writer.rs
+++ b/src/lazy/encoder/binary/v1_1/writer.rs
@@ -137,6 +137,14 @@ impl<W: Write> LazyRawWriter<W> for LazyRawBinaryWriter_1_1<W> {
             fn flush(&mut self) -> IonResult<()>;
         }
     }
+
+    fn output(&self) -> &W {
+        &self.output
+    }
+
+    fn output_mut(&mut self) -> &mut W {
+        &mut self.output
+    }
 }
 
 impl<W: Write> MakeValueWriter for LazyRawBinaryWriter_1_1<W> {

--- a/src/lazy/encoder/text/mod.rs
+++ b/src/lazy/encoder/text/mod.rs
@@ -3,10 +3,10 @@ use crate::lazy::encoder::text::value_writer::TextValueWriter_1_0;
 use crate::lazy::encoder::value_writer::internal::MakeValueWriter;
 use crate::lazy::encoder::value_writer::SequenceWriter;
 use crate::lazy::encoder::write_as_ion::WriteAsIon;
-use crate::lazy::encoder::{LazyEncoder, LazyRawWriter};
+use crate::lazy::encoder::{LazyEncoder, LazyRawWriter, SymbolCreationPolicy};
 use crate::lazy::encoding::{Encoding, TextEncoding_1_0};
 use crate::text::raw_text_writer::{WhitespaceConfig, PRETTY_WHITESPACE_CONFIG};
-use crate::IonResult;
+use crate::{IonResult, TextKind};
 use delegate::delegate;
 use std::io::Write;
 
@@ -96,8 +96,24 @@ impl<W: Write> LazyRawWriter<W> for LazyRawTextWriter_1_0<W> {
             fn flush(&mut self) -> IonResult<()>;
         }
     }
+
+    fn output(&self) -> &W {
+        &self.output
+    }
+
+    fn output_mut(&mut self) -> &mut W {
+        &mut self.output
+    }
 }
 
 impl LazyEncoder for TextEncoding_1_0 {
+    const SUPPORTS_TEXT_TOKENS: bool = true;
+    const DEFAULT_SYMBOL_CREATION_POLICY: SymbolCreationPolicy =
+        SymbolCreationPolicy::WriteProvidedToken;
+
     type Writer<W: Write> = LazyRawTextWriter_1_0<W>;
+
+    fn default_write_config() -> WriteConfig<Self> {
+        WriteConfig::<Self>::new(TextKind::Pretty)
+    }
 }

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -1,0 +1,497 @@
+use std::io::Write;
+
+use delegate::delegate;
+use ice_code::ice as cold_path;
+
+use crate::constants::v1_0::system_symbol_ids;
+use crate::lazy::encoder::annotation_seq::AnnotationSeq;
+use crate::lazy::encoder::value_writer::internal::{FieldEncoder, MakeValueWriter};
+use crate::lazy::encoder::value_writer::{
+    AnnotatableWriter, EExpWriter, SequenceWriter, StructWriter, ValueWriter,
+};
+use crate::lazy::encoder::{LazyEncoder, LazyRawWriter, SymbolCreationPolicy};
+use crate::lazy::encoding::Encoding;
+use crate::lazy::text::raw::v1_1::reader::MacroIdRef;
+use crate::raw_symbol_token_ref::AsRawSymbolTokenRef;
+use crate::result::IonFailure;
+use crate::{
+    Decimal, Element, ElementWriter, Int, IonResult, IonType, RawSymbolTokenRef, Symbol, SymbolId,
+    SymbolTable, Timestamp, Value, WriteConfig,
+};
+
+pub(crate) struct EncodingContext {
+    symbol_table: SymbolTable,
+    num_pending_symbols: usize,
+    symbol_creation_policy: SymbolCreationPolicy,
+    supports_text_tokens: bool,
+}
+
+impl EncodingContext {
+    pub fn new(
+        symbol_table: SymbolTable,
+        symbol_creation_policy: SymbolCreationPolicy,
+        supports_text_tokens: bool,
+    ) -> Self {
+        Self {
+            symbol_table,
+            num_pending_symbols: 0,
+            symbol_creation_policy,
+            supports_text_tokens,
+        }
+    }
+}
+
+pub struct ApplicationWriter<E: LazyEncoder + Encoding, Output: Write> {
+    encoding_context: EncodingContext,
+    data_writer: E::Writer<Vec<u8>>,
+    directive_writer: E::Writer<Vec<u8>>,
+    output: Output,
+}
+
+impl<E: LazyEncoder, Output: Write> ApplicationWriter<E, Output> {
+    pub fn new(output: Output) -> IonResult<Self> {
+        Self::build(E::default_write_config(), output)
+    }
+
+    pub fn build(config: WriteConfig<E>, output: Output) -> IonResult<Self> {
+        let directive_writer = E::Writer::build(config.clone(), vec![])?;
+        let mut data_writer = E::Writer::build(config, vec![])?;
+        // Erase the IVM that's created by default
+        data_writer.output_mut().clear();
+        // TODO: LazyEncoder should define a method to construct a new symtab and/or macro table
+        let symbol_table = SymbolTable::new();
+        let encoding_context = EncodingContext::new(
+            symbol_table,
+            E::DEFAULT_SYMBOL_CREATION_POLICY,
+            E::SUPPORTS_TEXT_TOKENS,
+        );
+        let mut writer = ApplicationWriter {
+            encoding_context,
+            data_writer,
+            directive_writer,
+            output,
+        };
+        writer.flush()?;
+        Ok(writer)
+    }
+
+    pub fn flush(&mut self) -> IonResult<()> {
+        if self.encoding_context.num_pending_symbols > 0 {
+            self.write_lst_append()?;
+            self.encoding_context.num_pending_symbols = 0;
+        }
+
+        self.directive_writer.flush()?;
+        self.output
+            .write_all(self.directive_writer.output().as_slice())?;
+        self.directive_writer.output_mut().clear();
+
+        self.data_writer.flush()?;
+        self.output
+            .write_all(self.data_writer.output().as_slice())?;
+        self.data_writer.output_mut().clear();
+        Ok(())
+    }
+
+    fn write_lst_append(&mut self) -> IonResult<()> {
+        let Self {
+            encoding_context,
+            directive_writer,
+            ..
+        } = self;
+
+        let num_existing_symbols = encoding_context.symbol_table.len();
+        let num_pending_symbols = encoding_context.num_pending_symbols;
+
+        let mut lst = directive_writer
+            .value_writer()
+            .with_annotations(system_symbol_ids::ION_SYMBOL_TABLE)?
+            .struct_writer()?;
+
+        lst.field_writer(system_symbol_ids::IMPORTS)
+            .write_symbol(system_symbol_ids::ION_SYMBOL_TABLE)?;
+
+        let mut new_symbol_list = lst.field_writer(system_symbol_ids::SYMBOLS).list_writer()?;
+
+        let pending_symbols = encoding_context
+            .symbol_table
+            .symbols_tail(num_existing_symbols - num_pending_symbols)
+            .iter()
+            .map(Symbol::text);
+
+        new_symbol_list.write_all(pending_symbols)?;
+        new_symbol_list.close()?;
+
+        lst.close()
+    }
+}
+
+impl<Encoding: LazyEncoder, Output: Write> MakeValueWriter for ApplicationWriter<Encoding, Output> {
+    type ValueWriter<'a> = ApplicationValueWriter<'a, <Encoding::Writer<Vec<u8>> as MakeValueWriter>::ValueWriter<'a>>
+    where
+        Self: 'a;
+
+    fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
+        let raw_value_writer = self.data_writer.make_value_writer();
+
+        ApplicationValueWriter {
+            raw_value_writer,
+            encoding: &mut self.encoding_context,
+        }
+    }
+}
+
+impl<Encoding: LazyEncoder, Output: Write> SequenceWriter for ApplicationWriter<Encoding, Output> {
+    type Resources = Output;
+
+    fn close(mut self) -> IonResult<Self::Resources> {
+        self.flush()?;
+        Ok(self.output)
+    }
+}
+
+pub struct ApplicationValueWriter<'a, V: ValueWriter> {
+    encoding: &'a mut EncodingContext,
+    raw_value_writer: V,
+}
+
+impl<'a, V: ValueWriter> ApplicationValueWriter<'a, V> {
+    pub(crate) fn new(encoding_context: &'a mut EncodingContext, raw_value_writer: V) -> Self {
+        Self {
+            encoding: encoding_context,
+            raw_value_writer,
+        }
+    }
+
+    fn symbol_table(&mut self) -> &mut SymbolTable {
+        &mut self.encoding.symbol_table
+    }
+}
+
+impl<'value, V: ValueWriter> AnnotatableWriter for ApplicationValueWriter<'value, V> {
+    type AnnotatedValueWriter<'a> = ApplicationValueWriter<'a, V::AnnotatedValueWriter<'a>> where Self: 'a;
+
+    fn with_annotations<'a>(
+        mut self,
+        annotations: impl AnnotationSeq<'a>,
+    ) -> IonResult<Self::AnnotatedValueWriter<'a>>
+    where
+        Self: 'a,
+    {
+        if self.encoding.symbol_creation_policy == SymbolCreationPolicy::WriteProvidedToken {
+            // Store the tokens as they are. Text will be written as text, symbol IDs will be written
+            // as symbol IDs. TODO: Lookup SIDs to see if they have text?
+            return Ok(ApplicationValueWriter {
+                encoding: self.encoding,
+                raw_value_writer: self.raw_value_writer.with_annotations(annotations)?,
+            });
+        }
+
+        // Otherwise, we're going to write everything as a symbol ID. Replace all text tokens in the
+        // annotations with the corresponding symbol ID, creating a new one if necessary.
+        let mut annotations = annotations.into_annotations_vec();
+        for annotation in &mut annotations {
+            let sid: SymbolId = match annotation.as_raw_symbol_token_ref() {
+                // The token is already a symbol ID.
+                RawSymbolTokenRef::SymbolId(sid) => sid,
+                // The token is text...
+                RawSymbolTokenRef::Text(text) => {
+                    if let Some(sid) = self.symbol_table().sid_for(&text.as_ref()) {
+                        //...that was already in the symbol table.
+                        sid
+                    } else {
+                        // ...that we need to add to the symbol table.
+                        self.encoding.num_pending_symbols += 1;
+                        self.symbol_table().add_symbol(text.as_ref())
+                    }
+                }
+            };
+            *annotation = RawSymbolTokenRef::SymbolId(sid);
+        }
+
+        Ok(ApplicationValueWriter {
+            encoding: self.encoding,
+            raw_value_writer: self.raw_value_writer.with_annotations(annotations)?,
+        })
+    }
+}
+
+impl<'value, V: ValueWriter> ValueWriter for ApplicationValueWriter<'value, V> {
+    type ListWriter = ApplicationListWriter<'value, V>;
+    type SExpWriter = ApplicationSExpWriter<'value, V>;
+    type StructWriter = ApplicationStructWriter<'value, V>;
+    type EExpWriter = ApplicationEExpWriter<'value, V>;
+
+    delegate! {
+        to self.raw_value_writer {
+            fn write_null(self, ion_type: IonType) -> IonResult<()> ;
+            fn write_bool(self, value: bool) -> IonResult<()>;
+            fn write_i64(self, value: i64) -> IonResult<()>;
+            fn write_int(self, value: &Int) -> IonResult<()>;
+            fn write_f32(self, value: f32) -> IonResult<()>;
+            fn write_f64(self, value: f64) -> IonResult<()>;
+            fn write_decimal(self, value: &Decimal) -> IonResult<()>;
+            fn write_timestamp(self, value: &Timestamp) -> IonResult<()>;
+            fn write_string(self, value: impl AsRef<str>) -> IonResult<()>;
+            fn write_clob(self, value: impl AsRef<[u8]>) -> IonResult<()>;
+            fn write_blob(self, value: impl AsRef<[u8]>) -> IonResult<()>;
+        }
+    }
+
+    fn write_symbol(mut self, value: impl AsRawSymbolTokenRef) -> IonResult<()> {
+        // If it's a symbol ID, do a bounds check and then write it.
+        // Otherwise, get its associated text.
+        let text = match value.as_raw_symbol_token_ref() {
+            RawSymbolTokenRef::SymbolId(symbol_id) => {
+                if !self.symbol_table().sid_is_valid(symbol_id) {
+                    return cold_path!(IonResult::encoding_error(format!(
+                        "symbol ID ${symbol_id} is out of bounds"
+                    )));
+                }
+                return self.raw_value_writer.write_symbol(symbol_id);
+            }
+            RawSymbolTokenRef::Text(text) => text,
+        };
+
+        // If the writer can write it as inline text, do so.
+        if self.encoding.supports_text_tokens
+            && self.encoding.symbol_creation_policy == SymbolCreationPolicy::WriteProvidedToken
+        {
+            return self.raw_value_writer.write_symbol(text.as_ref());
+        }
+
+        // Otherwise, see if the symbol is already in the symbol table.
+        let symbol_id = match self.symbol_table().sid_for(&text.as_ref()) {
+            // If so, use the existing ID.
+            Some(sid) => sid,
+            // If not, add it to the symbol table and make a note to add it to the LST on the next
+            // call to `flush()`. Use the new ID.
+            None => {
+                self.encoding.num_pending_symbols += 1;
+                self.symbol_table().add_symbol(text)
+            }
+        };
+
+        // Finally, write out the SID.
+        self.raw_value_writer.write_symbol(symbol_id)
+    }
+
+    fn list_writer(self) -> IonResult<Self::ListWriter> {
+        Ok(ApplicationListWriter::new(
+            self.encoding,
+            self.raw_value_writer.list_writer()?,
+        ))
+    }
+
+    fn sexp_writer(self) -> IonResult<Self::SExpWriter> {
+        Ok(ApplicationSExpWriter::new(
+            self.encoding,
+            self.raw_value_writer.sexp_writer()?,
+        ))
+    }
+
+    fn struct_writer(self) -> IonResult<Self::StructWriter> {
+        Ok(ApplicationStructWriter::new(
+            self.encoding,
+            self.raw_value_writer.struct_writer()?,
+        ))
+    }
+
+    fn eexp_writer<'a>(self, macro_id: impl Into<MacroIdRef<'a>>) -> IonResult<Self::EExpWriter> {
+        Ok(ApplicationEExpWriter::new(
+            self.encoding,
+            self.raw_value_writer.eexp_writer(macro_id)?,
+        ))
+    }
+}
+
+pub struct ApplicationStructWriter<'value, V: ValueWriter> {
+    encoding: &'value mut EncodingContext,
+    raw_struct_writer: V::StructWriter,
+}
+
+impl<'value, V: ValueWriter> ApplicationStructWriter<'value, V> {
+    pub(crate) fn new(
+        encoding_context: &'value mut EncodingContext,
+        raw_struct_writer: V::StructWriter,
+    ) -> Self {
+        Self {
+            encoding: encoding_context,
+            raw_struct_writer,
+        }
+    }
+}
+
+impl<'value, V: ValueWriter> MakeValueWriter for ApplicationStructWriter<'value, V> {
+    type ValueWriter<'a> = ApplicationValueWriter<'a, <V::StructWriter as MakeValueWriter>::ValueWriter<'a>>
+    where
+        Self: 'a;
+
+    fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
+        ApplicationValueWriter::new(self.encoding, self.raw_struct_writer.make_value_writer())
+    }
+}
+
+impl<'value, V: ValueWriter> FieldEncoder for ApplicationStructWriter<'value, V> {
+    fn encode_field_name(&mut self, name: impl AsRawSymbolTokenRef) -> IonResult<()> {
+        // If it's a symbol ID, do a bounds check and then write it.
+        // Otherwise, get its associated text.
+        let text = match name.as_raw_symbol_token_ref() {
+            RawSymbolTokenRef::SymbolId(symbol_id) => {
+                if !self.encoding.symbol_table.sid_is_valid(symbol_id) {
+                    return cold_path!(IonResult::encoding_error(format!(
+                        "symbol ID ${symbol_id} is out of bounds"
+                    )));
+                }
+                return self.raw_struct_writer.encode_field_name(symbol_id);
+            }
+            RawSymbolTokenRef::Text(text) => text,
+        };
+
+        // If the writer can write it as inline text, do so.
+        if self.encoding.supports_text_tokens
+            && self.encoding.symbol_creation_policy == SymbolCreationPolicy::WriteProvidedToken
+        {
+            return self.raw_struct_writer.encode_field_name(text.as_ref());
+        }
+
+        // Otherwise, see if the symbol is already in the symbol table.
+        let symbol_id = match self.encoding.symbol_table.sid_for(&text.as_ref()) {
+            // If so, use the existing ID.
+            Some(sid) => sid,
+            // If not, add it to the symbol table and make a note to add it to the LST on the next
+            // call to `flush()`. Use the new ID.
+            None => {
+                self.encoding.num_pending_symbols += 1;
+                self.encoding.symbol_table.add_symbol(text)
+            }
+        };
+
+        // Finally, write out the SID.
+        self.raw_struct_writer.encode_field_name(symbol_id)
+    }
+}
+
+impl<'value, V: ValueWriter> StructWriter for ApplicationStructWriter<'value, V> {
+    fn close(self) -> IonResult<()> {
+        self.raw_struct_writer.close()
+    }
+}
+
+pub struct ApplicationListWriter<'value, V: ValueWriter> {
+    encoding: &'value mut EncodingContext,
+    raw_list_writer: V::ListWriter,
+}
+
+impl<'value, V: ValueWriter> ApplicationListWriter<'value, V> {
+    pub(crate) fn new(
+        encoding_context: &'value mut EncodingContext,
+        raw_list_writer: V::ListWriter,
+    ) -> Self {
+        Self {
+            encoding: encoding_context,
+            raw_list_writer,
+        }
+    }
+}
+
+impl<'value, V: ValueWriter> MakeValueWriter for ApplicationListWriter<'value, V> {
+    type ValueWriter<'a> = ApplicationValueWriter<'a, <V::ListWriter as MakeValueWriter>::ValueWriter<'a>>
+    where
+        Self: 'a;
+
+    fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
+        ApplicationValueWriter::new(self.encoding, self.raw_list_writer.make_value_writer())
+    }
+}
+
+impl<'value, V: ValueWriter> SequenceWriter for ApplicationListWriter<'value, V> {
+    type Resources = ();
+
+    fn close(self) -> IonResult<Self::Resources> {
+        self.raw_list_writer.close()
+    }
+}
+
+pub struct ApplicationSExpWriter<'value, V: ValueWriter> {
+    encoding: &'value mut EncodingContext,
+    raw_sexp_writer: V::SExpWriter,
+}
+
+impl<'value, V: ValueWriter> ApplicationSExpWriter<'value, V> {
+    pub(crate) fn new(
+        encoding: &'value mut EncodingContext,
+        raw_sexp_writer: V::SExpWriter,
+    ) -> Self {
+        Self {
+            encoding,
+            raw_sexp_writer,
+        }
+    }
+}
+
+impl<'value, V: ValueWriter> MakeValueWriter for ApplicationSExpWriter<'value, V> {
+    type ValueWriter<'a> =
+        ApplicationValueWriter<'a, <V::SExpWriter as MakeValueWriter>::ValueWriter<'a>> where Self: 'a;
+
+    fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
+        ApplicationValueWriter::new(self.encoding, self.raw_sexp_writer.make_value_writer())
+    }
+}
+
+impl<'value, V: ValueWriter> SequenceWriter for ApplicationSExpWriter<'value, V> {
+    type Resources = ();
+
+    fn close(self) -> IonResult<Self::Resources> {
+        self.raw_sexp_writer.close()
+    }
+}
+
+pub struct ApplicationEExpWriter<'value, V: ValueWriter> {
+    encoding: &'value mut EncodingContext,
+    raw_eexp_writer: V::EExpWriter,
+}
+
+impl<'value, V: ValueWriter> ApplicationEExpWriter<'value, V> {
+    pub(crate) fn new(
+        encoding: &'value mut EncodingContext,
+        raw_eexp_writer: V::EExpWriter,
+    ) -> Self {
+        Self {
+            encoding,
+            raw_eexp_writer,
+        }
+    }
+}
+
+impl<'value, V: ValueWriter> SequenceWriter for ApplicationEExpWriter<'value, V> {
+    type Resources = ();
+
+    fn close(self) -> IonResult<Self::Resources> {
+        self.raw_eexp_writer.close()
+    }
+}
+
+impl<'value, V: ValueWriter> MakeValueWriter for ApplicationEExpWriter<'value, V> {
+    type ValueWriter<'a> = ApplicationValueWriter<'a, <<V as ValueWriter>::EExpWriter as MakeValueWriter>::ValueWriter<'a>> where Self: 'a;
+
+    fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
+        ApplicationValueWriter::new(self.encoding, self.raw_eexp_writer.make_value_writer())
+    }
+}
+
+impl<'value, V: ValueWriter> EExpWriter for ApplicationEExpWriter<'value, V> {
+    // Default methods
+}
+
+impl<E: LazyEncoder, O: Write> ElementWriter for ApplicationWriter<E, O> {
+    fn write_value(&mut self, value: &Value) -> IonResult<()> {
+        self.write(value)?;
+        Ok(())
+    }
+
+    fn write_element(&mut self, element: &Element) -> IonResult<()> {
+        self.write(element)?;
+        Ok(())
+    }
+}

--- a/src/lazy/never.rs
+++ b/src/lazy/never.rs
@@ -1,8 +1,11 @@
 use std::fmt::Debug;
 
 use crate::lazy::decoder::{LazyDecoder, LazyRawValueExpr};
+use crate::lazy::encoder::annotation_seq::AnnotationSeq;
 use crate::lazy::encoder::value_writer::internal::{FieldEncoder, MakeValueWriter};
-use crate::lazy::encoder::value_writer::{delegate_value_writer_to_self, ValueWriter};
+use crate::lazy::encoder::value_writer::{
+    delegate_value_writer_to_self, AnnotatableWriter, ValueWriter,
+};
 use crate::lazy::encoder::value_writer::{EExpWriter, SequenceWriter, StructWriter};
 use crate::lazy::expanded::macro_evaluator::{MacroExpr, RawEExpression};
 use crate::lazy::text::raw::v1_1::reader::MacroIdRef;
@@ -51,7 +54,7 @@ impl FieldEncoder for Never {
 }
 
 impl StructWriter for Never {
-    fn end(self) -> IonResult<()> {
+    fn close(self) -> IonResult<()> {
         unreachable!("StructWriter::end in Never")
     }
 }
@@ -66,22 +69,25 @@ impl MakeValueWriter for Never {
 
 impl EExpWriter for Never {}
 
+impl AnnotatableWriter for Never {
+    type AnnotatedValueWriter<'a> = Never where Self: 'a;
+
+    fn with_annotations<'a>(
+        self,
+        _annotations: impl AnnotationSeq<'a>,
+    ) -> IonResult<Self::AnnotatedValueWriter<'a>>
+    where
+        Self: 'a,
+    {
+        unreachable!("<Never as AnnotatableWriter>::with_annotations");
+    }
+}
+
 impl ValueWriter for Never {
-    type AnnotatedValueWriter<'a, SymbolType: AsRawSymbolTokenRef + 'a> = Never where Self: 'a;
     type ListWriter = Never;
     type SExpWriter = Never;
     type StructWriter = Never;
     type EExpWriter = Never;
 
     delegate_value_writer_to_self!();
-
-    fn with_annotations<'a, SymbolType: 'a + AsRawSymbolTokenRef>(
-        self,
-        _annotations: &'a [SymbolType],
-    ) -> Self::AnnotatedValueWriter<'a, SymbolType>
-    where
-        Self: 'a,
-    {
-        unreachable!("Never as MutRefValueWriter")
-    }
 }

--- a/src/raw_symbol_token_ref.rs
+++ b/src/raw_symbol_token_ref.rs
@@ -1,4 +1,5 @@
 use crate::raw_symbol_token::RawSymbolToken;
+use crate::types::symbol::SymbolText;
 use crate::{Symbol, SymbolId};
 use std::borrow::Cow;
 
@@ -77,6 +78,15 @@ impl AsRawSymbolTokenRef for RawSymbolToken {
     }
 }
 
+impl<'a> From<RawSymbolToken> for RawSymbolTokenRef<'a> {
+    fn from(value: RawSymbolToken) -> Self {
+        match value {
+            RawSymbolToken::SymbolId(sid) => RawSymbolTokenRef::SymbolId(sid),
+            RawSymbolToken::Text(text) => RawSymbolTokenRef::Text(text.into()),
+        }
+    }
+}
+
 impl<'a> From<&'a RawSymbolToken> for RawSymbolTokenRef<'a> {
     fn from(value: &'a RawSymbolToken) -> Self {
         value.as_raw_symbol_token_ref()
@@ -95,9 +105,34 @@ impl<'a> From<&'a str> for RawSymbolTokenRef<'a> {
     }
 }
 
+impl<'a> From<&'a &str> for RawSymbolTokenRef<'a> {
+    fn from(value: &'a &str) -> Self {
+        RawSymbolTokenRef::Text(Cow::Borrowed(value))
+    }
+}
+
 impl<'a> From<SymbolId> for RawSymbolTokenRef<'a> {
     fn from(value: SymbolId) -> Self {
         RawSymbolTokenRef::SymbolId(value)
+    }
+}
+
+impl<'a> From<&'a SymbolId> for RawSymbolTokenRef<'a> {
+    fn from(value: &'a SymbolId) -> Self {
+        RawSymbolTokenRef::SymbolId(*value)
+    }
+}
+
+impl<'a> From<Symbol> for RawSymbolTokenRef<'a> {
+    fn from(value: Symbol) -> Self {
+        let Symbol { text } = value;
+        match text {
+            SymbolText::Shared(shared) => {
+                RawSymbolTokenRef::Text(String::from(shared.as_ref()).into())
+            }
+            SymbolText::Owned(owned) => RawSymbolTokenRef::Text(owned.into()),
+            SymbolText::Unknown => RawSymbolTokenRef::SymbolId(0),
+        }
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -13,7 +13,7 @@ mod null;
 mod sexp;
 mod string;
 mod r#struct;
-mod symbol;
+pub(crate) mod symbol;
 mod timestamp;
 
 pub use crate::types::bytes::Bytes;

--- a/src/types/symbol.rs
+++ b/src/types/symbol.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 /// Stores or points to the text of a given [Symbol].
 #[derive(Debug, Eq)]
-enum SymbolText {
+pub(crate) enum SymbolText {
     // This Symbol refers to a string in the symbol table
     Shared(Arc<str>),
     // This Symbol owns its own text
@@ -79,7 +79,7 @@ impl Ord for SymbolText {
 /// reference to text in a symbol table.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub struct Symbol {
-    text: SymbolText,
+    pub(crate) text: SymbolText,
 }
 
 impl Symbol {

--- a/tests/ion_tests/mod.rs
+++ b/tests/ion_tests/mod.rs
@@ -51,7 +51,7 @@ pub fn serialize(format: Format, elements: &Sequence) -> IonResult<Vec<u8>> {
     match format {
         Format::Text(kind) => {
             let write_config = WriteConfig::<TextEncoding_1_0>::new(kind);
-            let mut writer = ApplicationWriter::build(write_config, buffer)?;
+            let mut writer = ApplicationWriter::with_config(write_config, buffer)?;
             writer.write_elements(elements)?;
             buffer = writer.close()?;
             println!(

--- a/tests/ion_tests/mod.rs
+++ b/tests/ion_tests/mod.rs
@@ -3,13 +3,16 @@
 #![cfg(feature = "experimental-writer")]
 #![allow(dead_code)]
 
-use ion_rs::{
-    BinaryWriterBuilder, Element, ElementReader, ElementWriter, Format, IonData, IonError,
-    IonResult, IonWriter, SExp, Sequence, Symbol, TextKind, TextWriterBuilder, Value,
-};
-
 use std::fs::read;
 use std::path::MAIN_SEPARATOR as PATH_SEPARATOR;
+
+use ion_rs::lazy::encoder::value_writer::SequenceWriter;
+use ion_rs::lazy::encoder::writer::ApplicationWriter;
+use ion_rs::lazy::encoding::{BinaryEncoding_1_0, TextEncoding_1_0};
+use ion_rs::{
+    Element, ElementReader, ElementWriter, Format, IonData, IonError, IonResult, SExp, Sequence,
+    Symbol, Value, WriteConfig,
+};
 
 /// Concatenates two slices of string slices together.
 #[inline]
@@ -47,19 +50,19 @@ pub fn serialize(format: Format, elements: &Sequence) -> IonResult<Vec<u8>> {
     let mut buffer = Vec::with_capacity(2048);
     match format {
         Format::Text(kind) => {
-            let mut writer = match kind {
-                TextKind::Compact => TextWriterBuilder::default().build(&mut buffer),
-                TextKind::Lines => TextWriterBuilder::lines().build(&mut buffer),
-                TextKind::Pretty => TextWriterBuilder::pretty().build(&mut buffer),
-                _ => unimplemented!("No text writer available for requested TextKind {:?}", kind),
-            }?;
+            let write_config = WriteConfig::<TextEncoding_1_0>::new(kind);
+            let mut writer = ApplicationWriter::build(write_config, buffer)?;
             writer.write_elements(elements)?;
-            writer.flush()?;
+            buffer = writer.close()?;
+            println!(
+                "Serialized as {kind:?}:\n{}",
+                std::str::from_utf8(buffer.as_slice()).unwrap()
+            );
         }
         Format::Binary => {
-            let mut binary_writer = BinaryWriterBuilder::new().build(&mut buffer)?;
+            let mut binary_writer = ApplicationWriter::<BinaryEncoding_1_0, _>::new(buffer)?;
             binary_writer.write_elements(elements)?;
-            binary_writer.flush()?;
+            buffer = binary_writer.close()?;
         }
         _ => unimplemented!("requested format '{:?}' is not supported", format),
     };
@@ -93,7 +96,11 @@ pub trait ElementApi {
 
     fn not_eq_error_message(e1: &Sequence, e2: &Sequence) -> String {
         if e1.len() != e2.len() {
-            return format!("e1 has {} elements, e2 has {} elements", e1.len(), e2.len());
+            return format!(
+                "e1 has {} elements, e2 has {} elements\n{e1:?} != {e2:?}",
+                e1.len(),
+                e2.len()
+            );
         }
 
         for (index, (element1, element2)) in e1.iter().zip(e2.iter()).enumerate() {


### PR DESCRIPTION
Adds an `ApplicationWriter` that wraps the various lazy raw writer types and creates new symbol table entries as needed. The new writer is now being used in our `ion-tests` integration.

I intend to rename the `ApplicationWriter` once the legacy writer is removed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
