### PR TITLE
`Writer::new()` takes an `impl Into<WriteConfig>`

### DIFF
--- a/src/binary/decimal.rs
+++ b/src/binary/decimal.rs
@@ -151,8 +151,7 @@ mod binary_decimal_tests {
     #[case::foo(Decimal::new(i128::MIN, i32::MIN))]
     #[case::foo(Decimal::new(i128::MIN + 1, i32::MIN))]
     fn roundtrip_decimals_with_extreme_values(#[case] value: Decimal) -> IonResult<()> {
-        let mut writer =
-            Writer::with_config(BinaryEncoding_1_0::default_write_config(), Vec::new())?;
+        let mut writer = Writer::new(BinaryEncoding_1_0::default_write_config(), Vec::new())?;
         writer.write(value)?;
         let output = writer.close()?;
         let mut reader = Reader::new(output)?;

--- a/src/lazy/binary/test_utilities.rs
+++ b/src/lazy/binary/test_utilities.rs
@@ -8,7 +8,7 @@ use crate::IonResult;
 pub fn to_binary_ion(text_ion: &str) -> IonResult<Vec<u8>> {
     let buffer = Vec::new();
     let config = WriteConfig::<BinaryEncoding_1_0>::new();
-    let mut writer = Writer::with_config(config, buffer)?;
+    let mut writer = Writer::new(config, buffer)?;
     let elements = Element::read_all(text_ion)?;
     for element in &elements {
         writer.write(element)?;

--- a/src/lazy/encoder/annotate.rs
+++ b/src/lazy/encoder/annotate.rs
@@ -18,11 +18,10 @@ pub trait Annotatable {
     ///# use ion_rs::IonResult;
     ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
-    /// use ion_rs::{Annotatable, Element, IonData};
-    /// use ion_rs::v1_0::TextWriter;
+    /// use ion_rs::{Annotatable, Element, IonData, Writer, v1_0::Text};
     ///
     /// let mut buffer = vec![];
-    /// let mut writer = TextWriter::new(&mut buffer)?;
+    /// let mut writer = Writer::new(Text, &mut buffer)?;
     ///
     /// writer.write(42_usize.annotated_with(["foo", "bar", "baz"]))?.flush()?;
     ///

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -59,13 +59,9 @@ pub type TextWriter_1_1<Output> = Writer<TextEncoding_1_1, Output>;
 pub type BinaryWriter_1_1<Output> = Writer<BinaryEncoding_1_1, Output>;
 
 impl<E: Encoding, Output: Write> Writer<E, Output> {
-    /// Constructs a writer for the requested encoding using its default configuration.
-    pub fn new(output: Output) -> IonResult<Self> {
-        Self::with_config(E::default_write_config(), output)
-    }
-
     /// Constructs a writer for the requested encoding using the provided configuration.
-    pub fn with_config(config: WriteConfig<E>, output: Output) -> IonResult<Self> {
+    pub fn new(config: impl Into<WriteConfig<E>>, output: Output) -> IonResult<Self> {
+        let config = config.into();
         let directive_writer = E::Writer::build(config.clone(), vec![])?;
         let mut data_writer = E::Writer::build(config, vec![])?;
         // Erase the IVM that's created by default

--- a/src/lazy/reader.rs
+++ b/src/lazy/reader.rs
@@ -205,7 +205,7 @@ mod tests {
     fn to_binary_ion(text_ion: &str) -> IonResult<Vec<u8>> {
         let buffer = Vec::new();
         let config = WriteConfig::<BinaryEncoding_1_0>::new();
-        let mut writer = Writer::with_config(config, buffer)?;
+        let mut writer = Writer::new(config, buffer)?;
         let elements = Element::read_all(text_ion)?;
         writer.write_elements(&elements)?;
         writer.flush()?;

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -29,7 +29,7 @@ fn write_with_config<T: Serialize, E: Encoding>(
     value: &T,
     config: WriteConfig<E>,
 ) -> IonResult<Vec<u8>> {
-    let mut writer = Writer::with_config(config, vec![])?;
+    let mut writer = Writer::new(config, vec![])?;
     write_to(value, &mut writer)?;
     writer.close()
 }

--- a/src/write_config.rs
+++ b/src/write_config.rs
@@ -38,7 +38,7 @@ impl<E: Encoding> WriteConfig<E> {
         value: V,
         output: W,
     ) -> IonResult<W> {
-        let mut writer = Writer::with_config(self.clone(), output)?;
+        let mut writer = Writer::new(self.clone(), output)?;
         writer.write(value)?;
         writer.close()
     }
@@ -48,21 +48,21 @@ impl<E: Encoding> WriteConfig<E> {
         output: W,
         values: I,
     ) -> IonResult<W> {
-        let mut writer = Writer::with_config(self.clone(), output)?;
+        let mut writer = Writer::new(self.clone(), output)?;
         writer.write_all(values)?;
         writer.close()
     }
 
     #[cfg(feature = "experimental-reader-writer")]
     pub fn build_writer<W: io::Write>(self, output: W) -> IonResult<Writer<E, W>> {
-        Writer::with_config(self, output)
+        Writer::new(self, output)
     }
 
     // When the experimental-reader-writer feature is disabled, this method is `pub(crate)` instead
     // of `pub`
     #[cfg(not(feature = "experimental-reader-writer"))]
     pub(crate) fn build_writer<W: io::Write>(self, output: W) -> IonResult<Writer<E, W>> {
-        Writer::with_config(self, output)
+        Writer::new(self, output)
     }
 
     #[cfg(feature = "experimental-tooling-apis")]

--- a/tests/ion_tests/mod.rs
+++ b/tests/ion_tests/mod.rs
@@ -52,7 +52,7 @@ pub fn serialize(format: Format, elements: &Sequence) -> IonResult<Vec<u8>> {
     match format {
         Format::Text(kind) => {
             let write_config = WriteConfig::<TextEncoding_1_0>::new(kind);
-            let mut writer = Writer::with_config(write_config, buffer)?;
+            let mut writer = Writer::new(write_config, buffer)?;
             writer.write_elements(elements)?;
             buffer = writer.close()?;
             println!(


### PR DESCRIPTION
Consolidates the `Writer::new()` and `Writer::with_config() methods into a single `new` method that accepts an `impl Into<WriteConfig>`. This allows users to create a writer via code like:

```rust
let mut writer = Writer::new(v1_0::Binary, Vec::new())?;
let mut writer = Writer::new(v1_0::Text.with_format(TextFormat::Pretty), Vec::new())?;
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
