### PR TITLE
Modifies the serde serializer to use the new writer

### DIFF
--- a/src/element/writer.rs
+++ b/src/element/writer.rs
@@ -80,7 +80,7 @@ pub(crate) enum WriteConfigKind {
 /// Text writer configuration with text kind to be used to create a writer
 #[derive(Clone, Debug)]
 pub(crate) struct TextWriteConfig {
-    text_kind: TextKind,
+    pub(crate) text_kind: TextKind,
 }
 
 /// Binary writer configuration to be used to create a writer

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -406,8 +406,6 @@ impl<'a, 'de> de::Deserializer<'de> for ValueDeserializer<'a, 'de> {
         if self.value.annotations().next() != Some(Ok(name.as_symbol_ref())) {
             return IonResult::decoding_error("expected an instance of enum {name}");
         }
-        // let annotations = self.value.annotations().collect::<IonResult<Vec<_>>>()?;
-        // println!("annotations: {annotations:?}");
         match self.value.ion_type() {
             Symbol => visitor.visit_enum(UnitVariantAccess::new(self)),
             // All the parameterized Rust enums use annotations for representing enum variants
@@ -440,24 +438,6 @@ impl<'a, 'de> de::Deserializer<'de> for ValueDeserializer<'a, 'de> {
                 visitor.visit_str(variant_id)
             }
         }
-
-        // The enum variant identifier is either the second annotation or, in the case of a unit struct variant,
-        // the symbol value.
-        // let Some(annotation) = self.value.annotations().next().transpose()? else {
-        //     return IonResult::decoding_error(
-        //         "expected a type annotation but found an unannotated value",
-        //     );
-        // };
-        // let Some(text) = annotation.text() else {
-        //     return IonResult::decoding_error("found a type annotation with unknown text");
-        // };
-        // visitor.visit_str(text)
-        // annotations are currently only supported with parameterized Rust enums
-        // if let Some(annotation) = self.value.annotations().next() {
-        //     visitor.visit_str(annotation?.text().unwrap())
-        // } else {
-        //     visitor.visit_str(self.value.read()?.expect_text()?)
-        // }
     }
 
     fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -10,6 +10,7 @@ use crate::lazy::value_ref::ValueRef;
 use crate::result::IonFailure;
 use crate::serde::decimal::TUNNELED_DECIMAL_TYPE_NAME;
 use crate::serde::timestamp::TUNNELED_TIMESTAMP_TYPE_NAME;
+use crate::symbol_ref::AsSymbolRef;
 use crate::{Decimal, IonError, IonResult, IonType, Timestamp};
 
 /// Generic method that can deserialize an object from any given type
@@ -304,7 +305,10 @@ impl<'a, 'de> de::Deserializer<'de> for ValueDeserializer<'a, 'de> {
     where
         V: Visitor<'de>,
     {
-        self.deserialize_unit(visitor)
+        // This is NOT the same as `deserialize_unit` above, which expects the unit type `()` and
+        // not some unit struct `Foo`. Calling `visitor.visit_unit()` will invoke
+        // `<Foo as Deserialize>::visit_unit()`, which will construct a new instance of `Foo`.
+        visitor.visit_unit()
     }
 
     fn deserialize_newtype_struct<V>(
@@ -391,7 +395,7 @@ impl<'a, 'de> de::Deserializer<'de> for ValueDeserializer<'a, 'de> {
 
     fn deserialize_enum<V>(
         self,
-        _name: &'static str,
+        name: &'static str,
         _variants: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Self::Error>
@@ -399,9 +403,14 @@ impl<'a, 'de> de::Deserializer<'de> for ValueDeserializer<'a, 'de> {
         V: Visitor<'de>,
     {
         use IonType::*;
+        if self.value.annotations().next() != Some(Ok(name.as_symbol_ref())) {
+            return IonResult::decoding_error("expected an instance of enum {name}");
+        }
+        // let annotations = self.value.annotations().collect::<IonResult<Vec<_>>>()?;
+        // println!("annotations: {annotations:?}");
         match self.value.ion_type() {
-            String => visitor.visit_enum(UnitVariantAccess::new(self)),
-            // All the parameterized Rust enums uses annotations for representing enum variant
+            Symbol => visitor.visit_enum(UnitVariantAccess::new(self)),
+            // All the parameterized Rust enums use annotations for representing enum variants
             _ => visitor.visit_enum(VariantAccess::new(self)),
         }
     }
@@ -410,12 +419,45 @@ impl<'a, 'de> de::Deserializer<'de> for ValueDeserializer<'a, 'de> {
     where
         V: Visitor<'de>,
     {
-        // annotations are currently only supported with parameterized Rust enums
-        if let Some(annotation) = self.value.annotations().next() {
-            visitor.visit_str(annotation?.text().unwrap())
-        } else {
-            visitor.visit_str(self.value.read()?.expect_text()?)
+        let mut annotations = self.value.annotations();
+        let first_annotation = annotations.next().transpose()?;
+        let second_annotation = annotations.next().transpose()?;
+        match (first_annotation, second_annotation) {
+            (None, _) => IonResult::decoding_error("expected an enum type identifier annotation"),
+            (Some(_), None) => {
+                let symbol = self.value.read()?.expect_symbol()?;
+                let symbol_text = symbol.text().ok_or_else(|| {
+                    IonError::decoding_error(
+                        "expected a symbol representing an enum's unit struct variant",
+                    )
+                })?;
+                visitor.visit_str(symbol_text)
+            }
+            (Some(_), Some(a2)) => {
+                let variant_id = a2.text().ok_or_else(|| {
+                    IonError::decoding_error("expected an enum variant identifier annotation")
+                })?;
+                visitor.visit_str(variant_id)
+            }
         }
+
+        // The enum variant identifier is either the second annotation or, in the case of a unit struct variant,
+        // the symbol value.
+        // let Some(annotation) = self.value.annotations().next().transpose()? else {
+        //     return IonResult::decoding_error(
+        //         "expected a type annotation but found an unannotated value",
+        //     );
+        // };
+        // let Some(text) = annotation.text() else {
+        //     return IonResult::decoding_error("found a type annotation with unknown text");
+        // };
+        // visitor.visit_str(text)
+        // annotations are currently only supported with parameterized Rust enums
+        // if let Some(annotation) = self.value.annotations().next() {
+        //     visitor.visit_str(annotation?.text().unwrap())
+        // } else {
+        //     visitor.visit_str(self.value.read()?.expect_text()?)
+        // }
     }
 
     fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -66,16 +66,17 @@
 //!
 //! fn main() -> IonResult<()> {
 //!     // data structure for representing address
+//!     use ion_rs::{Element, ion_struct};
 //!     let address = Address {
 //!         street: "10 Downing Street".to_owned(),
 //!         city: "London".to_owned(),
 //!     };
 //!
-//!     // serialize it to an Ion data
+//!     // serialize it to Ion text
 //!     let ion = to_string(&address)?;
 //!
 //!     // assert that the serialized Ion data is as expected
-//!     assert_eq!(r#"{street: "10 Downing Street", city: "London"}"#, ion);
+//!     assert_eq!(r#"{street: "10 Downing Street", city: "London", } "#, ion);
 //!
 //!     Ok(())
 //! }
@@ -198,14 +199,14 @@ pub mod ser;
 mod timestamp;
 
 pub use de::from_ion;
-pub use ser::{to_binary, to_pretty, to_string, Serializer};
+pub use ser::{to_binary, to_pretty, to_string};
 
 #[cfg(test)]
 #[cfg(feature = "experimental-serde")]
 mod tests {
-    use crate::serde::{from_ion, to_string};
+    use crate::serde::{from_ion, to_pretty, to_string};
 
-    use crate::{Decimal, Timestamp};
+    use crate::{Decimal, Element, Timestamp};
     use chrono::{DateTime, FixedOffset, Utc};
     use serde::{Deserialize, Serialize};
     use serde_with::serde_as;
@@ -275,8 +276,8 @@ mod tests {
             optional: None,
         };
 
-        let result = to_string(&test).expect("failed to serialize");
-
+        let result = to_pretty(&test).expect("failed to serialize");
+        println!("result: {}", result);
         let back_result: Test = from_ion(result.as_str()).expect("failed to deserialize");
 
         assert_eq!(back_result.int, 1);
@@ -308,24 +309,36 @@ mod tests {
             Struct { a: u32 },
         }
 
-        let i = r#""Unit""#;
+        let i = r#"E::Unit"#;
         let expected = E::Unit;
         assert_eq!(expected, from_ion(i).unwrap());
-        assert_eq!(i, to_string(&expected).unwrap());
+        assert_eq!(
+            Element::read_first(i),
+            Element::read_first(to_string(&expected).unwrap())
+        );
 
-        let i = r#"Newtype::1"#;
+        let i = r#"E::Newtype::1"#;
         let expected = E::Newtype(1);
         assert_eq!(expected, from_ion(i).unwrap());
-        assert_eq!(i, to_string(&expected).unwrap());
+        assert_eq!(
+            Element::read_first(i),
+            Element::read_first(to_string(&expected).unwrap())
+        );
 
-        let i = r#"Tuple::[1, 2]"#;
+        let i = r#"E::Tuple::[1, 2]"#;
         let expected = E::Tuple(1, 2);
         assert_eq!(expected, from_ion(i).unwrap());
-        assert_eq!(i, to_string(&expected).unwrap());
+        assert_eq!(
+            Element::read_first(i),
+            Element::read_first(to_string(&expected).unwrap())
+        );
 
-        let i = r#"Struct::{a: 1}"#;
+        let i = r#"E::Struct::{a: 1}"#;
         let expected = E::Struct { a: 1 };
         assert_eq!(expected, from_ion(i).unwrap());
-        assert_eq!(i, to_string(&expected).unwrap());
+        assert_eq!(
+            Element::read_first(i),
+            Element::read_first(to_string(&expected).unwrap())
+        );
     }
 }

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -1,33 +1,46 @@
-use std::io::Cursor;
+use std::io::Write;
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
 
-use crate::ion_writer::IonWriter;
+use serde::ser::Impossible;
+use serde::{ser, Serialize};
+
+use crate::lazy::encoder::value_writer::internal::{FieldEncoder, MakeValueWriter};
+use crate::lazy::encoder::value_writer::{SequenceWriter, StructWriter, ValueWriter};
+use crate::lazy::encoder::writer::ApplicationWriter;
+use crate::lazy::encoder::LazyEncoder;
+use crate::lazy::encoding::{BinaryEncoding_1_0, TextEncoding_1_0};
 use crate::result::IonFailure;
 use crate::serde::decimal::TUNNELED_DECIMAL_TYPE_NAME;
 use crate::serde::timestamp::TUNNELED_TIMESTAMP_TYPE_NAME;
-use crate::types::Int;
-use crate::{
-    BinaryWriterBuilder, Decimal, IonError, IonResult, IonType, TextKind, TextWriterBuilder,
-    Timestamp,
-};
-use serde::ser::Impossible;
-use serde::{ser, Serialize};
+use crate::symbol_ref::AsSymbolRef;
+use crate::Value::Null;
+use crate::{Decimal, IonError, IonResult, IonType, TextKind, Timestamp, WriteConfig};
+
+pub fn write_to<T: Serialize, E: LazyEncoder, O: Write>(
+    value: &T,
+    writer: &mut ApplicationWriter<E, O>,
+) -> IonResult<()> {
+    let serializer = ValueSerializer::new(writer.value_writer());
+    value.serialize(serializer)
+}
+
+fn write_with_config<T: Serialize, E: LazyEncoder>(
+    value: &T,
+    config: WriteConfig<E>,
+) -> IonResult<Vec<u8>> {
+    let mut writer = ApplicationWriter::with_config(config, vec![])?;
+    write_to(value, &mut writer)?;
+    writer.close()
+}
 
 /// Serialize an object into pretty formatted Ion text
 pub fn to_pretty<T>(value: &T) -> IonResult<String>
 where
     T: Serialize,
 {
-    let mut cursor = Cursor::new(Vec::new());
-    let mut serializer = Serializer {
-        writer: TextWriterBuilder::pretty().build(&mut cursor)?,
-    };
-
-    value.serialize(&mut serializer)?;
-    serializer.writer.flush()?;
-    drop(serializer);
-
-    let bytes = cursor.get_ref().clone();
-
+    let config = WriteConfig::<TextEncoding_1_0>::new(TextKind::Pretty);
+    let bytes = write_with_config(value, config)?;
     match String::from_utf8(bytes) {
         Ok(data) => Ok(data),
         Err(e) => IonResult::encoding_error(e.to_string()),
@@ -39,17 +52,8 @@ pub fn to_string<T>(value: &T) -> IonResult<String>
 where
     T: Serialize,
 {
-    let mut cursor = Cursor::new(Vec::new());
-    let mut serializer = Serializer {
-        writer: TextWriterBuilder::new(TextKind::Compact).build(&mut cursor)?,
-    };
-
-    value.serialize(&mut serializer)?;
-    serializer.writer.flush()?;
-    drop(serializer);
-
-    let bytes = cursor.get_ref().clone();
-
+    let config = WriteConfig::<TextEncoding_1_0>::new(TextKind::Compact);
+    let bytes = write_with_config(value, config)?;
     match String::from_utf8(bytes) {
         Ok(data) => Ok(data),
         Err(e) => IonResult::encoding_error(e.to_string()),
@@ -61,105 +65,105 @@ pub fn to_binary<T>(value: &T) -> IonResult<Vec<u8>>
 where
     T: Serialize,
 {
-    let mut cursor = Cursor::new(Vec::new());
-    let mut serializer = Serializer {
-        writer: BinaryWriterBuilder::new().build(&mut cursor)?,
-    };
-
-    value.serialize(&mut serializer)?;
-    serializer.writer.flush()?;
-    drop(serializer);
-
-    Ok(cursor.get_ref().clone())
+    let config = WriteConfig::<BinaryEncoding_1_0>::new();
+    write_with_config(value, config)
 }
 
 /// Implements a standard serializer for Ion
-pub struct Serializer<E> {
-    pub(crate) writer: E,
+pub struct ValueSerializer<'a, V: ValueWriter> {
+    pub(crate) value_writer: V,
+    lifetime: PhantomData<&'a ()>,
 }
 
-impl<'a, E> ser::Serializer for &'a mut Serializer<E>
-where
-    E: IonWriter,
-{
+impl<'a, V: ValueWriter> ValueSerializer<'a, V> {
+    pub fn new(value_writer: V) -> Self {
+        Self {
+            value_writer,
+            lifetime: PhantomData,
+        }
+    }
+}
+
+impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
     type Ok = ();
     type Error = IonError;
 
-    type SerializeSeq = Self;
-    type SerializeTuple = Self;
-    type SerializeTupleStruct = Self;
-    type SerializeTupleVariant = Self;
-    type SerializeMap = Self;
-    type SerializeStruct = Self;
-    type SerializeStructVariant = Self;
+    type SerializeSeq = SeqWriter<V>;
+    type SerializeTuple = SeqWriter<V>;
+    type SerializeTupleStruct = SeqWriter<V::AnnotatedValueWriter<'a>>;
+    type SerializeTupleVariant = SeqWriter<V::AnnotatedValueWriter<'a>>;
+    type SerializeMap = MapWriter<V>;
+    type SerializeStruct = MapWriter<V>;
+    type SerializeStructVariant = MapWriter<V::AnnotatedValueWriter<'a>>;
 
     /// Serialize a boolean to a bool value
     fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_bool(v)
+        self.value_writer.write(v)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_i64(v.into())
+        self.value_writer.write(v as i64)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_i64(v.into())
+        self.value_writer.write(v as i64)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_i64(v.into())
+        self.value_writer.write(v)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_i64(v.into())
+        self.value_writer.write(v)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_i64(v.into())
+        self.value_writer.write(v)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_i64(v.into())
+        self.value_writer.write(v)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_i64(v)
+        self.value_writer.write(v)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_int(&Int::from(v))
+        self.value_writer.write(v)
     }
 
     fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_f32(v)
+        self.value_writer.write(v)
     }
 
     fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_f64(v)
+        self.value_writer.write(v)
     }
 
     fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_string(v.to_string())
+        // TODO: This could be optimized.
+        self.value_writer.write(v.to_string())
     }
 
     fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_string(v)
+        self.value_writer.write(v)
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_blob(v)
+        self.value_writer.write(v)
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_null(IonType::Null)
+        self.value_writer.write(Null(IonType::Null))
     }
 
     fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
@@ -173,17 +177,19 @@ where
         self.serialize_none()
     }
 
-    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
-        self.serialize_unit()
+    fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
+        self.value_writer.write(name.as_symbol_ref())
     }
 
     fn serialize_unit_variant(
         self,
-        _name: &'static str,
+        name: &'static str,
         _variant_index: u32,
         variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
-        self.serialize_str(variant)
+        self.value_writer
+            .with_annotations(name)?
+            .write(variant.as_symbol_ref())
     }
 
     fn serialize_newtype_struct<T: ?Sized>(
@@ -204,7 +210,7 @@ where
             // we are using TUNNELED_TIMESTAMP_TYPE_NAME flag here which indicates a timestamp value
             // The assert statement above that compares the sizes of the Timestamp and value types
             let timestamp = unsafe { std::mem::transmute_copy::<&T, &Timestamp>(&value) };
-            self.writer.write_timestamp(timestamp)
+            self.value_writer.write_timestamp(timestamp)
         } else if name == TUNNELED_DECIMAL_TYPE_NAME {
             // # Safety
             // compiler doesn't understand that the generic T here is actually Decimal here since
@@ -212,15 +218,16 @@ where
             // The assert statement above that compares the sizes of the Decimal and value types
             assert_eq!(std::mem::size_of_val(value), std::mem::size_of::<Decimal>());
             let decimal = unsafe { std::mem::transmute_copy::<&T, &Decimal>(&value) };
-            self.writer.write_decimal(decimal)
+            self.value_writer.write_decimal(decimal)
         } else {
-            value.serialize(self)
+            let serializer = ValueSerializer::new(self.value_writer.with_annotations(name)?);
+            value.serialize(serializer)
         }
     }
 
     fn serialize_newtype_variant<T: ?Sized>(
         self,
-        _name: &'static str,
+        name: &'static str,
         _variant_index: u32,
         variant: &'static str,
         value: &T,
@@ -228,44 +235,52 @@ where
     where
         T: Serialize,
     {
-        self.writer.set_annotations(vec![variant]);
-        value.serialize(&mut *self)
+        value.serialize(ValueSerializer::new(
+            self.value_writer.with_annotations([name, variant])?,
+        ))
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        self.writer.step_in(IonType::List)?;
-        Ok(self)
+        Ok(SeqWriter {
+            seq_writer: self.value_writer.list_writer()?,
+        })
     }
 
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        self.writer.step_in(IonType::List)?;
-        Ok(self)
+        Ok(SeqWriter {
+            seq_writer: self.value_writer.list_writer()?,
+        })
     }
 
     fn serialize_tuple_struct(
         self,
-        _name: &'static str,
+        name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        self.writer.step_in(IonType::List)?;
-        Ok(self)
+        Ok(SeqWriter {
+            seq_writer: self.value_writer.with_annotations(name)?.list_writer()?,
+        })
     }
 
     fn serialize_tuple_variant(
         self,
-        _name: &'static str,
+        name: &'static str,
         _variant_index: u32,
         variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        self.writer.set_annotations(vec![variant]);
-        self.writer.step_in(IonType::List)?;
-        Ok(self)
+        Ok(SeqWriter {
+            seq_writer: self
+                .value_writer
+                .with_annotations([name, variant])?
+                .list_writer()?,
+        })
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-        self.writer.step_in(IonType::Struct)?;
-        Ok(self)
+        Ok(MapWriter {
+            map_writer: self.value_writer.struct_writer()?,
+        })
     }
 
     fn serialize_struct(
@@ -273,27 +288,46 @@ where
         _name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
-        self.writer.step_in(IonType::Struct)?;
-        Ok(self)
+        Ok(MapWriter {
+            map_writer: self.value_writer.struct_writer()?,
+        })
     }
 
     fn serialize_struct_variant(
         self,
-        _name: &'static str,
+        name: &'static str,
         _variant_index: u32,
         variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        self.writer.set_annotations(vec![variant]);
-        self.writer.step_in(IonType::Struct)?;
-        Ok(self)
+        Ok(MapWriter {
+            map_writer: self
+                .value_writer
+                .with_annotations([name, variant])?
+                .struct_writer()?,
+        })
     }
 }
 
-impl<'a, E> ser::SerializeSeq for &'a mut Serializer<E>
-where
-    E: IonWriter,
-{
+pub struct SeqWriter<V: ValueWriter> {
+    seq_writer: V::ListWriter,
+}
+
+impl<V: ValueWriter> Deref for SeqWriter<V> {
+    type Target = V::ListWriter;
+
+    fn deref(&self) -> &Self::Target {
+        &self.seq_writer
+    }
+}
+
+impl<V: ValueWriter> DerefMut for SeqWriter<V> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.seq_writer
+    }
+}
+
+impl<V: ValueWriter> ser::SerializeSeq for SeqWriter<V> {
     type Ok = ();
     type Error = IonError;
 
@@ -301,18 +335,15 @@ where
     where
         T: Serialize,
     {
-        value.serialize(&mut **self)
+        value.serialize(ValueSerializer::new(self.value_writer()))
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        self.writer.step_out()
+        self.seq_writer.close()
     }
 }
 
-impl<'a, E> ser::SerializeTuple for &'a mut Serializer<E>
-where
-    E: IonWriter,
-{
+impl<V: ValueWriter> ser::SerializeTuple for SeqWriter<V> {
     type Ok = ();
     type Error = IonError;
 
@@ -320,18 +351,15 @@ where
     where
         T: Serialize,
     {
-        value.serialize(&mut **self)
+        value.serialize(ValueSerializer::new(self.value_writer()))
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        self.writer.step_out()
+        self.seq_writer.close()
     }
 }
 
-impl<'a, E> ser::SerializeTupleStruct for &'a mut Serializer<E>
-where
-    E: IonWriter,
-{
+impl<V: ValueWriter> ser::SerializeTupleStruct for SeqWriter<V> {
     type Ok = ();
     type Error = IonError;
 
@@ -339,18 +367,15 @@ where
     where
         T: Serialize,
     {
-        value.serialize(&mut **self)
+        value.serialize(ValueSerializer::new(self.value_writer()))
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        self.writer.step_out()
+        self.seq_writer.close()
     }
 }
 
-impl<'a, E> ser::SerializeTupleVariant for &'a mut Serializer<E>
-where
-    E: IonWriter,
-{
+impl<V: ValueWriter> ser::SerializeTupleVariant for SeqWriter<V> {
     type Ok = ();
     type Error = IonError;
 
@@ -358,18 +383,33 @@ where
     where
         T: Serialize,
     {
-        value.serialize(&mut **self)
+        value.serialize(ValueSerializer::new(self.value_writer()))
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        self.writer.step_out()
+        self.seq_writer.close()
     }
 }
 
-impl<'a, E> ser::SerializeMap for &'a mut Serializer<E>
-where
-    E: IonWriter,
-{
+pub struct MapWriter<V: ValueWriter> {
+    map_writer: V::StructWriter,
+}
+
+impl<V: ValueWriter> Deref for MapWriter<V> {
+    type Target = V::StructWriter;
+
+    fn deref(&self) -> &Self::Target {
+        &self.map_writer
+    }
+}
+
+impl<V: ValueWriter> DerefMut for MapWriter<V> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.map_writer
+    }
+}
+
+impl<V: ValueWriter> ser::SerializeMap for MapWriter<V> {
     type Ok = ();
     type Error = IonError;
 
@@ -380,27 +420,24 @@ where
         // We need to verify that the key is a string type or can be converted
         // to string
         let mk_serializer = MapKeySerializer {};
-        let field: String = key.serialize(mk_serializer)?;
-        self.writer.set_field_name(field);
-        Ok(())
+        let field_name: String = key.serialize(mk_serializer)?;
+        self.encode_field_name(field_name.as_str())
     }
 
     fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
     where
         T: Serialize,
     {
-        value.serialize(&mut **self)
+        let serializer = ValueSerializer::new(self.make_value_writer());
+        value.serialize(serializer)
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        self.writer.step_out()
+        self.map_writer.close()
     }
 }
 
-impl<'a, E> ser::SerializeStructVariant for &'a mut Serializer<E>
-where
-    E: IonWriter,
-{
+impl<V: ValueWriter> ser::SerializeStructVariant for MapWriter<V> {
     type Ok = ();
     type Error = IonError;
 
@@ -412,19 +449,16 @@ where
     where
         T: Serialize,
     {
-        self.writer.set_field_name(key);
-        value.serialize(&mut **self)
+        let serializer = ValueSerializer::new(self.field_writer(key));
+        value.serialize(serializer)
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        self.writer.step_out()
+        self.map_writer.close()
     }
 }
 
-impl<'a, E> ser::SerializeStruct for &'a mut Serializer<E>
-where
-    E: IonWriter,
-{
+impl<V: ValueWriter> ser::SerializeStruct for MapWriter<V> {
     type Ok = ();
     type Error = IonError;
 
@@ -436,13 +470,12 @@ where
     where
         T: Serialize,
     {
-        self.writer.set_field_name(key);
-        value.serialize(&mut **self)
+        let serializer = ValueSerializer::new(self.field_writer(key));
+        value.serialize(serializer)
     }
 
     fn end(self) -> Result<(), IonError> {
-        self.writer.step_out()?;
-        Ok(())
+        self.map_writer.close()
     }
 }
 
@@ -456,6 +489,8 @@ fn key_must_be_a_string() -> IonError {
 }
 
 impl ser::Serializer for MapKeySerializer {
+    // TODO: Adding a lifetime to MapKeySerializer would allow this to be Cow<'a, str> and avoid
+    //       allocating in some cases.
     type Ok = String;
     type Error = IonError;
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -90,15 +90,86 @@ impl IonOrd for IonType {
     }
 }
 
-// Represents a level into which the writer has stepped.
-// A writer that has not yet called step_in() is at the top level.
-#[derive(Debug, PartialEq, Default)]
+/// An Ion container type.
+///
+/// This is similar to [`ParentType`], but does not include the top level as a variant.
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub(crate) enum ContainerType {
+    /// An s-expression
+    SExp,
+    /// A list
+    List,
+    /// A struct
+    Struct,
+}
+
+impl From<ContainerType> for IonType {
+    fn from(value: ContainerType) -> Self {
+        match value {
+            ContainerType::SExp => IonType::SExp,
+            ContainerType::List => IonType::List,
+            ContainerType::Struct => IonType::Struct,
+        }
+    }
+}
+
+/// The enclosing context in which a value is found.
+///
+/// This is a superset of [`ContainerType`], which does not include a variant for the top
+/// level.
+#[derive(Debug, PartialEq, Default, Copy, Clone)]
+pub(crate) enum ParentType {
+    /// The value is not inside a container.
     #[default]
     TopLevel,
-    SExpression,
+    /// The value is inside of an s-expression.
+    SExp,
+    /// The value is inside of a list.
     List,
+    /// The value is inside of a struct.
     Struct,
+}
+
+impl From<ContainerType> for ParentType {
+    fn from(value: ContainerType) -> Self {
+        match value {
+            ContainerType::SExp => ParentType::SExp,
+            ContainerType::List => ParentType::List,
+            ContainerType::Struct => ParentType::Struct,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Default, Copy, Clone)]
+pub(crate) enum ScalarType {
+    #[default]
+    Null,
+    Bool,
+    Int,
+    Float,
+    Decimal,
+    Timestamp,
+    Symbol,
+    String,
+    Clob,
+    Blob,
+}
+
+impl From<ScalarType> for IonType {
+    fn from(value: ScalarType) -> Self {
+        match value {
+            ScalarType::Null => IonType::Null,
+            ScalarType::Bool => IonType::Bool,
+            ScalarType::Int => IonType::Int,
+            ScalarType::Float => IonType::Float,
+            ScalarType::Decimal => IonType::Decimal,
+            ScalarType::Timestamp => IonType::Timestamp,
+            ScalarType::Symbol => IonType::Symbol,
+            ScalarType::String => IonType::String,
+            ScalarType::Clob => IonType::Clob,
+            ScalarType::Blob => IonType::Blob,
+        }
+    }
 }
 
 /// Returns the number of base-10 digits needed to represent `value`.


### PR DESCRIPTION
This PR replaces usages of the old `UserWriter` with the new `ApplicationWriter` introduced in #745 (currently under review).

It also modifies the encoding of various serde data types to include type annotations:
<table >
  <tr>
    <td>Serde type</td>
    <td>Example Rust</td>
    <td>Old serialization</td>
    <td>New serialization</td>
  </tr>
  <tr>
    <td>Unit struct</td>
    <td>

```rust
struct Foo;
```

</td>
<td>

<pre>
"Foo"
</pre>

</td>

<td>

<pre>
Foo
</pre>

</td>
</tr>

<!-- ------------------------------ -->

<tr>
    <td>Newtype</td>
    <td>

```rust

struct Foo(i32);
```

</td>
<td>

<pre>
1
</pre>

</td>

<td>

<pre>
Foo::1
</pre>

</td>
</tr>

<!-- ------------------------------ -->

<tr>
    <td>Tuple struct</td>
    <td>

```rust
struct Foo(i32, i32);
```

</td>
<td>

<pre>
[1, 2]
</pre>

</td>

<td>

<pre>
Foo::[1, 2]
</pre>

</td>
</tr>

<!-- ------------------------------ -->

<tr>
    <td>Struct</td>
    <td>

```rust

struct Foo {
  x: i32,
  y: i32                    
}
```

</td>
<td>

<pre>
{
  x: 1,
  y: 2,
}
</pre>

</td>

<td>

<pre>
Foo::{
  x: 1,
  y: 2,
}
</pre>

</td>
</tr>

<!-- ------------------------------ -->

</table>

Similarly, enum variant kinds now also include the name of the enum type:

<table >
  <tr>
    <td>Serde type</td>
    <td>Example Rust</td>
    <td>Old serialization</td>
    <td>New serialization</td>
  </tr>
  <tr>
    <td>Unit struct variant</td>
    <td>

```rust
enum Foo {
  Bar // No associated data        
}
```

</td>
<td>

<pre>
"Bar"
</pre>

</td>

<td>

<pre>
Foo::Bar
</pre>

</td>
</tr>

<!-- ------------------------------ -->

<tr>
    <td>Newtype variant</td>
    <td>

```rust

enum Foo {
  Bar(i32)                          
}
```

</td>
<td>

<pre>
Bar::1
</pre>

</td>

<td>

<pre>
Foo::Bar::1
</pre>

</td>
</tr>

<!-- ------------------------------ -->

<tr>
    <td>Tuple variant</td>
    <td>

```rust

enum Foo {
  Bar(i32, i32)                          
}
```

</td>
<td>

<pre>
Bar::[1, 2]
</pre>

</td>

<td>

<pre>
Foo::Bar::[1, 2]
</pre>

</td>
</tr>

<!-- ------------------------------ -->

<tr>
    <td>Struct variant</td>
    <td>

```rust

enum Foo {
  Bar {
    x: i32,
    y: i32       
  }                   
}
```

</td>
<td>

<pre>
Bar::{
  x: 1,
  y: 2,
}
</pre>

</td>

<td>

<pre>
Foo::Bar::{
  x: 1,
  y: 2,
}
</pre>

</td>
</tr>

<!-- ------------------------------ -->

</table>

This clarity comes at the expense of a bit of data size, but macros make it possible to reduce the size again if you're so motivated. The type names are not strictly needed as `serde` can determine the expected type from context. However, it may be helpful for humans.

Feedback on this tradeoff is welcome!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
