### PR TITLE
Add 1.1 binary reader support for length-prefixed structs

### DIFF
--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -7,6 +7,7 @@ use crate::lazy::binary::raw::v1_1::{Header, LengthType, Opcode, ION_1_1_OPCODES
 use crate::lazy::encoder::binary::v1_1::fixed_int::FixedInt;
 use crate::lazy::encoder::binary::v1_1::fixed_uint::FixedUInt;
 use crate::lazy::encoder::binary::v1_1::flex_int::FlexInt;
+use crate::lazy::encoder::binary::v1_1::flex_sym::FlexSym;
 use crate::lazy::encoder::binary::v1_1::flex_uint::FlexUInt;
 use crate::result::IonFailure;
 use crate::{IonError, IonResult};
@@ -163,6 +164,13 @@ impl<'a> ImmutableBuffer<'a> {
         let flex_uint = FlexUInt::read(self.bytes(), self.offset())?;
         let remaining = self.consume(flex_uint.size_in_bytes());
         Ok((flex_uint, remaining))
+    }
+
+    #[inline]
+    pub fn read_flex_sym(self) -> ParseResult<'a, FlexSym<'a>> {
+        let flex_sym = FlexSym::read(self.bytes(), self.offset())?;
+        let remaining = self.consume(flex_sym.size_in_bytes());
+        Ok((flex_sym, remaining))
     }
 
     /// Attempts to decode an annotations wrapper at the beginning of the buffer and returning

--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -1,5 +1,4 @@
 use crate::binary::constants::v1_1::IVM;
-use crate::binary::var_uint::VarUInt;
 use crate::lazy::binary::encoded_value::EncodedValue;
 use crate::lazy::binary::raw::v1_1::value::{
     LazyRawBinaryValue_1_1, LazyRawBinaryVersionMarker_1_1,
@@ -246,18 +245,6 @@ impl<'a> ImmutableBuffer<'a> {
         Ok((length, remaining))
     }
 
-    /// Reads a field ID and a value from the buffer.
-    pub(crate) fn peek_field(self) -> IonResult<Option<LazyRawBinaryValue_1_1<'a>>> {
-        todo!();
-    }
-
-    #[cold]
-    /// Consumes (field ID, NOP pad) pairs until a non-NOP value is encountered in field position or
-    /// the buffer is empty. Returns a buffer starting at the field ID before the non-NOP value.
-    fn read_struct_field_nop_pad(self) -> IonResult<Option<(usize, VarUInt, ImmutableBuffer<'a>)>> {
-        todo!();
-    }
-
     /// Reads a value without a field name from the buffer. This is applicable in lists, s-expressions,
     /// and at the top level.
     pub(crate) fn peek_sequence_value(self) -> IonResult<Option<LazyRawBinaryValue_1_1<'a>>> {
@@ -282,11 +269,11 @@ impl<'a> ImmutableBuffer<'a> {
 
     /// Reads a value from the buffer. The caller must confirm that the buffer is not empty and that
     /// the next byte (`type_descriptor`) is not a NOP.
-    fn read_value(self, type_descriptor: Opcode) -> IonResult<LazyRawBinaryValue_1_1<'a>> {
-        if type_descriptor.is_annotation_wrapper() {
-            self.read_annotated_value(type_descriptor)
+    pub fn read_value(self, opcode: Opcode) -> IonResult<LazyRawBinaryValue_1_1<'a>> {
+        if opcode.is_annotation_wrapper() {
+            self.read_annotated_value(opcode)
         } else {
-            self.read_value_without_annotations(type_descriptor)
+            self.read_value_without_annotations(opcode)
         }
     }
 

--- a/src/lazy/binary/raw/v1_1/reader.rs
+++ b/src/lazy/binary/raw/v1_1/reader.rs
@@ -756,6 +756,7 @@ mod tests {
         Ok(())
     }
 
+
     #[test]
     fn nulls() -> IonResult<()> {
         #[rustfmt::skip]
@@ -778,6 +779,82 @@ mod tests {
             let mut reader = LazyRawBinaryReader_1_1::new(&data);
             let actual_type = reader.next()?.expect_value()?.read()?.expect_null()?;
             assert_eq!(actual_type, expected_type);
+        }
+        Ok(())
+    }
+
+    fn structs() -> IonResult<()> {
+        use crate::lazy::decoder::{LazyRawFieldExpr, LazyRawFieldName};
+        use crate::raw_symbol_ref::RawSymbolRef;
+
+        #[rustfmt::skip]
+        #[allow(clippy::type_complexity)]
+        let tests: &[(&[u8], &[(RawSymbolRef, IonType)])] = &[
+            // Symbol Address
+            (
+                // { $10: 1, $11: 2 }
+                &[0xC6, 0x15, 0x51, 0x01, 0x17, 0x51, 0x02],
+                &[
+                    (10usize.into(), IonType::Int),
+                    (11usize.into(), IonType::Int),
+                ]
+            ),
+            (
+                // { $10: '', $11: 0e0 }
+                &[0xC4, 0x15, 0x90, 0x17, 0x5A],
+                &[
+                    (10usize.into(), IonType::Symbol),
+                    (11usize.into(), IonType::Float),
+                ],
+            ),
+            (
+                // { $10: <NOP>, $11: 0e0 } - with nops, skip the NOP'd fields.
+                &[ 0xC4, 0x15, 0xEC, 0x17, 0x5A ],
+                &[
+                    (11usize.into(), IonType::Float),
+                ],
+            ),
+            (
+                // { $10: "variable length struct" }
+                &[
+                    0xFC, 0x33, 0x15, 0xF8, 0x2D, 0x76, 0x61, 0x72, 0x69, 0x61,
+                    0x62, 0x6C, 0x65, 0x20, 0x6c, 0x65, 0x6E, 0x67, 0x74, 0x68,
+                    0x20, 0x73, 0x74, 0x72, 0x75, 0x63, 0x74
+                ],
+                &[ (10usize.into(), IonType::String) ],
+            ),
+            // FlexSym
+            (
+                // { "foo": 1, $11: 2 }
+                &[ 0xD9, 0xFB, 0x66, 0x6F, 0x6F, 0x51, 0x01, 0x17, 0x91, 0x02],
+                &[ ("foo".into(), IonType::Int), (11usize.into(), IonType::Symbol)],
+            ),
+            (
+                // { "foo": 1, $11: 2 }
+                &[ 0xFD, 0x13, 0xFB, 0x66, 0x6F, 0x6F, 0x51, 0x01, 0x17, 0x91, 0x02],
+                &[ ("foo".into(), IonType::Int), (11usize.into(), IonType::Symbol)],
+            ),
+            (
+                // { "foo": <NOP>, $11: 2 }
+                &[ 0xFD, 0x11, 0xFB, 0x66, 0x6F, 0x6F, 0xEC, 0x17, 0x91, 0x02],
+                &[ (11usize.into(), IonType::Symbol) ],
+            ),
+        ];
+
+        for (ion_data, field_pairs) in tests {
+            let mut reader = LazyRawBinaryReader_1_1::new(ion_data);
+            let actual_data = reader.next()?.expect_value()?.read()?.expect_struct()?;
+
+            for (actual_field, expected_field) in actual_data.iter().zip(field_pairs.iter()) {
+                let (expected_name, expected_value_type) = expected_field;
+                match actual_field {
+                    Ok(LazyRawFieldExpr::NameValue(name, value)) => {
+                        assert_eq!(name.read()?, *expected_name);
+                        assert_eq!(value.ion_type(), *expected_value_type);
+                    }
+                    other => panic!("unexpected value for field: {:?}", other),
+                }
+            }
         }
         Ok(())
     }

--- a/src/lazy/binary/raw/v1_1/struct.rs
+++ b/src/lazy/binary/raw/v1_1/struct.rs
@@ -36,13 +36,13 @@ impl<'top> LazyRawBinaryFieldName_1_1<'top> {
 
 impl<'top> HasSpan<'top> for LazyRawBinaryFieldName_1_1<'top> {
     fn span(&self) -> Span<'top> {
-        todo!()
+        Span::with_offset(self.matched.offset(), self.matched.bytes())
     }
 }
 
 impl<'top> HasRange for LazyRawBinaryFieldName_1_1<'top> {
     fn range(&self) -> Range<usize> {
-        todo!()
+        self.matched.range()
     }
 }
 

--- a/src/lazy/binary/raw/v1_1/struct.rs
+++ b/src/lazy/binary/raw/v1_1/struct.rs
@@ -6,7 +6,7 @@ use std::ops::Range;
 
 use crate::lazy::binary::raw::v1_1::annotations_iterator::RawBinaryAnnotationsIterator_1_1;
 use crate::lazy::binary::raw::v1_1::{
-    immutable_buffer::ImmutableBuffer, value::LazyRawBinaryValue_1_1,
+    immutable_buffer::ImmutableBuffer, value::LazyRawBinaryValue_1_1, OpcodeType,
 };
 use crate::lazy::decoder::private::LazyContainerPrivate;
 use crate::lazy::decoder::{
@@ -14,7 +14,7 @@ use crate::lazy::decoder::{
 };
 use crate::lazy::encoding::BinaryEncoding_1_1;
 use crate::lazy::span::Span;
-use crate::{IonResult, RawSymbolRef};
+use crate::{result::IonFailure, IonResult, RawSymbolRef};
 
 #[derive(Debug, Copy, Clone)]
 pub struct LazyRawBinaryFieldName_1_1<'top> {
@@ -48,7 +48,7 @@ impl<'top> HasRange for LazyRawBinaryFieldName_1_1<'top> {
 
 impl<'top> LazyRawFieldName<'top> for LazyRawBinaryFieldName_1_1<'top> {
     fn read(&self) -> IonResult<RawSymbolRef<'top>> {
-        todo!()
+        Ok(self.field_name)
     }
 }
 
@@ -88,7 +88,10 @@ impl<'top> LazyRawBinaryStruct_1_1<'top> {
         // Get as much of the struct's body as is available in the input buffer.
         // Reading a child value may fail as `Incomplete`
         let buffer_slice = self.value.available_body();
-        RawBinaryStructIterator_1_1::new(buffer_slice)
+        RawBinaryStructIterator_1_1::new(
+            self.value.encoded_value.header.ion_type_code,
+            buffer_slice,
+        )
     }
 }
 
@@ -116,13 +119,153 @@ impl<'top> LazyRawStruct<'top, BinaryEncoding_1_1> for LazyRawBinaryStruct_1_1<'
     }
 }
 
+enum StructType {
+    Invalid,
+    FlexSym,
+    SymbolAddress,
+}
+
 pub struct RawBinaryStructIterator_1_1<'top> {
     source: ImmutableBuffer<'top>,
+    bytes_to_skip: usize,
+    struct_type: StructType,
 }
 
 impl<'top> RawBinaryStructIterator_1_1<'top> {
-    pub(crate) fn new(input: ImmutableBuffer<'top>) -> RawBinaryStructIterator_1_1<'top> {
-        RawBinaryStructIterator_1_1 { source: input }
+    pub(crate) fn new(
+        opcode_type: OpcodeType,
+        input: ImmutableBuffer<'top>,
+    ) -> RawBinaryStructIterator_1_1<'top> {
+        RawBinaryStructIterator_1_1 {
+            source: input,
+            bytes_to_skip: 0,
+            struct_type: match opcode_type {
+                OpcodeType::StructSymAddress => StructType::SymbolAddress,
+                OpcodeType::StructFlexSym => StructType::FlexSym,
+                _ => StructType::Invalid,
+            },
+        }
+    }
+
+    /// Helper function called by [`Self::peek_field`] in order to parse a FlexSym encoded
+    /// struct field names. If no field is available, None is returned, otherwise the symbol and an
+    /// [`ImmutableBuffer`] positioned after the field name is returned.
+    ///
+    /// The opcode variant of the FlexSym is not currently implemented.
+    fn peek_field_flexsym(
+        buffer: ImmutableBuffer<'top>,
+    ) -> IonResult<Option<(LazyRawBinaryFieldName_1_1<'top>, ImmutableBuffer<'top>)>> {
+        use crate::IonError;
+        use std::cmp::Ordering;
+
+        if buffer.is_empty() {
+            return Ok(None);
+        }
+
+        let (flex_sym, after) = buffer.read_flex_int()?;
+        let sym_value = flex_sym.value();
+        let (sym, after) = match sym_value.cmp(&0) {
+            Ordering::Greater => (RawSymbolRef::SymbolId(sym_value as usize), after),
+            Ordering::Less => {
+                let len = sym_value.unsigned_abs() as usize;
+                let text = after.bytes_range(0, len);
+                let text = std::str::from_utf8(text).map_err(|_| {
+                    IonError::decoding_error("found FlexSym with invalid UTF-8 data")
+                })?;
+                (RawSymbolRef::Text(text), after.consume(len))
+            }
+            Ordering::Equal => todo!(),
+        };
+
+        let matched_field_id = buffer.slice(0, flex_sym.size_in_bytes());
+        let field_name = LazyRawBinaryFieldName_1_1::new(sym, matched_field_id);
+        Ok(Some((field_name, after)))
+    }
+
+    /// Helper function called by [`Self::peek_field`] in order to parse a symbol address encoded
+    /// struct field names. If no field is available, None is returned, otherwise the symbol and an
+    /// [`ImmutableBuffer`] positioned after the field name is returned.
+    fn peek_field_symbol_addr(
+        buffer: ImmutableBuffer<'top>,
+    ) -> IonResult<Option<(LazyRawBinaryFieldName_1_1<'top>, ImmutableBuffer<'top>)>> {
+        if buffer.is_empty() {
+            return Ok(None);
+        }
+
+        let (symbol_address, after) = buffer.read_flex_uint()?;
+
+        let field_id = symbol_address.value() as usize;
+        let matched_field_id = buffer.slice(0, symbol_address.size_in_bytes());
+        let field_name = LazyRawBinaryFieldName_1_1::new(
+            RawSymbolRef::SymbolId(field_id),
+            matched_field_id,
+        );
+        Ok(Some((field_name, after)))
+    }
+
+    /// Helper function called by [`Self::peek_field`] in order to parse a struct field's value.
+    /// If a value is parsed successfully, it is returned along with an [`ImmutableBuffer`]
+    /// positioned after the value. If the value consists of NOPs, no value is returned but a
+    /// buffer positioned after the NOPs is returned.
+    fn peek_value(
+        buffer: ImmutableBuffer<'top>,
+    ) -> IonResult<(Option<LazyRawBinaryValue_1_1<'top>>, ImmutableBuffer<'top>)> {
+        let opcode = buffer.peek_opcode()?;
+        if opcode.is_nop() {
+            let after_nops = buffer.consume_nop_padding(opcode)?.1;
+            if after_nops.is_empty() {
+                // Non-NOP field wasn't found, nothing remaining.
+                return Ok((None, after_nops));
+            }
+            Ok((None, after_nops))
+        } else {
+            buffer
+                .read_value(opcode)
+                .map(|v| (Some(v), v.input.consume(v.encoded_value.total_length)))
+        }
+    }
+
+    /// Helper function called from [`Self::next`] to parse the current field and value from the
+    /// struct. On success, returns an both the field pair via [`LazyRawFieldExpr`] as well as the
+    /// total bytes needed to skip the field.
+    fn peek_field(&self) -> IonResult<Option<(LazyRawFieldExpr<'top, BinaryEncoding_1_1>, usize)>> {
+        let mut buffer = self.source;
+        loop {
+            // Peek at our field name.
+            let peek_result = match self.struct_type {
+                StructType::SymbolAddress => Self::peek_field_symbol_addr(buffer)?,
+                StructType::FlexSym => Self::peek_field_flexsym(buffer)?,
+                _ => todo!(),
+            };
+
+            let Some((field_name, after_name)) = peek_result else {
+                return Ok(None);
+            };
+
+            if after_name.is_empty() {
+                return IonResult::incomplete("found field name but no value", after_name.offset());
+            }
+
+            let (value, after_value) = match Self::peek_value(after_name)? {
+                (None, after) => {
+                    if after.is_empty() {
+                        return IonResult::incomplete(
+                            "found field name but no value",
+                            after.offset(),
+                        );
+                    }
+                    buffer = after;
+                    continue; // No value for this field, loop to try next field.
+                }
+                (Some(value), after) => (value, after),
+            };
+
+            let bytes_to_skip = after_value.offset() - self.source.offset();
+            return Ok(Some((
+                LazyRawFieldExpr::NameValue(field_name, value),
+                bytes_to_skip,
+            )));
+        }
     }
 }
 
@@ -130,6 +273,13 @@ impl<'top> Iterator for RawBinaryStructIterator_1_1<'top> {
     type Item = IonResult<LazyRawFieldExpr<'top, BinaryEncoding_1_1>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        todo!()
+        self.source = self.source.consume(self.bytes_to_skip);
+        let (field_expr, bytes_to_skip) = match self.peek_field() {
+            Ok(Some((value, bytes_to_skip))) => (Some(Ok(value)), bytes_to_skip),
+            Ok(None) => (None, 0),
+            Err(e) => (Some(Err(e)), 0),
+        };
+        self.bytes_to_skip = bytes_to_skip;
+        field_expr
     }
 }

--- a/src/lazy/binary/raw/v1_1/type_code.rs
+++ b/src/lazy/binary/raw/v1_1/type_code.rs
@@ -26,7 +26,7 @@ pub enum OpcodeType {
     SExpression,               // 0xB0-0xBF -
     StructEmpty,               // 0xC0      -
     // reserved
-    StructSymAddress, // 0xD2-0xDF -
+    StructSymAddress, // 0xC2-0xCF -
     // reserved
     StructFlexSym,    // 0xD2-0xDF -
     IonVersionMarker, // 0xE0      -

--- a/src/lazy/binary/raw/v1_1/type_descriptor.rs
+++ b/src/lazy/binary/raw/v1_1/type_descriptor.rs
@@ -65,6 +65,8 @@ impl Opcode {
             (0x9, _) => (InlineSymbol, low_nibble, Some(IonType::Symbol)),
             (0xA, _) => (List, low_nibble, Some(IonType::List)),
             (0xB, _) => (SExpression, low_nibble, Some(IonType::SExp)),
+            (0xC, _) => (StructSymAddress, low_nibble, Some(IonType::Struct)),
+            (0xD, _) => (StructFlexSym, low_nibble, Some(IonType::Struct)),
             (0xE, 0x0) => (IonVersionMarker, low_nibble, None),
             (0xE, 0x1..=0x3) => (SymbolAddress, low_nibble, Some(IonType::Symbol)),
             (0xE, 0xA) => (NullNull, low_nibble, Some(IonType::Null)),
@@ -76,6 +78,8 @@ impl Opcode {
             (0xF, 0x9) => (InlineSymbol, 0xFF, Some(IonType::Symbol)),
             (0xF, 0xA) => (List, 0xFF, Some(IonType::List)),
             (0xF, 0xB) => (SExpression, 0xFF, Some(IonType::SExp)),
+            (0xF, 0xC) => (StructSymAddress, 0xFF, Some(IonType::Struct)),
+            (0xF, 0xD) => (StructFlexSym, 0xFF, Some(IonType::Struct)),
             (0xF, 0xE) => (Blob, low_nibble, Some(IonType::Blob)),
             (0xF, 0xF) => (Clob, low_nibble, Some(IonType::Clob)),
             (0xF, 0x7) => (TimestampLong, low_nibble, Some(IonType::Timestamp)),
@@ -155,6 +159,8 @@ impl Header {
                 InOpcode(ION_1_1_TIMESTAMP_SHORT_SIZE[self.length_code as usize])
             }
             (OpcodeType::TypedNull, _) => InOpcode(1),
+            (OpcodeType::StructSymAddress, n) if n < 16 => InOpcode(n),
+            (OpcodeType::StructFlexSym, n) if n < 16 => InOpcode(n),
             _ => FlexUIntFollows,
         }
     }

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -526,7 +526,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
     fn read_timestamp_long(&self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
         use crate::lazy::encoder::binary::v1_1::fixed_uint::FixedUInt;
         use crate::lazy::encoder::binary::v1_1::flex_uint::FlexUInt;
-        use crate::types::decimal::{*, coefficient::Coefficient};
+        use crate::types::decimal::{coefficient::Coefficient, *};
 
         const YEAR_MASK_16BIT: u16 = 0x3FFF;
         const MONTH_MASK_16BIT: u16 = 0x03_C0;

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -700,6 +700,10 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
 
     /// Helper method called by [`Self::read`]. Reads the current value as a struct.
     fn read_struct(&self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
-        todo!();
+        use crate::lazy::binary::raw::v1_1::r#struct::LazyRawBinaryStruct_1_1;
+        use crate::lazy::decoder::private::LazyContainerPrivate;
+        Ok(RawValueRef::Struct(LazyRawBinaryStruct_1_1::from_value(
+            *self,
+        )))
     }
 }

--- a/src/lazy/encoder/binary/v1_1/fixed_uint.rs
+++ b/src/lazy/encoder/binary/v1_1/fixed_uint.rs
@@ -2,12 +2,12 @@ use std::io::Write;
 
 use ice_code::ice as cold_path;
 
+use crate::decimal::coefficient::Coefficient;
 use crate::lazy::encoder::binary::v1_1::fixed_int::{
     MAX_INT_SIZE_IN_BYTES, MAX_UINT_SIZE_IN_BYTES,
 };
-use crate::decimal::coefficient::Coefficient;
 use crate::result::IonFailure;
-use crate::{IonResult, UInt, IonError};
+use crate::{IonError, IonResult, UInt};
 
 /// An Ion 1.1 encoding primitive that represents a fixed-length unsigned integer.
 #[derive(Debug)]

--- a/src/lazy/reader.rs
+++ b/src/lazy/reader.rs
@@ -3,16 +3,14 @@
 use crate::element::reader::ElementReader;
 use crate::element::Element;
 use crate::lazy::decoder::Decoder;
-use crate::lazy::encoding::{TextEncoding_1_1};
+use crate::lazy::encoding::TextEncoding_1_1;
 use crate::lazy::streaming_raw_reader::IonInput;
-use crate::lazy::system_reader::{
-    SystemReader,
-};
+use crate::lazy::system_reader::SystemReader;
 use crate::lazy::text::raw::v1_1::reader::MacroAddress;
 use crate::lazy::value::LazyValue;
+use crate::read_config::ReadConfig;
 use crate::result::IonFailure;
 use crate::{IonError, IonResult};
-use crate::read_config::ReadConfig;
 
 /// A binary reader that only reads each value that it visits upon request (that is: lazily).
 ///
@@ -120,7 +118,10 @@ impl<Encoding: Decoder, Input: IonInput> Reader<Encoding, Input> {
 }
 
 impl<Encoding: Decoder, Input: IonInput> Reader<Encoding, Input> {
-    pub fn new(config: impl Into<ReadConfig<Encoding>>, ion_data: Input) -> IonResult<Reader<Encoding, Input>> {
+    pub fn new(
+        config: impl Into<ReadConfig<Encoding>>,
+        ion_data: Input,
+    ) -> IonResult<Reader<Encoding, Input>> {
         let system_reader = SystemReader::new(config, ion_data);
         Ok(Reader { system_reader })
     }
@@ -154,9 +155,7 @@ impl<'iter, Encoding: Decoder, Input: IonInput> Iterator
     }
 }
 
-impl<Encoding: Decoder, Input: IonInput> ElementReader
-    for Reader<Encoding, Input>
-{
+impl<Encoding: Decoder, Input: IonInput> ElementReader for Reader<Encoding, Input> {
     type ElementIterator<'a> = LazyElementIterator<'a, Encoding, Input> where Self: 'a,;
 
     fn read_next_element(&mut self) -> IonResult<Option<Element>> {
@@ -178,10 +177,10 @@ mod tests {
     use crate::element::element_writer::ElementWriter;
     use crate::element::Element;
     use crate::lazy::encoder::writer::Writer;
+    use crate::lazy::encoding::BinaryEncoding_1_0;
     use crate::lazy::value_ref::ValueRef;
     use crate::write_config::WriteConfig;
-    use crate::{ion_list, ion_sexp, ion_struct, Int, IonResult, IonType, v1_0};
-    use crate::lazy::encoding::BinaryEncoding_1_0;
+    use crate::{ion_list, ion_sexp, ion_struct, v1_0, Int, IonResult, IonType};
 
     use super::*;
 


### PR DESCRIPTION
*Issue #, if available:* #664

*Description of changes:*
This PR adds support to the 1.1 raw binary reader for length-prefixed structs.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
