### PR TITLE
Add 1.1 binary reader support for typed nulls

### DIFF
--- a/src/lazy/binary/raw/v1_1/reader.rs
+++ b/src/lazy/binary/raw/v1_1/reader.rs
@@ -755,4 +755,30 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn nulls() -> IonResult<()> {
+        #[rustfmt::skip]
+        let data: Vec<([u8; 2], IonType)> = vec![
+            ([0xEB, 0x00], IonType::Bool),      // null.bool
+            ([0xEB, 0x01], IonType::Int),       // null.int
+            ([0xEB, 0x02], IonType::Float),     // null.float
+            ([0xEB, 0x03], IonType::Decimal),   // null.decimal
+            ([0xEB, 0x04], IonType::Timestamp), // null.timestamp
+            ([0xEB, 0x05], IonType::String),    // null.string
+            ([0xEB, 0x06], IonType::Symbol),    // null.symbol
+            ([0xEB, 0x07], IonType::Blob),      // null.blob
+            ([0xEB, 0x08], IonType::Clob),      // null.clob
+            ([0xEB, 0x09], IonType::List),      // null.list
+            ([0xEB, 0x0A], IonType::SExp),      // null.sexp
+            ([0xEB, 0x0B], IonType::Struct),    // null.struct
+        ];
+
+        for (data, expected_type) in data {
+            let mut reader = LazyRawBinaryReader_1_1::new(&data);
+            let actual_type = reader.next()?.expect_value()?.read()?.expect_null()?;
+            assert_eq!(actual_type, expected_type);
+        }
+        Ok(())
+    }
 }

--- a/src/lazy/binary/raw/v1_1/type_descriptor.rs
+++ b/src/lazy/binary/raw/v1_1/type_descriptor.rs
@@ -14,6 +14,20 @@ pub struct Opcode {
 /// A statically defined array of TypeDescriptor that allows a binary reader to map a given
 /// byte (`u8`) to a `TypeDescriptor` without having to perform any masking or bitshift operations.
 pub(crate) static ION_1_1_OPCODES: &[Opcode; 256] = &init_opcode_cache();
+pub(crate) static ION_1_1_TYPED_NULL_TYPES: &[IonType; 12] = &[
+    IonType::Bool,
+    IonType::Int,
+    IonType::Float,
+    IonType::Decimal,
+    IonType::Timestamp,
+    IonType::String,
+    IonType::Symbol,
+    IonType::Blob,
+    IonType::Clob,
+    IonType::List,
+    IonType::SExp,
+    IonType::Struct,
+];
 
 static ION_1_1_TIMESTAMP_SHORT_SIZE: [u8; 13] = [1, 2, 2, 4, 5, 6, 7, 8, 5, 5, 7, 8, 9];
 
@@ -54,6 +68,7 @@ impl Opcode {
             (0xE, 0x0) => (IonVersionMarker, low_nibble, None),
             (0xE, 0x1..=0x3) => (SymbolAddress, low_nibble, Some(IonType::Symbol)),
             (0xE, 0xA) => (NullNull, low_nibble, Some(IonType::Null)),
+            (0xE, 0xB) => (TypedNull, low_nibble, Some(IonType::Null)),
             (0xE, 0xC..=0xD) => (Nop, low_nibble, None),
             (0xF, 0x5) => (LargeInteger, low_nibble, Some(IonType::Int)),
             (0xF, 0x6) => (Decimal, 0xFF, Some(IonType::Decimal)),
@@ -139,6 +154,7 @@ impl Header {
             (OpcodeType::TimestampShort, 0..=12) => {
                 InOpcode(ION_1_1_TIMESTAMP_SHORT_SIZE[self.length_code as usize])
             }
+            (OpcodeType::TypedNull, _) => InOpcode(1),
             _ => FlexUIntFollows,
         }
     }

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -174,7 +174,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
                 let body = self.value_body()?;
                 ION_1_1_TYPED_NULL_TYPES[body[0] as usize]
             } else {
-                self.ion_type()
+                IonType::Null
             };
             return Ok(RawValueRef::Null(ion_type));
         }


### PR DESCRIPTION
*Issue #, if available:* #662

*Description of changes:*
This PR adds support for typed nulls to the binary ion 1.1 reader.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
