### PR TITLE
Doc cleanup and 2x bug fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,6 @@ rstest_reuse = "0.6.0"
 # Used by ion-tests integration
 walkdir = "2.5.0"
 test-generator = "0.3"
-memmap = "0.7.0"
 criterion = "0.5.1"
 rand = "0.8.5"
 tempfile = "3.10.0"

--- a/README.md
+++ b/README.md
@@ -10,13 +10,12 @@ A Rust implementation of the [Amazon Ion][spec] data format.
 
 ## Example
 
-For more information, please see our [official documentation](https://docs.rs/ion-rs). 
+For more information, please see the [documentation](https://docs.rs/ion-rs).
 
 ```rust
-use ion_rs::{Element, IonResult, IonType, ion_seq};
+use crate::{ion_seq, Element, IonResult, Timestamp};
 
 fn main() -> IonResult<()> {
-
     // Read a single value from a string/slice/Vec
     let element = Element::read_one("\"Hello, world!\"")?;
     let text = element.expect_string()?;
@@ -35,25 +34,23 @@ fn main() -> IonResult<()> {
     for element in Element::iter(ion_file)? {
         println!("{}", element?)
     }
-    
+
     // Construct a sequence of Ion elements from Rust values
     let values = ion_seq!(
         "foo",
-        Timestamp::with_ymd(2016, 5, 11).build(),
+        Timestamp::with_ymd(2016, 5, 11).build()?,
         3.1416f64,
         true
     );
 
-    // Write values to a buffer in generously-spaced text
-    let mut text_buffer: Vec<u8> = Vec::new();
-    Element::write_all_as(&values, Format::Text(TextKind::Pretty), &mut text_buffer)?;
-    assert_eq!(values, Element::read_all(text_buffer)?);
+    // Write values to a String using generously-spaced text
+    let text_ion: String = values.encode_as(v1_0::Text.with_format(TextFormat::Pretty))?;
+    assert_eq!(values, Element::read_all(text_ion)?);
 
     // Write values to a buffer in compact binary
-    let mut binary_buffer: Vec<u8> = Vec::new();
-    Element::write_all_as(&values, Format::Binary, &mut binary_buffer)?;
+    let binary_buffer: Vec<u8> = values.encode_as(v1_0::Binary)?;
     assert_eq!(values, Element::read_all(binary_buffer)?);
-    
+
     Ok(())
 }
 ```
@@ -64,11 +61,10 @@ The `ion_rs` library has a number of features that users can opt into. While the
 are complete and well-tested, their APIs are not stable and are subject to change without notice
 between minor versions of the library.
 
-1. `experimental-ion-hash`, an implementation of [Ion Hash][ion-hash-spec].
-2. `experimental-reader`, a streaming reader API.
-3. `experimental-writer`, a streaming writer API.
-
-Features that are defined in `Cargo.toml` but not listed above have not been thoroughly tested.
+1. `experimental-reader-writer`, a streaming reader and writer API.
+2. `experimental-tooling-apis`, APIs for accessing the encoding-level details of the stream.
+3. `experimental-serde`, a `serde` serializer and deserializer.
+4. `experimental-ion-hash`, an implementation of [Ion Hash][ion-hash-spec].
 
 ## Development
 
@@ -106,6 +102,9 @@ $ ./clean-rebuild.sh
 ```
 
 [spec]: https://amazon-ion.github.io/ion-docs/docs/spec.html
+
 [ion-tests]: https://github.com/amazon-ion/ion-tests
+
 [ion-hash-spec]: https://amazon-ion.github.io/ion-hash/docs/spec.html
+
 [ion-hash-tests]: https://github.com/amazon-ion/ion-hash-tests

--- a/benches/read_many_structs.rs
+++ b/benches/read_many_structs.rs
@@ -12,7 +12,7 @@ mod benchmark {
 mod benchmark {
     use criterion::{black_box, Criterion};
     use ion_rs::{v1_0, v1_1, ElementReader, Encoding, IonData, IonReader, WriteConfig};
-    use ion_rs::{Element, IonResult, LazyDecoder, LazyStruct, LazyValue, ValueRef};
+    use ion_rs::{Decoder, Element, IonResult, LazyStruct, LazyValue, ValueRef};
 
     fn rewrite_as<E: Encoding>(
         pretty_ion: &str,
@@ -24,7 +24,7 @@ mod benchmark {
         Ok(buffer)
     }
 
-    fn count_value_and_children<D: LazyDecoder>(lazy_value: &LazyValue<'_, D>) -> IonResult<usize> {
+    fn count_value_and_children<D: Decoder>(lazy_value: &LazyValue<'_, D>) -> IonResult<usize> {
         use ValueRef::*;
         let child_count = match lazy_value.read()? {
             List(s) => count_sequence_children(s.iter())?,
@@ -38,7 +38,7 @@ mod benchmark {
         Ok(1 + child_count)
     }
 
-    fn count_sequence_children<'a, D: LazyDecoder>(
+    fn count_sequence_children<'a, D: Decoder>(
         lazy_sequence: impl Iterator<Item = IonResult<LazyValue<'a, D>>>,
     ) -> IonResult<usize> {
         let mut count = 0;
@@ -48,7 +48,7 @@ mod benchmark {
         Ok(count)
     }
 
-    fn count_struct_children<D: LazyDecoder>(lazy_struct: &LazyStruct<'_, D>) -> IonResult<usize> {
+    fn count_struct_children<D: Decoder>(lazy_struct: &LazyStruct<'_, D>) -> IonResult<usize> {
         let mut count = 0;
         for field in lazy_struct {
             count += count_value_and_children(&field?.value())?;

--- a/benches/write_many_structs.rs
+++ b/benches/write_many_structs.rs
@@ -11,9 +11,7 @@ mod benchmark {
 #[cfg(feature = "experimental")]
 mod benchmark {
     use criterion::{black_box, Criterion};
-    use ion_rs::v1_0::LazyRawBinaryWriter_1_0;
-    use ion_rs::v1_1::LazyRawBinaryWriter_1_1;
-    use ion_rs::{IonResult, RawSymbolRef, SequenceWriter, StructWriter, ValueWriter};
+    use ion_rs::{v1_0, v1_1, IonResult, RawSymbolRef, SequenceWriter, StructWriter, ValueWriter};
 
     fn write_struct_with_string_values(value_writer: impl ValueWriter) -> IonResult<()> {
         let mut struct_ = value_writer.struct_writer()?;
@@ -131,7 +129,7 @@ mod benchmark {
         binary_1_0_group.bench_function("write structs with string values", |b| {
             b.iter(|| {
                 buffer.clear();
-                let mut writer = LazyRawBinaryWriter_1_0::new(&mut buffer).unwrap();
+                let mut writer = v1_0::RawBinaryWriter::new(&mut buffer).unwrap();
                 write_struct_with_string_values(writer.value_writer()).unwrap();
                 writer.flush().unwrap();
                 black_box(buffer.as_slice());
@@ -149,7 +147,7 @@ mod benchmark {
         binary_1_0_group.bench_function("write structs with symbol values", |b| {
             b.iter(|| {
                 buffer.clear();
-                let mut writer = LazyRawBinaryWriter_1_0::new(&mut buffer).unwrap();
+                let mut writer = v1_0::RawBinaryWriter::new(&mut buffer).unwrap();
                 write_struct_with_symbol_values(writer.value_writer()).unwrap();
                 writer.flush().unwrap();
 
@@ -166,7 +164,7 @@ mod benchmark {
         binary_1_1_group.bench_function("write structs with string values", |b| {
             b.iter(|| {
                 buffer.clear();
-                let mut writer = LazyRawBinaryWriter_1_1::new(&mut buffer).unwrap();
+                let mut writer = v1_1::RawBinaryWriter::new(&mut buffer).unwrap();
                 write_struct_with_string_values(writer.value_writer()).unwrap();
                 writer.flush().unwrap();
                 black_box(buffer.as_slice());
@@ -180,7 +178,7 @@ mod benchmark {
         binary_1_1_group.bench_function("write structs with symbol values", |b| {
             b.iter(|| {
                 buffer.clear();
-                let mut writer = LazyRawBinaryWriter_1_1::new(&mut buffer).unwrap();
+                let mut writer = v1_1::RawBinaryWriter::new(&mut buffer).unwrap();
                 write_struct_with_symbol_values(writer.value_writer()).unwrap();
                 writer.flush().unwrap();
 
@@ -195,7 +193,7 @@ mod benchmark {
         binary_1_1_group.bench_function("write delimited structs with string values", |b| {
             b.iter(|| {
                 buffer.clear();
-                let mut writer = LazyRawBinaryWriter_1_1::new(&mut buffer).unwrap();
+                let mut writer = v1_1::RawBinaryWriter::new(&mut buffer).unwrap();
                 write_struct_with_string_values(writer.value_writer().with_delimited_containers())
                     .unwrap();
                 writer.flush().unwrap();
@@ -213,7 +211,7 @@ mod benchmark {
         binary_1_1_group.bench_function("write delimited structs with symbol values", |b| {
             b.iter(|| {
                 buffer.clear();
-                let mut writer = LazyRawBinaryWriter_1_1::new(&mut buffer).unwrap();
+                let mut writer = v1_1::RawBinaryWriter::new(&mut buffer).unwrap();
                 write_struct_with_symbol_values(writer.value_writer().with_delimited_containers())
                     .unwrap();
                 writer.flush().unwrap();
@@ -229,7 +227,7 @@ mod benchmark {
         binary_1_1_group.bench_function("write structs with string values using macros", |b| {
             b.iter(|| {
                 buffer.clear();
-                let mut writer = LazyRawBinaryWriter_1_1::new(&mut buffer).unwrap();
+                let mut writer = v1_1::RawBinaryWriter::new(&mut buffer).unwrap();
                 write_eexp_with_string_values(writer.value_writer()).unwrap();
                 writer.flush().unwrap();
                 black_box(buffer.as_slice());
@@ -246,7 +244,7 @@ mod benchmark {
         binary_1_1_group.bench_function("write structs with symbol values using macros", |b| {
             b.iter(|| {
                 buffer.clear();
-                let mut writer = LazyRawBinaryWriter_1_1::new(&mut buffer).unwrap();
+                let mut writer = v1_1::RawBinaryWriter::new(&mut buffer).unwrap();
                 write_eexp_with_symbol_values(writer.value_writer()).unwrap();
                 writer.flush().unwrap();
                 black_box(buffer.as_slice());

--- a/src/binary/decimal.rs
+++ b/src/binary/decimal.rs
@@ -107,7 +107,7 @@ where
 
 #[cfg(test)]
 mod binary_decimal_tests {
-    use crate::lazy::encoder::writer::IonWriter;
+    use crate::lazy::encoder::writer::Writer;
     use crate::lazy::encoding::{BinaryEncoding_1_0, Encoding};
     use crate::lazy::reader::Reader;
     use rstest::*;
@@ -152,10 +152,10 @@ mod binary_decimal_tests {
     #[case::foo(Decimal::new(i128::MIN + 1, i32::MIN))]
     fn roundtrip_decimals_with_extreme_values(#[case] value: Decimal) -> IonResult<()> {
         let mut writer =
-            IonWriter::with_config(BinaryEncoding_1_0::default_write_config(), Vec::new())?;
+            Writer::with_config(BinaryEncoding_1_0::default_write_config(), Vec::new())?;
         writer.write(value)?;
         let output = writer.close()?;
-        let mut reader = Reader::new(output);
+        let mut reader = Reader::new(output)?;
         let after_round_trip = reader.expect_next()?.read()?.expect_decimal()?;
         assert_eq!(value, after_round_trip);
         Ok(())

--- a/src/binary/timestamp.rs
+++ b/src/binary/timestamp.rs
@@ -147,7 +147,7 @@ mod binary_timestamp_tests {
         #[case] input: &str,
         #[case] expected: usize,
     ) -> IonResult<()> {
-        let mut reader = Reader::new(input);
+        let mut reader = Reader::new(input)?;
         let timestamp = reader.expect_next()?.read()?.expect_timestamp()?;
         let mut buf = vec![];
         let written = buf.encode_timestamp_value(&timestamp)?;

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -653,14 +653,14 @@ impl Element {
     /// If the data source has at least one value, returns `Ok(Some(Element))`.
     /// If the data source has invalid data, returns `Err`.
     pub fn read_first<A: AsRef<[u8]>>(data: A) -> IonResult<Option<Element>> {
-        let mut reader = Reader::new(IonSlice::new(data));
+        let mut reader = Reader::new(IonSlice::new(data))?;
         reader.read_next_element()
     }
 
     /// Reads a single Ion [`Element`] from the provided data source. If the input has invalid
     /// data or does not contain at exactly one Ion value, returns `Err(IonError)`.
     pub fn read_one<A: AsRef<[u8]>>(data: A) -> IonResult<Element> {
-        let mut reader = Reader::new(IonSlice::new(data));
+        let mut reader = Reader::new(IonSlice::new(data))?;
         reader.read_one_element()
     }
 
@@ -669,7 +669,7 @@ impl Element {
     /// If the input has valid data, returns `Ok(Sequence)`.
     /// If the input has invalid data, returns `Err(IonError)`.
     pub fn read_all<A: AsRef<[u8]>>(data: A) -> IonResult<Sequence> {
-        Ok(Reader::new(IonSlice::new(data))
+        Ok(Reader::new(IonSlice::new(data))?
             .into_elements()
             .collect::<IonResult<Vec<_>>>()?
             .into())
@@ -681,7 +681,7 @@ impl Element {
     pub fn iter<'a, I: IonInput + 'a>(
         source: I,
     ) -> IonResult<impl Iterator<Item = IonResult<Element>> + 'a> {
-        Ok(Reader::new(source).into_elements())
+        Ok(Reader::new(source)?.into_elements())
     }
 
     /// Encodes this element as an Ion stream with itself as the only top-level value.

--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -28,7 +28,7 @@ use crate::lazy::binary::raw::v1_1::RawBinaryAnnotationsIterator_1_1;
 use crate::lazy::binary::raw::value::{LazyRawBinaryValue_1_0, LazyRawBinaryVersionMarker_1_0};
 use crate::lazy::decoder::private::LazyContainerPrivate;
 use crate::lazy::decoder::{
-    HasRange, HasSpan, LazyDecoder, LazyRawContainer, LazyRawFieldExpr, LazyRawFieldName,
+    Decoder, HasRange, HasSpan, LazyRawContainer, LazyRawFieldExpr, LazyRawFieldName,
     LazyRawReader, LazyRawSequence, LazyRawStruct, LazyRawValue, LazyRawValueExpr, RawValueExpr,
     RawVersionMarker,
 };
@@ -65,7 +65,7 @@ pub struct AnyEncoding;
 // This family of types avoids boxing and dynamic dispatch by using enums of the supported formats
 // within each type. Trait methods are implemented by forwarding the call to the appropriate
 // underlying type.
-impl LazyDecoder for AnyEncoding {
+impl Decoder for AnyEncoding {
     type Reader<'data> = LazyRawAnyReader<'data>;
     type ReaderSavedState = RawReaderType;
     type Value<'top> = LazyRawAnyValue<'top>;
@@ -358,7 +358,7 @@ impl<'data> LazyRawReader<'data, AnyEncoding> for LazyRawAnyReader<'data> {
     }
 
     #[inline]
-    fn save_state(&self) -> <AnyEncoding as LazyDecoder>::ReaderSavedState {
+    fn save_state(&self) -> <AnyEncoding as Decoder>::ReaderSavedState {
         use RawReaderKind::*;
         match &self.encoding {
             Text_1_0(_) => RawReaderType::Text_1_0,
@@ -837,7 +837,7 @@ impl<'data> Iterator for RawAnyListIterator<'data> {
 }
 
 impl<'top> LazyRawContainer<'top, AnyEncoding> for LazyRawAnyList<'top> {
-    fn as_value(&self) -> <AnyEncoding as LazyDecoder>::Value<'top> {
+    fn as_value(&self) -> <AnyEncoding as Decoder>::Value<'top> {
         match &self.encoding {
             LazyRawListKind::Text_1_0(s) => s.as_value().into(),
             LazyRawListKind::Binary_1_0(s) => s.as_value().into(),
@@ -850,7 +850,7 @@ impl<'top> LazyRawContainer<'top, AnyEncoding> for LazyRawAnyList<'top> {
 impl<'top> LazyRawSequence<'top, AnyEncoding> for LazyRawAnyList<'top> {
     type Iterator = RawAnyListIterator<'top>;
 
-    fn annotations(&self) -> <AnyEncoding as LazyDecoder>::AnnotationsIterator<'top> {
+    fn annotations(&self) -> <AnyEncoding as Decoder>::AnnotationsIterator<'top> {
         self.as_value().annotations()
     }
 
@@ -935,7 +935,7 @@ pub enum LazyRawSExpKind<'data> {
 }
 
 impl<'top> LazyRawContainer<'top, AnyEncoding> for LazyRawAnySExp<'top> {
-    fn as_value(&self) -> <AnyEncoding as LazyDecoder>::Value<'top> {
+    fn as_value(&self) -> <AnyEncoding as Decoder>::Value<'top> {
         use LazyRawSExpKind::*;
         match self.encoding {
             Text_1_0(s) => s.as_value().into(),
@@ -1000,7 +1000,7 @@ impl<'data> Iterator for RawAnySExpIterator<'data> {
 impl<'top> LazyRawSequence<'top, AnyEncoding> for LazyRawAnySExp<'top> {
     type Iterator = RawAnySExpIterator<'top>;
 
-    fn annotations(&self) -> <AnyEncoding as LazyDecoder>::AnnotationsIterator<'top> {
+    fn annotations(&self) -> <AnyEncoding as Decoder>::AnnotationsIterator<'top> {
         self.as_value().annotations()
     }
 
@@ -1079,7 +1079,7 @@ pub enum LazyRawStructKind<'data> {
 }
 
 impl<'top> LazyRawContainer<'top, AnyEncoding> for LazyRawAnyStruct<'top> {
-    fn as_value(&self) -> <AnyEncoding as LazyDecoder>::Value<'top> {
+    fn as_value(&self) -> <AnyEncoding as Decoder>::Value<'top> {
         match self.encoding {
             LazyRawStructKind::Text_1_0(s) => s.as_value().into(),
             LazyRawStructKind::Binary_1_0(s) => s.as_value().into(),
@@ -1274,7 +1274,7 @@ impl<'data> LazyContainerPrivate<'data, AnyEncoding> for LazyRawAnyStruct<'data>
 impl<'top> LazyRawStruct<'top, AnyEncoding> for LazyRawAnyStruct<'top> {
     type Iterator = RawAnyStructIterator<'top>;
 
-    fn annotations(&self) -> <AnyEncoding as LazyDecoder>::AnnotationsIterator<'top> {
+    fn annotations(&self) -> <AnyEncoding as Decoder>::AnnotationsIterator<'top> {
         match &self.encoding {
             LazyRawStructKind::Text_1_0(s) => RawAnyAnnotationsIterator {
                 encoding: RawAnnotationsIteratorKind::Text_1_0(s.annotations()),

--- a/src/lazy/binary/encoded_value.rs
+++ b/src/lazy/binary/encoded_value.rs
@@ -222,8 +222,8 @@ impl<HeaderType: EncodedHeader> EncodedValue<HeaderType> {
     /// complete encoding, not including any annotations.
     pub fn unannotated_value_range(&self) -> Range<usize> {
         // [ annotations? | header (type descriptor) | header_length? | value ]
-        let start = self.header_offset - self.annotations_header_length as usize;
-        let end = start + self.total_length;
+        let start = self.header_offset;
+        let end = start + self.total_length - self.annotations_header_length as usize;
         start..end
     }
 

--- a/src/lazy/binary/immutable_buffer.rs
+++ b/src/lazy/binary/immutable_buffer.rs
@@ -429,6 +429,12 @@ impl<'a> ImmutableBuffer<'a> {
 
         // Skip over the annotations sequence itself; the reader will return to it if/when the
         // reader asks to iterate over those symbol IDs.
+        if input_after_annotations_length.len() < annotations_length.value() {
+            return IonResult::incomplete(
+                "an annotations sequence",
+                input_after_annotations_length.offset(),
+            );
+        }
         let final_input = input_after_annotations_length.consume(annotations_length.value());
 
         // Here, `self` is the (immutable) buffer we started with. Comparing it with `input`

--- a/src/lazy/binary/raw/reader.rs
+++ b/src/lazy/binary/raw/reader.rs
@@ -2,9 +2,7 @@
 
 use crate::lazy::binary::immutable_buffer::ImmutableBuffer;
 use crate::lazy::binary::raw::value::LazyRawBinaryValue_1_0;
-use crate::lazy::decoder::{
-    HasRange, LazyDecoder, LazyRawFieldExpr, LazyRawReader, RawVersionMarker,
-};
+use crate::lazy::decoder::{Decoder, HasRange, LazyRawFieldExpr, LazyRawReader, RawVersionMarker};
 use crate::lazy::encoding::BinaryEncoding_1_0;
 use crate::lazy::raw_stream_item::{EndPosition, LazyRawStreamItem, RawStreamItem};
 use crate::result::IonFailure;
@@ -114,7 +112,7 @@ impl<'data> LazyRawReader<'data, BinaryEncoding_1_0> for LazyRawBinaryReader_1_0
     fn resume_at_offset(
         data: &'data [u8],
         offset: usize,
-        _config: <BinaryEncoding_1_0 as LazyDecoder>::ReaderSavedState,
+        _config: <BinaryEncoding_1_0 as Decoder>::ReaderSavedState,
     ) -> Self {
         LazyRawBinaryReader_1_0 {
             data: DataSource {

--- a/src/lazy/binary/raw/sequence.rs
+++ b/src/lazy/binary/raw/sequence.rs
@@ -6,7 +6,7 @@ use crate::lazy::binary::raw::reader::DataSource;
 use crate::lazy::binary::raw::value::LazyRawBinaryValue_1_0;
 use crate::lazy::decoder::private::LazyContainerPrivate;
 use crate::lazy::decoder::{
-    LazyDecoder, LazyRawContainer, LazyRawSequence, LazyRawValueExpr, RawValueExpr,
+    Decoder, LazyRawContainer, LazyRawSequence, LazyRawValueExpr, RawValueExpr,
 };
 use crate::lazy::encoding::BinaryEncoding_1_0;
 use crate::{IonResult, IonType};
@@ -37,7 +37,7 @@ impl<'top> LazyContainerPrivate<'top, BinaryEncoding_1_0> for LazyRawBinaryList_
 }
 
 impl<'top> LazyRawContainer<'top, BinaryEncoding_1_0> for LazyRawBinaryList_1_0<'top> {
-    fn as_value(&self) -> <BinaryEncoding_1_0 as LazyDecoder>::Value<'top> {
+    fn as_value(&self) -> <BinaryEncoding_1_0 as Decoder>::Value<'top> {
         self.sequence.value
     }
 }
@@ -67,7 +67,7 @@ impl<'top> LazyContainerPrivate<'top, BinaryEncoding_1_0> for LazyRawBinarySExp_
 }
 
 impl<'top> LazyRawContainer<'top, BinaryEncoding_1_0> for LazyRawBinarySExp_1_0<'top> {
-    fn as_value(&self) -> <BinaryEncoding_1_0 as LazyDecoder>::Value<'top> {
+    fn as_value(&self) -> <BinaryEncoding_1_0 as Decoder>::Value<'top> {
         self.sequence.value
     }
 }

--- a/src/lazy/binary/raw/struct.rs
+++ b/src/lazy/binary/raw/struct.rs
@@ -10,8 +10,7 @@ use crate::lazy::binary::raw::reader::DataSource;
 use crate::lazy::binary::raw::value::LazyRawBinaryValue_1_0;
 use crate::lazy::decoder::private::LazyContainerPrivate;
 use crate::lazy::decoder::{
-    HasRange, HasSpan, LazyDecoder, LazyRawContainer, LazyRawFieldExpr, LazyRawFieldName,
-    LazyRawStruct,
+    Decoder, HasRange, HasSpan, LazyRawContainer, LazyRawFieldExpr, LazyRawFieldName, LazyRawStruct,
 };
 use crate::lazy::encoding::BinaryEncoding_1_0;
 use crate::lazy::span::Span;
@@ -70,7 +69,7 @@ impl<'top> LazyContainerPrivate<'top, BinaryEncoding_1_0> for LazyRawBinaryStruc
 }
 
 impl<'top> LazyRawContainer<'top, BinaryEncoding_1_0> for LazyRawBinaryStruct_1_0<'top> {
-    fn as_value(&self) -> <BinaryEncoding_1_0 as LazyDecoder>::Value<'top> {
+    fn as_value(&self) -> <BinaryEncoding_1_0 as Decoder>::Value<'top> {
         self.value
     }
 }

--- a/src/lazy/binary/raw/v1_1/reader.rs
+++ b/src/lazy/binary/raw/v1_1/reader.rs
@@ -2,7 +2,7 @@
 
 use crate::lazy::binary::raw::v1_1::immutable_buffer::ImmutableBuffer;
 use crate::lazy::binary::raw::v1_1::value::LazyRawBinaryValue_1_1;
-use crate::lazy::decoder::{LazyDecoder, LazyRawReader, RawVersionMarker};
+use crate::lazy::decoder::{Decoder, LazyRawReader, RawVersionMarker};
 use crate::lazy::encoder::private::Sealed;
 use crate::lazy::encoding::BinaryEncoding_1_1;
 use crate::lazy::raw_stream_item::{EndPosition, LazyRawStreamItem, RawStreamItem};
@@ -156,7 +156,7 @@ impl<'data> LazyRawReader<'data, BinaryEncoding_1_1> for LazyRawBinaryReader_1_1
     fn resume_at_offset(
         data: &'data [u8],
         offset: usize,
-        _saved_state: <BinaryEncoding_1_1 as LazyDecoder>::ReaderSavedState,
+        _saved_state: <BinaryEncoding_1_1 as Decoder>::ReaderSavedState,
     ) -> Self {
         Self::new_with_offset(data, offset)
     }

--- a/src/lazy/binary/raw/v1_1/sequence.rs
+++ b/src/lazy/binary/raw/v1_1/sequence.rs
@@ -5,7 +5,7 @@ use crate::lazy::binary::raw::v1_1::immutable_buffer::ImmutableBuffer;
 use crate::lazy::binary::raw::v1_1::value::LazyRawBinaryValue_1_1;
 use crate::lazy::decoder::private::LazyContainerPrivate;
 use crate::lazy::decoder::{
-    LazyDecoder, LazyRawContainer, LazyRawSequence, LazyRawValueExpr, RawValueExpr,
+    Decoder, LazyRawContainer, LazyRawSequence, LazyRawValueExpr, RawValueExpr,
 };
 use crate::lazy::encoding::BinaryEncoding_1_1;
 use crate::{IonResult, IonType};
@@ -30,7 +30,7 @@ impl<'top> LazyContainerPrivate<'top, BinaryEncoding_1_1> for LazyRawBinaryList_
 }
 
 impl<'top> LazyRawContainer<'top, BinaryEncoding_1_1> for LazyRawBinaryList_1_1<'top> {
-    fn as_value(&self) -> <BinaryEncoding_1_1 as LazyDecoder>::Value<'top> {
+    fn as_value(&self) -> <BinaryEncoding_1_1 as Decoder>::Value<'top> {
         self.sequence.value
     }
 }
@@ -60,7 +60,7 @@ impl<'top> LazyContainerPrivate<'top, BinaryEncoding_1_1> for LazyRawBinarySExp_
 }
 
 impl<'top> LazyRawContainer<'top, BinaryEncoding_1_1> for LazyRawBinarySExp_1_1<'top> {
-    fn as_value(&self) -> <BinaryEncoding_1_1 as LazyDecoder>::Value<'top> {
+    fn as_value(&self) -> <BinaryEncoding_1_1 as Decoder>::Value<'top> {
         self.sequence.value
     }
 }

--- a/src/lazy/binary/raw/v1_1/struct.rs
+++ b/src/lazy/binary/raw/v1_1/struct.rs
@@ -10,8 +10,7 @@ use crate::lazy::binary::raw::v1_1::{
 };
 use crate::lazy::decoder::private::LazyContainerPrivate;
 use crate::lazy::decoder::{
-    HasRange, HasSpan, LazyDecoder, LazyRawContainer, LazyRawFieldExpr, LazyRawFieldName,
-    LazyRawStruct,
+    Decoder, HasRange, HasSpan, LazyRawContainer, LazyRawFieldExpr, LazyRawFieldName, LazyRawStruct,
 };
 use crate::lazy::encoding::BinaryEncoding_1_1;
 use crate::lazy::span::Span;
@@ -100,7 +99,7 @@ impl<'top> LazyContainerPrivate<'top, BinaryEncoding_1_1> for LazyRawBinaryStruc
 }
 
 impl<'top> LazyRawContainer<'top, BinaryEncoding_1_1> for LazyRawBinaryStruct_1_1<'top> {
-    fn as_value(&self) -> <BinaryEncoding_1_1 as LazyDecoder>::Value<'top> {
+    fn as_value(&self) -> <BinaryEncoding_1_1 as Decoder>::Value<'top> {
         self.value
     }
 }

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -16,7 +16,7 @@ use crate::{
                 value::ValueParseResult,
             },
         },
-        decoder::{LazyDecoder, LazyRawValue},
+        decoder::{Decoder, LazyRawValue},
         encoder::binary::v1_1::fixed_int::FixedInt,
         encoding::BinaryEncoding_1_1,
         raw_value_ref::RawValueRef,
@@ -91,7 +91,7 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_1> for LazyRawBinaryValue_1_1<'to
         self.is_null()
     }
 
-    fn annotations(&self) -> <BinaryEncoding_1_1 as LazyDecoder>::AnnotationsIterator<'top> {
+    fn annotations(&self) -> <BinaryEncoding_1_1 as Decoder>::AnnotationsIterator<'top> {
         self.annotations()
     }
 

--- a/src/lazy/binary/test_utilities.rs
+++ b/src/lazy/binary/test_utilities.rs
@@ -1,5 +1,5 @@
 use crate::element::Element;
-use crate::lazy::encoder::writer::IonWriter;
+use crate::lazy::encoder::writer::Writer;
 use crate::lazy::encoding::BinaryEncoding_1_0;
 use crate::write_config::WriteConfig;
 use crate::IonResult;
@@ -8,7 +8,7 @@ use crate::IonResult;
 pub fn to_binary_ion(text_ion: &str) -> IonResult<Vec<u8>> {
     let buffer = Vec::new();
     let config = WriteConfig::<BinaryEncoding_1_0>::new();
-    let mut writer = IonWriter::with_config(config, buffer)?;
+    let mut writer = Writer::with_config(config, buffer)?;
     let elements = Element::read_all(text_ion)?;
     for element in &elements {
         writer.write(element)?;

--- a/src/lazy/encoder/binary/v1_0/mod.rs
+++ b/src/lazy/encoder/binary/v1_0/mod.rs
@@ -1,5 +1,5 @@
 use crate::lazy::encoder::binary::v1_0::writer::LazyRawBinaryWriter_1_0;
-use crate::lazy::encoder::{LazyEncoder, SymbolCreationPolicy};
+use crate::lazy::encoder::{Encoder, SymbolCreationPolicy};
 use crate::lazy::encoding::BinaryEncoding_1_0;
 use std::io::Write;
 
@@ -7,7 +7,7 @@ mod container_writers;
 pub mod value_writer;
 pub mod writer;
 
-impl LazyEncoder for BinaryEncoding_1_0 {
+impl Encoder for BinaryEncoding_1_0 {
     const SUPPORTS_TEXT_TOKENS: bool = false;
     const DEFAULT_SYMBOL_CREATION_POLICY: SymbolCreationPolicy =
         SymbolCreationPolicy::RequireSymbolId;

--- a/src/lazy/encoder/binary/v1_1/mod.rs
+++ b/src/lazy/encoder/binary/v1_1/mod.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use crate::lazy::encoder::binary::v1_1::writer::LazyRawBinaryWriter_1_1;
-use crate::lazy::encoder::{LazyEncoder, SymbolCreationPolicy};
+use crate::lazy::encoder::{Encoder, SymbolCreationPolicy};
 use crate::lazy::encoding::BinaryEncoding_1_1;
 
 pub mod container_writers;
@@ -13,7 +13,7 @@ pub mod flex_uint;
 pub mod value_writer;
 pub mod writer;
 
-impl LazyEncoder for BinaryEncoding_1_1 {
+impl Encoder for BinaryEncoding_1_1 {
     const SUPPORTS_TEXT_TOKENS: bool = true;
     const DEFAULT_SYMBOL_CREATION_POLICY: SymbolCreationPolicy =
         SymbolCreationPolicy::RequireSymbolId;

--- a/src/lazy/encoder/mod.rs
+++ b/src/lazy/encoder/mod.rs
@@ -24,10 +24,7 @@ pub mod writer;
 // However, many types are generic over some `E: LazyEncoder`, and having this trait
 // extend 'static, Sized, Debug, Clone and Copy means that those types can #[derive(...)]
 // those traits themselves without boilerplate `where` clauses.
-pub trait LazyEncoder: 'static + Sized + Debug + Clone + Copy {
-    // XXX: ^-- This is named 'Lazy' for symmetry with the `LazyDecoder`. In reality, there's nothing
-    //      lazy about it. We should revisit the Lazy* naming scheme, as eventually it will be the
-    //      only implementation of a reader and won't need the word 'Lazy' to distinguish itself.
+pub trait Encoder: 'static + Sized + Debug + Clone + Copy {
     const SUPPORTS_TEXT_TOKENS: bool;
     const DEFAULT_SYMBOL_CREATION_POLICY: SymbolCreationPolicy;
 

--- a/src/lazy/encoder/text/v1_0/mod.rs
+++ b/src/lazy/encoder/text/v1_0/mod.rs
@@ -1,13 +1,13 @@
 use std::io::Write;
 
 use crate::lazy::encoder::text::v1_0::writer::LazyRawTextWriter_1_0;
-use crate::lazy::encoder::{LazyEncoder, SymbolCreationPolicy};
+use crate::lazy::encoder::{Encoder, SymbolCreationPolicy};
 use crate::lazy::encoding::TextEncoding_1_0;
 
 pub mod value_writer;
 pub mod writer;
 
-impl LazyEncoder for TextEncoding_1_0 {
+impl Encoder for TextEncoding_1_0 {
     const SUPPORTS_TEXT_TOKENS: bool = true;
     const DEFAULT_SYMBOL_CREATION_POLICY: SymbolCreationPolicy =
         SymbolCreationPolicy::WriteProvidedToken;

--- a/src/lazy/encoder/text/v1_1/mod.rs
+++ b/src/lazy/encoder/text/v1_1/mod.rs
@@ -2,11 +2,11 @@ pub(crate) mod value_writer;
 pub(crate) mod writer;
 
 use crate::lazy::encoder::text::v1_1::writer::LazyRawTextWriter_1_1;
-use crate::lazy::encoder::{LazyEncoder, SymbolCreationPolicy};
+use crate::lazy::encoder::{Encoder, SymbolCreationPolicy};
 use crate::lazy::encoding::TextEncoding_1_1;
 use std::io::Write;
 
-impl LazyEncoder for TextEncoding_1_1 {
+impl Encoder for TextEncoding_1_1 {
     const SUPPORTS_TEXT_TOKENS: bool = true;
     const DEFAULT_SYMBOL_CREATION_POLICY: SymbolCreationPolicy =
         SymbolCreationPolicy::WriteProvidedToken;

--- a/src/lazy/encoder/write_as_ion.rs
+++ b/src/lazy/encoder/write_as_ion.rs
@@ -17,7 +17,7 @@
 use std::io;
 use std::marker::PhantomData;
 
-use crate::lazy::decoder::LazyDecoder;
+use crate::lazy::decoder::Decoder;
 use crate::lazy::encoder::annotation_seq::AnnotationsVec;
 use crate::lazy::encoder::value_writer::{SequenceWriter, StructWriter, ValueWriter};
 use crate::lazy::encoding::Encoding;
@@ -271,7 +271,7 @@ impl WriteAsIon for Value {
     }
 }
 
-impl<'a, D: LazyDecoder> WriteAsIon for LazyValue<'a, D> {
+impl<'a, D: Decoder> WriteAsIon for LazyValue<'a, D> {
     fn write_as_ion<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
         let mut annotations = AnnotationsVec::new();
         for annotation in self.annotations() {
@@ -282,7 +282,7 @@ impl<'a, D: LazyDecoder> WriteAsIon for LazyValue<'a, D> {
     }
 }
 
-impl<'a, D: LazyDecoder> WriteAsIon for ValueRef<'a, D> {
+impl<'a, D: Decoder> WriteAsIon for ValueRef<'a, D> {
     fn write_as_ion<V: ValueWriter>(&self, value_writer: V) -> IonResult<()> {
         use ValueRef::*;
         match self {

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -4,7 +4,6 @@ use delegate::delegate;
 use ice_code::ice as cold_path;
 
 use crate::constants::v1_0::system_symbol_ids;
-use crate::lazy::any_encoding::AnyEncoding;
 use crate::lazy::encoder::annotation_seq::AnnotationSeq;
 use crate::lazy::encoder::value_writer::internal::{FieldEncoder, MakeValueWriter};
 use crate::lazy::encoder::value_writer::{
@@ -47,20 +46,19 @@ impl EncodingContext {
 }
 
 /// An Ion writer that maintains a symbol table and creates new entries as needed.
-pub struct IonWriter<E: Encoding, Output: Write> {
+pub struct Writer<E: Encoding, Output: Write> {
     encoding_context: EncodingContext,
     data_writer: E::Writer<Vec<u8>>,
     directive_writer: E::Writer<Vec<u8>>,
     output: Output,
 }
 
-pub type Writer<Output> = IonWriter<AnyEncoding, Output>;
-pub type TextWriter_1_0<Output> = IonWriter<TextEncoding_1_0, Output>;
-pub type BinaryWriter_1_0<Output> = IonWriter<BinaryEncoding_1_0, Output>;
-pub type TextWriter_1_1<Output> = IonWriter<TextEncoding_1_1, Output>;
-pub type BinaryWriter_1_1<Output> = IonWriter<BinaryEncoding_1_1, Output>;
+pub type TextWriter_1_0<Output> = Writer<TextEncoding_1_0, Output>;
+pub type BinaryWriter_1_0<Output> = Writer<BinaryEncoding_1_0, Output>;
+pub type TextWriter_1_1<Output> = Writer<TextEncoding_1_1, Output>;
+pub type BinaryWriter_1_1<Output> = Writer<BinaryEncoding_1_1, Output>;
 
-impl<E: Encoding, Output: Write> IonWriter<E, Output> {
+impl<E: Encoding, Output: Write> Writer<E, Output> {
     /// Constructs a writer for the requested encoding using its default configuration.
     pub fn new(output: Output) -> IonResult<Self> {
         Self::with_config(E::default_write_config(), output)
@@ -79,7 +77,7 @@ impl<E: Encoding, Output: Write> IonWriter<E, Output> {
             E::DEFAULT_SYMBOL_CREATION_POLICY,
             E::SUPPORTS_TEXT_TOKENS,
         );
-        let mut writer = IonWriter {
+        let mut writer = Writer {
             encoding_context,
             data_writer,
             directive_writer,
@@ -162,7 +160,7 @@ impl<E: Encoding, Output: Write> IonWriter<E, Output> {
     }
 }
 
-impl<E: Encoding, Output: Write> MakeValueWriter for IonWriter<E, Output> {
+impl<E: Encoding, Output: Write> MakeValueWriter for Writer<E, Output> {
     type ValueWriter<'a> = ApplicationValueWriter<'a, <E::Writer<Vec<u8>> as MakeValueWriter>::ValueWriter<'a>>
     where
         Self: 'a;
@@ -177,7 +175,7 @@ impl<E: Encoding, Output: Write> MakeValueWriter for IonWriter<E, Output> {
     }
 }
 
-impl<E: Encoding, Output: Write> SequenceWriter for IonWriter<E, Output> {
+impl<E: Encoding, Output: Write> SequenceWriter for Writer<E, Output> {
     type Resources = Output;
 
     fn close(mut self) -> IonResult<Self::Resources> {

--- a/src/lazy/encoding.rs
+++ b/src/lazy/encoding.rs
@@ -18,9 +18,9 @@ use crate::lazy::binary::raw::v1_1::{
     RawBinaryAnnotationsIterator_1_1,
 };
 use crate::lazy::binary::raw::value::{LazyRawBinaryValue_1_0, LazyRawBinaryVersionMarker_1_0};
-use crate::lazy::decoder::LazyDecoder;
+use crate::lazy::decoder::Decoder;
 use crate::lazy::encoder::write_as_ion::WriteAsIon;
-use crate::lazy::encoder::LazyEncoder;
+use crate::lazy::encoder::Encoder;
 use crate::lazy::never::Never;
 use crate::lazy::text::raw::r#struct::{LazyRawTextFieldName_1_0, LazyRawTextStruct_1_0};
 use crate::lazy::text::raw::reader::LazyRawTextReader_1_0;
@@ -37,7 +37,7 @@ use crate::lazy::text::value::{
 use crate::{IonResult, TextFormat, WriteConfig};
 
 /// Marker trait for types that represent an Ion encoding.
-pub trait Encoding: LazyEncoder + LazyDecoder {
+pub trait Encoding: Encoder + Decoder {
     type Output: 'static + OutputFromBytes + AsRef<[u8]>;
 
     fn encode<V: WriteAsIon>(value: V) -> IonResult<Self::Output> {
@@ -156,12 +156,12 @@ impl Encoding for TextEncoding_1_1 {
 }
 
 /// Marker trait for binary encodings of any version.
-pub trait BinaryEncoding<'top>: Encoding<Output = Vec<u8>> + LazyDecoder {}
+pub trait BinaryEncoding<'top>: Encoding<Output = Vec<u8>> + Decoder {}
 
 /// Marker trait for text encodings.
 pub trait TextEncoding<'top>:
     Encoding<Output = String>
-    + LazyDecoder<
+    + Decoder<
         AnnotationsIterator<'top> = RawTextAnnotationsIterator<'top>,
         Value<'top> = LazyRawTextValue<'top, Self>,
     >
@@ -175,7 +175,7 @@ impl<'top> TextEncoding<'top> for TextEncoding_1_1 {}
 pub trait EncodingWithMacroSupport {}
 impl EncodingWithMacroSupport for TextEncoding_1_1 {}
 
-impl LazyDecoder for BinaryEncoding_1_0 {
+impl Decoder for BinaryEncoding_1_0 {
     type Reader<'data> = LazyRawBinaryReader_1_0<'data>;
     type ReaderSavedState = ();
     type Value<'top> = LazyRawBinaryValue_1_0<'top>;
@@ -189,7 +189,7 @@ impl LazyDecoder for BinaryEncoding_1_0 {
     type VersionMarker<'top> = LazyRawBinaryVersionMarker_1_0<'top>;
 }
 
-impl LazyDecoder for TextEncoding_1_0 {
+impl Decoder for TextEncoding_1_0 {
     type Reader<'data> = LazyRawTextReader_1_0<'data>;
     type ReaderSavedState = ();
     type Value<'top> = LazyRawTextValue_1_0<'top>;
@@ -203,7 +203,7 @@ impl LazyDecoder for TextEncoding_1_0 {
     type VersionMarker<'top> = LazyRawTextVersionMarker_1_0<'top>;
 }
 
-impl LazyDecoder for TextEncoding_1_1 {
+impl Decoder for TextEncoding_1_1 {
     type Reader<'data> = LazyRawTextReader_1_1<'data>;
     type ReaderSavedState = ();
     type Value<'top> = LazyRawTextValue_1_1<'top>;
@@ -216,7 +216,7 @@ impl LazyDecoder for TextEncoding_1_1 {
     type VersionMarker<'top> = LazyRawTextVersionMarker_1_1<'top>;
 }
 
-impl LazyDecoder for BinaryEncoding_1_1 {
+impl Decoder for BinaryEncoding_1_1 {
     type Reader<'data> = LazyRawBinaryReader_1_1<'data>;
     type ReaderSavedState = ();
     type Value<'top> = LazyRawBinaryValue_1_1<'top>;

--- a/src/lazy/encoding.rs
+++ b/src/lazy/encoding.rs
@@ -101,7 +101,7 @@ impl<'top> BinaryEncoding<'top> for BinaryEncoding_1_1 {}
 pub struct TextEncoding_1_0;
 
 impl TextEncoding_1_0 {
-    fn with_format(self, format: TextFormat) -> WriteConfig<Self> {
+    pub fn with_format(self, format: TextFormat) -> WriteConfig<Self> {
         WriteConfig::<Self>::new(format)
     }
 }
@@ -111,7 +111,7 @@ impl TextEncoding_1_0 {
 pub struct TextEncoding_1_1;
 
 impl TextEncoding_1_1 {
-    fn with_format(self, format: TextFormat) -> WriteConfig<Self> {
+    pub fn with_format(self, format: TextFormat) -> WriteConfig<Self> {
         WriteConfig::<Self>::new(format)
     }
 }

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::ops::Range;
 
-use crate::lazy::decoder::LazyDecoder;
+use crate::lazy::decoder::Decoder;
 use crate::lazy::expanded::template::{
     ExprRange, MacroSignature, Parameter, ParameterEncoding, TemplateBody, TemplateBodyElement,
     TemplateBodyMacroInvocation, TemplateBodyValueExpr, TemplateMacro, TemplateStructIndex,
@@ -136,7 +136,7 @@ impl TemplateCompiler {
     /// [`TemplateBodyValueExpr`] sequences to the `TemplateBody`.
     ///
     /// If `is_quoted` is true, nested symbols and s-expressions will not be interpreted.
-    fn compile_value<'top, D: LazyDecoder>(
+    fn compile_value<'top, D: Decoder>(
         context: EncodingContextRef<'top>,
         signature: &MacroSignature,
         definition: &mut TemplateBody,
@@ -209,7 +209,7 @@ impl TemplateCompiler {
     }
 
     /// Helper method for visiting all of the child expressions in a list.
-    fn compile_list<'top, D: LazyDecoder>(
+    fn compile_list<'top, D: Decoder>(
         context: EncodingContextRef<'top>,
         signature: &MacroSignature,
         definition: &mut TemplateBody,
@@ -237,7 +237,7 @@ impl TemplateCompiler {
     }
 
     /// Helper method for visiting all of the child expressions in a sexp.
-    fn compile_sexp<'top, D: LazyDecoder>(
+    fn compile_sexp<'top, D: Decoder>(
         context: EncodingContextRef<'top>,
         signature: &MacroSignature,
         definition: &mut TemplateBody,
@@ -271,7 +271,7 @@ impl TemplateCompiler {
 
     /// Adds a `lazy_sexp` that has been determined to represent a macro invocation to the
     /// TemplateBody.
-    fn compile_macro<'top, D: LazyDecoder>(
+    fn compile_macro<'top, D: Decoder>(
         context: EncodingContextRef<'top>,
         signature: &MacroSignature,
         definition: &mut TemplateBody,
@@ -310,7 +310,7 @@ impl TemplateCompiler {
 
     /// Given a `LazyValue` that represents a macro ID (name or address), attempts to resolve the
     /// ID to a macro address.
-    fn name_and_address_from_id_expr<'top, D: LazyDecoder>(
+    fn name_and_address_from_id_expr<'top, D: Decoder>(
         context: EncodingContextRef<'top>,
         id_expr: Option<IonResult<LazyValue<'top, D>>>,
     ) -> IonResult<(Option<String>, usize)> {
@@ -351,7 +351,7 @@ impl TemplateCompiler {
     /// Visits all of the child expressions of `lazy_sexp`, adding them to the `TemplateBody`
     /// without interpretation. `lazy_sexp` itself is the `quote` macro, and does not get added
     /// to the template body as there is nothing more for it to do at evaluation time.
-    fn compile_quoted_elements<'top, D: LazyDecoder>(
+    fn compile_quoted_elements<'top, D: Decoder>(
         context: EncodingContextRef<'top>,
         signature: &MacroSignature,
         definition: &mut TemplateBody,
@@ -374,7 +374,7 @@ impl TemplateCompiler {
     }
 
     /// Adds `lazy_sexp` to the template body without interpretation.
-    fn compile_quoted_sexp<'top, D: LazyDecoder>(
+    fn compile_quoted_sexp<'top, D: Decoder>(
         context: EncodingContextRef<'top>,
         signature: &MacroSignature,
         definition: &mut TemplateBody,
@@ -404,7 +404,7 @@ impl TemplateCompiler {
 
     /// Returns `Ok(true)` if the first child value in the `LazySexp` is the symbol `quote`.
     /// This method should only be called in an unquoted context.
-    fn sexp_is_quote_macro<D: LazyDecoder>(sexp: &LazySExp<D>) -> IonResult<bool> {
+    fn sexp_is_quote_macro<D: Decoder>(sexp: &LazySExp<D>) -> IonResult<bool> {
         let first_expr = sexp.iter().next();
         match first_expr {
             // If the sexp is empty and we're not in a quoted context, that's an error.
@@ -418,7 +418,7 @@ impl TemplateCompiler {
     }
 
     /// Recursively adds all of the expressions in `lazy_struct` to the `TemplateBody`.
-    fn compile_struct<'top, D: LazyDecoder>(
+    fn compile_struct<'top, D: Decoder>(
         context: EncodingContextRef<'top>,
         signature: &MacroSignature,
         definition: &mut TemplateBody,

--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -1,7 +1,7 @@
 //! Types and traits representing an e-expression in an Ion stream.
 #![allow(non_camel_case_types)]
 
-use crate::lazy::decoder::{LazyDecoder, LazyRawValueExpr};
+use crate::lazy::decoder::{Decoder, LazyRawValueExpr};
 use crate::lazy::encoding::TextEncoding_1_1;
 use crate::lazy::expanded::macro_evaluator::{MacroExpr, RawEExpression, ValueExpr};
 use crate::lazy::expanded::macro_table::MacroRef;
@@ -12,13 +12,13 @@ use std::fmt::{Debug, Formatter};
 
 /// An e-expression (in Ion format `D`) that has been resolved in the current encoding context.
 #[derive(Copy, Clone)]
-pub struct EExpression<'top, D: LazyDecoder> {
+pub struct EExpression<'top, D: Decoder> {
     pub(crate) context: EncodingContextRef<'top>,
     pub(crate) raw_invocation: D::EExp<'top>,
     pub(crate) invoked_macro: MacroRef<'top>,
 }
 
-impl<'top, D: LazyDecoder> EExpression<'top, D> {
+impl<'top, D: Decoder> EExpression<'top, D> {
     pub fn context(&self) -> EncodingContextRef<'top> {
         self.context
     }
@@ -30,13 +30,13 @@ impl<'top, D: LazyDecoder> EExpression<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> Debug for EExpression<'top, D> {
+impl<'top, D: Decoder> Debug for EExpression<'top, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "EExpression {:?}", self.raw_invocation)
     }
 }
 
-impl<'top, D: LazyDecoder> EExpression<'top, D> {
+impl<'top, D: Decoder> EExpression<'top, D> {
     pub fn new(
         context: EncodingContextRef<'top>,
         raw_invocation: D::EExp<'top>,
@@ -50,7 +50,7 @@ impl<'top, D: LazyDecoder> EExpression<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> EExpression<'top, D> {
+impl<'top, D: Decoder> EExpression<'top, D> {
     pub fn id(&self) -> MacroIdRef<'top> {
         self.raw_invocation.id()
     }
@@ -63,18 +63,18 @@ impl<'top, D: LazyDecoder> EExpression<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> From<EExpression<'top, D>> for MacroExpr<'top, D> {
+impl<'top, D: Decoder> From<EExpression<'top, D>> for MacroExpr<'top, D> {
     fn from(value: EExpression<'top, D>) -> Self {
         MacroExpr::EExp(value)
     }
 }
 
-pub struct EExpressionArgsIterator<'top, D: LazyDecoder> {
+pub struct EExpressionArgsIterator<'top, D: Decoder> {
     context: EncodingContextRef<'top>,
     raw_args: <D::EExp<'top> as RawEExpression<'top, D>>::RawArgumentsIterator<'top>,
 }
 
-impl<'top, D: LazyDecoder> Iterator for EExpressionArgsIterator<'top, D> {
+impl<'top, D: Decoder> Iterator for EExpressionArgsIterator<'top, D> {
     type Item = IonResult<ValueExpr<'top, D>>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::ops::{Deref, Range};
 
-use crate::lazy::decoder::LazyDecoder;
+use crate::lazy::decoder::Decoder;
 use crate::lazy::expanded::macro_evaluator::{MacroEvaluator, MacroExpr, ValueExpr};
 use crate::lazy::expanded::macro_table::MacroRef;
 use crate::lazy::expanded::r#struct::UnexpandedField;
@@ -143,7 +143,7 @@ impl<'top> Deref for TemplateMacroRef<'top> {
 }
 
 /// Steps over the child expressions of a list or s-expression found in the body of a template.
-pub struct TemplateSequenceIterator<'top, D: LazyDecoder> {
+pub struct TemplateSequenceIterator<'top, D: Decoder> {
     context: EncodingContextRef<'top>,
     template: TemplateMacroRef<'top>,
     evaluator: MacroEvaluator<'top, D>,
@@ -151,7 +151,7 @@ pub struct TemplateSequenceIterator<'top, D: LazyDecoder> {
     index: usize,
 }
 
-impl<'top, D: LazyDecoder> TemplateSequenceIterator<'top, D> {
+impl<'top, D: Decoder> TemplateSequenceIterator<'top, D> {
     pub fn new(
         context: EncodingContextRef<'top>,
         evaluator: MacroEvaluator<'top, D>,
@@ -168,7 +168,7 @@ impl<'top, D: LazyDecoder> TemplateSequenceIterator<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> Iterator for TemplateSequenceIterator<'top, D> {
+impl<'top, D: Decoder> Iterator for TemplateSequenceIterator<'top, D> {
     type Item = IonResult<LazyExpandedValue<'top, D>>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -247,7 +247,7 @@ impl<'top, D: LazyDecoder> Iterator for TemplateSequenceIterator<'top, D> {
 /// An iterator that pulls expressions from a template body and wraps them in a [`UnexpandedField`] to
 /// mimic reading them from input. The [`LazyExpandedStruct`](crate::lazy::expanded::struct) handles
 /// evaluating any macro invocations that this yields.
-pub struct TemplateStructUnexpandedFieldsIterator<'top, D: LazyDecoder> {
+pub struct TemplateStructUnexpandedFieldsIterator<'top, D: Decoder> {
     context: EncodingContextRef<'top>,
     environment: Environment<'top, D>,
     template: TemplateMacroRef<'top>,
@@ -255,13 +255,13 @@ pub struct TemplateStructUnexpandedFieldsIterator<'top, D: LazyDecoder> {
     index: usize,
 }
 
-impl<'top, D: LazyDecoder> TemplateStructUnexpandedFieldsIterator<'top, D> {
+impl<'top, D: Decoder> TemplateStructUnexpandedFieldsIterator<'top, D> {
     pub fn context(&self) -> EncodingContextRef<'top> {
         self.context
     }
 }
 
-impl<'top, D: LazyDecoder> TemplateStructUnexpandedFieldsIterator<'top, D> {
+impl<'top, D: Decoder> TemplateStructUnexpandedFieldsIterator<'top, D> {
     pub fn new(
         context: EncodingContextRef<'top>,
         environment: Environment<'top, D>,
@@ -278,7 +278,7 @@ impl<'top, D: LazyDecoder> TemplateStructUnexpandedFieldsIterator<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> Iterator for TemplateStructUnexpandedFieldsIterator<'top, D> {
+impl<'top, D: Decoder> Iterator for TemplateStructUnexpandedFieldsIterator<'top, D> {
     type Item = IonResult<UnexpandedField<'top, D>>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -698,7 +698,7 @@ impl<'top> TemplateMacroInvocation<'top> {
     pub fn id(&self) -> MacroIdRef<'top> {
         MacroIdRef::LocalAddress(self.invoked_macro.address())
     }
-    pub fn arguments<D: LazyDecoder>(
+    pub fn arguments<D: Decoder>(
         &self,
         environment: Environment<'top, D>,
     ) -> TemplateMacroInvocationArgsIterator<'top, D> {
@@ -718,20 +718,20 @@ impl<'top> TemplateMacroInvocation<'top> {
     }
 }
 
-impl<'top, D: LazyDecoder> From<TemplateMacroInvocation<'top>> for MacroExpr<'top, D> {
+impl<'top, D: Decoder> From<TemplateMacroInvocation<'top>> for MacroExpr<'top, D> {
     fn from(value: TemplateMacroInvocation<'top>) -> Self {
         MacroExpr::TemplateMacro(value)
     }
 }
 
 /// Steps over the argument expressions passed to a macro invocation found in a template body.
-pub struct TemplateMacroInvocationArgsIterator<'top, D: LazyDecoder> {
+pub struct TemplateMacroInvocationArgsIterator<'top, D: Decoder> {
     environment: Environment<'top, D>,
     invocation: TemplateMacroInvocation<'top>,
     arg_index: usize,
 }
 
-impl<'top, D: LazyDecoder> TemplateMacroInvocationArgsIterator<'top, D> {
+impl<'top, D: Decoder> TemplateMacroInvocationArgsIterator<'top, D> {
     pub fn new(
         environment: Environment<'top, D>,
         invocation: TemplateMacroInvocation<'top>,
@@ -744,7 +744,7 @@ impl<'top, D: LazyDecoder> TemplateMacroInvocationArgsIterator<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> Iterator for TemplateMacroInvocationArgsIterator<'top, D> {
+impl<'top, D: Decoder> Iterator for TemplateMacroInvocationArgsIterator<'top, D> {
     type Item = IonResult<ValueExpr<'top, D>>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/lazy/lazy_value_cache.rs
+++ b/src/lazy/lazy_value_cache.rs
@@ -1,6 +1,6 @@
-use crate::lazy::decoder::{LazyDecoder, LazyRawValueExpr};
+use crate::lazy::decoder::{Decoder, LazyRawValueExpr};
 use bumpalo::collections::Vec as BumpVec;
 
-pub struct RawValueExprCache<'top, D: LazyDecoder> {
+pub struct RawValueExprCache<'top, D: Decoder> {
     values: BumpVec<'top, LazyRawValueExpr<'top, D>>,
 }

--- a/src/lazy/never.rs
+++ b/src/lazy/never.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 use std::ops::Range;
 
-use crate::lazy::decoder::{HasRange, HasSpan, LazyDecoder, LazyRawValueExpr};
+use crate::lazy::decoder::{Decoder, HasRange, HasSpan, LazyRawValueExpr};
 use crate::lazy::encoder::annotation_seq::AnnotationSeq;
 use crate::lazy::encoder::value_writer::internal::{FieldEncoder, MakeValueWriter};
 use crate::lazy::encoder::value_writer::{
@@ -34,7 +34,7 @@ impl HasRange for Never {
 
 // Ion 1.0 uses `Never` as a placeholder type for MacroInvocation.
 // The compiler should optimize these methods away.
-impl<'top, D: LazyDecoder<EExp<'top> = Self>> RawEExpression<'top, D> for Never {
+impl<'top, D: Decoder<EExp<'top> = Self>> RawEExpression<'top, D> for Never {
     // These use Box<dyn> to avoid defining yet another placeholder type.
     type RawArgumentsIterator<'a> = Box<dyn Iterator<Item = IonResult<LazyRawValueExpr<'top, D>>>>;
 
@@ -47,7 +47,7 @@ impl<'top, D: LazyDecoder<EExp<'top> = Self>> RawEExpression<'top, D> for Never 
     }
 }
 
-impl<'top, D: LazyDecoder> From<Never> for MacroExpr<'top, D> {
+impl<'top, D: Decoder> From<Never> for MacroExpr<'top, D> {
     fn from(_value: Never) -> Self {
         unreachable!("macro in Ion 1.0 (method: into)")
     }

--- a/src/lazy/raw_stream_item.rs
+++ b/src/lazy/raw_stream_item.rs
@@ -1,4 +1,4 @@
-use crate::lazy::decoder::{HasRange, HasSpan, LazyDecoder};
+use crate::lazy::decoder::{Decoder, HasRange, HasSpan};
 use crate::lazy::span::Span;
 use crate::result::IonFailure;
 use crate::{IonError, IonResult};
@@ -22,9 +22,9 @@ pub enum RawStreamItem<M: Debug, V: Debug, E: Debug> {
 }
 
 pub type LazyRawStreamItem<'top, D> = RawStreamItem<
-    <D as LazyDecoder>::VersionMarker<'top>,
-    <D as LazyDecoder>::Value<'top>,
-    <D as LazyDecoder>::EExp<'top>,
+    <D as Decoder>::VersionMarker<'top>,
+    <D as Decoder>::Value<'top>,
+    <D as Decoder>::EExp<'top>,
 >;
 
 impl<M: Debug + HasRange, V: Debug + HasRange, E: Debug + HasRange> HasRange

--- a/src/lazy/raw_value_ref.rs
+++ b/src/lazy/raw_value_ref.rs
@@ -1,5 +1,5 @@
 use crate::lazy::bytes_ref::BytesRef;
-use crate::lazy::decoder::LazyDecoder;
+use crate::lazy::decoder::Decoder;
 use crate::lazy::str_ref::StrRef;
 use crate::result::IonFailure;
 use crate::{Decimal, Int, IonResult, IonType, RawSymbolRef, Timestamp};
@@ -11,7 +11,7 @@ use std::fmt::{Debug, Formatter};
 ///
 /// For a resolved version of this type, see [crate::lazy::value_ref::ValueRef].
 #[derive(Copy, Clone)]
-pub enum RawValueRef<'top, D: LazyDecoder> {
+pub enum RawValueRef<'top, D: Decoder> {
     Null(IonType),
     Bool(bool),
     Int(Int),
@@ -28,7 +28,7 @@ pub enum RawValueRef<'top, D: LazyDecoder> {
 }
 
 // Provides equality for scalar types, but not containers.
-impl<'top, D: LazyDecoder> PartialEq for RawValueRef<'top, D> {
+impl<'top, D: Decoder> PartialEq for RawValueRef<'top, D> {
     fn eq(&self, other: &Self) -> bool {
         use RawValueRef::*;
         match (self, other) {
@@ -49,7 +49,7 @@ impl<'top, D: LazyDecoder> PartialEq for RawValueRef<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> Debug for RawValueRef<'top, D> {
+impl<'top, D: Decoder> Debug for RawValueRef<'top, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             RawValueRef::Null(ion_type) => write!(f, "null.{}", ion_type),
@@ -69,7 +69,7 @@ impl<'top, D: LazyDecoder> Debug for RawValueRef<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> RawValueRef<'top, D> {
+impl<'top, D: Decoder> RawValueRef<'top, D> {
     pub fn expect_null(self) -> IonResult<IonType> {
         if let RawValueRef::Null(ion_type) = self {
             Ok(ion_type)

--- a/src/lazy/sequence.rs
+++ b/src/lazy/sequence.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 
-use crate::lazy::decoder::LazyDecoder;
+use crate::lazy::decoder::Decoder;
 use crate::lazy::encoding::BinaryEncoding_1_0;
 use crate::lazy::expanded::sequence::{
     ExpandedListIterator, ExpandedSExpIterator, LazyExpandedList, LazyExpandedSExp,
@@ -52,13 +52,13 @@ use crate::{IonError, IonResult};
 ///# fn main() -> IonResult<()> { Ok(()) }
 /// ```
 #[derive(Copy, Clone)]
-pub struct LazyList<'top, D: LazyDecoder> {
+pub struct LazyList<'top, D: Decoder> {
     pub(crate) expanded_list: LazyExpandedList<'top, D>,
 }
 
 pub type LazyBinarySequence<'top, 'data> = LazyList<'top, BinaryEncoding_1_0>;
 
-impl<'top, D: LazyDecoder> LazyList<'top, D> {
+impl<'top, D: Decoder> LazyList<'top, D> {
     /// Returns an iterator over the values in this sequence. See: [`LazyValue`].
     pub fn iter(&self) -> ListIterator<'top, D> {
         ListIterator {
@@ -115,7 +115,7 @@ impl<'top, D: LazyDecoder> LazyList<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> TryFrom<LazyList<'top, D>> for Sequence {
+impl<'top, D: Decoder> TryFrom<LazyList<'top, D>> for Sequence {
     type Error = IonError;
 
     fn try_from(lazy_sequence: LazyList<'top, D>) -> Result<Self, Self::Error> {
@@ -128,7 +128,7 @@ impl<'top, D: LazyDecoder> TryFrom<LazyList<'top, D>> for Sequence {
     }
 }
 
-impl<'top, D: LazyDecoder> TryFrom<LazyList<'top, D>> for Element {
+impl<'top, D: Decoder> TryFrom<LazyList<'top, D>> for Element {
     type Error = IonError;
 
     fn try_from(lazy_list: LazyList<'top, D>) -> Result<Self, Self::Error> {
@@ -139,7 +139,7 @@ impl<'top, D: LazyDecoder> TryFrom<LazyList<'top, D>> for Element {
     }
 }
 
-impl<'a, 'top, 'data: 'top, D: LazyDecoder> IntoIterator for &'a LazyList<'top, D> {
+impl<'a, 'top, 'data: 'top, D: Decoder> IntoIterator for &'a LazyList<'top, D> {
     type Item = IonResult<LazyValue<'top, D>>;
     type IntoIter = ListIterator<'top, D>;
 
@@ -148,11 +148,11 @@ impl<'a, 'top, 'data: 'top, D: LazyDecoder> IntoIterator for &'a LazyList<'top, 
     }
 }
 
-pub struct ListIterator<'top, D: LazyDecoder> {
+pub struct ListIterator<'top, D: Decoder> {
     expanded_list_iter: ExpandedListIterator<'top, D>,
 }
 
-impl<'top, D: LazyDecoder> Iterator for ListIterator<'top, D> {
+impl<'top, D: Decoder> Iterator for ListIterator<'top, D> {
     type Item = IonResult<LazyValue<'top, D>>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -167,7 +167,7 @@ impl<'top, D: LazyDecoder> Iterator for ListIterator<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> Debug for LazyList<'top, D> {
+impl<'top, D: Decoder> Debug for LazyList<'top, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "[")?;
         for value in self {
@@ -182,11 +182,11 @@ impl<'top, D: LazyDecoder> Debug for LazyList<'top, D> {
 // ===== SExps =====
 
 #[derive(Copy, Clone)]
-pub struct LazySExp<'top, D: LazyDecoder> {
+pub struct LazySExp<'top, D: Decoder> {
     pub(crate) expanded_sexp: LazyExpandedSExp<'top, D>,
 }
 
-impl<'top, D: LazyDecoder> Debug for LazySExp<'top, D> {
+impl<'top, D: Decoder> Debug for LazySExp<'top, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "(")?;
         for value in self {
@@ -198,7 +198,7 @@ impl<'top, D: LazyDecoder> Debug for LazySExp<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> LazySExp<'top, D> {
+impl<'top, D: Decoder> LazySExp<'top, D> {
     pub fn lower(&self) -> LazyExpandedSExp<'top, D> {
         self.expanded_sexp
     }
@@ -249,7 +249,7 @@ impl<'top, D: LazyDecoder> LazySExp<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> TryFrom<LazySExp<'top, D>> for Sequence {
+impl<'top, D: Decoder> TryFrom<LazySExp<'top, D>> for Sequence {
     type Error = IonError;
 
     fn try_from(lazy_sequence: LazySExp<'top, D>) -> Result<Self, Self::Error> {
@@ -262,7 +262,7 @@ impl<'top, D: LazyDecoder> TryFrom<LazySExp<'top, D>> for Sequence {
     }
 }
 
-impl<'top, D: LazyDecoder> TryFrom<LazySExp<'top, D>> for Element {
+impl<'top, D: Decoder> TryFrom<LazySExp<'top, D>> for Element {
     type Error = IonError;
 
     fn try_from(lazy_sequence: LazySExp<'top, D>) -> Result<Self, Self::Error> {
@@ -273,7 +273,7 @@ impl<'top, D: LazyDecoder> TryFrom<LazySExp<'top, D>> for Element {
     }
 }
 
-impl<'a, 'top, 'data: 'top, D: LazyDecoder> IntoIterator for &'a LazySExp<'top, D> {
+impl<'a, 'top, 'data: 'top, D: Decoder> IntoIterator for &'a LazySExp<'top, D> {
     type Item = IonResult<LazyValue<'top, D>>;
     type IntoIter = SExpIterator<'top, D>;
 
@@ -282,11 +282,11 @@ impl<'a, 'top, 'data: 'top, D: LazyDecoder> IntoIterator for &'a LazySExp<'top, 
     }
 }
 
-pub struct SExpIterator<'top, D: LazyDecoder> {
+pub struct SExpIterator<'top, D: Decoder> {
     expanded_sexp_iter: ExpandedSExpIterator<'top, D>,
 }
 
-impl<'top, D: LazyDecoder> Iterator for SExpIterator<'top, D> {
+impl<'top, D: Decoder> Iterator for SExpIterator<'top, D> {
     type Item = IonResult<LazyValue<'top, D>>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/lazy/streaming_raw_reader.rs
+++ b/src/lazy/streaming_raw_reader.rs
@@ -4,12 +4,12 @@ use std::io::{BufReader, Read, StdinLock};
 
 use bumpalo::Bump as BumpAllocator;
 
-use crate::lazy::decoder::{LazyDecoder, LazyRawReader};
+use crate::lazy::decoder::{Decoder, LazyRawReader};
 use crate::lazy::raw_stream_item::LazyRawStreamItem;
 use crate::IonResult;
 
 /// Wraps an implementation of [`IonDataSource`] and reads one top level value at a time from the input.
-pub struct StreamingRawReader<Encoding: LazyDecoder, Input: IonInput> {
+pub struct StreamingRawReader<Encoding: Decoder, Input: IonInput> {
     // The Ion encoding that this reader recognizes.
     encoding: Encoding,
     // The StreamingRawReader works by reading the next value from the bytes currently available
@@ -45,7 +45,7 @@ pub struct StreamingRawReader<Encoding: LazyDecoder, Input: IonInput> {
 
 const DEFAULT_IO_BUFFER_SIZE: usize = 4 * 1024;
 
-impl<Encoding: LazyDecoder, Input: IonInput> StreamingRawReader<Encoding, Input> {
+impl<Encoding: Decoder, Input: IonInput> StreamingRawReader<Encoding, Input> {
     pub fn new(encoding: Encoding, input: Input) -> StreamingRawReader<Encoding, Input> {
         StreamingRawReader {
             encoding,
@@ -325,13 +325,13 @@ mod tests {
     use bumpalo::Bump as BumpAllocator;
 
     use crate::lazy::any_encoding::AnyEncoding;
-    use crate::lazy::decoder::{LazyDecoder, LazyRawValue};
+    use crate::lazy::decoder::{Decoder, LazyRawValue};
     use crate::lazy::raw_stream_item::LazyRawStreamItem;
     use crate::lazy::raw_value_ref::RawValueRef;
     use crate::lazy::streaming_raw_reader::{IonInput, StreamingRawReader};
     use crate::{IonError, IonResult};
 
-    fn expect_value<'a, D: LazyDecoder>(
+    fn expect_value<'a, D: Decoder>(
         actual: LazyRawStreamItem<'a, D>,
         expected: RawValueRef<'a, D>,
     ) -> IonResult<()> {

--- a/src/lazy/struct.rs
+++ b/src/lazy/struct.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::fmt::{Debug, Formatter};
 
 use crate::element::builders::StructBuilder;
-use crate::lazy::decoder::{LazyDecoder, LazyRawContainer};
+use crate::lazy::decoder::{Decoder, LazyRawContainer};
 use crate::lazy::encoding::BinaryEncoding_1_0;
 use crate::lazy::expanded::r#struct::{
     ExpandedStructIterator, ExpandedStructSource, LazyExpandedField, LazyExpandedStruct,
@@ -49,7 +49,7 @@ use crate::{Annotations, Element, IntoAnnotatedElement, IonError, IonResult, Str
 ///# fn main() -> IonResult<()> { Ok(()) }
 /// ```
 #[derive(Copy, Clone)]
-pub struct LazyStruct<'top, D: LazyDecoder> {
+pub struct LazyStruct<'top, D: Decoder> {
     pub(crate) expanded_struct: LazyExpandedStruct<'top, D>,
 }
 
@@ -57,7 +57,7 @@ pub type LazyBinaryStruct_1_0<'top> = LazyStruct<'top, BinaryEncoding_1_0>;
 
 // Best-effort debug formatting for LazyStruct. Any failures that occur during reading will result
 // in the output being silently truncated.
-impl<'top, D: LazyDecoder> Debug for LazyStruct<'top, D> {
+impl<'top, D: Decoder> Debug for LazyStruct<'top, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{{")?;
         for field in self {
@@ -72,7 +72,7 @@ impl<'top, D: LazyDecoder> Debug for LazyStruct<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> LazyStruct<'top, D> {
+impl<'top, D: Decoder> LazyStruct<'top, D> {
     /// Returns an iterator over this struct's fields. See [`LazyField`].
     pub fn iter(&self) -> StructIterator<'top, D> {
         StructIterator {
@@ -273,11 +273,11 @@ impl<'top, D: LazyDecoder> LazyStruct<'top, D> {
 }
 
 /// A single field within a [`LazyStruct`].
-pub struct LazyField<'top, D: LazyDecoder> {
+pub struct LazyField<'top, D: Decoder> {
     pub(crate) expanded_field: LazyExpandedField<'top, D>,
 }
 
-impl<'top, D: LazyDecoder> Debug for LazyField<'top, D> {
+impl<'top, D: Decoder> Debug for LazyField<'top, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -288,7 +288,7 @@ impl<'top, D: LazyDecoder> Debug for LazyField<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> LazyField<'top, D> {
+impl<'top, D: Decoder> LazyField<'top, D> {
     /// Returns a symbol representing the name of this field.
     pub fn name(&self) -> IonResult<SymbolRef<'top>> {
         self.expanded_field.name().read()
@@ -303,11 +303,11 @@ impl<'top, D: LazyDecoder> LazyField<'top, D> {
     }
 }
 
-pub struct StructIterator<'top, D: LazyDecoder> {
+pub struct StructIterator<'top, D: Decoder> {
     pub(crate) expanded_struct_iter: ExpandedStructIterator<'top, D>,
 }
 
-impl<'top, D: LazyDecoder> Iterator for StructIterator<'top, D> {
+impl<'top, D: Decoder> Iterator for StructIterator<'top, D> {
     type Item = IonResult<LazyField<'top, D>>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -315,7 +315,7 @@ impl<'top, D: LazyDecoder> Iterator for StructIterator<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> StructIterator<'top, D> {
+impl<'top, D: Decoder> StructIterator<'top, D> {
     pub fn next_field(&mut self) -> IonResult<Option<LazyField<'top, D>>> {
         let expanded_field = match self.expanded_struct_iter.next() {
             Some(expanded_field) => expanded_field?,
@@ -327,7 +327,7 @@ impl<'top, D: LazyDecoder> StructIterator<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> TryFrom<LazyStruct<'top, D>> for Struct {
+impl<'top, D: Decoder> TryFrom<LazyStruct<'top, D>> for Struct {
     type Error = IonError;
 
     fn try_from(lazy_struct: LazyStruct<'top, D>) -> Result<Self, Self::Error> {
@@ -340,7 +340,7 @@ impl<'top, D: LazyDecoder> TryFrom<LazyStruct<'top, D>> for Struct {
     }
 }
 
-impl<'top, D: LazyDecoder> TryFrom<LazyStruct<'top, D>> for Element {
+impl<'top, D: Decoder> TryFrom<LazyStruct<'top, D>> for Element {
     type Error = IonError;
 
     fn try_from(lazy_struct: LazyStruct<'top, D>) -> Result<Self, Self::Error> {
@@ -350,7 +350,7 @@ impl<'top, D: LazyDecoder> TryFrom<LazyStruct<'top, D>> for Element {
     }
 }
 
-impl<'a, 'top, 'data: 'top, D: LazyDecoder> IntoIterator for &'a LazyStruct<'top, D> {
+impl<'a, 'top, 'data: 'top, D: Decoder> IntoIterator for &'a LazyStruct<'top, D> {
     type Item = IonResult<LazyField<'top, D>>;
     type IntoIter = StructIterator<'top, D>;
 

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -1,7 +1,7 @@
 #![allow(non_camel_case_types)]
 
 use crate::lazy::any_encoding::AnyEncoding;
-use crate::lazy::decoder::LazyDecoder;
+use crate::lazy::decoder::Decoder;
 use crate::lazy::encoding::{BinaryEncoding_1_0, TextEncoding_1_0, TextEncoding_1_1};
 use crate::lazy::expanded::{ExpandedValueRef, ExpandingReader, LazyExpandedValue};
 use crate::lazy::streaming_raw_reader::{IonInput, StreamingRawReader};
@@ -69,7 +69,7 @@ const SYMBOLS: RawSymbolRef = RawSymbolRef::SymbolId(7);
 ///# #[cfg(not(feature = "experimental-reader-writer"))]
 ///# fn main() -> IonResult<()> { Ok(()) }
 /// ```
-pub struct SystemReader<Encoding: LazyDecoder, Input: IonInput> {
+pub struct SystemReader<Encoding: Decoder, Input: IonInput> {
     pub(crate) expanding_reader: ExpandingReader<Encoding, Input>,
 }
 
@@ -122,7 +122,7 @@ impl<Input: IonInput> SystemTextReader_1_1<Input> {
     }
 }
 
-impl<Encoding: LazyDecoder, Input: IonInput> SystemReader<Encoding, Input> {
+impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
     // Returns `true` if the provided [`LazyRawValue`] is a struct whose first annotation is
     // `$ion_symbol_table`.
     pub fn is_symbol_table_struct(

--- a/src/lazy/system_stream_item.rs
+++ b/src/lazy/system_stream_item.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Debug, Formatter};
 
-use crate::lazy::decoder::{LazyDecoder, RawVersionMarker};
+use crate::lazy::decoder::{Decoder, RawVersionMarker};
 use crate::lazy::expanded::ExpandedValueSource;
 use crate::lazy::r#struct::LazyStruct;
 use crate::lazy::raw_stream_item::{EndPosition, LazyRawStreamItem, RawStreamItem};
@@ -10,7 +10,7 @@ use crate::{IonError, IonResult};
 
 /// System stream elements that a SystemReader may encounter.
 #[non_exhaustive]
-pub enum SystemStreamItem<'top, D: LazyDecoder> {
+pub enum SystemStreamItem<'top, D: Decoder> {
     /// An Ion Version Marker (IVM) indicating the Ion major and minor version that were used to
     /// encode the values that follow.
     VersionMarker(D::VersionMarker<'top>),
@@ -22,7 +22,7 @@ pub enum SystemStreamItem<'top, D: LazyDecoder> {
     EndOfStream(EndPosition),
 }
 
-impl<'top, D: LazyDecoder> Debug for SystemStreamItem<'top, D> {
+impl<'top, D: Decoder> Debug for SystemStreamItem<'top, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             SystemStreamItem::VersionMarker(marker) => {
@@ -35,7 +35,7 @@ impl<'top, D: LazyDecoder> Debug for SystemStreamItem<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> SystemStreamItem<'top, D> {
+impl<'top, D: Decoder> SystemStreamItem<'top, D> {
     /// If this item is an Ion version marker (IVM), returns `Some(version_marker)` indicating the
     /// version. Otherwise, returns `None`.
     pub fn version_marker(&self) -> Option<D::VersionMarker<'top>> {

--- a/src/lazy/text/matched.rs
+++ b/src/lazy/text/matched.rs
@@ -36,7 +36,7 @@ use smallvec::SmallVec;
 
 use crate::decimal::coefficient::Coefficient;
 use crate::lazy::bytes_ref::BytesRef;
-use crate::lazy::decoder::{LazyDecoder, LazyRawFieldExpr, LazyRawValueExpr};
+use crate::lazy::decoder::{Decoder, LazyRawFieldExpr, LazyRawValueExpr};
 use crate::lazy::span::Span;
 use crate::lazy::str_ref::StrRef;
 use crate::lazy::text::as_utf8::AsUtf8;
@@ -49,7 +49,7 @@ use crate::{
 
 /// A partially parsed Ion value.
 #[derive(Clone, Copy, Debug)]
-pub enum MatchedValue<'top, D: LazyDecoder> {
+pub enum MatchedValue<'top, D: Decoder> {
     // `Null` and `Bool` are fully parsed because they only involve matching a keyword.
     Null(IonType),
     Bool(bool),
@@ -66,7 +66,7 @@ pub enum MatchedValue<'top, D: LazyDecoder> {
     Struct(&'top [LazyRawFieldExpr<'top, D>]),
 }
 
-impl<'top, D: LazyDecoder> PartialEq for MatchedValue<'top, D> {
+impl<'top, D: Decoder> PartialEq for MatchedValue<'top, D> {
     fn eq(&self, other: &Self) -> bool {
         use MatchedValue::*;
         match (self, other) {

--- a/src/lazy/text/raw/reader.rs
+++ b/src/lazy/text/raw/reader.rs
@@ -2,7 +2,7 @@
 
 use bumpalo::Bump as BumpAllocator;
 
-use crate::lazy::decoder::{LazyDecoder, LazyRawReader, RawVersionMarker};
+use crate::lazy::decoder::{Decoder, LazyRawReader, RawVersionMarker};
 use crate::lazy::encoding::TextEncoding_1_0;
 use crate::lazy::raw_stream_item::{EndPosition, LazyRawStreamItem, RawStreamItem};
 use crate::lazy::text::buffer::TextBufferView;
@@ -89,7 +89,7 @@ impl<'data> LazyRawReader<'data, TextEncoding_1_0> for LazyRawTextReader_1_0<'da
     fn resume_at_offset(
         data: &'data [u8],
         offset: usize,
-        _config: <TextEncoding_1_0 as LazyDecoder>::ReaderSavedState,
+        _config: <TextEncoding_1_0 as Decoder>::ReaderSavedState,
     ) -> Self {
         LazyRawTextReader_1_0::new_with_offset(data, offset)
     }

--- a/src/lazy/text/raw/sequence.rs
+++ b/src/lazy/text/raw/sequence.rs
@@ -7,7 +7,7 @@ use nom::character::streaming::satisfy;
 
 use crate::lazy::decoder::private::LazyContainerPrivate;
 use crate::lazy::decoder::{
-    LazyDecoder, LazyRawContainer, LazyRawSequence, LazyRawValue, LazyRawValueExpr, RawValueExpr,
+    Decoder, LazyRawContainer, LazyRawSequence, LazyRawValue, LazyRawValueExpr, RawValueExpr,
 };
 use crate::lazy::encoding::TextEncoding_1_0;
 use crate::lazy::text::buffer::TextBufferView;
@@ -43,7 +43,7 @@ impl<'data> LazyContainerPrivate<'data, TextEncoding_1_0> for LazyRawTextList_1_
 }
 
 impl<'data> LazyRawContainer<'data, TextEncoding_1_0> for LazyRawTextList_1_0<'data> {
-    fn as_value(&self) -> <TextEncoding_1_0 as LazyDecoder>::Value<'data> {
+    fn as_value(&self) -> <TextEncoding_1_0 as Decoder>::Value<'data> {
         self.value
     }
 }
@@ -255,7 +255,7 @@ impl<'data> LazyContainerPrivate<'data, TextEncoding_1_0> for LazyRawTextSExp_1_
 }
 
 impl<'data> LazyRawContainer<'data, TextEncoding_1_0> for LazyRawTextSExp_1_0<'data> {
-    fn as_value(&self) -> <TextEncoding_1_0 as LazyDecoder>::Value<'data> {
+    fn as_value(&self) -> <TextEncoding_1_0 as Decoder>::Value<'data> {
         self.value
     }
 }

--- a/src/lazy/text/raw/struct.rs
+++ b/src/lazy/text/raw/struct.rs
@@ -6,7 +6,7 @@ use nom::character::streaming::satisfy;
 
 use crate::lazy::decoder::private::LazyContainerPrivate;
 use crate::lazy::decoder::{
-    HasRange, HasSpan, LazyDecoder, LazyRawContainer, LazyRawFieldExpr, LazyRawFieldName,
+    Decoder, HasRange, HasSpan, LazyRawContainer, LazyRawFieldExpr, LazyRawFieldName,
     LazyRawStruct, LazyRawValue,
 };
 use crate::lazy::encoding::TextEncoding_1_0;
@@ -124,7 +124,7 @@ impl<'top> LazyContainerPrivate<'top, TextEncoding_1_0> for LazyRawTextStruct_1_
 }
 
 impl<'top> LazyRawContainer<'top, TextEncoding_1_0> for LazyRawTextStruct_1_0<'top> {
-    fn as_value(&self) -> <TextEncoding_1_0 as LazyDecoder>::Value<'top> {
+    fn as_value(&self) -> <TextEncoding_1_0 as Decoder>::Value<'top> {
         self.value
     }
 }

--- a/src/lazy/text/raw/v1_1/reader.rs
+++ b/src/lazy/text/raw/v1_1/reader.rs
@@ -10,7 +10,7 @@ use nom::character::streaming::satisfy;
 
 use crate::lazy::decoder::private::LazyContainerPrivate;
 use crate::lazy::decoder::{
-    HasRange, HasSpan, LazyDecoder, LazyRawContainer, LazyRawFieldExpr, LazyRawFieldName,
+    Decoder, HasRange, HasSpan, LazyRawContainer, LazyRawFieldExpr, LazyRawFieldName,
     LazyRawReader, LazyRawSequence, LazyRawStruct, LazyRawValue, LazyRawValueExpr,
     RawVersionMarker,
 };
@@ -138,7 +138,7 @@ impl<'data> LazyRawReader<'data, TextEncoding_1_1> for LazyRawTextReader_1_1<'da
     fn resume_at_offset(
         data: &'data [u8],
         offset: usize,
-        _config: <TextEncoding_1_1 as LazyDecoder>::ReaderSavedState,
+        _config: <TextEncoding_1_1 as Decoder>::ReaderSavedState,
     ) -> Self {
         LazyRawTextReader_1_1 {
             input: data,
@@ -414,7 +414,7 @@ impl<'top> LazyContainerPrivate<'top, TextEncoding_1_1> for LazyRawTextSExp_1_1<
 }
 
 impl<'top> LazyRawContainer<'top, TextEncoding_1_1> for LazyRawTextSExp_1_1<'top> {
-    fn as_value(&self) -> <TextEncoding_1_1 as LazyDecoder>::Value<'top> {
+    fn as_value(&self) -> <TextEncoding_1_1 as Decoder>::Value<'top> {
         self.value
     }
 }
@@ -624,7 +624,7 @@ impl<'top> LazyContainerPrivate<'top, TextEncoding_1_1> for LazyRawTextStruct_1_
 }
 
 impl<'top> LazyRawContainer<'top, TextEncoding_1_1> for LazyRawTextStruct_1_1<'top> {
-    fn as_value(&self) -> <TextEncoding_1_1 as LazyDecoder>::Value<'top> {
+    fn as_value(&self) -> <TextEncoding_1_1 as Decoder>::Value<'top> {
         self.value
     }
 }

--- a/src/lazy/text/value.rs
+++ b/src/lazy/text/value.rs
@@ -6,7 +6,7 @@ use std::marker::PhantomData;
 use std::ops::Range;
 
 use crate::lazy::decoder::private::LazyContainerPrivate;
-use crate::lazy::decoder::{HasRange, HasSpan, LazyDecoder, LazyRawValue, RawVersionMarker};
+use crate::lazy::decoder::{Decoder, HasRange, HasSpan, LazyRawValue, RawVersionMarker};
 use crate::lazy::encoding::{TextEncoding, TextEncoding_1_0, TextEncoding_1_1};
 use crate::lazy::raw_value_ref::RawValueRef;
 use crate::lazy::span::Span;
@@ -178,7 +178,7 @@ impl<'top, E: TextEncoding<'top>> LazyRawValue<'top, E> for LazyRawTextValue<'to
         self.encoded_value.is_null()
     }
 
-    fn annotations(&self) -> <E as LazyDecoder>::AnnotationsIterator<'top> {
+    fn annotations(&self) -> <E as Decoder>::AnnotationsIterator<'top> {
         let range = self
             .encoded_value
             .annotations_range()

--- a/src/lazy/value.rs
+++ b/src/lazy/value.rs
@@ -1,4 +1,4 @@
-use crate::lazy::decoder::LazyDecoder;
+use crate::lazy::decoder::Decoder;
 use crate::lazy::encoding::BinaryEncoding_1_0;
 use crate::lazy::expanded::{ExpandedAnnotationsIterator, ExpandedValueRef, LazyExpandedValue};
 use crate::lazy::r#struct::LazyStruct;
@@ -55,13 +55,13 @@ use crate::{
 ///# fn main() -> IonResult<()> { Ok(()) }
 /// ```
 #[derive(Copy, Clone)]
-pub struct LazyValue<'top, D: LazyDecoder> {
+pub struct LazyValue<'top, D: Decoder> {
     pub(crate) expanded_value: LazyExpandedValue<'top, D>,
 }
 
 pub type LazyBinaryValue<'top> = LazyValue<'top, BinaryEncoding_1_0>;
 
-impl<'top, D: LazyDecoder> LazyValue<'top, D> {
+impl<'top, D: Decoder> LazyValue<'top, D> {
     pub(crate) fn new(expanded_value: LazyExpandedValue<'top, D>) -> LazyValue<'top, D> {
         LazyValue { expanded_value }
     }
@@ -273,7 +273,7 @@ impl<'top, D: LazyDecoder> LazyValue<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> TryFrom<LazyValue<'top, D>> for Element {
+impl<'top, D: Decoder> TryFrom<LazyValue<'top, D>> for Element {
     type Error = IonError;
 
     fn try_from(value: LazyValue<'top, D>) -> Result<Self, Self::Error> {
@@ -285,12 +285,12 @@ impl<'top, D: LazyDecoder> TryFrom<LazyValue<'top, D>> for Element {
 
 /// Iterates over a slice of bytes, lazily reading them as a sequence of symbol tokens encoded
 /// using the format described by generic type parameter `D`.
-pub struct AnnotationsIterator<'top, D: LazyDecoder> {
+pub struct AnnotationsIterator<'top, D: Decoder> {
     pub(crate) expanded_annotations: ExpandedAnnotationsIterator<'top, D>,
     pub(crate) symbol_table: &'top SymbolTable,
 }
 
-impl<'top, D: LazyDecoder> AnnotationsIterator<'top, D> {
+impl<'top, D: Decoder> AnnotationsIterator<'top, D> {
     /// Returns `Ok(true)` if this annotations iterator matches the provided sequence exactly, or
     /// `Ok(false)` if not. If a decoding error occurs while visiting and resolving each annotation,
     /// returns an `Err(IonError)`.
@@ -379,7 +379,7 @@ impl<'top, D: LazyDecoder> AnnotationsIterator<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> Iterator for AnnotationsIterator<'top, D> {
+impl<'top, D: Decoder> Iterator for AnnotationsIterator<'top, D> {
     type Item = IonResult<SymbolRef<'top>>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -397,7 +397,7 @@ impl<'top, D: LazyDecoder> Iterator for AnnotationsIterator<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> TryFrom<AnnotationsIterator<'top, D>> for Annotations {
+impl<'top, D: Decoder> TryFrom<AnnotationsIterator<'top, D>> for Annotations {
     type Error = IonError;
 
     fn try_from(iter: AnnotationsIterator<'top, D>) -> Result<Self, Self::Error> {

--- a/src/lazy/value_ref.rs
+++ b/src/lazy/value_ref.rs
@@ -1,6 +1,6 @@
 use crate::element::Value;
 use crate::lazy::bytes_ref::BytesRef;
-use crate::lazy::decoder::LazyDecoder;
+use crate::lazy::decoder::Decoder;
 use crate::lazy::r#struct::LazyStruct;
 use crate::lazy::sequence::{LazyList, LazySExp};
 use crate::lazy::str_ref::StrRef;
@@ -16,7 +16,7 @@ use std::fmt::{Debug, Formatter};
 /// to existing resources. Numeric values and timestamps are stored within the `ValueRef` itself.
 /// Text values and lobs hold references to either a slice of input data or text in the symbol table.
 #[derive(Copy, Clone)]
-pub enum ValueRef<'top, D: LazyDecoder> {
+pub enum ValueRef<'top, D: Decoder> {
     Null(IonType),
     Bool(bool),
     Int(Int),
@@ -32,7 +32,7 @@ pub enum ValueRef<'top, D: LazyDecoder> {
     Struct(LazyStruct<'top, D>),
 }
 
-impl<'top, D: LazyDecoder> PartialEq for ValueRef<'top, D> {
+impl<'top, D: Decoder> PartialEq for ValueRef<'top, D> {
     fn eq(&self, other: &Self) -> bool {
         use ValueRef::*;
         match (self, other) {
@@ -55,7 +55,7 @@ impl<'top, D: LazyDecoder> PartialEq for ValueRef<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> Debug for ValueRef<'top, D> {
+impl<'top, D: Decoder> Debug for ValueRef<'top, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use ValueRef::*;
         match self {
@@ -76,7 +76,7 @@ impl<'top, D: LazyDecoder> Debug for ValueRef<'top, D> {
     }
 }
 
-impl<'top, D: LazyDecoder> TryFrom<ValueRef<'top, D>> for Value {
+impl<'top, D: Decoder> TryFrom<ValueRef<'top, D>> for Value {
     type Error = IonError;
 
     fn try_from(value: ValueRef<'top, D>) -> Result<Self, Self::Error> {
@@ -100,7 +100,7 @@ impl<'top, D: LazyDecoder> TryFrom<ValueRef<'top, D>> for Value {
     }
 }
 
-impl<'top, D: LazyDecoder> TryFrom<ValueRef<'top, D>> for Element {
+impl<'top, D: Decoder> TryFrom<ValueRef<'top, D>> for Element {
     type Error = IonError;
 
     fn try_from(value_ref: ValueRef<'top, D>) -> Result<Self, Self::Error> {
@@ -109,7 +109,7 @@ impl<'top, D: LazyDecoder> TryFrom<ValueRef<'top, D>> for Element {
     }
 }
 
-impl<'top, D: LazyDecoder> ValueRef<'top, D> {
+impl<'top, D: Decoder> ValueRef<'top, D> {
     pub fn expect_null(self) -> IonResult<IonType> {
         if let ValueRef::Null(ion_type) = self {
             Ok(ion_type)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,8 +199,8 @@ macro_rules! v1_x_reader_writer {
         #[allow(unused_imports)]
         $visibility use crate::{
             lazy::streaming_raw_reader::{IonInput, IonSlice, IonStream},
-            lazy::decoder::LazyDecoder,
-            lazy::encoder::LazyEncoder,
+            lazy::decoder::Decoder,
+            lazy::encoder::Encoder,
             lazy::encoding::Encoding,
             lazy::encoder::annotate::Annotatable,
             lazy::encoder::write_as_ion::WriteAsIon,

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -19,7 +19,7 @@ where
     T: DeserializeOwned,
     I: IonInput,
 {
-    let mut reader = Reader::new(input);
+    let mut reader = Reader::new(input)?;
     let value = reader.expect_next()?;
     let value_deserializer = ValueDeserializer::new(&value);
     T::deserialize(value_deserializer)

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -7,7 +7,7 @@ use serde::{ser, Serialize};
 
 use crate::lazy::encoder::value_writer::internal::{FieldEncoder, MakeValueWriter};
 use crate::lazy::encoder::value_writer::{SequenceWriter, StructWriter, ValueWriter};
-use crate::lazy::encoder::writer::IonWriter;
+use crate::lazy::encoder::writer::Writer;
 use crate::lazy::encoding::{BinaryEncoding_1_0, Encoding, TextEncoding_1_0};
 use crate::result::IonFailure;
 use crate::serde::decimal::TUNNELED_DECIMAL_TYPE_NAME;
@@ -19,7 +19,7 @@ use crate::{Decimal, IonError, IonResult, IonType, TextFormat, Timestamp};
 
 pub fn write_to<T: Serialize, E: Encoding, O: Write>(
     value: &T,
-    writer: &mut IonWriter<E, O>,
+    writer: &mut Writer<E, O>,
 ) -> IonResult<()> {
     let serializer = ValueSerializer::new(writer.value_writer());
     value.serialize(serializer)
@@ -29,7 +29,7 @@ fn write_with_config<T: Serialize, E: Encoding>(
     value: &T,
     config: WriteConfig<E>,
 ) -> IonResult<Vec<u8>> {
-    let mut writer = IonWriter::with_config(config, vec![])?;
+    let mut writer = Writer::with_config(config, vec![])?;
     write_to(value, &mut writer)?;
     writer.close()
 }

--- a/src/write_config.rs
+++ b/src/write_config.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 
 use crate::lazy::encoder::value_writer::SequenceWriter;
 use crate::lazy::encoder::write_as_ion::WriteAsIon;
-use crate::lazy::encoder::writer::IonWriter;
+use crate::lazy::encoder::writer::Writer;
 use crate::lazy::encoder::LazyRawWriter;
 use crate::lazy::encoding::{
     BinaryEncoding_1_0, BinaryEncoding_1_1, Encoding, OutputFromBytes, TextEncoding_1_0,
@@ -38,7 +38,7 @@ impl<E: Encoding> WriteConfig<E> {
         value: V,
         output: W,
     ) -> IonResult<W> {
-        let mut writer = IonWriter::with_config(self.clone(), output)?;
+        let mut writer = Writer::with_config(self.clone(), output)?;
         writer.write(value)?;
         writer.close()
     }
@@ -48,21 +48,21 @@ impl<E: Encoding> WriteConfig<E> {
         output: W,
         values: I,
     ) -> IonResult<W> {
-        let mut writer = IonWriter::with_config(self.clone(), output)?;
+        let mut writer = Writer::with_config(self.clone(), output)?;
         writer.write_all(values)?;
         writer.close()
     }
 
     #[cfg(feature = "experimental-reader-writer")]
-    pub fn build_writer<W: io::Write>(self, output: W) -> IonResult<IonWriter<E, W>> {
-        IonWriter::with_config(self, output)
+    pub fn build_writer<W: io::Write>(self, output: W) -> IonResult<Writer<E, W>> {
+        Writer::with_config(self, output)
     }
 
     // When the experimental-reader-writer feature is disabled, this method is `pub(crate)` instead
     // of `pub`
     #[cfg(not(feature = "experimental-reader-writer"))]
-    pub(crate) fn build_writer<W: io::Write>(self, output: W) -> IonResult<IonWriter<E, W>> {
-        IonWriter::with_config(self, output)
+    pub(crate) fn build_writer<W: io::Write>(self, output: W) -> IonResult<Writer<E, W>> {
+        Writer::with_config(self, output)
     }
 
     #[cfg(feature = "experimental-tooling-apis")]

--- a/tests/ion_hash_tests.rs
+++ b/tests/ion_hash_tests.rs
@@ -122,7 +122,7 @@ fn ion_hash_tests() -> IonHashTestResult<()> {
 
 fn test_file(file_name: &str) -> IonHashTestResult<()> {
     let data = read(file_name).map_err(IonError::from)?;
-    let mut reader = Reader::new(data);
+    let mut reader = Reader::new(data)?;
     let mut elems = Vec::new();
     while let Some(value) = reader.next()? {
         // Similar logic to skip test cases with a name on the skip list also appears in the

--- a/tests/ion_tests/mod.rs
+++ b/tests/ion_tests/mod.rs
@@ -7,7 +7,7 @@ use std::fs::read;
 use std::path::MAIN_SEPARATOR as PATH_SEPARATOR;
 
 use ion_rs::lazy::encoder::value_writer::SequenceWriter;
-use ion_rs::lazy::encoder::writer::IonWriter;
+use ion_rs::lazy::encoder::writer::Writer;
 use ion_rs::lazy::encoding::{BinaryEncoding_1_0, TextEncoding_1_0};
 use ion_rs::WriteConfig;
 use ion_rs::{
@@ -52,7 +52,7 @@ pub fn serialize(format: Format, elements: &Sequence) -> IonResult<Vec<u8>> {
     match format {
         Format::Text(kind) => {
             let write_config = WriteConfig::<TextEncoding_1_0>::new(kind);
-            let mut writer = IonWriter::with_config(write_config, buffer)?;
+            let mut writer = Writer::with_config(write_config, buffer)?;
             writer.write_elements(elements)?;
             buffer = writer.close()?;
             println!(
@@ -61,7 +61,7 @@ pub fn serialize(format: Format, elements: &Sequence) -> IonResult<Vec<u8>> {
             );
         }
         Format::Binary => {
-            let mut binary_writer = IonWriter::<BinaryEncoding_1_0, _>::new(buffer)?;
+            let mut binary_writer = Writer::<BinaryEncoding_1_0, _>::new(buffer)?;
             binary_writer.write_elements(elements)?;
             buffer = binary_writer.close()?;
         }


### PR DESCRIPTION
This PR includes a handful of cleanup changes I'd like to get in before cutting an RC4 release.

* 4d931f5c8e922cb4ed9c8d880800be2fa81ffc1c Removes our dev dependency on `memmap` now that we have a streaming reader. Also removes the word `Lazy` from the `LazyDecoder` and `LazyEncoder` trait names.
* 41f1d67a4bf5e5fb60856fd8117443360d9797aa Fixes a panic that would happen if the input buffer ended in the middle of an annotations sequence.
* 1396aff7756be88975da2131ae0325629a66b833 Updates the `write_many_structs` benchmark to use the latest APIs.
* 0caf5b98f888caa695d62c75b62d231e8a5620d3 Updates the `README.md` and makes `Text.with_format(...)` public.
* d54664f34320a18f0faf49c033445a0e148eacb6 Fixes a tooling API bug that caused the `opcode_span` to return bytes from the annotations sequence instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
