### PR TITLE
Add 1.1 binary reader support for bools

### DIFF
--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -229,7 +229,10 @@ impl<'a> ImmutableBuffer<'a> {
     /// read, the returned `FlexUInt`'s `size_in_bytes()` method will return `0`.
     pub fn read_value_length(self, header: Header) -> ParseResult<'a, FlexUInt> {
         let length = match header.length_type() {
-            LengthType::InOpcode(n) => FlexUInt::new(1, n as u64),
+            LengthType::InOpcode(n) => {
+                // FlexUInt represents the length, but is not physically present, hence the 0 size.
+                FlexUInt::new(0, n as u64)
+            }
             LengthType::FlexUIntFollows => {
                 let (flexuint, _) = self.read_flex_uint()?;
                 flexuint

--- a/src/lazy/binary/raw/v1_1/reader.rs
+++ b/src/lazy/binary/raw/v1_1/reader.rs
@@ -194,9 +194,9 @@ mod tests {
         let mut reader = LazyRawBinaryReader_1_1::new(&data);
         let _ivm = reader.next()?.expect_ivm()?;
 
-        assert_eq!(reader.next()?.expect_value()?.read()?.expect_bool()?, true,);
+        assert!(reader.next()?.expect_value()?.read()?.expect_bool()?);
 
-        assert_eq!(reader.next()?.expect_value()?.read()?.expect_bool()?, false,);
+        assert!(!(reader.next()?.expect_value()?.read()?.expect_bool()?));
 
         Ok(())
     }

--- a/src/lazy/binary/raw/v1_1/reader.rs
+++ b/src/lazy/binary/raw/v1_1/reader.rs
@@ -182,4 +182,22 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn bools() -> IonResult<()> {
+        let data: Vec<u8> = vec![
+            0xE0, 0x01, 0x01, 0xEA, // IVM
+            0x5E, // true
+            0x5F, // false
+        ];
+
+        let mut reader = LazyRawBinaryReader_1_1::new(&data);
+        let _ivm = reader.next()?.expect_ivm()?;
+
+        assert_eq!(reader.next()?.expect_value()?.read()?.expect_bool()?, true,);
+
+        assert_eq!(reader.next()?.expect_value()?.read()?.expect_bool()?, false,);
+
+        Ok(())
+    }
 }

--- a/src/lazy/binary/raw/v1_1/type_descriptor.rs
+++ b/src/lazy/binary/raw/v1_1/type_descriptor.rs
@@ -40,6 +40,7 @@ impl Opcode {
         use OpcodeType::*;
 
         let opcode_type = match (high_nibble, low_nibble) {
+            (0x5, 0xE..=0xF) => Boolean,
             (0xE, 0x0) => IonVersionMarker,
             (0xE, 0xA) => NullNull,
             (0xE, 0xC..=0xD) => Nop,
@@ -110,6 +111,7 @@ impl Header {
     pub fn length_type(&self) -> LengthType {
         use LengthType::*;
         match (self.ion_type_code, self.length_code) {
+            (OpcodeType::Boolean, 0xE..=0xF) => InOpcode(0),
             (OpcodeType::Nop, 0xC) => InOpcode(0),
             (OpcodeType::NullNull, 0xA) => InOpcode(0),
             _ => FlexUIntFollows,

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -192,12 +192,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
         let value = match (representation, header.length_code) {
             (OpcodeType::Boolean, 0xE) => true,
             (OpcodeType::Boolean, 0xF) => false,
-            invalid => {
-                return IonResult::decoding_error(format!(
-                    "found a boolean value with an illegal type code representation: {:?}",
-                    invalid
-                ))
-            }
+            _ => unreachable!("found a boolean value with an illegal length code."),
         };
         Ok(RawValueRef::Bool(value))
     }


### PR DESCRIPTION
*Issue #, if available:* #662

*Description of changes:*
This PR is the first in the chain of scalar value implementations, implementing the parsing of boolean values.

I've tried to keep each value type separated into its own PR, in order to keep the changes trivial and quick to review.. this is proving to be irritating, so I might merge a few.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
