### PR TITLE
Text reader implementation cleanup

### DIFF
--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -175,7 +175,6 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
     fn value_body(&self) -> IonResult<&'top [u8]> {
         let value_total_length = self.encoded_value.total_length();
         if self.input.len() < value_total_length {
-            eprintln!("[value_body] Incomplete {:?}", self);
             return IonResult::incomplete(
                 "only part of the requested value is available in the buffer",
                 self.input.offset(),

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -231,7 +231,7 @@ impl<'a, 'top> EncodedBinaryValueData_1_0<'a, 'top> {
     pub fn trailing_length_span(&self) -> Span<'top> {
         let stream_range = self.trailing_length_range();
         let offset = self.value.input.offset();
-        let local_range = stream_range.start - offset .. stream_range.end - offset;
+        let local_range = stream_range.start - offset..stream_range.end - offset;
         let bytes = &self.value.input.bytes()[local_range];
         Span::with_offset(stream_range.start, bytes)
     }
@@ -252,7 +252,7 @@ impl<'a, 'top> EncodedBinaryValueData_1_0<'a, 'top> {
     pub fn body_span(&self) -> Span<'top> {
         let stream_range = self.body_range();
         let offset = self.value.input.offset();
-        let local_range = stream_range.start - offset .. stream_range.end - offset;
+        let local_range = stream_range.start - offset..stream_range.end - offset;
         let bytes = &self.span().bytes()[local_range];
         Span::with_offset(stream_range.start, bytes)
     }

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -269,7 +269,7 @@ impl<'top, D: LazyDecoder> HasRange for LazyRawFieldExpr<'top, D> {
 // function while also preventing users from seeing or depending on it.
 pub(crate) mod private {
     use crate::lazy::expanded::r#struct::UnexpandedField;
-    use crate::lazy::expanded::EncodingContext;
+    use crate::lazy::expanded::EncodingContextRef;
     use crate::IonResult;
 
     use super::{LazyDecoder, LazyRawFieldExpr, LazyRawStruct};
@@ -286,17 +286,17 @@ pub(crate) mod private {
         /// expansion process.
         fn unexpanded_fields(
             &self,
-            context: EncodingContext<'top>,
+            context: EncodingContextRef<'top>,
         ) -> RawStructUnexpandedFieldsIterator<'top, D>;
     }
 
     pub struct RawStructUnexpandedFieldsIterator<'top, D: LazyDecoder> {
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         raw_fields: <D::Struct<'top> as LazyRawStruct<'top, D>>::Iterator,
     }
 
     impl<'top, D: LazyDecoder> RawStructUnexpandedFieldsIterator<'top, D> {
-        pub fn context(&self) -> EncodingContext<'top> {
+        pub fn context(&self) -> EncodingContextRef<'top> {
             self.context
         }
     }
@@ -326,7 +326,7 @@ pub(crate) mod private {
     {
         fn unexpanded_fields(
             &self,
-            context: EncodingContext<'top>,
+            context: EncodingContextRef<'top>,
         ) -> RawStructUnexpandedFieldsIterator<'top, D> {
             let raw_fields = <Self as LazyRawStruct<'top, D>>::iter(self);
             RawStructUnexpandedFieldsIterator {

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -295,6 +295,12 @@ pub(crate) mod private {
         raw_fields: <D::Struct<'top> as LazyRawStruct<'top, D>>::Iterator,
     }
 
+    impl<'top, D: LazyDecoder> RawStructUnexpandedFieldsIterator<'top, D> {
+        pub fn context(&self) -> EncodingContext<'top> {
+            self.context
+        }
+    }
+
     impl<'top, D: LazyDecoder> Iterator for RawStructUnexpandedFieldsIterator<'top, D> {
         type Item = IonResult<UnexpandedField<'top, D>>;
 

--- a/src/lazy/encoding.rs
+++ b/src/lazy/encoding.rs
@@ -29,7 +29,7 @@ use crate::lazy::text::raw::v1_1::reader::{
 };
 use crate::lazy::text::value::{
     LazyRawTextValue, LazyRawTextValue_1_0, LazyRawTextValue_1_1, LazyRawTextVersionMarker_1_0,
-    LazyRawTextVersionMarker_1_1, MatchedRawTextValue, RawTextAnnotationsIterator,
+    LazyRawTextVersionMarker_1_1, RawTextAnnotationsIterator,
 };
 use crate::{TextKind, WriteConfig};
 
@@ -100,26 +100,16 @@ pub trait BinaryEncoding<'top>: Encoding + LazyDecoder {}
 
 /// Marker trait for text encodings.
 pub trait TextEncoding<'top>:
-    Encoding + LazyDecoder<AnnotationsIterator<'top> = RawTextAnnotationsIterator<'top>>
+    Encoding
+    + LazyDecoder<
+        AnnotationsIterator<'top> = RawTextAnnotationsIterator<'top>,
+        Value<'top> = LazyRawTextValue<'top, Self>,
+    >
 {
-    fn value_from_matched(
-        matched: MatchedRawTextValue<'top, Self>,
-    ) -> <Self as LazyDecoder>::Value<'top>;
+    // No methods, just a marker
 }
-impl<'top> TextEncoding<'top> for TextEncoding_1_0 {
-    fn value_from_matched(
-        matched: MatchedRawTextValue<'_, Self>,
-    ) -> <Self as LazyDecoder>::Value<'_> {
-        LazyRawTextValue_1_0::from(matched)
-    }
-}
-impl<'top> TextEncoding<'top> for TextEncoding_1_1 {
-    fn value_from_matched(
-        matched: MatchedRawTextValue<'_, Self>,
-    ) -> <Self as LazyDecoder>::Value<'_> {
-        LazyRawTextValue_1_1::from(matched)
-    }
-}
+impl<'top> TextEncoding<'top> for TextEncoding_1_0 {}
+impl<'top> TextEncoding<'top> for TextEncoding_1_1 {}
 
 /// Marker trait for encodings that support macros.
 pub trait EncodingWithMacroSupport {}
@@ -192,7 +182,6 @@ impl LazyDecoder for BinaryEncoding_1_1 {
 // the implementation will conflict with the core `impl<T> From<T> for T` implementation.
 pub trait RawValueLiteral {}
 
-impl<'top, E: TextEncoding<'top>> RawValueLiteral for MatchedRawTextValue<'top, E> {}
 impl<'top, E: TextEncoding<'top>> RawValueLiteral for LazyRawTextValue<'top, E> {}
 impl<'top> RawValueLiteral for LazyRawBinaryValue_1_0<'top> {}
 impl<'top> RawValueLiteral for LazyRawBinaryValue_1_1<'top> {}

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -9,7 +9,7 @@ use crate::lazy::expanded::template::{
     TemplateBodyMacroInvocation, TemplateBodyValueExpr, TemplateMacro, TemplateStructIndex,
     TemplateValue,
 };
-use crate::lazy::expanded::EncodingContext;
+use crate::lazy::expanded::EncodingContextRef;
 use crate::lazy::r#struct::LazyStruct;
 use crate::lazy::reader::LazyTextReader_1_1;
 use crate::lazy::sequence::{LazyList, LazySExp};
@@ -61,7 +61,7 @@ impl TemplateCompiler {
     /// to the template without interpretation. `(quote ...)` does not appear in the compiled
     /// template as there is nothing more for it to do at expansion time.
     pub fn compile_from_text(
-        context: EncodingContext,
+        context: EncodingContextRef,
         expression: &str,
     ) -> IonResult<TemplateMacro> {
         // TODO: This is a rudimentary implementation that panics instead of performing thorough
@@ -137,7 +137,7 @@ impl TemplateCompiler {
     ///
     /// If `is_quoted` is true, nested symbols and s-expressions will not be interpreted.
     fn compile_value<'top, D: LazyDecoder>(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         signature: &MacroSignature,
         definition: &mut TemplateBody,
         is_quoted: bool,
@@ -210,7 +210,7 @@ impl TemplateCompiler {
 
     /// Helper method for visiting all of the child expressions in a list.
     fn compile_list<'top, D: LazyDecoder>(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         signature: &MacroSignature,
         definition: &mut TemplateBody,
         is_quoted: bool,
@@ -238,7 +238,7 @@ impl TemplateCompiler {
 
     /// Helper method for visiting all of the child expressions in a sexp.
     fn compile_sexp<'top, D: LazyDecoder>(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         signature: &MacroSignature,
         definition: &mut TemplateBody,
         is_quoted: bool,
@@ -272,7 +272,7 @@ impl TemplateCompiler {
     /// Adds a `lazy_sexp` that has been determined to represent a macro invocation to the
     /// TemplateBody.
     fn compile_macro<'top, D: LazyDecoder>(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         signature: &MacroSignature,
         definition: &mut TemplateBody,
         lazy_sexp: LazySExp<'top, D>,
@@ -311,7 +311,7 @@ impl TemplateCompiler {
     /// Given a `LazyValue` that represents a macro ID (name or address), attempts to resolve the
     /// ID to a macro address.
     fn name_and_address_from_id_expr<'top, D: LazyDecoder>(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         id_expr: Option<IonResult<LazyValue<'top, D>>>,
     ) -> IonResult<(Option<String>, usize)> {
         match id_expr {
@@ -352,7 +352,7 @@ impl TemplateCompiler {
     /// without interpretation. `lazy_sexp` itself is the `quote` macro, and does not get added
     /// to the template body as there is nothing more for it to do at evaluation time.
     fn compile_quoted_elements<'top, D: LazyDecoder>(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         signature: &MacroSignature,
         definition: &mut TemplateBody,
         lazy_sexp: LazySExp<'top, D>,
@@ -375,7 +375,7 @@ impl TemplateCompiler {
 
     /// Adds `lazy_sexp` to the template body without interpretation.
     fn compile_quoted_sexp<'top, D: LazyDecoder>(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         signature: &MacroSignature,
         definition: &mut TemplateBody,
         annotations_range: Range<usize>,
@@ -419,7 +419,7 @@ impl TemplateCompiler {
 
     /// Recursively adds all of the expressions in `lazy_struct` to the `TemplateBody`.
     fn compile_struct<'top, D: LazyDecoder>(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         signature: &MacroSignature,
         definition: &mut TemplateBody,
         is_quoted: bool,
@@ -476,7 +476,7 @@ impl TemplateCompiler {
     /// Resolves `variable` to a parameter in the macro signature and adds a corresponding
     /// `TemplateExpansionStep` to the `TemplateBody`.
     fn compile_variable_reference(
-        _context: EncodingContext,
+        _context: EncodingContextRef,
         signature: &MacroSignature,
         definition: &mut TemplateBody,
         annotations_range: Range<usize>,
@@ -630,7 +630,7 @@ mod tests {
 
         let expression = "(macro foo () 42)";
 
-        let template = TemplateCompiler::compile_from_text(context, expression)?;
+        let template = TemplateCompiler::compile_from_text(context.get_ref(), expression)?;
         assert_eq!(template.name(), "foo");
         assert_eq!(template.signature().parameters().len(), 0);
         expect_value(&template, 0, TemplateValue::Int(42.into()))?;
@@ -644,7 +644,7 @@ mod tests {
 
         let expression = "(macro foo () [1, 2, 3])";
 
-        let template = TemplateCompiler::compile_from_text(context, expression)?;
+        let template = TemplateCompiler::compile_from_text(context.get_ref(), expression)?;
         assert_eq!(template.name(), "foo");
         assert_eq!(template.signature().parameters().len(), 0);
         expect_value(&template, 0, TemplateValue::List(ExprRange::new(1..4)))?;
@@ -661,7 +661,7 @@ mod tests {
 
         let expression = r#"(macro foo () (values 42 "hello" false))"#;
 
-        let template = TemplateCompiler::compile_from_text(context, expression)?;
+        let template = TemplateCompiler::compile_from_text(context.get_ref(), expression)?;
         assert_eq!(template.name(), "foo");
         assert_eq!(template.signature().parameters().len(), 0);
         expect_macro(
@@ -683,7 +683,7 @@ mod tests {
 
         let expression = "(macro foo (x y z) [100, [200, a::b::300], x, {y: [true, false, z]}])";
 
-        let template = TemplateCompiler::compile_from_text(context, expression)?;
+        let template = TemplateCompiler::compile_from_text(context.get_ref(), expression)?;
         expect_value(&template, 0, TemplateValue::List(ExprRange::new(1..12)))?;
         expect_value(&template, 1, TemplateValue::Int(Int::from(100)))?;
         expect_value(&template, 2, TemplateValue::List(ExprRange::new(3..5)))?;
@@ -713,7 +713,7 @@ mod tests {
 
         let expression = "(macro identity (x) x)";
 
-        let template = TemplateCompiler::compile_from_text(context, expression)?;
+        let template = TemplateCompiler::compile_from_text(context.get_ref(), expression)?;
         assert_eq!(template.name(), "identity");
         assert_eq!(template.signature().parameters().len(), 1);
         expect_variable(&template, 0, 0)?;
@@ -736,7 +736,7 @@ mod tests {
                         (values x))))
         "#;
 
-        let template = TemplateCompiler::compile_from_text(context, expression)?;
+        let template = TemplateCompiler::compile_from_text(context.get_ref(), expression)?;
         assert_eq!(template.name(), "foo");
         assert_eq!(template.signature().parameters().len(), 1);
         // Outer `values`

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -497,7 +497,10 @@ impl TemplateCompiler {
             .ok_or_else(|| {
                 IonError::decoding_error(format!("variable '{name}' is not recognized"))
             })?;
-        definition.push_variable(signature_index);
+        if signature_index > u16::MAX as usize {
+            return IonResult::decoding_error("this implementation supports up to 65K parameters");
+        }
+        definition.push_variable(signature_index as u16);
         Ok(())
     }
 }
@@ -558,7 +561,7 @@ mod tests {
             definition,
             index,
             TemplateBodyValueExpr::Variable(TemplateBodyVariableReference::new(
-                expected_signature_index,
+                expected_signature_index as u16,
             )),
         )
     }

--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -5,7 +5,7 @@ use crate::lazy::decoder::{LazyDecoder, LazyRawValueExpr};
 use crate::lazy::encoding::TextEncoding_1_1;
 use crate::lazy::expanded::macro_evaluator::{MacroExpr, RawEExpression, ValueExpr};
 use crate::lazy::expanded::macro_table::MacroRef;
-use crate::lazy::expanded::{EncodingContext, LazyExpandedValue};
+use crate::lazy::expanded::{EncodingContextRef, LazyExpandedValue};
 use crate::lazy::text::raw::v1_1::reader::MacroIdRef;
 use crate::IonResult;
 use std::fmt::{Debug, Formatter};
@@ -13,13 +13,13 @@ use std::fmt::{Debug, Formatter};
 /// An e-expression (in Ion format `D`) that has been resolved in the current encoding context.
 #[derive(Copy, Clone)]
 pub struct EExpression<'top, D: LazyDecoder> {
-    pub(crate) context: EncodingContext<'top>,
+    pub(crate) context: EncodingContextRef<'top>,
     pub(crate) raw_invocation: D::EExp<'top>,
     pub(crate) invoked_macro: MacroRef<'top>,
 }
 
 impl<'top, D: LazyDecoder> EExpression<'top, D> {
-    pub fn context(&self) -> EncodingContext<'top> {
+    pub fn context(&self) -> EncodingContextRef<'top> {
         self.context
     }
     pub fn raw_invocation(&self) -> D::EExp<'top> {
@@ -38,7 +38,7 @@ impl<'top, D: LazyDecoder> Debug for EExpression<'top, D> {
 
 impl<'top, D: LazyDecoder> EExpression<'top, D> {
     pub fn new(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         raw_invocation: D::EExp<'top>,
         invoked_macro: MacroRef<'top>,
     ) -> Self {
@@ -70,7 +70,7 @@ impl<'top, D: LazyDecoder> From<EExpression<'top, D>> for MacroExpr<'top, D> {
 }
 
 pub struct EExpressionArgsIterator<'top, D: LazyDecoder> {
-    context: EncodingContext<'top>,
+    context: EncodingContextRef<'top>,
     raw_args: <D::EExp<'top> as RawEExpression<'top, D>>::RawArgumentsIterator<'top>,
 }
 

--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -19,6 +19,9 @@ pub struct EExpression<'top, D: LazyDecoder> {
 }
 
 impl<'top, D: LazyDecoder> EExpression<'top, D> {
+    pub fn context(&self) -> EncodingContext<'top> {
+        self.context
+    }
     pub fn raw_invocation(&self) -> D::EExp<'top> {
         self.raw_invocation
     }

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -25,7 +25,7 @@ use crate::lazy::expanded::template::{
     TemplateMacroInvocationArgsIterator, TemplateMacroRef, TemplateValue,
 };
 use crate::lazy::expanded::EncodingContextRef;
-use crate::lazy::expanded::{ExpandedValueRef, ExpandedValueSource, LazyExpandedValue};
+use crate::lazy::expanded::{ExpandedValueRef, LazyExpandedValue};
 use crate::lazy::str_ref::StrRef;
 use crate::lazy::text::raw::v1_1::reader::MacroIdRef;
 use crate::result::IonFailure;
@@ -607,11 +607,9 @@ impl<'top, D: LazyDecoder> MakeStringExpansion<'top, D> {
         static EMPTY_ANNOTATIONS: &[&str] = &[];
 
         self.is_complete = true;
-        Ok(Some(ValueExpr::ValueLiteral(LazyExpandedValue {
-            context,
-            source: ExpandedValueSource::Constructed(EMPTY_ANNOTATIONS, expanded_value_ref),
-            variable: None,
-        })))
+        Ok(Some(ValueExpr::ValueLiteral(
+            LazyExpandedValue::from_constructed(context, EMPTY_ANNOTATIONS, expanded_value_ref),
+        )))
     }
 
     /// Appends a string fragment to the `BumpString` being constructed.

--- a/src/lazy/expanded/sequence.rs
+++ b/src/lazy/expanded/sequence.rs
@@ -7,8 +7,8 @@ use crate::lazy::expanded::template::{
     AnnotationsRange, ExprRange, TemplateMacroRef, TemplateSequenceIterator,
 };
 use crate::lazy::expanded::{
-    EncodingContext, ExpandedAnnotationsIterator, ExpandedAnnotationsSource, ExpandedValueSource,
-    LazyExpandedValue,
+    EncodingContextRef, ExpandedAnnotationsIterator, ExpandedAnnotationsSource,
+    ExpandedValueSource, LazyExpandedValue,
 };
 use crate::result::IonFailure;
 use crate::{IonError, IonResult, IonType};
@@ -84,13 +84,13 @@ pub enum ExpandedListSource<'top, D: LazyDecoder> {
 /// a template.
 #[derive(Clone, Copy)]
 pub struct LazyExpandedList<'top, D: LazyDecoder> {
-    pub(crate) context: EncodingContext<'top>,
+    pub(crate) context: EncodingContextRef<'top>,
     pub(crate) source: ExpandedListSource<'top, D>,
 }
 
 impl<'top, D: LazyDecoder> LazyExpandedList<'top, D> {
     pub fn from_literal(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         list: D::List<'top>,
     ) -> LazyExpandedList<'top, D> {
         let source = ExpandedListSource::ValueLiteral(list);
@@ -98,7 +98,7 @@ impl<'top, D: LazyDecoder> LazyExpandedList<'top, D> {
     }
 
     pub fn from_template(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         environment: Environment<'top, D>,
         template: TemplateMacroRef<'top>,
         annotations_range: AnnotationsRange,
@@ -173,7 +173,7 @@ pub enum ExpandedListIteratorSource<'top, D: LazyDecoder> {
 
 /// Iterates over the child values of a [`LazyExpandedList`].
 pub struct ExpandedListIterator<'top, D: LazyDecoder> {
-    context: EncodingContext<'top>,
+    context: EncodingContextRef<'top>,
     source: ExpandedListIteratorSource<'top, D>,
 }
 
@@ -209,7 +209,7 @@ pub enum ExpandedSExpSource<'top, D: LazyDecoder> {
 #[derive(Clone, Copy)]
 pub struct LazyExpandedSExp<'top, D: LazyDecoder> {
     pub(crate) source: ExpandedSExpSource<'top, D>,
-    pub(crate) context: EncodingContext<'top>,
+    pub(crate) context: EncodingContextRef<'top>,
 }
 
 impl<'top, D: LazyDecoder> LazyExpandedSExp<'top, D> {
@@ -263,7 +263,7 @@ impl<'top, D: LazyDecoder> LazyExpandedSExp<'top, D> {
     }
 
     pub fn from_literal(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         sexp: D::SExp<'top>,
     ) -> LazyExpandedSExp<'top, D> {
         let source = ExpandedSExpSource::ValueLiteral(sexp);
@@ -271,7 +271,7 @@ impl<'top, D: LazyDecoder> LazyExpandedSExp<'top, D> {
     }
 
     pub fn from_template(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         environment: Environment<'top, D>,
         template: TemplateMacroRef<'top>,
         annotations: AnnotationsRange,
@@ -296,7 +296,7 @@ pub enum ExpandedSExpIteratorSource<'top, D: LazyDecoder> {
 
 /// Iterates over the child values of a [`LazyExpandedSExp`].
 pub struct ExpandedSExpIterator<'top, D: LazyDecoder> {
-    context: EncodingContext<'top>,
+    context: EncodingContextRef<'top>,
     source: ExpandedSExpIteratorSource<'top, D>,
 }
 
@@ -316,7 +316,7 @@ impl<'top, D: LazyDecoder> Iterator for ExpandedSExpIterator<'top, D> {
 /// For both lists and s-expressions, yields the next sequence value by either continuing a macro
 /// evaluation already in progress or reading the next item from the input stream.
 fn expand_next_sequence_value<'top, D: LazyDecoder>(
-    context: EncodingContext<'top>,
+    context: EncodingContextRef<'top>,
     evaluator: &mut MacroEvaluator<'top, D>,
     iter: &mut impl Iterator<Item = IonResult<LazyRawValueExpr<'top, D>>>,
 ) -> Option<IonResult<LazyExpandedValue<'top, D>>> {

--- a/src/lazy/expanded/sequence.rs
+++ b/src/lazy/expanded/sequence.rs
@@ -7,8 +7,7 @@ use crate::lazy::expanded::template::{
     AnnotationsRange, ExprRange, TemplateMacroRef, TemplateSequenceIterator,
 };
 use crate::lazy::expanded::{
-    EncodingContextRef, ExpandedAnnotationsIterator, ExpandedAnnotationsSource,
-    ExpandedValueSource, LazyExpandedValue,
+    EncodingContextRef, ExpandedAnnotationsIterator, ExpandedAnnotationsSource, LazyExpandedValue,
 };
 use crate::result::IonFailure;
 use crate::{IonError, IonResult, IonType};
@@ -335,11 +334,7 @@ fn expand_next_sequence_value<'top, D: LazyDecoder>(
         match iter.next() {
             None => return None,
             Some(Ok(RawValueExpr::ValueLiteral(value))) => {
-                return Some(Ok(LazyExpandedValue {
-                    source: ExpandedValueSource::ValueLiteral(value),
-                    context,
-                    variable: None,
-                }))
+                return Some(Ok(LazyExpandedValue::from_literal(context, value)))
             }
             Some(Ok(RawValueExpr::MacroInvocation(invocation))) => {
                 let resolved_invocation = match invocation.resolve(context) {

--- a/src/lazy/expanded/struct.rs
+++ b/src/lazy/expanded/struct.rs
@@ -13,7 +13,7 @@ use crate::lazy::expanded::template::{
 };
 use crate::lazy::expanded::{
     EncodingContextRef, ExpandedAnnotationsIterator, ExpandedAnnotationsSource, ExpandedValueRef,
-    ExpandedValueSource, LazyExpandedValue, TemplateVariableReference,
+    LazyExpandedValue, TemplateVariableReference,
 };
 use crate::result::IonFailure;
 use crate::symbol_ref::AsSymbolRef;
@@ -272,14 +272,11 @@ impl<'top, D: LazyDecoder> LazyExpandedStruct<'top, D> {
                 match first_result_expr {
                     // If the expression is a value literal, wrap it in a LazyExpandedValue and return it.
                     TemplateBodyValueExpr::Element(element) => {
-                        let value = LazyExpandedValue {
-                            context: self.context,
-                            source: ExpandedValueSource::Template(
-                                *environment,
-                                TemplateElement::new(*template, element),
-                            ),
-                            variable: None,
-                        };
+                        let value = LazyExpandedValue::from_template(
+                            self.context,
+                            *environment,
+                            TemplateElement::new(*template, element),
+                        );
                         Ok(Some(value))
                     }
                     // If the expression is a variable, resolve it in the current environment.

--- a/src/lazy/expanded/struct.rs
+++ b/src/lazy/expanded/struct.rs
@@ -12,7 +12,7 @@ use crate::lazy::expanded::template::{
     TemplateMacroRef, TemplateStructIndex, TemplateStructUnexpandedFieldsIterator,
 };
 use crate::lazy::expanded::{
-    EncodingContext, ExpandedAnnotationsIterator, ExpandedAnnotationsSource, ExpandedValueRef,
+    EncodingContextRef, ExpandedAnnotationsIterator, ExpandedAnnotationsSource, ExpandedValueRef,
     ExpandedValueSource, LazyExpandedValue, TemplateVariableReference,
 };
 use crate::result::IonFailure;
@@ -27,9 +27,9 @@ use crate::{IonError, IonResult, RawSymbolTokenRef, SymbolRef};
 // and expands the field as part of its iteration process.
 #[derive(Debug, Clone, Copy)]
 pub enum UnexpandedField<'top, D: LazyDecoder> {
-    RawNameValue(EncodingContext<'top>, D::FieldName<'top>, D::Value<'top>),
-    RawNameEExp(EncodingContext<'top>, D::FieldName<'top>, D::EExp<'top>),
-    RawEExp(EncodingContext<'top>, D::EExp<'top>),
+    RawNameValue(EncodingContextRef<'top>, D::FieldName<'top>, D::Value<'top>),
+    RawNameEExp(EncodingContextRef<'top>, D::FieldName<'top>, D::EExp<'top>),
+    RawEExp(EncodingContextRef<'top>, D::EExp<'top>),
     TemplateNameValue(SymbolRef<'top>, TemplateElement<'top>),
     TemplateNameMacro(SymbolRef<'top>, TemplateMacroInvocation<'top>),
     TemplateNameVariable(
@@ -65,7 +65,7 @@ impl<'top, D: LazyDecoder> LazyExpandedField<'top, D> {
 
 impl<'top, D: LazyDecoder> LazyExpandedField<'top, D> {
     fn from_raw_field(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         name: D::FieldName<'top>,
         value: impl Into<LazyExpandedValue<'top, D>>,
     ) -> Self {
@@ -89,7 +89,7 @@ impl<'top, D: LazyDecoder> LazyExpandedField<'top, D> {
 
 #[derive(Debug, Clone, Copy)]
 pub enum LazyExpandedFieldName<'top, D: LazyDecoder> {
-    RawName(EncodingContext<'top>, D::FieldName<'top>),
+    RawName(EncodingContextRef<'top>, D::FieldName<'top>),
     TemplateName(TemplateMacroRef<'top>, SymbolRef<'top>),
     // TODO: `Constructed` needed for names in `(make_struct ...)`
 }
@@ -136,13 +136,13 @@ pub enum ExpandedStructSource<'top, D: LazyDecoder> {
 
 #[derive(Copy, Clone)]
 pub struct LazyExpandedStruct<'top, D: LazyDecoder> {
-    pub(crate) context: EncodingContext<'top>,
+    pub(crate) context: EncodingContextRef<'top>,
     pub(crate) source: ExpandedStructSource<'top, D>,
 }
 
 //TODO: Feature gate
 impl<'top, D: LazyDecoder> LazyExpandedStruct<'top, D> {
-    pub fn context(&self) -> EncodingContext<'top> {
+    pub fn context(&self) -> EncodingContextRef<'top> {
         self.context
     }
     pub fn source(&self) -> ExpandedStructSource<'top, D> {
@@ -152,7 +152,7 @@ impl<'top, D: LazyDecoder> LazyExpandedStruct<'top, D> {
 
 impl<'top, D: LazyDecoder> LazyExpandedStruct<'top, D> {
     pub fn from_literal(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         sexp: D::Struct<'top>,
     ) -> LazyExpandedStruct<'top, D> {
         let source = ExpandedStructSource::ValueLiteral(sexp);
@@ -160,7 +160,7 @@ impl<'top, D: LazyDecoder> LazyExpandedStruct<'top, D> {
     }
 
     pub fn from_template(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         environment: Environment<'top, D>,
         template: TemplateMacroRef<'top>,
         annotations: AnnotationsRange,
@@ -424,7 +424,7 @@ impl<'top, D: LazyDecoder> ExpandedStructIterator<'top, D> {
         // LazyRawStruct, or it could be a `TemplateStructRawFieldsIterator`.
         I: Iterator<Item = IonResult<UnexpandedField<'top, D>>>,
     >(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         state: &'a mut ExpandedStructIteratorState<'top, D>,
         evaluator: &'a mut MacroEvaluator<'top, D>,
         iter: &'a mut I,
@@ -488,7 +488,7 @@ impl<'top, D: LazyDecoder> ExpandedStructIterator<'top, D> {
     /// Pulls a single unexpanded field expression from the source iterator and sets `state` according to
     /// the expression's kind.
     fn next_from_iterator<I: Iterator<Item = IonResult<UnexpandedField<'top, D>>>>(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         state: &mut ExpandedStructIteratorState<'top, D>,
         evaluator: &mut MacroEvaluator<'top, D>,
         iter: &mut I,

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -256,6 +256,12 @@ pub struct TemplateStructUnexpandedFieldsIterator<'top, D: LazyDecoder> {
 }
 
 impl<'top, D: LazyDecoder> TemplateStructUnexpandedFieldsIterator<'top, D> {
+    pub fn context(&self) -> EncodingContext<'top> {
+        self.context
+    }
+}
+
+impl<'top, D: LazyDecoder> TemplateStructUnexpandedFieldsIterator<'top, D> {
     pub fn new(
         context: EncodingContext<'top>,
         environment: Environment<'top, D>,
@@ -706,6 +712,9 @@ impl<'top> TemplateMacroInvocation<'top> {
     }
     pub fn invoked_macro(&self) -> MacroRef<'top> {
         self.invoked_macro
+    }
+    pub fn context(&self) -> EncodingContext<'top> {
+        self.context
     }
 }
 

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -373,7 +373,7 @@ impl TemplateBody {
             .push(TemplateBodyValueExpr::Element(element))
     }
 
-    pub fn push_variable(&mut self, signature_index: usize) {
+    pub fn push_variable(&mut self, signature_index: u16) {
         self.expressions.push(TemplateBodyValueExpr::Variable(
             TemplateBodyVariableReference::new(signature_index),
         ))
@@ -792,20 +792,20 @@ impl<'top, D: LazyDecoder> Iterator for TemplateMacroInvocationArgsIterator<'top
 /// A reference to a variable in a template body.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TemplateBodyVariableReference {
-    signature_index: usize,
+    signature_index: u16,
 }
 
 impl TemplateBodyVariableReference {
-    pub fn new(signature_index: usize) -> Self {
+    pub fn new(signature_index: u16) -> Self {
         Self { signature_index }
     }
     pub fn signature_index(&self) -> usize {
-        self.signature_index
+        self.signature_index as usize
     }
     pub fn name<'a>(&self, signature: &'a MacroSignature) -> &'a str {
         signature
             .parameters()
-            .get(self.signature_index)
+            .get(self.signature_index())
             .unwrap()
             .name()
     }

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -9,7 +9,7 @@ use crate::lazy::expanded::macro_table::MacroRef;
 use crate::lazy::expanded::r#struct::UnexpandedField;
 use crate::lazy::expanded::sequence::Environment;
 use crate::lazy::expanded::{
-    EncodingContext, ExpandedValueSource, LazyExpandedValue, TemplateVariableReference,
+    EncodingContextRef, ExpandedValueSource, LazyExpandedValue, TemplateVariableReference,
 };
 use crate::lazy::text::raw::v1_1::reader::{MacroAddress, MacroIdRef};
 use crate::result::IonFailure;
@@ -144,7 +144,7 @@ impl<'top> Deref for TemplateMacroRef<'top> {
 
 /// Steps over the child expressions of a list or s-expression found in the body of a template.
 pub struct TemplateSequenceIterator<'top, D: LazyDecoder> {
-    context: EncodingContext<'top>,
+    context: EncodingContextRef<'top>,
     template: TemplateMacroRef<'top>,
     evaluator: MacroEvaluator<'top, D>,
     value_expressions: &'top [TemplateBodyValueExpr],
@@ -153,7 +153,7 @@ pub struct TemplateSequenceIterator<'top, D: LazyDecoder> {
 
 impl<'top, D: LazyDecoder> TemplateSequenceIterator<'top, D> {
     pub fn new(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         evaluator: MacroEvaluator<'top, D>,
         template: TemplateMacroRef<'top>,
         value_expressions: &'top [TemplateBodyValueExpr],
@@ -248,7 +248,7 @@ impl<'top, D: LazyDecoder> Iterator for TemplateSequenceIterator<'top, D> {
 /// mimic reading them from input. The [`LazyExpandedStruct`](crate::lazy::expanded::struct) handles
 /// evaluating any macro invocations that this yields.
 pub struct TemplateStructUnexpandedFieldsIterator<'top, D: LazyDecoder> {
-    context: EncodingContext<'top>,
+    context: EncodingContextRef<'top>,
     environment: Environment<'top, D>,
     template: TemplateMacroRef<'top>,
     expressions: &'top [TemplateBodyValueExpr],
@@ -256,14 +256,14 @@ pub struct TemplateStructUnexpandedFieldsIterator<'top, D: LazyDecoder> {
 }
 
 impl<'top, D: LazyDecoder> TemplateStructUnexpandedFieldsIterator<'top, D> {
-    pub fn context(&self) -> EncodingContext<'top> {
+    pub fn context(&self) -> EncodingContextRef<'top> {
         self.context
     }
 }
 
 impl<'top, D: LazyDecoder> TemplateStructUnexpandedFieldsIterator<'top, D> {
     pub fn new(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         environment: Environment<'top, D>,
         template: TemplateMacroRef<'top>,
         expressions: &'top [TemplateBodyValueExpr],
@@ -628,12 +628,12 @@ impl TemplateBodyMacroInvocation {
 
     /// Finds the definition of the macro being invoked in the provided `context`'s macro table.
     ///
-    /// It is a logic error for this method to be called with an [`EncodingContext`] that does not
+    /// It is a logic error for this method to be called with an [`EncodingContextRef`] that does not
     /// contain the necessary information; doing so will cause this method to panic.
     pub(crate) fn resolve<'top>(
         self,
         host_template: TemplateMacroRef<'top>,
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
     ) -> TemplateMacroInvocation<'top> {
         let invoked_macro = context
             .macro_table
@@ -659,7 +659,7 @@ impl TemplateBodyMacroInvocation {
 /// holds references to the invoked macro and its argument expressions.
 #[derive(Copy, Clone)]
 pub struct TemplateMacroInvocation<'top> {
-    context: EncodingContext<'top>,
+    context: EncodingContextRef<'top>,
     // The definition of the template in which this macro invocation appears. This is useful as
     // debugging information / viewing in stack traces.
     host_template: TemplateMacroRef<'top>,
@@ -682,7 +682,7 @@ impl<'top> Debug for TemplateMacroInvocation<'top> {
 
 impl<'top> TemplateMacroInvocation<'top> {
     pub fn new(
-        context: EncodingContext<'top>,
+        context: EncodingContextRef<'top>,
         host_template: TemplateMacroRef<'top>,
         invoked_macro: MacroRef<'top>,
         arg_expressions: &'top [TemplateBodyValueExpr],
@@ -713,7 +713,7 @@ impl<'top> TemplateMacroInvocation<'top> {
     pub fn invoked_macro(&self) -> MacroRef<'top> {
         self.invoked_macro
     }
-    pub fn context(&self) -> EncodingContext<'top> {
+    pub fn context(&self) -> EncodingContextRef<'top> {
         self.context
     }
 }

--- a/src/lazy/text/buffer.rs
+++ b/src/lazy/text/buffer.rs
@@ -27,8 +27,8 @@ use crate::lazy::raw_stream_item::{EndPosition, LazyRawStreamItem, RawStreamItem
 use crate::lazy::text::encoded_value::EncodedTextValue;
 use crate::lazy::text::matched::{
     MatchedBlob, MatchedClob, MatchedDecimal, MatchedFieldName, MatchedFieldNameSyntax,
-    MatchedFloat, MatchedHoursAndMinutes, MatchedInt, MatchedString, MatchedSymbol,
-    MatchedTimestamp, MatchedTimestampOffset, MatchedValue,
+    MatchedFloat, MatchedInt, MatchedString, MatchedSymbol, MatchedTimestamp,
+    MatchedTimestampOffset, MatchedValue,
 };
 use crate::lazy::text::parse_result::{InvalidInputError, IonParseError};
 use crate::lazy::text::parse_result::{IonMatchResult, IonParseResult};
@@ -311,14 +311,25 @@ impl<'top> TextBufferView<'top> {
 
     /// Matches one or more annotations.
     pub fn match_annotations(self) -> IonMatchResult<'top> {
-        recognize(many1_count(Self::match_annotation))(self)
+        let (remaining, matched) = recognize(many1_count(Self::match_annotation))(self)?;
+        if matched.len() > u16::MAX as usize {
+            let error = InvalidInputError::new(matched)
+                .with_description("the maximum supported annotations sequence length is 65KB")
+                .with_label("parsing annotations");
+            Err(nom::Err::Error(IonParseError::Invalid(error)))
+        } else {
+            Ok((remaining, matched))
+        }
     }
 
     /// Matches an annotation (symbol token) and a terminating '::'.
     pub fn match_annotation(self) -> IonParseResult<'top, (MatchedSymbol, Range<usize>)> {
         terminated(
             whitespace_and_then(match_and_span(Self::match_symbol)),
-            whitespace_and_then(complete_tag("::")),
+            whitespace_and_then(terminated(
+                complete_tag("::"),
+                Self::match_optional_comments_and_whitespace,
+            )),
         )(self)
     }
 
@@ -336,16 +347,8 @@ impl<'top> TextBufferView<'top> {
                 // `-3` as an operator (`-`) and an int (`3`). Thus, we run `match_value` first.
                 whitespace_and_then(alt((Self::match_value, Self::match_operator))),
             )
-            .map(|(maybe_annotations, mut value)| {
-                if let Some(annotations) = maybe_annotations {
-                    value.encoded_value = value
-                        .encoded_value
-                        .with_annotations_sequence(annotations.offset(), annotations.len());
-                    // Rewind the value's input to include the annotations sequence.
-                    value.input = self.slice_to_end(annotations.offset() - self.offset());
-                }
-                Some(value)
-            }),
+            .map(|(maybe_annotations, value)| self.apply_annotations(maybe_annotations, value))
+            .map(Some),
         )))
         .parse(self)
     }
@@ -367,21 +370,33 @@ impl<'top> TextBufferView<'top> {
                 // `-3` as an operator (`-`) and an int (`3`). Thus, we run `match_value` first.
                 whitespace_and_then(alt((Self::match_value_1_1, Self::match_operator))),
             )
-            .map(|(maybe_annotations, mut value)| {
-                if let Some(annotations) = maybe_annotations {
-                    value.encoded_value = value
-                        .encoded_value
-                        .with_annotations_sequence(annotations.offset(), annotations.len());
-                    // Rewind the value's input to include the annotations sequence.
-                    value.input = self.slice_to_end(annotations.offset() - self.offset());
-                }
-                Some(value)
-            })
-            .map(|maybe_matched| {
-                maybe_matched.map(|matched| RawValueExpr::ValueLiteral(matched.into()))
-            }),
+            .map(|(maybe_annotations, value)| self.apply_annotations(maybe_annotations, value))
+            .map(|matched| RawValueExpr::ValueLiteral(matched.into()))
+            .map(Some),
         )))
         .parse(self)
+    }
+
+    fn apply_annotations<E: TextEncoding<'top>>(
+        self,
+        maybe_annotations: Option<TextBufferView<'top>>,
+        mut value: MatchedRawTextValue<'top, E>,
+    ) -> MatchedRawTextValue<'top, E> {
+        if let Some(annotations) = maybe_annotations {
+            let annotations_length =
+                u16::try_from(annotations.len()).expect("already length checked");
+            // Update the encoded value's record of how many bytes of annotations precede the data.
+            value.encoded_value = value
+                .encoded_value
+                .with_annotations_sequence(annotations_length);
+            let unannotated_value_length = value.input.len();
+            // Rewind the value's input to include the annotations sequence.
+            value.input = self.slice(
+                annotations.offset() - self.offset(),
+                annotations_length as usize + unannotated_value_length,
+            );
+        }
+        value
     }
 
     /// Matches a struct field name/value pair.
@@ -516,16 +531,7 @@ impl<'top> TextBufferView<'top> {
             opt(Self::match_annotations),
             whitespace_and_then(Self::match_value),
         )
-        .map(|(maybe_annotations, mut value)| {
-            if let Some(annotations) = maybe_annotations {
-                value.encoded_value = value
-                    .encoded_value
-                    .with_annotations_sequence(annotations.offset(), annotations.len());
-                // Rewind the value's input to include the annotations sequence.
-                value.input = self.slice_to_end(annotations.offset() - self.offset());
-            }
-            value
-        })
+        .map(|(maybe_annotations, value)| self.apply_annotations(maybe_annotations, value))
         .parse(self)
     }
 
@@ -537,16 +543,7 @@ impl<'top> TextBufferView<'top> {
             opt(Self::match_annotations),
             whitespace_and_then(Self::match_value_1_1),
         )
-        .map(|(maybe_annotations, mut value)| {
-            if let Some(annotations) = maybe_annotations {
-                value.encoded_value = value
-                    .encoded_value
-                    .with_annotations_sequence(annotations.offset(), annotations.len());
-                // Rewind the value's input to include the annotations sequence.
-                value.input = self.slice_to_end(annotations.offset() - self.offset());
-            }
-            value
-        })
+        .map(|(maybe_annotations, value)| self.apply_annotations(maybe_annotations, value))
         .parse(self)
     }
 
@@ -612,124 +609,63 @@ impl<'top> TextBufferView<'top> {
 
     /// Matches a single scalar value or the beginning of a container.
     pub fn match_value(self) -> IonParseResult<'top, MatchedRawTextValue<'top, TextEncoding_1_0>> {
-        alt((
+        consumed(alt((
             // For `null` and `bool`, we use `read_` instead of `match_` because there's no additional
             // parsing to be done.
-            map(match_and_length(Self::match_null), |(ion_type, length)| {
-                EncodedTextValue::new(MatchedValue::Null(ion_type), self.offset(), length)
+            map(Self::match_null, |ion_type| {
+                EncodedTextValue::new(MatchedValue::Null(ion_type))
             }),
-            map(match_and_length(Self::match_bool), |(value, length)| {
-                EncodedTextValue::new(MatchedValue::Bool(value), self.offset(), length)
+            map(Self::match_bool, |value| {
+                EncodedTextValue::new(MatchedValue::Bool(value))
             }),
             // For `int` and the other types, we use `match` and store the partially-processed input in the
             // `matched_value` field of the `EncodedTextValue` we return.
-            map(
-                match_and_length(Self::match_int),
-                |(matched_int, length)| {
-                    EncodedTextValue::new(MatchedValue::Int(matched_int), self.offset(), length)
-                },
-            ),
-            map(
-                match_and_length(Self::match_float),
-                |(matched_float, length)| {
-                    EncodedTextValue::new(MatchedValue::Float(matched_float), self.offset(), length)
-                },
-            ),
-            map(
-                match_and_length(Self::match_decimal),
-                |(matched_decimal, length)| {
-                    EncodedTextValue::new(
-                        MatchedValue::Decimal(matched_decimal),
-                        self.offset(),
-                        length,
-                    )
-                },
-            ),
-            map(
-                match_and_length(Self::match_timestamp),
-                |(matched_timestamp, length)| {
-                    EncodedTextValue::new(
-                        MatchedValue::Timestamp(matched_timestamp),
-                        self.offset(),
-                        length,
-                    )
-                },
-            ),
-            map(
-                match_and_length(Self::match_string),
-                |(matched_string, length)| {
-                    EncodedTextValue::new(
-                        MatchedValue::String(matched_string),
-                        self.offset(),
-                        length,
-                    )
-                },
-            ),
-            map(
-                match_and_length(Self::match_symbol),
-                |(matched_symbol, length)| {
-                    EncodedTextValue::new(
-                        MatchedValue::Symbol(matched_symbol),
-                        self.offset(),
-                        length,
-                    )
-                },
-            ),
-            map(
-                match_and_length(Self::match_blob),
-                |(matched_blob, length)| {
-                    EncodedTextValue::new(MatchedValue::Blob(matched_blob), self.offset(), length)
-                },
-            ),
-            map(
-                match_and_length(Self::match_clob),
-                |(matched_clob, length)| {
-                    EncodedTextValue::new(MatchedValue::Clob(matched_clob), self.offset(), length)
-                },
-            ),
-            map(
-                match_and_length(Self::match_list),
-                |(matched_list, length)| {
-                    // TODO: Cache child expressions found in 1.0 list
-                    let not_yet_used_in_1_0 =
-                        bumpalo::collections::Vec::new_in(self.allocator).into_bump_slice();
-                    EncodedTextValue::new(
-                        MatchedValue::List(not_yet_used_in_1_0),
-                        matched_list.offset(),
-                        length,
-                    )
-                },
-            ),
-            map(
-                match_and_length(Self::match_sexp),
-                |(matched_list, length)| {
-                    // TODO: Cache child expressions found in 1.0 sexp
-                    let not_yet_used_in_1_0 =
-                        bumpalo::collections::Vec::new_in(self.allocator).into_bump_slice();
-                    EncodedTextValue::new(
-                        MatchedValue::SExp(not_yet_used_in_1_0),
-                        matched_list.offset(),
-                        length,
-                    )
-                },
-            ),
-            map(
-                match_and_length(Self::match_struct),
-                |(matched_struct, length)| {
-                    // TODO: Cache child expressions found in 1.0 struct
-                    let not_yet_used_in_1_0 =
-                        bumpalo::collections::Vec::new_in(self.allocator).into_bump_slice();
-                    EncodedTextValue::new(
-                        MatchedValue::Struct(not_yet_used_in_1_0),
-                        matched_struct.offset(),
-                        length,
-                    )
-                },
-            ),
-        ))
-        .map(|encoded_value| MatchedRawTextValue {
+            map(Self::match_int, |matched_int| {
+                EncodedTextValue::new(MatchedValue::Int(matched_int))
+            }),
+            map(Self::match_float, |matched_float| {
+                EncodedTextValue::new(MatchedValue::Float(matched_float))
+            }),
+            map(Self::match_decimal, |matched_decimal| {
+                EncodedTextValue::new(MatchedValue::Decimal(matched_decimal))
+            }),
+            map(Self::match_timestamp, |matched_timestamp| {
+                EncodedTextValue::new(MatchedValue::Timestamp(matched_timestamp))
+            }),
+            map(Self::match_string, |matched_string| {
+                EncodedTextValue::new(MatchedValue::String(matched_string))
+            }),
+            map(Self::match_symbol, |matched_symbol| {
+                EncodedTextValue::new(MatchedValue::Symbol(matched_symbol))
+            }),
+            map(Self::match_blob, |matched_blob| {
+                EncodedTextValue::new(MatchedValue::Blob(matched_blob))
+            }),
+            map(Self::match_clob, |matched_clob| {
+                EncodedTextValue::new(MatchedValue::Clob(matched_clob))
+            }),
+            map(Self::match_list, |_matched_list| {
+                // TODO: Cache child expressions found in 1.0 list
+                let not_yet_used_in_1_0 =
+                    bumpalo::collections::Vec::new_in(self.allocator).into_bump_slice();
+                EncodedTextValue::new(MatchedValue::List(not_yet_used_in_1_0))
+            }),
+            map(Self::match_sexp, |_matched_sexp| {
+                // TODO: Cache child expressions found in 1.0 sexp
+                let not_yet_used_in_1_0 =
+                    bumpalo::collections::Vec::new_in(self.allocator).into_bump_slice();
+                EncodedTextValue::new(MatchedValue::SExp(not_yet_used_in_1_0))
+            }),
+            map(Self::match_struct, |_matched_struct| {
+                // TODO: Cache child expressions found in 1.0 struct
+                let not_yet_used_in_1_0 =
+                    bumpalo::collections::Vec::new_in(self.allocator).into_bump_slice();
+                EncodedTextValue::new(MatchedValue::Struct(not_yet_used_in_1_0))
+            }),
+        )))
+        .map(|(input, encoded_value)| MatchedRawTextValue {
             encoded_value,
-            input: self,
+            input,
         })
         .parse(self)
     }
@@ -737,115 +673,57 @@ impl<'top> TextBufferView<'top> {
     pub fn match_value_1_1(
         self,
     ) -> IonParseResult<'top, MatchedRawTextValue<'top, TextEncoding_1_1>> {
-        alt((
+        consumed(alt((
             // For `null` and `bool`, we use `read_` instead of `match_` because there's no additional
             // parsing to be done.
-            map(match_and_length(Self::match_null), |(ion_type, length)| {
-                EncodedTextValue::new(MatchedValue::Null(ion_type), self.offset(), length)
+            map(Self::match_null, |ion_type| {
+                EncodedTextValue::new(MatchedValue::Null(ion_type))
             }),
-            map(match_and_length(Self::match_bool), |(value, length)| {
-                EncodedTextValue::new(MatchedValue::Bool(value), self.offset(), length)
+            map(Self::match_bool, |value| {
+                EncodedTextValue::new(MatchedValue::Bool(value))
             }),
             // For `int` and the other types, we use `match` and store the partially-processed input in the
             // `matched_value` field of the `EncodedTextValue` we return.
+            map(Self::match_int, |matched_int| {
+                EncodedTextValue::new(MatchedValue::Int(matched_int))
+            }),
+            map(Self::match_float, |matched_float| {
+                EncodedTextValue::new(MatchedValue::Float(matched_float))
+            }),
+            map(Self::match_decimal, |matched_decimal| {
+                EncodedTextValue::new(MatchedValue::Decimal(matched_decimal))
+            }),
+            map(Self::match_timestamp, |matched_timestamp| {
+                EncodedTextValue::new(MatchedValue::Timestamp(matched_timestamp))
+            }),
+            map(Self::match_string, |matched_string| {
+                EncodedTextValue::new(MatchedValue::String(matched_string))
+            }),
+            map(Self::match_symbol, |matched_symbol| {
+                EncodedTextValue::new(MatchedValue::Symbol(matched_symbol))
+            }),
+            map(Self::match_blob, |matched_blob| {
+                EncodedTextValue::new(MatchedValue::Blob(matched_blob))
+            }),
+            map(Self::match_clob, |matched_clob| {
+                EncodedTextValue::new(MatchedValue::Clob(matched_clob))
+            }),
+            map(Self::match_list_1_1, |(_matched_list, child_expr_cache)| {
+                EncodedTextValue::new(MatchedValue::List(child_expr_cache))
+            }),
+            map(Self::match_sexp_1_1, |(_matched_sexp, child_expr_cache)| {
+                EncodedTextValue::new(MatchedValue::SExp(child_expr_cache))
+            }),
             map(
-                match_and_length(Self::match_int),
-                |(matched_int, length)| {
-                    EncodedTextValue::new(MatchedValue::Int(matched_int), self.offset(), length)
+                Self::match_struct_1_1,
+                |(_matched_struct, field_expr_cache)| {
+                    EncodedTextValue::new(MatchedValue::Struct(field_expr_cache))
                 },
             ),
-            map(
-                match_and_length(Self::match_float),
-                |(matched_float, length)| {
-                    EncodedTextValue::new(MatchedValue::Float(matched_float), self.offset(), length)
-                },
-            ),
-            map(
-                match_and_length(Self::match_decimal),
-                |(matched_decimal, length)| {
-                    EncodedTextValue::new(
-                        MatchedValue::Decimal(matched_decimal),
-                        self.offset(),
-                        length,
-                    )
-                },
-            ),
-            map(
-                match_and_length(Self::match_timestamp),
-                |(matched_timestamp, length)| {
-                    EncodedTextValue::new(
-                        MatchedValue::Timestamp(matched_timestamp),
-                        self.offset(),
-                        length,
-                    )
-                },
-            ),
-            map(
-                match_and_length(Self::match_string),
-                |(matched_string, length)| {
-                    EncodedTextValue::new(
-                        MatchedValue::String(matched_string),
-                        self.offset(),
-                        length,
-                    )
-                },
-            ),
-            map(
-                match_and_length(Self::match_symbol),
-                |(matched_symbol, length)| {
-                    EncodedTextValue::new(
-                        MatchedValue::Symbol(matched_symbol),
-                        self.offset(),
-                        length,
-                    )
-                },
-            ),
-            map(
-                match_and_length(Self::match_blob),
-                |(matched_blob, length)| {
-                    EncodedTextValue::new(MatchedValue::Blob(matched_blob), self.offset(), length)
-                },
-            ),
-            map(
-                match_and_length(Self::match_clob),
-                |(matched_clob, length)| {
-                    EncodedTextValue::new(MatchedValue::Clob(matched_clob), self.offset(), length)
-                },
-            ),
-            map(
-                match_and_length(Self::match_list_1_1),
-                |((matched_list, child_expr_cache), length)| {
-                    EncodedTextValue::new(
-                        MatchedValue::List(child_expr_cache),
-                        matched_list.offset(),
-                        length,
-                    )
-                },
-            ),
-            map(
-                match_and_length(Self::match_sexp_1_1),
-                |((matched_sexp, child_expr_cache), length)| {
-                    EncodedTextValue::new(
-                        MatchedValue::SExp(child_expr_cache),
-                        matched_sexp.offset(),
-                        length,
-                    )
-                },
-            ),
-            map(
-                match_and_length(Self::match_struct_1_1),
-                |((matched_struct, field_expr_cache), length)| {
-                    EncodedTextValue::new(
-                        MatchedValue::Struct(field_expr_cache),
-                        matched_struct.offset(),
-                        length,
-                    )
-                },
-            ),
-        ))
-        .map(|encoded_value| MatchedRawTextValue {
+        )))
+        .map(|(input, encoded_value)| MatchedRawTextValue {
             encoded_value,
-            input: self,
+            input,
         })
         .parse(self)
     }
@@ -956,7 +834,7 @@ impl<'top> TextBufferView<'top> {
                 Err(e) => {
                     return {
                         let error = InvalidInputError::new(self)
-                            .with_label("matching a sexp")
+                            .with_label("matching a 1.1 sexp")
                             .with_description(format!("{}", e));
                         Err(nom::Err::Failure(IonParseError::Invalid(error)))
                     }
@@ -1620,17 +1498,11 @@ impl<'top> TextBufferView<'top> {
     fn match_operator<E: TextEncoding<'top>>(
         self,
     ) -> IonParseResult<'top, MatchedRawTextValue<'top, E>> {
-        match_and_length(is_a("!#%&*+-./;<=>?@^`|~"))
-            .map(
-                |(text, length): (TextBufferView, usize)| MatchedRawTextValue {
-                    input: self,
-                    encoded_value: EncodedTextValue::new(
-                        MatchedValue::Symbol(MatchedSymbol::Operator),
-                        text.offset(),
-                        length,
-                    ),
-                },
-            )
+        is_a("!#%&*+-./;<=>?@^`|~")
+            .map(|text: TextBufferView| MatchedRawTextValue {
+                input: text,
+                encoded_value: EncodedTextValue::new(MatchedValue::Symbol(MatchedSymbol::Operator)),
+            })
             .parse(self)
     }
 
@@ -2019,13 +1891,12 @@ impl<'top> TextBufferView<'top> {
                     complete_one_of("-+"),
                     Self::match_timestamp_offset_hours_and_minutes,
                 ),
-                |(sign, (hours, _minutes))| {
-                    let is_negative = sign == '-';
-                    let hours_offset = hours.offset();
-                    MatchedTimestampOffset::HoursAndMinutes(MatchedHoursAndMinutes::new(
-                        is_negative,
-                        hours_offset,
-                    ))
+                |(sign, (_hours, _minutes))| {
+                    if sign == '-' {
+                        MatchedTimestampOffset::NegativeHoursAndMinutes
+                    } else {
+                        MatchedTimestampOffset::PositiveHoursAndMinutes
+                    }
                 },
             ),
         ))(self)
@@ -2898,6 +2769,7 @@ mod tests {
             "(:foo foo)",
         ];
         for input in good_inputs {
+            println!("test: {input}");
             match_macro_invocation(input);
         }
 

--- a/src/lazy/text/buffer.rs
+++ b/src/lazy/text/buffer.rs
@@ -369,7 +369,7 @@ impl<'top> TextBufferView<'top> {
                 whitespace_and_then(alt((Self::match_value_1_1, Self::match_operator))),
             )
             .map(|(maybe_annotations, value)| self.apply_annotations(maybe_annotations, value))
-            .map(|matched| RawValueExpr::ValueLiteral(matched.into()))
+            .map(RawValueExpr::ValueLiteral)
             .map(Some),
         )))
         .parse(self)
@@ -863,9 +863,7 @@ impl<'top> TextBufferView<'top> {
                 // ...followed by a comma or end-of-list
                 Self::match_delimiter_after_list_value,
             )
-            .map(|maybe_matched| {
-                maybe_matched.map(|matched| RawValueExpr::ValueLiteral(matched.into()))
-            }),
+            .map(|maybe_matched| maybe_matched.map(RawValueExpr::ValueLiteral)),
         )))
         .parse(self)
     }

--- a/src/lazy/text/encoded_value.rs
+++ b/src/lazy/text/encoded_value.rs
@@ -7,7 +7,7 @@ use crate::IonType;
 /// Represents the type, offset, and length metadata of the various components of an encoded value
 /// in a text input stream.
 ///
-/// Each [`LazyRawTextValue`](crate::lazy::text::value::MatchedRawTextValue) contains an `EncodedTextValue`,
+/// Each [`LazyRawTextValue`](crate::lazy::text::value::LazyRawTextValue) contains an `EncodedTextValue`,
 /// allowing a user to re-read (that is: parse) the body of the value as many times as necessary
 /// without re-parsing its header information each time.
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/src/lazy/text/encoded_value.rs
+++ b/src/lazy/text/encoded_value.rs
@@ -7,54 +7,31 @@ use crate::IonType;
 /// Represents the type, offset, and length metadata of the various components of an encoded value
 /// in a text input stream.
 ///
-/// Each [`LazyRawTextValue`](crate::lazy::text::value::MatchedRawTextValue) contains an `EncodedValue`,
+/// Each [`LazyRawTextValue`](crate::lazy::text::value::MatchedRawTextValue) contains an `EncodedTextValue`,
 /// allowing a user to re-read (that is: parse) the body of the value as many times as necessary
 /// without re-parsing its header information each time.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) struct EncodedTextValue<'top, E: TextEncoding<'top>> {
-    // TODO: Update this comment now that field_name is not part of 'value'
-
     // Each encoded text value has up to three components, appearing in the following order:
     //
-    //     [ field_name? | annotations? | data ]
+    //     [annotations? | data ]
     //
     // Components shown with a `?` are optional.
 
-    // The following is an example encoding of a struct field with an annotated value-- the only kind
-    // of Ion value that has both of the optional components--that appears 5 gigabytes into the input
-    // stream:
+    // The following is an example encoding of an annotated value:
     //
-    //   ┌─── field_name_offset: 12
-    //   │      ┌─── annotations_offset: 5
-    //   │      │    ┌─── data_offset: 5_000_000_012
-    //   price: USD::55.99,
-    //   └─┬─┘  └─┬─┘└─┬─┘
-    //     │      │    └─ data_length: 5
-    //     │      └─ annotations_length: 5
-    //     └─ field_name_length: 5
+    //   USD::55.99,
+    //   └─┬─┘
+    //     └─ data_offset: 5
     //
-    // Notice that only `data_offset` is an absolute offset from the beginning of the stream;
-    // this is because `data` is the only field that is always guaranteed to be present.
-    // `field_name_offset` and `annotations_offset` are stored as the number of bytes _before_
-    // `data_offset`, allowing them to be stored in fewer bytes.
+    // Notice that `data_offset` is a relative offset from the beginning of the matched buffer.
+    // The offset accommodates leading annotations, potentially including interstitial whitespace
+    // and/or comments.
 
-    // The absolute position (in bytes) of this value's `data` component within the overall stream
-    // being decoded.
-    data_offset: usize,
-    // The number of bytes _before_ `data_offset` at which the field name begins. If this value
-    // does not have a field name, this value will be zero.
-    // field_name_offset: u32,
-    // The number of bytes _before_ `data_offset` at which the annotations sequence begins.
-    // If this value does not have a field name, this value will be zero.
-    annotations_offset: u32,
-
-    // The number of bytes used to encode the data component of this Ion value.
-    data_length: usize,
-
-    // The number of bytes used to encode the annotations sequence preceding the data, if any.
-    // If there is no annotations sequence, this will be zero. If there is whitespace before the
-    // annotations sequence, this will not include it.
-    annotations_length: u32,
+    // The relative position within the buffer at which the data portion of this value begins.
+    // All buffer contents beyond this point are part of the data; the buffer ends when the value
+    // ends.
+    data_offset: u16,
 
     // Information that was recorded about the value as it was being matched.
     // For some types (e.g. bool), matching the text is the complete parsing process so the whole
@@ -64,34 +41,22 @@ pub(crate) struct EncodedTextValue<'top, E: TextEncoding<'top>> {
 }
 
 impl<'top, E: TextEncoding<'top>> EncodedTextValue<'top, E> {
-    pub(crate) fn new(
-        matched_value: MatchedValue<'top, E>,
-        offset: usize,
-        length: usize,
-    ) -> EncodedTextValue<'top, E> {
+    pub(crate) fn new(matched_value: MatchedValue<'top, E>) -> EncodedTextValue<'top, E> {
         EncodedTextValue {
-            data_offset: offset,
-            data_length: length,
-            annotations_offset: 0,
-            annotations_length: 0,
+            data_offset: 0,
             matched_value,
         }
     }
 
     // The annotations should include all of the symbol tokens, their delimiting '::'s, and any
-    // interstitial whitespace. It should not include any leading/trailing whitespace or the value
-    // itself.
+    // interstitial or trailing whitespace. It should not include any leading whitespace or the
+    // value itself.
     // Examples:
     //    foo::bar::
     //    'foo'::'bar'::
     //    foo   ::         'bar'      ::
-    pub(crate) fn with_annotations_sequence(
-        mut self,
-        offset: usize,
-        length: usize,
-    ) -> EncodedTextValue<'top, E> {
-        self.annotations_offset = (self.data_offset - offset) as u32;
-        self.annotations_length = length as u32;
+    pub(crate) fn with_annotations_sequence(mut self, length: u16) -> EncodedTextValue<'top, E> {
+        self.data_offset = length;
         self
     }
 
@@ -118,65 +83,21 @@ impl<'top, E: TextEncoding<'top>> EncodedTextValue<'top, E> {
     }
 
     pub fn data_offset(&self) -> usize {
-        self.data_offset
-    }
-
-    pub fn data_length(&self) -> usize {
-        self.data_length
-    }
-
-    pub fn data_range(&self) -> Range<usize> {
-        self.data_offset..(self.data_offset + self.data_length)
+        self.data_offset as usize
     }
 
     pub fn annotations_range(&self) -> Option<Range<usize>> {
-        if self.annotations_offset == 0 {
+        if self.data_offset == 0 {
             return None;
         }
-        let start = self.data_offset - (self.annotations_offset as usize);
-        let end = start + (self.annotations_length as usize);
-        Some(start..end)
+        Some(0..self.data_offset as usize)
     }
 
     pub fn has_annotations(&self) -> bool {
-        self.annotations_offset > 0
-    }
-
-    /// Returns the total number of bytes used to represent the current value, including its
-    /// annotations (if any), its header (type descriptor + length bytes), and its value.
-    pub fn total_length(&self) -> usize {
-        self.data_length + self.annotations_offset as usize
-    }
-
-    pub fn annotated_value_range(&self) -> Range<usize> {
-        let start = self.data_offset - self.annotations_length as usize;
-        let end = self.data_offset + self.data_length;
-        start..end
+        self.data_offset > 0
     }
 
     pub fn matched(&self) -> MatchedValue<'top, E> {
         self.matched_value
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::lazy::encoding::TextEncoding_1_0;
-
-    use super::*;
-
-    #[test]
-    fn total_length_data_only() {
-        let value =
-            EncodedTextValue::<TextEncoding_1_0>::new(MatchedValue::Null(IonType::Null), 100, 12);
-        assert_eq!(value.total_length(), 12);
-    }
-
-    #[test]
-    fn total_length_data_with_annotations() {
-        let value =
-            EncodedTextValue::<TextEncoding_1_0>::new(MatchedValue::Null(IonType::Null), 100, 12)
-                .with_annotations_sequence(90, 4);
-        assert_eq!(value.total_length(), 22);
     }
 }

--- a/src/lazy/text/parse_result.rs
+++ b/src/lazy/text/parse_result.rs
@@ -251,7 +251,14 @@ impl<'data, T> AddContext<'data, T> for IonParseError<'data> {
         'data: 'a,
     {
         match self {
-            IonParseError::Incomplete => IonResult::incomplete(label, input.offset()),
+            IonParseError::Incomplete => IonResult::incomplete(
+                format!(
+                    "{}; buffer utf-8: {}",
+                    label.into(),
+                    input.as_text().unwrap_or("<invalid utf-8>")
+                ),
+                input.offset(),
+            ),
             IonParseError::Invalid(invalid_input_error) => Err(IonError::from(invalid_input_error)),
         }
     }

--- a/src/lazy/text/raw/reader.rs
+++ b/src/lazy/text/raw/reader.rs
@@ -62,7 +62,6 @@ impl<'data> LazyRawTextReader_1_0<'data> {
             )));
         }
         let buffer_after_whitespace = buffer_after_whitespace.local_lifespan();
-
         let (remaining, matched_item) = buffer_after_whitespace
             .match_top_level_item_1_0()
             .with_context("reading a top-level value", buffer_after_whitespace)?;
@@ -297,7 +296,6 @@ mod tests {
         reader.expect_next(RawValueRef::Null(IonType::Bool));
         // null.int
         reader.expect_next(RawValueRef::Null(IonType::Int));
-
         // false
         reader.expect_next(RawValueRef::Bool(false));
         // true
@@ -336,7 +334,6 @@ mod tests {
         reader.expect_next(RawValueRef::Decimal(Decimal::new(-6, 5)));
         //         6d-5
         reader.expect_next(RawValueRef::Decimal(Decimal::new(6, -5)));
-
         // 2023T
         reader.expect_next(RawValueRef::Timestamp(Timestamp::with_year(2023).build()?));
         // 2023-08-13T
@@ -411,7 +408,6 @@ mod tests {
             sum += value?.expect_value()?.read()?.expect_i64()?;
         }
         assert_eq!(sum, 6);
-
         // (foo++ 1 2)
         let sexp = reader.next()?.expect_value()?.read()?.expect_sexp()?;
         let mut sexp_elements = sexp.iter();

--- a/src/lazy/text/raw/sequence.rs
+++ b/src/lazy/text/raw/sequence.rs
@@ -30,9 +30,9 @@ impl<'data> LazyRawTextList_1_0<'data> {
 
     pub fn iter(&self) -> RawTextListIterator_1_0<'data> {
         // Skip past any annotations and the opening '['
-        let list_contents_start = self.value.matched.encoded_value.data_offset() + 1;
+        let list_contents_start = self.value.encoded_value.data_offset() + 1;
         // Make an iterator over the input bytes that follow the initial `[`
-        RawTextListIterator_1_0::new(self.value.matched.input.slice_to_end(list_contents_start))
+        RawTextListIterator_1_0::new(self.value.input.slice_to_end(list_contents_start))
     }
 }
 
@@ -109,9 +109,8 @@ impl<'data> RawTextListIterator_1_0<'data> {
         let input_after_last = if let Some(value_result) = self.last() {
             let value = value_result?.expect_value()?;
             // ...the input slice that follows the last sequence value...
-            self.input.slice_to_end(
-                value.matched.input.offset() + value.total_length() - self.input.offset(),
-            )
+            self.input
+                .slice_to_end(value.input.offset() + value.total_length() - self.input.offset())
         } else {
             // ...or there aren't values, so it's just the input after the opening delimiter.
             self.input
@@ -175,8 +174,8 @@ impl<'data> LazyRawTextSExp_1_0<'data> {
     pub fn iter(&self) -> RawTextSExpIterator_1_0<'data> {
         // Make an iterator over the input bytes that follow the initial `(`; account for
         // a leading annotations sequence.
-        let sexp_contents_start = self.value.matched.encoded_value.data_offset() + 1;
-        RawTextSExpIterator_1_0::new(self.value.matched.input.slice_to_end(sexp_contents_start))
+        let sexp_contents_start = self.value.encoded_value.data_offset() + 1;
+        RawTextSExpIterator_1_0::new(self.value.input.slice_to_end(sexp_contents_start))
     }
 }
 
@@ -209,9 +208,8 @@ impl<'top> RawTextSExpIterator_1_0<'top> {
         let input_after_last = if let Some(value_result) = self.last() {
             let value = value_result?.expect_value()?;
             // ...the input slice that follows the last sequence value...
-            self.input.slice_to_end(
-                value.matched.input.offset() + value.total_length() - self.input.offset(),
-            )
+            self.input
+                .slice_to_end(value.input.offset() + value.total_length() - self.input.offset())
         } else {
             // ...or there aren't values, so it's just the input after the opening delimiter.
             self.input

--- a/src/lazy/text/raw/struct.rs
+++ b/src/lazy/text/raw/struct.rs
@@ -139,8 +139,8 @@ impl<'top> LazyRawStruct<'top, TextEncoding_1_0> for LazyRawTextStruct_1_0<'top>
     fn iter(&self) -> Self::Iterator {
         // Make an iterator over the input bytes that follow the initial `{`; account for
         // a leading annotations sequence.
-        let struct_contents_start = self.value.matched.encoded_value.data_offset() + 1;
-        RawTextStructIterator_1_0::new(self.value.matched.input.slice_to_end(struct_contents_start))
+        let struct_contents_start = self.value.encoded_value.data_offset() + 1;
+        RawTextStructIterator_1_0::new(self.value.input.slice_to_end(struct_contents_start))
     }
 }
 

--- a/src/lazy/text/raw/v1_1/reader.rs
+++ b/src/lazy/text/raw/v1_1/reader.rs
@@ -415,7 +415,7 @@ impl<'top> LazyContainerPrivate<'top, TextEncoding_1_1> for LazyRawTextSExp_1_1<
 
 impl<'top> LazyRawContainer<'top, TextEncoding_1_1> for LazyRawTextSExp_1_1<'top> {
     fn as_value(&self) -> <TextEncoding_1_1 as LazyDecoder>::Value<'top> {
-        self.value.into()
+        self.value
     }
 }
 
@@ -569,7 +569,7 @@ impl<'top> LazyContainerPrivate<'top, TextEncoding_1_1> for LazyRawTextList_1_1<
 
 impl<'top> LazyRawContainer<'top, TextEncoding_1_1> for LazyRawTextList_1_1<'top> {
     fn as_value(&self) -> LazyRawTextValue_1_1<'top> {
-        self.value.into()
+        self.value
     }
 }
 

--- a/src/lazy/text/raw/v1_1/reader.rs
+++ b/src/lazy/text/raw/v1_1/reader.rs
@@ -415,7 +415,7 @@ impl<'top> LazyContainerPrivate<'top, TextEncoding_1_1> for LazyRawTextSExp_1_1<
 
 impl<'top> LazyRawContainer<'top, TextEncoding_1_1> for LazyRawTextSExp_1_1<'top> {
     fn as_value(&self) -> <TextEncoding_1_1 as LazyDecoder>::Value<'top> {
-        self.value.matched.into()
+        self.value.into()
     }
 }
 
@@ -431,7 +431,7 @@ impl<'top> LazyRawSequence<'top, TextEncoding_1_1> for LazyRawTextSExp_1_1<'top>
     }
 
     fn iter(&self) -> Self::Iterator {
-        let MatchedValue::SExp(child_exprs) = self.value.matched.encoded_value.matched() else {
+        let MatchedValue::SExp(child_exprs) = self.value.encoded_value.matched() else {
             unreachable!("s-expression contained a matched value of the wrong type")
         };
         RawTextSequenceCacheIterator_1_1::new(child_exprs)
@@ -569,7 +569,7 @@ impl<'top> LazyContainerPrivate<'top, TextEncoding_1_1> for LazyRawTextList_1_1<
 
 impl<'top> LazyRawContainer<'top, TextEncoding_1_1> for LazyRawTextList_1_1<'top> {
     fn as_value(&self) -> LazyRawTextValue_1_1<'top> {
-        self.value.matched.into()
+        self.value.into()
     }
 }
 
@@ -585,7 +585,7 @@ impl<'top> LazyRawSequence<'top, TextEncoding_1_1> for LazyRawTextList_1_1<'top>
     }
 
     fn iter(&self) -> Self::Iterator {
-        let MatchedValue::List(child_exprs) = self.value.matched.encoded_value.matched() else {
+        let MatchedValue::List(child_exprs) = self.value.encoded_value.matched() else {
             unreachable!("list contained a matched value of the wrong type")
         };
         RawTextSequenceCacheIterator_1_1::new(child_exprs)
@@ -637,7 +637,7 @@ impl<'top> LazyRawStruct<'top, TextEncoding_1_1> for LazyRawTextStruct_1_1<'top>
     }
 
     fn iter(&self) -> Self::Iterator {
-        let MatchedValue::Struct(field_exprs) = self.value.matched.encoded_value.matched() else {
+        let MatchedValue::Struct(field_exprs) = self.value.encoded_value.matched() else {
             unreachable!("struct contained a matched value of the wrong type")
         };
         RawTextStructCacheIterator_1_1::new(field_exprs)

--- a/src/lazy/text/raw/v1_1/reader.rs
+++ b/src/lazy/text/raw/v1_1/reader.rs
@@ -4,27 +4,26 @@ use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::Range;
 
+use bumpalo::collections::Vec as BumpVec;
+use bumpalo::Bump as BumpAllocator;
 use nom::character::streaming::satisfy;
 
 use crate::lazy::decoder::private::LazyContainerPrivate;
 use crate::lazy::decoder::{
     HasRange, HasSpan, LazyDecoder, LazyRawContainer, LazyRawFieldExpr, LazyRawFieldName,
-    LazyRawReader, LazyRawSequence, LazyRawStruct, LazyRawValue, LazyRawValueExpr, RawValueExpr,
+    LazyRawReader, LazyRawSequence, LazyRawStruct, LazyRawValue, LazyRawValueExpr,
     RawVersionMarker,
 };
 use crate::lazy::encoding::TextEncoding_1_1;
+use crate::lazy::expanded::macro_evaluator::RawEExpression;
 use crate::lazy::raw_stream_item::{EndPosition, LazyRawStreamItem, RawStreamItem};
+use crate::lazy::span::Span;
 use crate::lazy::text::buffer::TextBufferView;
+use crate::lazy::text::matched::{MatchedFieldName, MatchedValue};
 use crate::lazy::text::parse_result::{AddContext, ToIteratorOutput};
 use crate::lazy::text::value::{LazyRawTextValue_1_1, RawTextAnnotationsIterator};
 use crate::result::IonFailure;
 use crate::{IonResult, IonType, RawSymbolTokenRef};
-
-use crate::lazy::expanded::macro_evaluator::RawEExpression;
-use crate::lazy::span::Span;
-use crate::lazy::text::matched::{MatchedFieldName, MatchedValue};
-use bumpalo::collections::Vec as BumpVec;
-use bumpalo::Bump as BumpAllocator;
 
 pub struct LazyRawTextReader_1_1<'data> {
     input: &'data [u8],
@@ -255,26 +254,14 @@ impl<'top> TextListSpanFinder_1_1<'top> {
             child_expr_cache.push(expr);
         }
 
-        let input_after_last_expr = if let Some(value_expr) = child_expr_cache.last() {
-            // ...the input slice that follows the last sequence value...
-            match value_expr {
-                RawValueExpr::ValueLiteral(value) => value
-                    .matched
-                    .input
-                    .slice_to_end(value.matched.encoded_value.total_length()),
-                RawValueExpr::MacroInvocation(invocation) => {
-                    let end_of_expr = invocation.input.offset() + invocation.input.len();
-                    let remaining = self
-                        .iterator
-                        .input
-                        .slice_to_end(end_of_expr - self.iterator.input.offset());
-                    remaining
-                }
-            }
-        } else {
-            // ...or there weren't any child values, so it's just the input after the opening delimiter.
-            self.iterator.input
-        };
+        let end = child_expr_cache
+            .last()
+            .map(|e| e.range().end)
+            .unwrap_or(self.iterator.input.offset());
+        let input_after_last_expr = self
+            .iterator
+            .input
+            .slice_to_end(end - self.iterator.input.offset());
 
         let (mut input_after_ws, _ws) = input_after_last_expr
             .match_optional_comments_and_whitespace()
@@ -393,31 +380,20 @@ impl<'top> TextSExpSpanFinder_1_1<'top> {
         // The input has already skipped past the opening delimiter.
         let start = self.iterator.input.offset() - initial_bytes_skipped;
         let mut child_expr_cache = BumpVec::new_in(self.allocator);
+
         for expr_result in self.iterator {
             let expr = expr_result?;
             child_expr_cache.push(expr);
         }
 
-        let input_after_last_expr = if let Some(value_expr) = child_expr_cache.last() {
-            // ...the input slice that follows the last sequence value...
-            match value_expr {
-                RawValueExpr::ValueLiteral(value) => value
-                    .matched
-                    .input
-                    .slice_to_end(value.matched.encoded_value.total_length()),
-                RawValueExpr::MacroInvocation(invocation) => {
-                    let end_of_expr = invocation.input.offset() + invocation.input.len();
-                    let remaining = self
-                        .iterator
-                        .input
-                        .slice_to_end(end_of_expr - self.iterator.input.offset());
-                    remaining
-                }
-            }
-        } else {
-            // ...or there weren't any child values, so it's just the input after the opening delimiter.
-            self.iterator.input
-        };
+        let end = child_expr_cache
+            .last()
+            .map(|e| e.range().end)
+            .unwrap_or(self.iterator.input.offset());
+        let input_after_last_expr = self
+            .iterator
+            .input
+            .slice_to_end(end - self.iterator.input.offset());
 
         let (input_after_ws, _ws) = input_after_last_expr
             .match_optional_comments_and_whitespace()
@@ -426,8 +402,8 @@ impl<'top> TextSExpSpanFinder_1_1<'top> {
             .with_context("seeking the closing delimiter of a sexp", input_after_ws)?;
         let end = input_after_end.offset();
 
-        let span = start..end;
-        Ok((span, child_expr_cache.into_bump_slice()))
+        let range = start..end;
+        Ok((range, child_expr_cache.into_bump_slice()))
     }
 }
 
@@ -722,28 +698,18 @@ impl<'top> TextStructSpanFinder_1_1<'top> {
             child_expr_cache.push(expr);
         }
 
-        // We need to find the input slice containing the closing delimiter.
-        let input_after_last = if let Some(field) = child_expr_cache.last() {
-            // If there are any field expressions, we need to isolate the input slice that follows
-            // the last one.
-            use LazyRawFieldExpr::*;
-            match field {
-                NameValue(_, value) => value
-                    .matched
-                    .input
-                    .slice_to_end(value.matched.encoded_value.total_length()),
-                NameEExp(_, eexp) | EExp(eexp) => {
-                    self.iterator.input.slice_to_end(eexp.input.len())
-                }
-            }
-        } else {
-            // ...or there aren't fields, so it's just the input after the opening delimiter.
-            self.iterator.input
-        };
-        let (mut input_after_ws, _ws) =
-            input_after_last
-                .match_optional_comments_and_whitespace()
-                .with_context("seeking the end of a struct", input_after_last)?;
+        let end = child_expr_cache
+            .last()
+            .map(|e| e.range().end)
+            .unwrap_or(start + 1);
+        let input_after_last_field_expr = self
+            .iterator
+            .input
+            .slice_to_end(end - self.iterator.input.offset());
+
+        let (mut input_after_ws, _ws) = input_after_last_field_expr
+            .match_optional_comments_and_whitespace()
+            .with_context("seeking the end of a struct", input_after_last_field_expr)?;
         // Skip an optional comma and more whitespace
         if input_after_ws.bytes().first() == Some(&b',') {
             (input_after_ws, _) = input_after_ws
@@ -760,8 +726,9 @@ impl<'top> TextStructSpanFinder_1_1<'top> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::lazy::raw_value_ref::RawValueRef;
+
+    use super::*;
 
     fn expect_next<'top, 'data: 'top>(
         allocator: &'top BumpAllocator,

--- a/src/lazy/text/value.rs
+++ b/src/lazy/text/value.rs
@@ -21,72 +21,60 @@ use crate::{IonResult, IonType, RawSymbolTokenRef};
 /// format than in its binary format, but is still possible.) For a resolved lazy value that
 /// includes a text definition for these items whenever one exists, see
 /// [`crate::lazy::value::LazyValue`].
-// This type is version agnostic, and is wrapped by the LazyRawValue implementations for all
-// existing encodings.
 #[derive(Copy, Clone)]
-pub struct MatchedRawTextValue<'top, E: TextEncoding<'top>> {
+pub struct LazyRawTextValue<'top, E: TextEncoding<'top>> {
     pub(crate) encoded_value: EncodedTextValue<'top, E>,
     pub(crate) input: TextBufferView<'top>,
 }
 
-impl<'top, E: TextEncoding<'top>> Debug for MatchedRawTextValue<'top, E> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "MatchedRawTextValue {{\n  val={:?},\n  buf={:?}\n}}\n",
-            self.encoded_value, self.input
-        )
+impl<'top, E: TextEncoding<'top>> LazyRawTextValue<'top, E> {
+    pub(crate) fn new(
+        input: TextBufferView<'top>,
+        encoded_value: EncodedTextValue<'top, E>,
+    ) -> Self {
+        Self {
+            encoded_value,
+            input,
+        }
     }
-}
-
-// ===== Version-specific wrappers =====
-//
-// These types provide Ion-version-specific impls of the LazyRawValue trait
-#[derive(Copy, Clone)]
-pub struct LazyRawTextValue<'top, E: TextEncoding<'top>> {
-    pub(crate) matched: MatchedRawTextValue<'top, E>,
 }
 
 impl<'top, E: TextEncoding<'top>> LazyRawTextValue<'top, E> {
-    pub fn new(matched: MatchedRawTextValue<'top, E>) -> Self {
-        Self { matched }
-    }
-
     pub fn data_range(&self) -> Range<usize> {
         // If the matched value has annotations, the `data_offset` will be the offset beyond
         // the annotations at which the value's data begins.
-        let data_offset = self.matched.encoded_value.data_offset();
-        let data_length = self.matched.input.len() - data_offset;
+        let data_offset = self.encoded_value.data_offset();
+        let data_length = self.input.len() - data_offset;
         // Add the input buffer's offset to the data offset to get the absolute offset.
-        let start = self.matched.input.offset() + data_offset;
+        let start = self.input.offset() + data_offset;
         let end = start + data_length;
         start..end
     }
 
     pub fn has_annotations(&self) -> bool {
-        self.matched.encoded_value.data_offset() > 0
+        self.encoded_value.data_offset() > 0
     }
 
     pub fn annotations_range(&self) -> Option<Range<usize>> {
         if !self.has_annotations() {
             return None;
         }
-        let annotations_length = self.matched.encoded_value.data_offset();
-        let start = self.matched.input.offset();
+        let annotations_length = self.encoded_value.data_offset();
+        let start = self.input.offset();
         let end = start + annotations_length;
         Some(start..end)
     }
 
     pub fn annotations_span(&self) -> Option<Span<'top>> {
         let range = self.annotations_range()?;
-        let bytes = &self.matched.input.bytes()[..range.len()];
+        let bytes = &self.input.bytes()[..range.len()];
         Some(Span::with_offset(range.start, bytes))
     }
 
     /// Returns the total number of bytes used to represent the current value, including its
     /// annotations (if any) and its value.
     pub fn total_length(&self) -> usize {
-        self.matched.input.len()
+        self.input.len()
     }
 }
 
@@ -149,20 +137,12 @@ impl<'top, E: TextEncoding<'top>> Debug for LazyRawTextValue<'top, E> {
             // If we can read the value, show it
             Ok(value) => write!(f, " {{{value:?}}}"),
             // Otherwise, write out diagnostic information
-            Err(e) => write!(f, " {{\n  matched={:?}\n  err={:?}\n}}\n", self.matched, e),
+            Err(e) => write!(
+                f,
+                " {{\n  encoded_value={:?}\n  {:?}\n  err={:?}\n}}\n",
+                self.encoded_value, self.input, e
+            ),
         }
-    }
-}
-
-impl<'top> From<MatchedRawTextValue<'top, TextEncoding_1_0>> for LazyRawTextValue_1_0<'top> {
-    fn from(matched: MatchedRawTextValue<'top, TextEncoding_1_0>) -> Self {
-        LazyRawTextValue::new(matched)
-    }
-}
-
-impl<'top> From<MatchedRawTextValue<'top, TextEncoding_1_1>> for LazyRawTextValue_1_1<'top> {
-    fn from(matched: MatchedRawTextValue<'top, TextEncoding_1_1>) -> Self {
-        LazyRawTextValue::new(matched)
     }
 }
 
@@ -171,22 +151,25 @@ impl<'top> From<MatchedRawTextValue<'top, TextEncoding_1_1>> for LazyRawTextValu
 // These trait impls are common to all Ion versions, but require the caller to specify a type
 // parameter.
 
-impl<'top, E: TextEncoding<'top>> HasRange for MatchedRawTextValue<'top, E> {
+impl<'top, E: TextEncoding<'top>> HasRange for LazyRawTextValue<'top, E> {
     fn range(&self) -> Range<usize> {
         self.input.range()
     }
 }
 
-impl<'top, E: TextEncoding<'top>> HasSpan<'top> for MatchedRawTextValue<'top, E> {
+impl<'top, E: TextEncoding<'top>> HasSpan<'top> for LazyRawTextValue<'top, E> {
     fn span(&self) -> Span<'top> {
+        Span::with_offset(self.input.offset(), self.input.bytes())
+        /*
         let range = self.range();
         let input_offset = self.input.offset();
         let local_range = (range.start - input_offset)..(range.end - input_offset);
         Span::with_offset(range.start, &self.input.bytes()[local_range])
+        */
     }
 }
 
-impl<'top, E: TextEncoding<'top>> LazyRawValue<'top, E> for MatchedRawTextValue<'top, E> {
+impl<'top, E: TextEncoding<'top>> LazyRawValue<'top, E> for LazyRawTextValue<'top, E> {
     fn ion_type(&self) -> IonType {
         self.encoded_value.ion_type()
     }
@@ -221,41 +204,11 @@ impl<'top, E: TextEncoding<'top>> LazyRawValue<'top, E> for MatchedRawTextValue<
             Symbol(s) => RawValueRef::Symbol(s.read(allocator, matched_input)?),
             Blob(b) => RawValueRef::Blob(b.read(allocator, matched_input)?),
             Clob(c) => RawValueRef::Clob(c.read(allocator, matched_input)?),
-            List(_) => RawValueRef::List(E::List::<'top>::from_value(E::value_from_matched(*self))),
-            SExp(_) => RawValueRef::SExp(E::SExp::<'top>::from_value(E::value_from_matched(*self))),
-            Struct(_) => RawValueRef::Struct(E::Struct::from_value(E::value_from_matched(*self))),
+            List(_) => RawValueRef::List(E::List::<'top>::from_value(*self)),
+            SExp(_) => RawValueRef::SExp(E::SExp::<'top>::from_value(*self)),
+            Struct(_) => RawValueRef::Struct(E::Struct::from_value(*self)),
         };
         Ok(value_ref)
-    }
-}
-
-impl<'top, E: TextEncoding<'top>> HasRange for LazyRawTextValue<'top, E> {
-    fn range(&self) -> Range<usize> {
-        self.matched.range()
-    }
-}
-
-impl<'top, E: TextEncoding<'top>> HasSpan<'top> for LazyRawTextValue<'top, E> {
-    fn span(&self) -> Span<'top> {
-        self.matched.span()
-    }
-}
-
-impl<'top, E: TextEncoding<'top>> LazyRawValue<'top, E> for LazyRawTextValue<'top, E> {
-    fn ion_type(&self) -> IonType {
-        self.matched.ion_type()
-    }
-
-    fn is_null(&self) -> bool {
-        self.matched.is_null()
-    }
-
-    fn annotations(&self) -> <E as LazyDecoder>::AnnotationsIterator<'top> {
-        self.matched.annotations()
-    }
-
-    fn read(&self) -> IonResult<RawValueRef<'top, E>> {
-        self.matched.read()
     }
 }
 


### PR DESCRIPTION
Many of the types that comprise the text reader API are quite large. This PR makes a variety of small changes to shrink their layout, hopefully helping to minimize the need for `memcpy`s and reducing bump allocated memory usage. Benchmarks showed modest improvements in the 1-3% range. I suggest reviewing the commits individually.

Following PR #760, field name information is no longer stored in the `LazyRawTextValue`; it has its own type that is only constructed in the context of a struct. Commit 3f68fab3b45a3be577bbc7a577da85cc97cb07b0 modifies text values so that their `TextBufferView` layout starts with the annotations sequence (if any) and ends with the final byte of the value. Prior to this change, many values held a slice that contained the rest of the available input. This change makes it possible to use the `TextBufferView`'s offset and length as a proxy for the value's own. It also eliminates most of the metadata stored in the `LazyRawTextValue`, leaving only a `data_offset: u16` that indicates where the first byte of the value is.

The same commit also modified the `MacroEvaluator` to avoid storing an extra copy of the allocator when one could be fetched from a nested `BumpVec`. Similarly, the `MacroEvaluator` can now reference the `EncodingContext` that lives on each `MacroExpansion`.

Commit 054df229fab481c6f95c1f166c60fcd798e41088 causes the `MacroEvaluator` to use a capacity hint when bump-allocating space to store macro argument expressions.

Commit a8514b600a86f8353738f24fbdfc846364543e59 moves the `EncodingContext` that was previously copied into  instances of most types into the bump allocator and passes around a reference to it instead. This shrank the size of many types by 16 bytes.

Commit c0256c078ead34dd3166529da44011f6946ace1d removes the superfluous `MatchedRawTextValue` type, which was intended to be a shim allowing the 1.0 and 1.1 text value types to use the same structure. I was able to remove the need for it via generics.

Commit 375915d43d9ccd492e42ae4f1a045ead6d4144e0 shrinks the size of the macro parameter index stored in each `TemplateVariableReference` from `usize` to `u16`. This made space for the `TemplateVariableReference`'s enum discriminant, saving 8 bytes.

-------

Here are some example data type size reductions for `AnyEncoding`:

| Data type | Size Before | Size After |
| ---------- |:-----------:|:---------:|
| `LazyValue` | 128 | 96 |
| `LazyField` | 208 | 160 |
| `StructIterator` | 320 | 224|

While some types were specifically target for improvement, many types benefitted from the `EncodingContext` change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
