### PR TITLE
Fix serde string deserialization for Ion symbols

### DIFF
--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -241,19 +241,14 @@ impl<'a, 'de> de::Deserializer<'de> for ValueDeserializer<'a, 'de> {
     where
         V: Visitor<'de>,
     {
-        let value = self.value.read()?.expect_string()?;
-        visitor.visit_str(value.text())
+        visitor.visit_str(self.value.read()?.expect_text()?)
     }
 
     fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        let value: crate::lazy::str_ref::StrRef = self.value.read()?.expect_string()?;
-        // The `StrRef` above may already contain an owned `String`. Using `into_owned()` will
-        // convert it into a `Str` (possibly preserving an existing `String`) and calling `into()`
-        // will discard the `Str` wrapper leaving a `String`.
-        visitor.visit_string(value.into_owned().into())
+        visitor.visit_string(self.value.read()?.expect_text()?.to_owned())
     }
 
     fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -39,7 +39,8 @@
 //!| char, string, unit_variant                                   | string                                      |
 //!| byte-array                                                   | blob                                        |
 //!| option                                                       | None - null, Some - based on other mappings |
-//!| unit, unit_struct                                            | null                                        |
+//!| unit                                                         | null                                        |
+//!| unit_struct                                                  | symbol                                      |
 //!| seq, tuple, tuple_struct                                     | list                                        |
 //!| newtype_struct, map, struct                                  | struct                                      |
 //!| newtype_variant                                              | variant value with annotation               |
@@ -339,5 +340,20 @@ mod tests {
             Element::read_first(i),
             Element::read_first(to_string(&expected).unwrap())
         );
+    }
+
+    #[test]
+    fn test_symbol() {
+        let i = r#"inches"#;
+        let expected = String::from("inches");
+        assert_eq!(expected, from_ion::<String, _>(i).unwrap());
+
+        let i = r#"'with space'"#;
+        let expected = String::from("with space");
+        assert_eq!(expected, from_ion::<String, _>(i).unwrap());
+
+        let i = r#"'\'embedded quotes\''"#;
+        let expected = String::from("'embedded quotes'");
+        assert_eq!(expected, from_ion::<String, _>(i).unwrap());
     }
 }


### PR DESCRIPTION
I noticed an issue with the serde module for Ion symbol to Rust string deserialization, which the module documentation says is supported. Because the current deserializer uses `expect_string()`, it panics on a symbol. I've updated this to use the existing `expect_text()` method to support both strings and symbols.

A couple other notes about this proposed change:

- I've deleted the comment about the `StrRef` possibly having an owned string. It looks like that was written before a recent change that replaced the `StrRef`'s `Cow` with `&str` (https://github.com/amazon-ion/ion-rust/commit/892ef2d084ac359f01cd10bc2710dee2a26725d6). I think this means that a new owned string will always have to be created.
- I updated the module documentation to reflect that unit structs are serialized as symbols (which currently is the only way to serialize a symbol, I believe?).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
