### PR TITLE
Add 1.1 binary reader support for length-prefixed Lists & S-Expressions

### DIFF
--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -362,27 +362,6 @@ impl<'a> ImmutableBuffer<'a> {
         todo!();
     }
 
-    /// Runs the provided parsing function on this DataSource's buffer.
-    /// If it succeeds, marks the `DataSource` as ready to advance by the 'n' bytes
-    /// that were consumed.
-    /// If it does not succeed, the `DataSource` remains unchanged.
-    pub(crate) fn try_parse_next<F: Fn(Self) -> IonResult<Option<LazyRawBinaryValue_1_1<'a>>>>(
-        &mut self,
-        parser: F,
-    ) -> IonResult<Option<LazyRawBinaryValue_1_1<'a>>> {
-        let buffer = *self;
-
-        let lazy_value = match parser(buffer) {
-            Ok(Some(output)) => output,
-            Ok(None) => return Ok(None),
-            Err(e) => return Err(e),
-        };
-
-        // If the value we read doesn't start where we began reading, there was a NOP.
-        let num_nop_bytes = lazy_value.input.offset() - buffer.offset();
-        self.consume(num_nop_bytes);
-        Ok(Some(lazy_value))
-    }
 }
 
 /// Represents the data found in an Ion 1.0 annotations wrapper.

--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -361,7 +361,6 @@ impl<'a> ImmutableBuffer<'a> {
     ) -> IonResult<LazyRawBinaryValue_1_1<'a>> {
         todo!();
     }
-
 }
 
 /// Represents the data found in an Ion 1.0 annotations wrapper.

--- a/src/lazy/binary/raw/v1_1/reader.rs
+++ b/src/lazy/binary/raw/v1_1/reader.rs
@@ -576,6 +576,7 @@ mod tests {
     fn lists() -> IonResult<()> {
         use crate::lazy::decoder::LazyRawSequence;
 
+        #[rustfmt::skip]
         let tests: &[(&[u8], &[IonType])] = &[
             // []
             (&[0xA0], &[]),
@@ -599,38 +600,21 @@ mod tests {
             ),
 
             // [3.1415927e0 3.1415927e0]
-            (&[0xAA, 0x5C, 0xDB, 0x0F, 0x49, 0x40, 0x5C, 0xDB, 0x0F, 0x49, 0x40], &[IonType::Float, IonType::Float]),
-        ];
+            (
+                &[0xAA, 0x5C, 0xDB, 0x0F, 0x49, 0x40, 0x5C, 0xDB, 0x0F, 0x49, 0x40],
+                &[IonType::Float, IonType::Float]
+            ),
 
-        for (data, expected_types) in tests {
-            let mut reader = LazyRawBinaryReader_1_1::new(data);
-            let container = reader.next()?.expect_value()?.read()?.expect_list()?;
-            let mut count = 0;
-            for (actual_lazy_value, expected_type) in container.iter().zip(expected_types.iter()) {
-                let value = actual_lazy_value?.expect_value()?;
-                assert_eq!(value.ion_type(), *expected_type);
-                count += 1;
-            }
-            assert_eq!(count, expected_types.len());
-        }
+            // Long List Encoding
 
-        Ok(())
-    }
-
-    #[test]
-    fn lists_long() -> IonResult<()> {
-        use crate::lazy::decoder::LazyRawSequence;
-
-        #[rustfmt::skip]
-        let tests: &[(&[u8], &[IonType])] = &[
             // []
             (&[0xFA, 0x01], &[]),
 
             // ["variable length list"]
             (
                 &[
-                    0xFA, 0x2D, 0xF8, 0x29, 0x76, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6C, 0x65, 0x20,
-                    0x6C, 0x65, 0x6E, 0x67, 0x74, 0x68, 0x20, 0x6C, 0x69, 0x73, 0x74,
+                    0xFA, 0x2D, 0xF8, 0x29, 0x76, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6C, 0x65,
+                    0x20, 0x6C, 0x65, 0x6E, 0x67, 0x74, 0x68, 0x20, 0x6C, 0x69, 0x73, 0x74,
                 ],
                 &[IonType::String]
             ),
@@ -639,8 +623,8 @@ mod tests {
             (&[0xFA, 0x03, 0xEC], &[]),
         ];
 
-        for (data, expected_types) in tests {
-            let mut reader = LazyRawBinaryReader_1_1::new(data);
+        for (ion_data, expected_types) in tests {
+            let mut reader = LazyRawBinaryReader_1_1::new(ion_data);
             let container = reader.next()?.expect_value()?.read()?.expect_list()?;
             let mut count = 0;
             for (actual_lazy_value, expected_type) in container.iter().zip(expected_types.iter()) {
@@ -668,27 +652,9 @@ mod tests {
                 &[0xB6, 0x51, 0x01, 0x51, 0x02, 0x51, 0x03],
                 &[IonType::Int, IonType::Int, IonType::Int],
             ),
-        ];
 
-        for (data, expected_types) in tests {
-            let mut reader = LazyRawBinaryReader_1_1::new(data);
-            let container = reader.next()?.expect_value()?.read()?.expect_sexp()?;
-            let mut count = 0;
-            for (actual_lazy_value, expected_type) in container.iter().zip(expected_types.iter()) {
-                let value = actual_lazy_value?.expect_value()?;
-                assert_eq!(value.ion_type(), *expected_type);
-                count += 1;
-            }
-            assert_eq!(count, expected_types.len());
-        }
+            // Long S-Expression Encoding
 
-        Ok(())
-    }
-
-    #[test]
-    fn sexp_long() -> IonResult<()> {
-        #[rustfmt::skip]
-        let tests: &[(&[u8], &[IonType])] = &[
             // ()
             (&[0xFB, 0x01], &[]),
 
@@ -708,12 +674,11 @@ mod tests {
             (&[0xFB, 0x07, 0xE2, 0x01, 0x00], &[IonType::Symbol]),
         ];
 
-        for (data, expected_types) in tests {
-            let mut reader = LazyRawBinaryReader_1_1::new(data);
+        for (ion_data, expected_types) in tests {
+            let mut reader = LazyRawBinaryReader_1_1::new(ion_data);
             let container = reader.next()?.expect_value()?.read()?.expect_sexp()?;
-            let iter = container.sequence.iter();
             let mut count = 0;
-            for (actual_lazy_value, expected_type) in iter.zip(expected_types.iter()) {
+            for (actual_lazy_value, expected_type) in container.iter().zip(expected_types.iter()) {
                 let value = actual_lazy_value?.expect_value()?;
                 assert_eq!(value.ion_type(), *expected_type);
                 count += 1;

--- a/src/lazy/binary/raw/v1_1/reader.rs
+++ b/src/lazy/binary/raw/v1_1/reader.rs
@@ -571,4 +571,156 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn lists() -> IonResult<()> {
+        use crate::lazy::decoder::LazyRawSequence;
+
+        let tests: &[(&[u8], &[IonType])] = &[
+            // []
+            (&[0xA0], &[]),
+
+            // [null.null]
+            (&[0xA1, 0xEA], &[IonType::Null]),
+
+            // ['']
+            (&[0xA1, 0x90], &[IonType::Symbol]),
+
+            // ["hello"]
+            (
+                &[0xA6, 0x85, 0x68, 0x65, 0x6C, 0x6C, 0x6F],
+                &[IonType::String],
+            ),
+
+            // [null.null, '', "hello"]
+            (
+                &[0xA8, 0xEA, 0x90, 0x85, 0x68, 0x65, 0x6C, 0x6c, 0x6F],
+                &[IonType::Null, IonType::Symbol, IonType::String],
+            ),
+
+            // [3.1415927e0 3.1415927e0]
+            (&[0xAA, 0x5C, 0xDB, 0x0F, 0x49, 0x40, 0x5C, 0xDB, 0x0F, 0x49, 0x40], &[IonType::Float, IonType::Float]),
+        ];
+
+        for (data, expected_types) in tests {
+            let mut reader = LazyRawBinaryReader_1_1::new(data);
+            let container = reader.next()?.expect_value()?.read()?.expect_list()?;
+            let mut count = 0;
+            for (actual_lazy_value, expected_type) in container.iter().zip(expected_types.iter()) {
+                let value = actual_lazy_value?.expect_value()?;
+                assert_eq!(value.ion_type(), *expected_type);
+                count += 1;
+            }
+            assert_eq!(count, expected_types.len());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn lists_long() -> IonResult<()> {
+        use crate::lazy::decoder::LazyRawSequence;
+
+        #[rustfmt::skip]
+        let tests: &[(&[u8], &[IonType])] = &[
+            // []
+            (&[0xFA, 0x01], &[]),
+
+            // ["variable length list"]
+            (
+                &[
+                    0xFA, 0x2D, 0xF8, 0x29, 0x76, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6C, 0x65, 0x20,
+                    0x6C, 0x65, 0x6E, 0x67, 0x74, 0x68, 0x20, 0x6C, 0x69, 0x73, 0x74,
+                ],
+                &[IonType::String]
+            ),
+
+            // [<nop>]
+            (&[0xFA, 0x03, 0xEC], &[]),
+        ];
+
+        for (data, expected_types) in tests {
+            let mut reader = LazyRawBinaryReader_1_1::new(data);
+            let container = reader.next()?.expect_value()?.read()?.expect_list()?;
+            let mut count = 0;
+            for (actual_lazy_value, expected_type) in container.iter().zip(expected_types.iter()) {
+                let value = actual_lazy_value?.expect_value()?;
+                assert_eq!(value.ion_type(), *expected_type);
+                count += 1;
+            }
+            assert_eq!(count, expected_types.len());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn sexp() -> IonResult<()> {
+        use crate::lazy::decoder::LazyRawSequence;
+
+        #[rustfmt::skip]
+        let tests: &[(&[u8], &[IonType])] = &[
+            // ()
+            (&[0xB0], &[]),
+
+            // (1 2 3)
+            (
+                &[0xB6, 0x51, 0x01, 0x51, 0x02, 0x51, 0x03],
+                &[IonType::Int, IonType::Int, IonType::Int],
+            ),
+        ];
+
+        for (data, expected_types) in tests {
+            let mut reader = LazyRawBinaryReader_1_1::new(data);
+            let container = reader.next()?.expect_value()?.read()?.expect_sexp()?;
+            let mut count = 0;
+            for (actual_lazy_value, expected_type) in container.iter().zip(expected_types.iter()) {
+                let value = actual_lazy_value?.expect_value()?;
+                assert_eq!(value.ion_type(), *expected_type);
+                count += 1;
+            }
+            assert_eq!(count, expected_types.len());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn sexp_long() -> IonResult<()> {
+        #[rustfmt::skip]
+        let tests: &[(&[u8], &[IonType])] = &[
+            // ()
+            (&[0xFB, 0x01], &[]),
+
+            // ("variable length sexp")
+            (
+                &[
+                    0xFB, 0x2D, 0xF8, 0x29, 0x76, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6C, 0x65, 0x20,
+                    0x6C, 0x65, 0x6E, 0x67, 0x74, 0x68, 0x20, 0x73, 0x65, 0x78, 0x70
+                ],
+                &[IonType::String]
+            ),
+
+            // ( () () [] )
+            (&[0xFB, 0x09, 0xFB, 0x01, 0xB0, 0xA0], &[IonType::SExp, IonType::SExp, IonType::List]),
+
+            // ( $257 )
+            (&[0xFB, 0x07, 0xE2, 0x01, 0x00], &[IonType::Symbol]),
+        ];
+
+        for (data, expected_types) in tests {
+            let mut reader = LazyRawBinaryReader_1_1::new(data);
+            let container = reader.next()?.expect_value()?.read()?.expect_sexp()?;
+            let iter = container.sequence.iter();
+            let mut count = 0;
+            for (actual_lazy_value, expected_type) in iter.zip(expected_types.iter()) {
+                let value = actual_lazy_value?.expect_value()?;
+                assert_eq!(value.ion_type(), *expected_type);
+                count += 1;
+            }
+            assert_eq!(count, expected_types.len());
+        }
+
+        Ok(())
+    }
 }

--- a/src/lazy/binary/raw/v1_1/type_descriptor.rs
+++ b/src/lazy/binary/raw/v1_1/type_descriptor.rs
@@ -46,6 +46,8 @@ impl Opcode {
             (0x6, _) => (Decimal, low_nibble, Some(IonType::Decimal)),
             (0x8, _) => (String, low_nibble, Some(IonType::String)),
             (0x9, _) => (InlineSymbol, low_nibble, Some(IonType::Symbol)),
+            (0xA, _) => (List, low_nibble, Some(IonType::List)),
+            (0xB, _) => (SExpression, low_nibble, Some(IonType::SExp)),
             (0xE, 0x0) => (IonVersionMarker, low_nibble, None),
             (0xE, 0x1..=0x3) => (SymbolAddress, low_nibble, Some(IonType::Symbol)),
             (0xE, 0xA) => (NullNull, low_nibble, Some(IonType::Null)),
@@ -54,6 +56,8 @@ impl Opcode {
             (0xF, 0x6) => (Decimal, 0xFF, Some(IonType::Decimal)),
             (0xF, 0x8) => (String, 0xFF, Some(IonType::String)), // 0xFF indicates >15 byte string.
             (0xF, 0x9) => (InlineSymbol, 0xFF, Some(IonType::Symbol)),
+            (0xF, 0xA) => (List, 0xFF, Some(IonType::List)),
+            (0xF, 0xB) => (SExpression, 0xFF, Some(IonType::SExp)),
             (0xF, 0xE) => (Blob, low_nibble, Some(IonType::Blob)),
             (0xF, 0xF) => (Clob, low_nibble, Some(IonType::Clob)),
             _ => (Invalid, low_nibble, None),
@@ -126,6 +130,8 @@ impl Header {
             (OpcodeType::InlineSymbol, n) if n < 16 => InOpcode(n),
             (OpcodeType::SymbolAddress, n) if n < 4 => InOpcode(n),
             (OpcodeType::Decimal, 0..=15) => InOpcode(self.length_code),
+            (OpcodeType::List, n) if n < 16 => InOpcode(n),
+            (OpcodeType::SExpression, n) if n < 16 => InOpcode(n),
             _ => FlexUIntFollows,
         }
     }

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -354,12 +354,18 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
 
     /// Helper method called by [`Self::read`]. Reads the current value as an S-expression.
     fn read_sexp(&self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
-        todo!();
+        use crate::lazy::binary::raw::v1_1::sequence::LazyRawBinarySExp_1_1;
+        use crate::lazy::decoder::private::LazyContainerPrivate;
+        debug_assert!(self.encoded_value.ion_type() == IonType::SExp);
+        Ok(RawValueRef::SExp(LazyRawBinarySExp_1_1::from_value(*self)))
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a list.
     fn read_list(&self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
-        todo!();
+        use crate::lazy::binary::raw::v1_1::sequence::LazyRawBinaryList_1_1;
+        use crate::lazy::decoder::private::LazyContainerPrivate;
+        debug_assert!(self.encoded_value.ion_type() == IonType::List);
+        Ok(RawValueRef::List(LazyRawBinaryList_1_1::from_value(*self)))
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a struct.


### PR DESCRIPTION
*Issue #, if available:* #664

*Description of changes:*
This PR adds length-prefixed Lists and S-Expressions to the 1.1 raw binary reader.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
