### PR TITLE
Ensure that FixedInt and FixedUInt handle zero-length integers

### DIFF
--- a/src/lazy/encoder/binary/v1_1/fixed_uint.rs
+++ b/src/lazy/encoder/binary/v1_1/fixed_uint.rs
@@ -173,6 +173,18 @@ mod tests {
     }
 
     #[test]
+    fn decode_zero_length_fixed_uint() -> IonResult<()> {
+        let encoding = &[];
+        let fixed_uint = FixedUInt::read(encoding, encoding.len(), 0)?;
+        let actual_value = fixed_uint.value().expect_u64()?;
+        assert_eq!(
+            actual_value, 0,
+            "actual value {actual_value} was != expected value 0 for encoding {encoding:x?}"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn encode_fixed_uint() -> IonResult<()> {
         // Make two copies of each of our tests. In the first, each u64 is turned into a UInt.
         let mut test_cases: Vec<_> = FIXED_UINT_TEST_CASES


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

As I was looking at #757, I realized that there are cases where we may have a zero-width FixedInt (and maybe FixedUInt), so I'm updating their implementations to be able to read that correctly. While I was at it, I managed to get rid of the branching for positive and negative numbers in `FlexInt::read`. No changes were needed in `FlexUInt::read`, but I added a test case for it anyway.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
