### PR TITLE
Values are no longer serialized with a type identifier annotation.

### DIFF
--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -308,7 +308,7 @@ mod tests {
             Struct { a: u32 },
         }
 
-        let i = r#"E::Unit"#;
+        let i = r#"Unit"#;
         let expected = E::Unit;
         assert_eq!(expected, from_ion(i).unwrap());
         assert_eq!(
@@ -316,7 +316,7 @@ mod tests {
             Element::read_first(to_string(&expected).unwrap())
         );
 
-        let i = r#"E::Newtype::1"#;
+        let i = r#"Newtype::1"#;
         let expected = E::Newtype(1);
         assert_eq!(expected, from_ion(i).unwrap());
         assert_eq!(
@@ -324,7 +324,7 @@ mod tests {
             Element::read_first(to_string(&expected).unwrap())
         );
 
-        let i = r#"E::Tuple::[1, 2]"#;
+        let i = r#"Tuple::[1, 2]"#;
         let expected = E::Tuple(1, 2);
         assert_eq!(expected, from_ion(i).unwrap());
         assert_eq!(
@@ -332,7 +332,7 @@ mod tests {
             Element::read_first(to_string(&expected).unwrap())
         );
 
-        let i = r#"E::Struct::{a: 1}"#;
+        let i = r#"Struct::{a: 1}"#;
         let expected = E::Struct { a: 1 };
         assert_eq!(expected, from_ion(i).unwrap());
         assert_eq!(


### PR DESCRIPTION
Addresses [this comment](https://github.com/amazon-ion/ion-rust/pull/747#issuecomment-2069824799) from PR #747.

Enum variants and struct types are no longer annotated with their Rust type name. Enums _are_ still annotated with their variant name, which can be modified using standard `serde` config attributes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
