### PR TITLE
Restores shared symbol table import functionality

### DIFF
--- a/examples/read_all_values.rs
+++ b/examples/read_all_values.rs
@@ -16,7 +16,7 @@ mod lazy_reader_example {
     use std::fs::File;
     use std::process::exit;
 
-    use ion_rs::{Decoder, IonResult, LazyStruct, LazyValue, Reader, ValueRef};
+    use ion_rs::{AnyEncoding, Decoder, IonResult, LazyStruct, LazyValue, Reader, ValueRef};
 
     pub fn read_all_values() -> IonResult<()> {
         let args: Vec<String> = std::env::args().collect();
@@ -27,7 +27,7 @@ mod lazy_reader_example {
         });
 
         let file = File::open(path).unwrap();
-        let mut reader = Reader::new(file)?;
+        let mut reader = Reader::new(AnyEncoding, file)?;
         // We're going to recursively visit and read every value in the input stream, counting
         // them as we go.
         let mut count = 0;

--- a/src/binary/decimal.rs
+++ b/src/binary/decimal.rs
@@ -107,6 +107,7 @@ where
 
 #[cfg(test)]
 mod binary_decimal_tests {
+    use crate::lazy::any_encoding::AnyEncoding;
     use crate::lazy::encoder::writer::Writer;
     use crate::lazy::encoding::{BinaryEncoding_1_0, Encoding};
     use crate::lazy::reader::Reader;
@@ -154,7 +155,7 @@ mod binary_decimal_tests {
         let mut writer = Writer::new(BinaryEncoding_1_0::default_write_config(), Vec::new())?;
         writer.write(value)?;
         let output = writer.close()?;
-        let mut reader = Reader::new(output)?;
+        let mut reader = Reader::new(AnyEncoding, output)?;
         let after_round_trip = reader.expect_next()?.read()?.expect_decimal()?;
         assert_eq!(value, after_round_trip);
         Ok(())

--- a/src/binary/timestamp.rs
+++ b/src/binary/timestamp.rs
@@ -131,6 +131,7 @@ where
 #[cfg(test)]
 mod binary_timestamp_tests {
     use super::*;
+    use crate::lazy::any_encoding::AnyEncoding;
     use crate::lazy::reader::Reader;
     use rstest::*;
 
@@ -147,7 +148,7 @@ mod binary_timestamp_tests {
         #[case] input: &str,
         #[case] expected: usize,
     ) -> IonResult<()> {
-        let mut reader = Reader::new(input)?;
+        let mut reader = Reader::new(AnyEncoding, input)?;
         let timestamp = reader.expect_next()?.read()?.expect_timestamp()?;
         let mut buf = vec![];
         let written = buf.encode_timestamp_value(&timestamp)?;

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -68,7 +68,7 @@ impl MapCatalog {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct EmptyCatalog {}
+pub struct EmptyCatalog;
 
 impl Catalog for EmptyCatalog {
     fn get_table(&self, _name: &str) -> Option<&SharedSymbolTable> {

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -25,6 +25,7 @@ use crate::{Blob, Bytes, Clob, List, SExp, Struct};
 use crate::element::builders::{SequenceBuilder, StructBuilder};
 use crate::element::reader::ElementReader;
 use crate::ion_data::{IonEq, IonOrd};
+use crate::lazy::any_encoding::AnyEncoding;
 use crate::lazy::encoding::Encoding;
 use crate::lazy::reader::Reader;
 use crate::lazy::streaming_raw_reader::{IonInput, IonSlice};
@@ -653,14 +654,14 @@ impl Element {
     /// If the data source has at least one value, returns `Ok(Some(Element))`.
     /// If the data source has invalid data, returns `Err`.
     pub fn read_first<A: AsRef<[u8]>>(data: A) -> IonResult<Option<Element>> {
-        let mut reader = Reader::new(IonSlice::new(data))?;
+        let mut reader = Reader::new(AnyEncoding, IonSlice::new(data))?;
         reader.read_next_element()
     }
 
     /// Reads a single Ion [`Element`] from the provided data source. If the input has invalid
     /// data or does not contain at exactly one Ion value, returns `Err(IonError)`.
     pub fn read_one<A: AsRef<[u8]>>(data: A) -> IonResult<Element> {
-        let mut reader = Reader::new(IonSlice::new(data))?;
+        let mut reader = Reader::new(AnyEncoding, IonSlice::new(data))?;
         reader.read_one_element()
     }
 
@@ -669,7 +670,7 @@ impl Element {
     /// If the input has valid data, returns `Ok(Sequence)`.
     /// If the input has invalid data, returns `Err(IonError)`.
     pub fn read_all<A: AsRef<[u8]>>(data: A) -> IonResult<Sequence> {
-        Ok(Reader::new(IonSlice::new(data))?
+        Ok(Reader::new(AnyEncoding, IonSlice::new(data))?
             .into_elements()
             .collect::<IonResult<Vec<_>>>()?
             .into())
@@ -681,7 +682,7 @@ impl Element {
     pub fn iter<'a, I: IonInput + 'a>(
         source: I,
     ) -> IonResult<impl Iterator<Item = IonResult<Element>> + 'a> {
-        Ok(Reader::new(source)?.into_elements())
+        Ok(Reader::new(AnyEncoding, source)?.into_elements())
     }
 
     /// Encodes this element as an Ion stream with itself as the only top-level value.

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -8,8 +8,9 @@ use crate::lazy::expanded::macro_evaluator::RawEExpression;
 use crate::lazy::raw_stream_item::LazyRawStreamItem;
 use crate::lazy::raw_value_ref::RawValueRef;
 use crate::lazy::span::Span;
+use crate::read_config::ReadConfig;
 use crate::result::IonFailure;
-use crate::{IonResult, IonType, RawSymbolRef};
+use crate::{Catalog, IonResult, IonType, RawSymbolRef};
 
 pub trait HasSpan<'top>: HasRange {
     fn span(&self) -> Span<'top>;
@@ -52,6 +53,10 @@ pub trait Decoder: 'static + Sized + Debug + Clone + Copy {
     type EExp<'top>: RawEExpression<'top, Self>;
 
     type VersionMarker<'top>: RawVersionMarker<'top>;
+
+    fn with_catalog(self, catalog: impl Catalog + 'static) -> ReadConfig<Self> {
+        ReadConfig::new_with_catalog(self, catalog)
+    }
 }
 
 pub trait RawVersionMarker<'top>: Debug + Copy + Clone + HasSpan<'top> {
@@ -61,7 +66,6 @@ pub trait RawVersionMarker<'top>: Debug + Copy + Clone + HasSpan<'top> {
     fn minor(&self) -> u8 {
         self.version().1
     }
-
     fn version(&self) -> (u8, u8);
 }
 

--- a/src/lazy/encoder/text/v1_1/writer.rs
+++ b/src/lazy/encoder/text/v1_1/writer.rs
@@ -100,11 +100,11 @@ mod tests {
     use crate::lazy::encoder::write_as_ion::WriteAsSExp;
     use crate::lazy::encoder::LazyRawWriter;
     use crate::lazy::expanded::macro_evaluator::RawEExpression;
-    use crate::lazy::reader::TextReader_1_1;
     use crate::lazy::text::raw::v1_1::reader::{LazyRawTextReader_1_1, MacroIdRef};
     use crate::symbol_ref::AsSymbolRef;
     use crate::{
-        Decimal, ElementReader, IonData, IonResult, IonType, Null, RawSymbolRef, Timestamp,
+        v1_1, Decimal, ElementReader, IonData, IonResult, IonType, Null, RawSymbolRef, Reader,
+        Timestamp,
     };
 
     #[test]
@@ -139,10 +139,10 @@ mod tests {
             {{"\xea\x01\x01\xee"}}
         "#;
 
-        let mut reader = TextReader_1_1::new(encoded_text)?;
+        let mut reader = Reader::new(v1_1::Text, encoded_text)?;
         let actual = reader.read_all_elements()?;
 
-        let mut reader = TextReader_1_1::new(expected_ion)?;
+        let mut reader = Reader::new(v1_1::Text, expected_ion)?;
         let expected = reader.read_all_elements()?;
 
         assert!(IonData::eq(&expected, &actual));
@@ -162,16 +162,17 @@ mod tests {
         let encoded_text = String::from_utf8(encoded_bytes).unwrap();
         println!("{encoded_text}");
         let expected_ion = r#"
+            $ion_1_1
             []
             [1]
             [1, 2]
             [[1, 2], [3, 4], [5, 6]]
         "#;
 
-        let mut reader = TextReader_1_1::new(encoded_text)?;
+        let mut reader = Reader::new(v1_1::Text, encoded_text)?;
         let actual = reader.read_all_elements()?;
 
-        let mut reader = TextReader_1_1::new(expected_ion)?;
+        let mut reader = Reader::new(v1_1::Text, expected_ion)?;
         let expected = reader.read_all_elements()?;
 
         assert!(IonData::eq(&expected, &actual));
@@ -191,16 +192,17 @@ mod tests {
         let encoded_text = String::from_utf8(encoded_bytes).unwrap();
         println!("{encoded_text}");
         let expected_ion = r#"
+            $ion_1_1
             ()
             (1)
             (1 2)
             ((1 2) (3 4) (5 6))
         "#;
 
-        let mut reader = TextReader_1_1::new(encoded_text)?;
+        let mut reader = Reader::new(v1_1::Text, encoded_text)?;
         let actual = reader.read_all_elements()?;
 
-        let mut reader = TextReader_1_1::new(expected_ion)?;
+        let mut reader = Reader::new(v1_1::Text, expected_ion)?;
         let expected = reader.read_all_elements()?;
 
         assert!(IonData::eq(&expected, &actual));
@@ -227,6 +229,7 @@ mod tests {
         let encoded_text = String::from_utf8(encoded_bytes).unwrap();
         println!("{encoded_text}");
         let expected_ion = r#"
+            $ion_1_1
             {}
             {foo: 1}
             {foo: 1, bar: 2}
@@ -234,10 +237,10 @@ mod tests {
             {quux: {quuz: 4}}
         "#;
 
-        let mut reader = TextReader_1_1::new(encoded_text)?;
+        let mut reader = Reader::new(v1_1::Text, encoded_text)?;
         let actual = reader.read_all_elements()?;
 
-        let mut reader = TextReader_1_1::new(expected_ion)?;
+        let mut reader = Reader::new(v1_1::Text, expected_ion)?;
         let expected = reader.read_all_elements()?;
 
         assert!(IonData::eq(&expected, &actual));

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -232,7 +232,7 @@ impl<'value, V: ValueWriter> AnnotatableWriter for ApplicationValueWriter<'value
                     } else {
                         // ...that we need to add to the symbol table.
                         self.encoding.num_pending_symbols += 1;
-                        self.symbol_table().add_symbol(text)
+                        self.symbol_table().add_symbol_for_text(text)
                     }
                 }
             };
@@ -298,7 +298,7 @@ impl<'value, V: ValueWriter> ValueWriter for ApplicationValueWriter<'value, V> {
             // call to `flush()`. Use the new ID.
             None => {
                 self.encoding.num_pending_symbols += 1;
-                self.symbol_table().add_symbol(text)
+                self.symbol_table().add_symbol_for_text(text)
             }
         };
 
@@ -393,7 +393,7 @@ impl<'value, V: ValueWriter> FieldEncoder for ApplicationStructWriter<'value, V>
             // call to `flush()`. Use the new ID.
             None => {
                 self.encoding.num_pending_symbols += 1;
-                self.encoding.symbol_table.add_symbol(text)
+                self.encoding.symbol_table.add_symbol_for_text(text)
             }
         };
 

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -11,13 +11,12 @@ use crate::lazy::expanded::template::{
 };
 use crate::lazy::expanded::EncodingContextRef;
 use crate::lazy::r#struct::LazyStruct;
-use crate::lazy::reader::TextReader_1_1;
 use crate::lazy::sequence::{LazyList, LazySExp};
 use crate::lazy::value::LazyValue;
 use crate::lazy::value_ref::ValueRef;
 use crate::result::IonFailure;
 use crate::symbol_ref::AsSymbolRef;
-use crate::{IonError, IonResult, IonType, SymbolRef};
+use crate::{v1_1, IonError, IonResult, IonType, Reader, SymbolRef};
 
 /// Validates a given TDL expression and compiles it into a [`TemplateMacro`] that can be added
 /// to a [`MacroTable`](crate::lazy::expanded::macro_table::MacroTable).
@@ -66,7 +65,7 @@ impl TemplateCompiler {
     ) -> IonResult<TemplateMacro> {
         // TODO: This is a rudimentary implementation that panics instead of performing thorough
         //       validation. Where it does surface errors, the messages are too terse.
-        let mut reader = TextReader_1_1::new(expression.as_bytes())?;
+        let mut reader = Reader::new(v1_1::Text, expression.as_bytes())?;
         let invocation = reader.expect_next()?.read()?.expect_sexp()?;
         let mut values = invocation.iter();
 

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -706,16 +706,15 @@ impl<'top> TemplateExpansion<'top> {
 
 #[cfg(test)]
 mod tests {
-    use crate::lazy::reader::TextReader_1_1;
-    use crate::{ElementReader, IonResult};
+    use crate::{v1_1, ElementReader, IonResult, Reader};
 
     /// Reads `input` and `expected` using an expanding reader and asserts that their output
     /// is the same.
     fn eval_enc_expr<'data>(input: &'data str, expected: &'data str) -> IonResult<()> {
-        let mut actual_reader = TextReader_1_1::new(input.as_bytes())?;
+        let mut actual_reader = Reader::new(v1_1::Text, input.as_bytes())?;
         let actual = actual_reader.read_all_elements()?;
 
-        let mut expected_reader = TextReader_1_1::new(expected.as_bytes())?;
+        let mut expected_reader = Reader::new(v1_1::Text, expected.as_bytes())?;
         // For the moment, this is using the old reader impl.
         let expected = expected_reader.read_all_elements()?;
 
@@ -738,10 +737,10 @@ mod tests {
         invocation: &str,
         expected: &str,
     ) -> IonResult<()> {
-        let mut reader = TextReader_1_1::new(invocation.as_bytes())?;
+        let mut reader = Reader::new(v1_1::Text, invocation.as_bytes())?;
         let _macro_address = reader.register_template(template_definition)?;
         let actual = reader.read_all_elements()?;
-        let mut expected_reader = TextReader_1_1::new(expected.as_bytes())?;
+        let mut expected_reader = Reader::new(v1_1::Text, expected.as_bytes())?;
         let expected = expected_reader.read_all_elements()?;
         assert_eq!(actual, expected);
         assert!(matches!(expected_reader.next(), Ok(None)));

--- a/src/lazy/reader.rs
+++ b/src/lazy/reader.rs
@@ -181,6 +181,7 @@ mod tests {
     use crate::lazy::value_ref::ValueRef;
     use crate::write_config::WriteConfig;
     use crate::{ion_list, ion_sexp, ion_struct, Int, IonResult, IonType, v1_0};
+    use crate::lazy::encoding::BinaryEncoding_1_0;
 
     use super::*;
 

--- a/src/lazy/sequence.rs
+++ b/src/lazy/sequence.rs
@@ -20,13 +20,13 @@ use crate::{IonError, IonResult};
 ///# fn main() -> IonResult<()> {
 ///
 /// // Construct an Element and serialize it as binary Ion.
-/// use ion_rs::{Element, ion_list};
-/// use ion_rs::v1_0::{Binary, BinaryReader};
+/// use ion_rs::{Element, ion_list, Reader};
+/// use ion_rs::v1_0::Binary;
 ///
 /// let element: Element = ion_list! [10, 20, 30].into();
 /// let binary_ion = element.encode_as(Binary)?;
 ///
-/// let mut lazy_reader = BinaryReader::new(binary_ion)?;
+/// let mut lazy_reader = Reader::new(Binary, binary_ion)?;
 ///
 /// // Get the first value from the stream and confirm that it's a list.
 /// let lazy_list = lazy_reader.expect_next()?.read()?.expect_list()?;
@@ -85,13 +85,13 @@ impl<'top, D: Decoder> LazyList<'top, D> {
     ///# fn main() -> IonResult<()> {
     ///
     /// // Construct an Element and serialize it as binary Ion.
-    /// use ion_rs::{ion_sexp, Element, IntoAnnotatedElement};
-    /// use ion_rs::v1_0::{Binary, BinaryReader};
+    /// use ion_rs::{ion_sexp, Element, IntoAnnotatedElement, Reader};
+    /// use ion_rs::v1_0::Binary;
     ///
     /// let element: Element = ion_sexp!(true false).with_annotations(["foo", "bar", "baz"]);
     /// let binary_ion = element.encode_as(Binary)?;
     ///
-    /// let mut lazy_reader = BinaryReader::new(binary_ion)?;
+    /// let mut lazy_reader = Reader::new(Binary, binary_ion)?;
     ///
     /// // Get the first lazy value from the stream.
     /// let lazy_sexp = lazy_reader.expect_next()?.read()?.expect_sexp()?;
@@ -219,13 +219,13 @@ impl<'top, D: Decoder> LazySExp<'top, D> {
     ///# fn main() -> IonResult<()> {
     ///
     /// // Construct an Element and serialize it as binary Ion.
-    /// use ion_rs::{ion_sexp, Element, IntoAnnotatedElement};
-    /// use ion_rs::v1_0::{Binary, BinaryReader};
+    /// use ion_rs::{ion_sexp, Element, IntoAnnotatedElement, Reader};
+    /// use ion_rs::v1_0::Binary;
     ///
     /// let element: Element = ion_sexp!(true false).with_annotations(["foo", "bar", "baz"]);
     /// let binary_ion = element.encode_as(Binary)?;
     ///
-    /// let mut lazy_reader = BinaryReader::new(binary_ion)?;
+    /// let mut lazy_reader = Reader::new(Binary, binary_ion)?;
     ///
     /// // Get the first lazy value from the stream.
     /// let lazy_sexp = lazy_reader.expect_next()?.read()?.expect_sexp()?;
@@ -305,13 +305,12 @@ impl<'top, D: Decoder> Iterator for SExpIterator<'top, D> {
 mod tests {
     use crate::element::Element;
     use crate::lazy::binary::test_utilities::to_binary_ion;
-    use crate::lazy::reader::BinaryReader_1_0;
-    use crate::IonResult;
+    use crate::{v1_0, IonResult, Reader};
 
     #[test]
     fn annotations() -> IonResult<()> {
         let binary_ion = to_binary_ion("foo::bar::baz::[1, 2, 3]")?;
-        let mut reader = BinaryReader_1_0::new(binary_ion)?;
+        let mut reader = Reader::new(v1_0::Binary, binary_ion)?;
         let list = reader.expect_next()?.read()?.expect_list()?;
         assert!(list.annotations().are(["foo", "bar", "baz"])?);
         list.annotations().expect(["foo", "bar", "baz"])?;
@@ -322,7 +321,7 @@ mod tests {
     fn try_into_element() -> IonResult<()> {
         let ion_text = "foo::baz::baz::[1, 2, 3]";
         let binary_ion = to_binary_ion(ion_text)?;
-        let mut reader = BinaryReader_1_0::new(binary_ion)?;
+        let mut reader = Reader::new(v1_0::Binary, binary_ion)?;
         let list = reader.expect_next()?.read()?.expect_list()?;
         let result: IonResult<Element> = list.try_into();
         assert!(result.is_ok());

--- a/src/lazy/struct.rs
+++ b/src/lazy/struct.rs
@@ -23,12 +23,12 @@ use crate::{Annotations, Element, IntoAnnotatedElement, IonError, IonResult, Str
 ///# use ion_rs::IonResult;
 ///# #[cfg(feature = "experimental-reader-writer")]
 ///# fn main() -> IonResult<()> {
-/// use ion_rs::Element;
-/// use ion_rs::v1_0::{Binary, BinaryReader};
+/// use ion_rs::{Element, Reader};
+/// use ion_rs::v1_0::Binary;
 ///
 /// let ion_data = r#"{foo: 1, bar: 2, foo: 3, bar: 4}"#;
 /// let ion_bytes: Vec<u8> = Element::read_one(ion_data)?.encode_as(Binary)?;
-/// let mut reader = BinaryReader::new(ion_bytes)?;
+/// let mut reader = Reader::new(Binary, ion_bytes)?;
 ///
 /// // Advance the reader to the first value and confirm it's a struct
 /// let lazy_struct = reader.expect_next()?.read()?.expect_struct()?;
@@ -118,12 +118,12 @@ impl<'top, D: Decoder> LazyStruct<'top, D> {
     ///# use ion_rs::IonResult;
     ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
-    /// use ion_rs::{Element, ValueRef};
-    /// use ion_rs::v1_0::{Binary, BinaryReader};
+    /// use ion_rs::{Element, ValueRef, Reader};
+    /// use ion_rs::v1_0::Binary;
     ///
     /// let ion_data = r#"{foo: "hello", bar: quux::5, baz: null, bar: false}"#;
     /// let ion_bytes: Vec<u8> = Element::read_one(ion_data)?.encode_as(Binary)?;
-    /// let mut reader = BinaryReader::new(ion_bytes)?;
+    /// let mut reader = Reader::new(Binary, ion_bytes)?;
     ///
     /// let lazy_struct = reader.expect_next()?.read()?.expect_struct()?;
     ///
@@ -155,12 +155,12 @@ impl<'top, D: Decoder> LazyStruct<'top, D> {
     ///# use ion_rs::IonResult;
     ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
-    /// use ion_rs::Element;
-    /// use ion_rs::v1_0::{Binary, BinaryReader};
+    /// use ion_rs::{Element, Reader};
+    /// use ion_rs::v1_0::Binary;
     ///
     /// let ion_data = r#"{foo: "hello", bar: quux::5, baz: null, bar: false}"#;
     /// let ion_bytes: Vec<u8> = Element::read_one(ion_data)?.encode_as(Binary)?;
-    /// let mut reader = BinaryReader::new(ion_bytes)?;
+    /// let mut reader = Reader::new(Binary, ion_bytes)?;
     ///
     /// let lazy_struct = reader.expect_next()?.read()?.expect_struct()?;
     ///
@@ -183,12 +183,12 @@ impl<'top, D: Decoder> LazyStruct<'top, D> {
     ///# use ion_rs::IonResult;
     ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
-    /// use ion_rs::{Element, IonType, ValueRef};
-    /// use ion_rs::v1_0::{Binary, BinaryReader};
+    /// use ion_rs::{Element, IonType, ValueRef, Reader};
+    /// use ion_rs::v1_0::Binary;
     ///
     /// let ion_data = r#"{foo: "hello", bar: null.list, baz: 3, bar: 4}"#;
     /// let ion_bytes = Element::read_one(ion_data)?.encode_as(Binary)?;
-    /// let mut reader = BinaryReader::new(ion_bytes)?;
+    /// let mut reader = Reader::new(Binary, ion_bytes)?;
     ///
     /// let lazy_struct = reader.expect_next()?.read()?.expect_struct()?;
     ///
@@ -210,12 +210,12 @@ impl<'top, D: Decoder> LazyStruct<'top, D> {
     ///# use ion_rs::IonResult;
     ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
-    /// use ion_rs::{Element, ValueRef};
-    /// use ion_rs::v1_0::{Binary, BinaryReader};
+    /// use ion_rs::{Element, ValueRef, Reader};
+    /// use ion_rs::v1_0::Binary;
     ///
     /// let ion_data = r#"{foo: "hello", bar: null.list, baz: 3, bar: 4}"#;
     /// let ion_bytes = Element::read_one(ion_data)?.encode_as(Binary)?;
-    /// let mut reader = BinaryReader::new(ion_bytes)?;
+    /// let mut reader = Reader::new(Binary, ion_bytes)?;
     ///
     /// let lazy_struct = reader.expect_next()?.read()?.expect_struct()?;
     ///
@@ -241,14 +241,14 @@ impl<'top, D: Decoder> LazyStruct<'top, D> {
     ///# fn main() -> IonResult<()> {
     ///
     /// // Construct an Element and serialize it as binary Ion.
-    /// use ion_rs::{Element, IntoAnnotatedElement};
+    /// use ion_rs::{Element, IntoAnnotatedElement, Reader};
     /// use ion_rs::ion_struct;
-    /// use ion_rs::v1_0::{Binary, BinaryReader};
+    /// use ion_rs::v1_0::Binary;
     ///
     /// let element: Element = ion_struct! {"foo": 1, "bar": 2}.with_annotations(["foo", "bar", "baz"]);
     /// let binary_ion = element.encode_as(Binary)?;
     ///
-    /// let mut lazy_reader = BinaryReader::new(binary_ion)?;
+    /// let mut lazy_reader = Reader::new(Binary, binary_ion)?;
     ///
     /// // Get the first lazy value from the stream.
     /// let lazy_struct = lazy_reader.expect_next()?.read()?.expect_struct()?;
@@ -362,14 +362,14 @@ impl<'a, 'top, 'data: 'top, D: Decoder> IntoIterator for &'a LazyStruct<'top, D>
 #[cfg(test)]
 mod tests {
     use crate::lazy::binary::test_utilities::to_binary_ion;
-    use crate::lazy::reader::BinaryReader_1_0;
+    use crate::{v1_0, Reader};
 
     use super::*;
 
     #[test]
     fn find() -> IonResult<()> {
         let ion_data = to_binary_ion("{foo: 1, bar: 2, baz: 3}")?;
-        let mut reader = BinaryReader_1_0::new(ion_data)?;
+        let mut reader = Reader::new(v1_0::Binary, ion_data)?;
         let struct_ = reader.expect_next()?.read()?.expect_struct()?;
         let baz = struct_.find("baz")?;
         assert!(baz.is_some());
@@ -382,7 +382,7 @@ mod tests {
     #[test]
     fn find_expected() -> IonResult<()> {
         let ion_data = to_binary_ion("{foo: 1, bar: 2, baz: 3}")?;
-        let mut reader = BinaryReader_1_0::new(ion_data)?;
+        let mut reader = Reader::new(v1_0::Binary, ion_data)?;
         let struct_ = reader.expect_next()?.read()?.expect_struct()?;
         let baz = struct_.find_expected("baz");
         assert!(baz.is_ok());
@@ -395,7 +395,7 @@ mod tests {
     #[test]
     fn get() -> IonResult<()> {
         let ion_data = to_binary_ion("{foo: 1, bar: 2, baz: 3}")?;
-        let mut reader = BinaryReader_1_0::new(ion_data)?;
+        let mut reader = Reader::new(v1_0::Binary, ion_data)?;
         let struct_ = reader.expect_next()?.read()?.expect_struct()?;
         let baz = struct_.get("baz")?;
         assert_eq!(baz, Some(ValueRef::Int(3.into())));
@@ -407,7 +407,7 @@ mod tests {
     #[test]
     fn get_expected() -> IonResult<()> {
         let ion_data = to_binary_ion("{foo: 1, bar: 2, baz: 3}")?;
-        let mut reader = BinaryReader_1_0::new(ion_data)?;
+        let mut reader = Reader::new(v1_0::Binary, ion_data)?;
         let struct_ = reader.expect_next()?.read()?.expect_struct()?;
         let baz = struct_.get_expected("baz");
         assert_eq!(baz, Ok(ValueRef::Int(3.into())));
@@ -419,7 +419,7 @@ mod tests {
     #[test]
     fn annotations() -> IonResult<()> {
         let ion_data = to_binary_ion("a::b::c::{foo: 1, bar: 2, baz: quux::quuz::3}")?;
-        let mut reader = BinaryReader_1_0::new(ion_data)?;
+        let mut reader = Reader::new(v1_0::Binary, ion_data)?;
         let struct_ = reader.expect_next()?.read()?.expect_struct()?;
         assert!(struct_.annotations().are(["a", "b", "c"])?);
         let baz = struct_.find_expected("baz")?;
@@ -431,7 +431,7 @@ mod tests {
     fn try_into_element() -> IonResult<()> {
         let ion_text = "foo::baz::baz::{a: 1, b: 2, c: 3}";
         let binary_ion = to_binary_ion(ion_text)?;
-        let mut reader = BinaryReader_1_0::new(binary_ion)?;
+        let mut reader = Reader::new(v1_0::Binary, binary_ion)?;
         let struct_ = reader.expect_next()?.read()?.expect_struct()?;
         let result: IonResult<Element> = struct_.try_into();
         assert!(result.is_ok());

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -1,15 +1,18 @@
 #![allow(non_camel_case_types)]
 
-use crate::lazy::any_encoding::AnyEncoding;
 use crate::lazy::decoder::Decoder;
-use crate::lazy::encoding::{BinaryEncoding_1_0, TextEncoding_1_0, TextEncoding_1_1};
 use crate::lazy::expanded::{ExpandedValueRef, ExpandingReader, LazyExpandedValue};
 use crate::lazy::streaming_raw_reader::{IonInput, StreamingRawReader};
 use crate::lazy::system_stream_item::SystemStreamItem;
 use crate::lazy::value::LazyValue;
 use crate::read_config::ReadConfig;
 use crate::result::IonFailure;
-use crate::{IonResult, IonType, RawSymbolRef, SymbolTable};
+use crate::{
+    Catalog, Int, IonError, IonResult, IonType, LazyExpandedField, RawSymbolRef, Symbol,
+    SymbolTable,
+};
+use std::ops::Deref;
+use std::sync::Arc;
 
 // Symbol IDs used for processing symbol table structs
 const ION_SYMBOL_TABLE: RawSymbolRef = RawSymbolRef::SymbolId(3);
@@ -74,19 +77,14 @@ pub struct SystemReader<Encoding: Decoder, Input: IonInput> {
     pub(crate) expanding_reader: ExpandingReader<Encoding, Input>,
 }
 
-pub type SystemBinaryReader_1_0<Input> = SystemReader<BinaryEncoding_1_0, Input>;
-pub type SystemTextReader_1_0<Input> = SystemReader<TextEncoding_1_0, Input>;
-pub type SystemTextReader_1_1<Input> = SystemReader<TextEncoding_1_1, Input>;
-
-pub type SystemAnyReader<Input> = SystemReader<AnyEncoding, Input>;
-
 // If the reader encounters a symbol table in the stream, it will store all of the symbols that
 // the table defines in this structure so that they may be applied when the reader next advances.
 #[derive(Default)]
-pub(crate) struct PendingLst {
+pub struct PendingLst {
     pub(crate) has_changes: bool,
     pub(crate) is_lst_append: bool,
-    pub(crate) symbols: Vec<Option<String>>,
+    pub(crate) symbols: Vec<Symbol>,
+    pub(crate) imported_symbols: Vec<Symbol>,
 }
 
 impl PendingLst {
@@ -95,7 +93,14 @@ impl PendingLst {
             has_changes: false,
             is_lst_append: false,
             symbols: Vec::new(),
+            imported_symbols: Vec::new(),
         }
+    }
+    pub fn local_symbols(&self) -> &[Symbol] {
+        &self.symbols
+    }
+    pub fn imported_symbols(&self) -> &[Symbol] {
+        &self.imported_symbols
     }
 }
 
@@ -108,7 +113,7 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
     ) -> SystemReader<Encoding, Input> {
         let config = config.into();
         let raw_reader = StreamingRawReader::new(config.encoding(), input);
-        let expanding_reader = ExpandingReader::new(raw_reader);
+        let expanding_reader = ExpandingReader::new(raw_reader, config.catalog);
         SystemReader { expanding_reader }
     }
 }
@@ -116,7 +121,7 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
 impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
     // Returns `true` if the provided [`LazyRawValue`] is a struct whose first annotation is
     // `$ion_symbol_table`.
-    pub fn is_symbol_table_struct(
+    pub(crate) fn is_symbol_table_struct(
         lazy_value: &'_ LazyExpandedValue<'_, Encoding>,
     ) -> IonResult<bool> {
         if lazy_value.ion_type() != IonType::Struct {
@@ -126,6 +131,14 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
             return Ok(symbol_ref?.matches_sid_or_text(3, "$ion_symbol_table"));
         };
         Ok(false)
+    }
+
+    pub fn symbol_table(&self) -> &SymbolTable {
+        self.expanding_reader.context().symbol_table
+    }
+
+    pub fn pending_symtab_changes(&self) -> &PendingLst {
+        self.expanding_reader.pending_symtab_changes()
     }
 
     /// Returns the next top-level stream item (IVM, Symbol Table, Value, or Nothing) as a
@@ -140,61 +153,92 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
         self.expanding_reader.next_value()
     }
 
-    // If the last stream item the reader visited was a symbol table, its `PendingLst` will
-    // contain new symbols that need to be added to the local symbol table.
-    fn apply_pending_lst(symbol_table: &mut SymbolTable, pending_lst: &mut PendingLst) {
-        // If the symbol table's `imports` field had a value of `$ion_symbol_table`, then we're
-        // appending the symbols it defined to the end of our existing local symbol table.
-        // Otherwise, we need to clear the existing table before appending the new symbols.
-        if pending_lst.is_lst_append {
-            if pending_lst.symbols.is_empty() {
-                return;
-            }
-        } else {
-            // We're setting the symbols list, not appending to it.
-            symbol_table.reset();
+    /// Like [`next_value`](Self::next_value) but returns an error if there is not another
+    /// application value in the stream.
+    pub fn expect_next_value(&mut self) -> IonResult<LazyValue<Encoding>> {
+        match self.next_value()? {
+            Some(value) => Ok(value),
+            None => IonResult::decoding_error("expected another application value but found none"),
         }
-        // `drain()` empties the pending symbols list
-        for symbol in pending_lst.symbols.drain(..) {
-            symbol_table.intern_or_add_placeholder(symbol);
-        }
-        pending_lst.is_lst_append = false;
     }
 
     // Traverses a symbol table, processing the `symbols` and `imports` fields as needed to
     // populate the `PendingLst`.
     pub(crate) fn process_symbol_table(
         pending_lst: &mut PendingLst,
+        catalog: &dyn Catalog,
         symbol_table: &LazyExpandedValue<'_, Encoding>,
     ) -> IonResult<()> {
         // We've already confirmed this is an annotated struct
         let symbol_table = symbol_table.read()?.expect_struct()?;
 
-        let mut found_symbols_field = false;
-        let mut found_imports_field = false;
+        // We're interested in the `imports` field and the `symbols` field. Both are optional;
+        // however, it is illegal to specify either field more than once.
+        let mut imports_field: Option<LazyExpandedField<Encoding>> = None;
+        let mut symbols_field: Option<LazyExpandedField<Encoding>> = None;
 
+        // Iterate through the fields of the symbol table struct, taking note of `imports` and `symbols`
+        // if we encounter them.
         for field_result in symbol_table.iter() {
             let field = field_result?;
-            if field.name().read_raw()?.matches_sid_or_text(7, "symbols") {
-                if found_symbols_field {
-                    return IonResult::decoding_error(
-                        "found symbol table with multiple 'symbols' fields",
-                    );
-                }
-                found_symbols_field = true;
-                Self::process_symbols(pending_lst, field.value())?;
-            }
             if field.name().read_raw()?.matches_sid_or_text(6, "imports") {
-                if found_imports_field {
+                if imports_field.is_some() {
                     return IonResult::decoding_error(
                         "found symbol table with multiple 'imports' fields",
                     );
                 }
-                found_imports_field = true;
-                Self::process_imports(pending_lst, field.value())?;
+                imports_field = Some(field);
+            } else if field.name().read_raw()?.matches_sid_or_text(7, "symbols") {
+                if symbols_field.is_some() {
+                    return IonResult::decoding_error(
+                        "found symbol table with multiple 'symbols' fields",
+                    );
+                }
+                symbols_field = Some(field);
             }
-            // Ignore other fields
         }
+
+        if let Some(imports_field) = imports_field {
+            let lazy_value = imports_field.value();
+            Self::clear_pending_lst_if_needed(pending_lst, lazy_value)?;
+            Self::process_imports(pending_lst, catalog, lazy_value)?;
+        }
+        if let Some(symbols_field) = symbols_field {
+            Self::process_symbols(pending_lst, symbols_field.value())?;
+        }
+
+        Ok(())
+    }
+
+    fn clear_pending_lst_if_needed(
+        pending_lst: &mut PendingLst,
+        imports_value: LazyExpandedValue<'_, Encoding>,
+    ) -> IonResult<()> {
+        match imports_value.read()? {
+            // If this is an LST append, there's nothing to do.
+            ExpandedValueRef::Symbol(raw_symbol)
+                if raw_symbol.matches_sid_or_text(3, "$ion_symbol_table") => {}
+            // If this is NOT an LST append, it will eventually cause the SymbolTable to reset.
+            // However, at this point in the processing the PendingLst may have symbols that have
+            // not yet made it to the SymbolTable. This can happen when a single top-level e-expression
+            // produces multiple LSTs.
+            //
+            //   // Top-level e-expression produces multiple LSTs
+            //   (:values
+            //     $ion_symbol_table::{imports: $ion_symbol_table, symbols: ["foo"]}
+            //     $ion_symbol_table::{imports: $ion_symbol_table, symbols: ["bar"]}
+            //     $ion_symbol_table::{symbols: ["baz"]}
+            //   )
+            //   // The reader does not apply their collective changes to its symbol table
+            //   // until it is done processing the complete output of the expression.
+            //   // That means that "foo" and "bar" get appended to the pending LST,
+            //   // but get discarded when the reader is parked on the third LST in the stream.
+            //   $10 // <-- 'baz'
+            _ => {
+                pending_lst.symbols.clear();
+                pending_lst.imported_symbols.clear();
+            }
+        };
         Ok(())
     }
 
@@ -206,9 +250,11 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
         if let ExpandedValueRef::List(list) = symbols.read()? {
             for symbol_text_result in list.iter() {
                 if let ExpandedValueRef::String(str_ref) = symbol_text_result?.read()? {
-                    pending_lst.symbols.push(Some(str_ref.text().to_owned()))
+                    pending_lst
+                        .symbols
+                        .push(Symbol::shared(Arc::from(str_ref.deref())))
                 } else {
-                    pending_lst.symbols.push(None)
+                    pending_lst.symbols.push(Symbol::unknown_text())
                 }
             }
         }
@@ -219,6 +265,7 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
     // Check for `imports: $ion_symbol_table`.
     fn process_imports(
         pending_lst: &mut PendingLst,
+        catalog: &dyn Catalog,
         imports: LazyExpandedValue<'_, Encoding>,
     ) -> IonResult<()> {
         match imports.read()? {
@@ -228,11 +275,61 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
                 }
                 // Any other symbol is ignored
             }
-            // TODO: Implement shared symbol table imports
-            ExpandedValueRef::List(_) => {
-                return IonResult::decoding_error(
-                    "This implementation does not yet support shared symbol table imports",
-                );
+            ExpandedValueRef::List(list) => {
+                for value in list.iter() {
+                    let ExpandedValueRef::Struct(import) = value?.read()? else {
+                        // If there's a value in the imports list that isn't a struct, it's malformed.
+                        // Ignore that value.
+                        continue;
+                    };
+                    let name = match import.get("name")? {
+                        // If `name` is missing, a non-string, or the empty string, ignore this import.
+                        Some(ExpandedValueRef::String(s)) if !s.is_empty() => s,
+                        _ => continue,
+                    };
+                    let version: usize = match import.get("version")? {
+                        Some(ExpandedValueRef::Int(i)) if i > Int::ZERO => usize::try_from(i)
+                            .map_err(|_|
+                            IonError::decoding_error(format!("found a symbol table import (name='{name}') with a version number too high to support: {i}")),
+                        ),
+                        // If there's no version, a non-int version, or a version <= 0, we treat it
+                        // as version 1.
+                        _ => Ok(1),
+                    }?;
+
+                    let shared_table = match catalog.get_table_with_version(name.as_ref(), version) {
+                        Some(table) => table,
+                        None => return IonResult::decoding_error(
+                            format!("symbol table import failed, could not find table with name='{name}' and version={version}")
+                        ),
+                    };
+
+                    let max_id = match import.get("max_id")? {
+                        Some(ExpandedValueRef::Int(i)) if i >= Int::ZERO => usize::try_from(i)
+                            .map_err(|_| {
+                                IonError::decoding_error(
+                                    "found a `max_id` beyond the range of usize",
+                                )
+                            })?,
+                        // If the max_id is unspecified, negative, or an invalid data type, we'll import all of the symbols from the requested table.
+                        _ => shared_table.symbols().len(),
+                    };
+
+                    let num_symbols_to_import = shared_table.symbols().len().min(max_id);
+
+                    pending_lst
+                        .imported_symbols
+                        .extend_from_slice(&shared_table.symbols()[..num_symbols_to_import]);
+
+                    if max_id > shared_table.symbols().len() {
+                        let num_pending_symbols = pending_lst.imported_symbols().len();
+                        let num_placeholders = max_id - shared_table.symbols().len();
+                        pending_lst.imported_symbols.resize(
+                            num_pending_symbols + num_placeholders,
+                            Symbol::unknown_text(),
+                        );
+                    }
+                }
             }
             _ => {
                 // Nulls and other types are ignored
@@ -248,7 +345,7 @@ mod tests {
     use crate::lazy::binary::test_utilities::to_binary_ion;
     use crate::lazy::decoder::RawVersionMarker;
     use crate::lazy::system_stream_item::SystemStreamItem;
-    use crate::IonResult;
+    use crate::{v1_0::Binary, AnyEncoding, Catalog, IonResult, SymbolRef};
 
     use super::*;
 
@@ -266,7 +363,7 @@ mod tests {
         hello
         "#,
         )?;
-        let mut system_reader = SystemReader::new(BinaryEncoding_1_0, ion_data);
+        let mut system_reader = SystemReader::new(Binary, ion_data);
         loop {
             match system_reader.next_item()? {
                 SystemStreamItem::VersionMarker(marker) => {
@@ -291,7 +388,7 @@ mod tests {
         )
         "#,
         )?;
-        let mut system_reader = SystemReader::new(BinaryEncoding_1_0, ion_data);
+        let mut system_reader = SystemReader::new(Binary, ion_data);
         loop {
             match system_reader.next_item()? {
                 SystemStreamItem::Value(value) => {
@@ -318,7 +415,7 @@ mod tests {
         }
         "#,
         )?;
-        let mut system_reader = SystemReader::new(BinaryEncoding_1_0, ion_data);
+        let mut system_reader = SystemReader::new(Binary, ion_data);
         loop {
             match system_reader.next_item()? {
                 SystemStreamItem::Value(value) => {
@@ -331,6 +428,264 @@ mod tests {
                 _ => {}
             }
         }
+        Ok(())
+    }
+
+    // === Shared Symbol Tables ===
+
+    use crate::{MapCatalog, SharedSymbolTable};
+
+    fn system_reader_for<I: IonInput>(ion: I) -> SystemReader<AnyEncoding, I> {
+        SystemReader::new(AnyEncoding, ion)
+    }
+
+    fn system_reader_with_catalog_for<Input: IonInput>(
+        input: Input,
+        catalog: impl Catalog + 'static,
+    ) -> SystemReader<AnyEncoding, Input> {
+        SystemReader::new(AnyEncoding.with_catalog(catalog), input)
+    }
+
+    #[test]
+    fn shared_and_local_symbols() -> IonResult<()> {
+        let mut map_catalog = MapCatalog::new();
+        map_catalog.insert_table(SharedSymbolTable::new("shared_table", 1, ["foo"])?);
+        // The stream contains a local symbol table that is not an append.
+        let mut reader = system_reader_with_catalog_for(
+            r#"
+                $ion_symbol_table::{
+                    imports: [ { name:"shared_table", version: 1 } ],
+                    symbols: [ "local_symbol" ]
+                }
+                $10 // "foo"
+                $11 // "local_symbol"
+            "#,
+            map_catalog,
+        );
+        // We step over the LST...
+        let _symtab = reader.next_item()?.expect_symbol_table()?;
+        // ...but expect all of the symbols we encounter after it to be in the symbol table,
+        // indicating that the SystemReader processed the LST even though we skipped it with `next()`
+        assert_eq!(
+            reader
+                .next_item()?
+                .expect_value()?
+                .read()?
+                .expect_symbol()?,
+            "foo"
+        );
+        assert_eq!(
+            reader
+                .next_item()?
+                .expect_value()?
+                .read()?
+                .expect_symbol()?,
+            "local_symbol"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn multiple_shared_symbol_table_imports() -> IonResult<()> {
+        let mut map_catalog = MapCatalog::new();
+        map_catalog.insert_table(SharedSymbolTable::new("shared_table_1", 1, ["foo"])?);
+        map_catalog.insert_table(SharedSymbolTable::new("shared_table_2", 1, ["bar"])?);
+        // The stream contains a local symbol table that is not an append.
+        let mut reader = system_reader_with_catalog_for(
+            r#"
+                // This symbol table will be overwritten by the following one
+                $ion_symbol_table::{
+                    symbols: [ "potato salad" ]
+                }
+                // This LST does not import `$ion_symbol_table`, so it resets rather than appending
+                $ion_symbol_table::{
+                    imports: [ { name:"shared_table_1", version: 1 }, { name:"shared_table_2", version: 1 } ],
+                    symbols: [ "local_symbol" ]
+                }
+                $10 // "foo"
+                $11 // "bar"
+                $12 // "local_symbol"
+          "#,
+            map_catalog,
+        );
+        // We step over the first LST, processing it but not yet applying it.
+        let _symtab = reader.next_item()?.expect_symbol_table()?;
+        // There are 10 symbols in the symbol table, $0 to $9 inclusive. $10 is not defined yet
+        // because we're still parked on the symtab.
+        assert_eq!(reader.symbol_table().len(), 10);
+        // The reader has analyzed the symtab struct and identified what symbols will be added when
+        // it advances beyond it.
+        assert_eq!(
+            reader.pending_symtab_changes().local_symbols()[0].text(),
+            Some("potato salad")
+        );
+
+        // We advance to the second LST, which causes the previous one to be applied.
+        let _symtab = reader.next_item()?.expect_symbol_table()?;
+        assert_eq!(reader.symbol_table().len(), 11);
+        assert_eq!(reader.symbol_table().text_for(10), Some("potato salad"));
+        // We can peak at the symbols that will be added by the second LST before they are applied.
+        assert_eq!(
+            reader.pending_symtab_changes().imported_symbols(),
+            &[Symbol::from("foo"), Symbol::from("bar")]
+        );
+        assert_eq!(
+            reader.pending_symtab_changes().local_symbols(),
+            &[Symbol::from("local_symbol")]
+        );
+        // Now we advance to the application data, confirming that the symbol IDs align with the
+        // expected text.
+        assert_eq!(reader.expect_next_value()?.read()?.expect_symbol()?, "foo");
+        assert_eq!(reader.expect_next_value()?.read()?.expect_symbol()?, "bar");
+        assert_eq!(
+            reader.expect_next_value()?.read()?.expect_symbol()?,
+            "local_symbol"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn shared_symbol_table_import_binary() -> IonResult<()> {
+        let mut map_catalog = MapCatalog::new();
+        // add a table with system symbol `name` and a new symbol `foo`
+        // reader should still add this system symbol `name` again($10), but whenever writing this symbol
+        // smallest ID($4) will be used
+        map_catalog.insert_table(SharedSymbolTable::new("shared_table", 1, ["name", "foo"])?);
+        // The stream contains a shared symbol table import
+        let mut reader = system_reader_with_catalog_for(
+            [
+                0xe0, 0x01, 0x00, 0xea, // Ion 1.0 Version Marker
+                0xee, 0x9d, 0x81, 0x83, // '$ion_symbol_table'::
+                0xde, 0x99, // 26 bytes struct
+                0x86, // Field $6 `imports`
+                0xbe, 0x96, // List
+                0xde, 0x94, // 21 bytes struct
+                0x84, // Field $4 `name`
+                0x8c, 0x73, 0x68, 0x61, 0x72, 0x65, 0x64, 0x5f, 0x74, 0x61, 0x62, 0x6c,
+                0x65, // "shared_table"
+                0x85, // Field $5 `version`
+                0x21, 0x01, // INT 1
+                0x88, // $8 `max_id`
+                0x21, 0x02, // INT 2
+                0x71, 0x04, // $4 `name`
+                0x71, 0x0a, // $10 `name`
+                0x71, 0x0b, // $11 `foo`
+            ]
+            .as_slice(),
+            map_catalog,
+        );
+        assert_eq!(reader.next_item()?.expect_ivm()?.version(), (1, 0));
+        let _symtab = reader.next_item()?.expect_symbol_table()?;
+        let pending_imported_symbols = reader.pending_symtab_changes().imported_symbols();
+        // This symbol table imports the symbols 'name' and 'foo'.
+        assert_eq!(pending_imported_symbols[0].text(), Some("name"));
+        assert_eq!(pending_imported_symbols[1].text(), Some("foo"));
+        // The new symbols have not been applied yet.
+        assert_eq!(reader.symbol_table().len(), 10);
+        // The application values have the expected text
+        assert_eq!(
+            reader.expect_next_value()?.read()?.expect_symbol()?.text(),
+            Some("name")
+        );
+        assert_eq!(
+            reader.expect_next_value()?.read()?.expect_symbol()?.text(),
+            Some("name")
+        );
+        assert_eq!(
+            reader.expect_next_value()?.read()?.expect_symbol()?.text(),
+            Some("foo")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn non_existent_shared_symbol_table_imports() -> IonResult<()> {
+        let mut map_catalog = MapCatalog::new();
+        map_catalog.insert_table(SharedSymbolTable::new("shared_table_1", 1, ["foo"])?);
+        map_catalog.insert_table(SharedSymbolTable::new("shared_table_2", 1, ["bar"])?);
+        // The stream contains a local symbol table that is not an append.
+        let mut reader = system_reader_with_catalog_for(
+            r#"
+                $ion_symbol_table::{
+                    imports: [ { name:"shared_table_3", version: 1, max_id: 3 }, { name:"shared_table_2", version: 1 }, { name:"shared_table_4", version: 1, max_id: 1 } ],
+                    symbols: [ "local_symbol" ]
+                }
+                $13 // "bar"
+            "#,
+            map_catalog,
+        );
+        // We step over the LST...
+        assert!(
+            matches!(reader.next_item(), Err(IonError::Decoding(_))),
+            "expected a decoding error because shared_table_3 does not exist"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn pad_with_max_id() -> IonResult<()> {
+        let mut map_catalog = MapCatalog::new();
+        map_catalog.insert_table(SharedSymbolTable::new("shared_table", 1, ["foo"])?);
+        let mut reader = system_reader_with_catalog_for(
+            r#"
+                $ion_symbol_table::{
+                    // This imports 3 symbols from shared_table v1, which only has a single symbol.
+                    // The reader will add symbols with unknown text ($0) for the other two.
+                    imports: [ { name:"shared_table", version: 1, max_id: 3 } ],
+                    // The symbol 'bar' will be assigned the first symbol ID following the import padding.
+                    symbols: [ "bar" ]
+                }
+                $10 // "foo"
+                $11 // == $0
+                $12 // == $0
+                $13 // "bar"
+            "#,
+            map_catalog,
+        );
+        assert_eq!(reader.expect_next_value()?.read()?.expect_symbol()?, "foo");
+        assert_eq!(
+            reader.expect_next_value()?.read()?.expect_symbol()?,
+            SymbolRef::with_unknown_text()
+        );
+        assert_eq!(
+            reader.expect_next_value()?.read()?.expect_symbol()?,
+            SymbolRef::with_unknown_text()
+        );
+        assert_eq!(
+            reader
+                .next_item()?
+                .expect_value()?
+                .read()?
+                .expect_symbol()?,
+            "bar"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn truncate_with_max_id() -> IonResult<()> {
+        let mut map_catalog = MapCatalog::new();
+        map_catalog.insert_table(SharedSymbolTable::new(
+            "shared_table",
+            1,
+            ["foo", "bar", "baz", "quux"],
+        )?);
+        // The stream contains a local symbol table that is not an append.
+        let mut reader = system_reader_with_catalog_for(
+            r#"
+                $ion_symbol_table::{
+                    imports: [ { name:"shared_table", version: 1, max_id: 2 } ],
+                    symbols: ["quuz"]
+                }
+                $10 // foo
+                $11 // bar
+                $12 // quuz
+            "#,
+            map_catalog,
+        );
+        assert_eq!(reader.expect_next_value()?.read()?.expect_symbol()?, "foo");
+        assert_eq!(reader.expect_next_value()?.read()?.expect_symbol()?, "bar");
+        assert_eq!(reader.expect_next_value()?.read()?.expect_symbol()?, "quuz");
         Ok(())
     }
 }

--- a/src/lazy/system_stream_item.rs
+++ b/src/lazy/system_stream_item.rs
@@ -55,9 +55,9 @@ impl<'top, D: Decoder> SystemStreamItem<'top, D> {
 
     /// If this item is a application-level value, returns `Some(&LazyValue)`. Otherwise,
     /// returns `None`.
-    pub fn value(&self) -> Option<&LazyValue<'top, D>> {
+    pub fn value(&self) -> Option<LazyValue<'top, D>> {
         if let Self::Value(value) = self {
-            Some(value)
+            Some(*value)
         } else {
             None
         }
@@ -70,6 +70,26 @@ impl<'top, D: Decoder> SystemStreamItem<'top, D> {
             Ok(value)
         } else {
             IonResult::decoding_error(format!("expected value, found {:?}", self))
+        }
+    }
+
+    /// Like [`Self::symbol_table`], but returns a [`IonError::Decoding`] if this item is not
+    /// a symbol table.
+    pub fn symbol_table(self) -> Option<LazyStruct<'top, D>> {
+        if let Self::SymbolTable(struct_) = self {
+            Some(struct_)
+        } else {
+            None
+        }
+    }
+
+    /// Like [`Self::symbol_table`], but returns a [`IonError::Decoding`] if this item is not
+    /// a symbol table.
+    pub fn expect_symbol_table(self) -> IonResult<LazyStruct<'top, D>> {
+        if let Self::SymbolTable(value) = self {
+            Ok(value)
+        } else {
+            IonResult::decoding_error(format!("expected symbol table, found {:?}", self))
         }
     }
 

--- a/src/lazy/value.rs
+++ b/src/lazy/value.rs
@@ -23,13 +23,13 @@ use crate::{
 ///# fn main() -> IonResult<()> {
 ///
 /// // Construct an Element and serialize it as binary Ion.
-/// use ion_rs::{Element, ion_list};
-/// use ion_rs::v1_0::{Binary, BinaryReader};
+/// use ion_rs::{Element, ion_list, Reader};
+/// use ion_rs::v1_0::Binary;
 ///
 /// let element: Element = ion_list! [10, 20, 30].into();
 /// let binary_ion = element.encode_as(Binary)?;
 ///
-/// let mut lazy_reader = BinaryReader::new(binary_ion)?;
+/// let mut lazy_reader = Reader::new(Binary, binary_ion)?;
 ///
 /// // Get the first value from the stream and confirm that it's a list.
 /// let lazy_list = lazy_reader.expect_next()?.read()?.expect_list()?;
@@ -76,13 +76,13 @@ impl<'top, D: Decoder> LazyValue<'top, D> {
     ///# fn main() -> IonResult<()> {
     ///
     /// // Construct an Element and serialize it as binary Ion.
-    /// use ion_rs::{Element, IonType};
-    /// use ion_rs::v1_0::{Binary, BinaryReader};
+    /// use ion_rs::{Element, IonType, Reader};
+    /// use ion_rs::v1_0::Binary;
     ///
     /// let element: Element = "hello".into();
     /// let binary_ion = element.encode_as(Binary)?;
     ///
-    /// let mut lazy_reader = BinaryReader::new(binary_ion)?;
+    /// let mut lazy_reader = Reader::new(Binary, binary_ion)?;
     ///
     /// // Get the first lazy value from the stream.
     /// let lazy_value = lazy_reader.expect_next()?;
@@ -129,18 +129,18 @@ impl<'top, D: Decoder> LazyValue<'top, D> {
     ///# fn main() -> IonResult<()> {
     ///
     /// // Construct an Element and serialize it as binary Ion.
-    /// use ion_rs::{Element, IonType};
-    /// use ion_rs::v1_0::{Binary, BinaryReader};
+    /// use ion_rs::{Element, IonType, Reader};
+    /// use ion_rs::v1_0::Binary;
     ///
     /// let element = Element::string("hello");
     /// let binary_ion = element.encode_as(Binary)?;
-    /// let mut lazy_reader = BinaryReader::new(binary_ion)?;
+    /// let mut lazy_reader = Reader::new(Binary, binary_ion)?;
     /// let lazy_value = lazy_reader.expect_next()?;
     /// assert!(!lazy_value.is_null());
     ///
     /// let element: Element = Element::null(IonType::String);
     /// let binary_ion = element.encode_as(Binary)?;
-    /// let mut lazy_reader = BinaryReader::new(binary_ion)?;
+    /// let mut lazy_reader = Reader::new(Binary, binary_ion)?;
     /// let lazy_value = lazy_reader.expect_next()?;
     /// assert!(lazy_value.is_null());
     ///
@@ -162,13 +162,13 @@ impl<'top, D: Decoder> LazyValue<'top, D> {
     ///# fn main() -> IonResult<()> {
     ///
     /// // Construct an Element and serialize it as binary Ion.
-    /// use ion_rs::{Element, IntoAnnotatedElement};
-    /// use ion_rs::v1_0::{Binary, BinaryReader};
+    /// use ion_rs::{Element, IntoAnnotatedElement, Reader};
+    /// use ion_rs::v1_0::Binary;
     ///
     /// let element: Element = "hello".with_annotations(["foo", "bar", "baz"]);
     /// let binary_ion = element.encode_as(Binary)?;
     ///
-    /// let mut lazy_reader = BinaryReader::new(binary_ion)?;
+    /// let mut lazy_reader = Reader::new(Binary, binary_ion)?;
     ///
     /// // Get the first lazy value from the stream.
     /// let lazy_value = lazy_reader.expect_next()?;
@@ -202,14 +202,14 @@ impl<'top, D: Decoder> LazyValue<'top, D> {
     ///# fn main() -> IonResult<()> {
     ///
     /// // Construct an Element and serialize it as binary Ion.
-    /// use ion_rs::{Element, IntoAnnotatedElement};
-    /// use ion_rs::v1_0::{Binary, BinaryReader};
+    /// use ion_rs::{Element, IntoAnnotatedElement, Reader};
+    /// use ion_rs::v1_0::Binary;
     /// use ion_rs::ValueRef;
     ///
     /// let element: Element = "hello".with_annotations(["foo", "bar", "baz"]);
     /// let binary_ion = element.encode_as(Binary)?;
     ///
-    /// let mut lazy_reader = BinaryReader::new(binary_ion)?;
+    /// let mut lazy_reader = Reader::new(Binary, binary_ion)?;
     ///
     /// // Get the first lazy value from the stream.
     /// let lazy_value = lazy_reader.expect_next()?;
@@ -300,12 +300,12 @@ impl<'top, D: Decoder> AnnotationsIterator<'top, D> {
     ///# fn main() -> IonResult<()> {
     ///
     /// // Construct an Element and serialize it as binary Ion.
-    /// use ion_rs::Element;
-    /// use ion_rs::v1_0::{Binary, BinaryReader};
+    /// use ion_rs::{Element, Reader};
+    /// use ion_rs::v1_0::Binary;
     ///
     /// let element = Element::read_one("foo::bar::baz::99")?;
     /// let binary_ion = element.encode_as(Binary)?;
-    /// let mut lazy_reader = BinaryReader::new(binary_ion)?;
+    /// let mut lazy_reader = Reader::new(Binary, binary_ion)?;
     ///
     /// // Get the first value from the stream
     /// let lazy_value = lazy_reader.expect_next()?;
@@ -345,12 +345,12 @@ impl<'top, D: Decoder> AnnotationsIterator<'top, D> {
     ///# fn main() -> IonResult<()> {
     ///
     /// // Construct an Element and serialize it as binary Ion.
-    /// use ion_rs::Element;
-    /// use ion_rs::v1_0::{Binary, BinaryReader};
+    /// use ion_rs::{Element, Reader};
+    /// use ion_rs::v1_0::Binary;
     ///
     /// let element = Element::read_one("foo::bar::baz::99")?;
     /// let binary_ion = element.encode_as(Binary)?;
-    /// let mut lazy_reader = BinaryReader::new(binary_ion)?;
+    /// let mut lazy_reader = Reader::new(Binary, binary_ion)?;
     ///
     /// // Get the first value from the stream
     /// let lazy_value = lazy_reader.expect_next()?;
@@ -417,14 +417,16 @@ mod tests {
     use rstest::*;
 
     use crate::lazy::binary::test_utilities::to_binary_ion;
-    use crate::lazy::reader::BinaryReader_1_0;
-    use crate::{ion_list, ion_sexp, ion_struct, Decimal, IonResult, IonType, Symbol, Timestamp};
+    use crate::{
+        ion_list, ion_sexp, ion_struct, v1_0, Decimal, IonResult, IonType, Reader, Symbol,
+        Timestamp,
+    };
     use crate::{Element, IntoAnnotatedElement};
 
     #[test]
     fn annotations_are() -> IonResult<()> {
         let ion_data = to_binary_ion("foo::bar::baz::5")?;
-        let mut reader = BinaryReader_1_0::new(ion_data)?;
+        let mut reader = Reader::new(v1_0::Binary, ion_data)?;
         let first = reader.expect_next()?;
         assert!(first.annotations().are(["foo", "bar", "baz"])?);
 
@@ -443,7 +445,7 @@ mod tests {
 
     fn lazy_value_equals(ion_text: &str, expected: impl Into<Element>) -> IonResult<()> {
         let binary_ion = to_binary_ion(ion_text)?;
-        let mut reader = BinaryReader_1_0::new(binary_ion)?;
+        let mut reader = Reader::new(v1_0::Binary, binary_ion)?;
         let value = reader.expect_next()?;
         let actual: Element = value.try_into()?;
         let expected = expected.into();
@@ -493,7 +495,7 @@ mod tests {
             // an error.
             0xE0, 0x01, 0x00, 0xEA,
         ];
-        let mut reader = BinaryReader_1_0::new(binary_ion)?;
+        let mut reader = Reader::new(v1_0::Binary, binary_ion)?;
         let list = reader.expect_next()?.read()?.expect_list()?;
         let result: IonResult<Element> = list.try_into();
         assert!(result.is_err());
@@ -517,7 +519,7 @@ mod tests {
     fn try_into_element_incomplete(#[case] ion_text: &str) -> IonResult<()> {
         let mut binary_ion = to_binary_ion(ion_text)?;
         let _oops_i_lost_a_byte = binary_ion.pop().unwrap();
-        let mut reader = BinaryReader_1_0::new(binary_ion)?;
+        let mut reader = Reader::new(v1_0::Binary, binary_ion)?;
         let result = reader.expect_next();
         assert!(matches!(result, Err(crate::IonError::Incomplete(_))));
         Ok(())

--- a/src/lazy/value_ref.rs
+++ b/src/lazy/value_ref.rs
@@ -65,7 +65,7 @@ impl<'top, D: Decoder> Debug for ValueRef<'top, D> {
             Float(float) => write!(f, "{}", float),
             Decimal(d) => write!(f, "{}", d),
             Timestamp(t) => write!(f, "{}", t),
-            String(s) => write!(f, "\"{}\"", s),
+            String(s) => write!(f, "{}", s),
             Symbol(s) => write!(f, "{}", s.text().unwrap_or("$0")),
             Blob(b) => write!(f, "blob ({} bytes)", b.len()),
             Clob(c) => write!(f, "clob ({} bytes)", c.len()),

--- a/src/lazy/value_ref.rs
+++ b/src/lazy/value_ref.rs
@@ -263,9 +263,8 @@ impl<'top, D: Decoder> ValueRef<'top, D> {
 #[cfg(test)]
 mod tests {
     use crate::lazy::binary::test_utilities::to_binary_ion;
-    use crate::lazy::reader::BinaryReader_1_0;
     use crate::lazy::value_ref::ValueRef;
-    use crate::{Decimal, IonResult, IonType, SymbolRef, Timestamp};
+    use crate::{v1_0, Decimal, IonResult, IonType, Reader, SymbolRef, Timestamp};
 
     #[test]
     fn expect_type() -> IonResult<()> {
@@ -286,7 +285,7 @@ mod tests {
             {this: is, a: struct}
         "#,
         )?;
-        let mut reader = BinaryReader_1_0::new(ion_data)?;
+        let mut reader = Reader::new(v1_0::Binary, ion_data)?;
         assert_eq!(reader.expect_next()?.read()?.expect_null()?, IonType::Null);
         assert!(reader.expect_next()?.read()?.expect_bool()?);
         assert_eq!(reader.expect_next()?.read()?.expect_i64()?, 1);
@@ -335,7 +334,7 @@ mod tests {
             {{"Clob"}}
         "#,
         )?;
-        let mut reader = BinaryReader_1_0::new(ion_data)?;
+        let mut reader = Reader::new(v1_0::Binary, ion_data)?;
         let first_value = reader.expect_next()?.read()?;
         assert_ne!(first_value, ValueRef::String("it's not a string".into()));
         assert_eq!(first_value, ValueRef::Null(IonType::Null));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@
 use rstest_reuse;
 
 // Exposed to allow benchmark comparisons between the 1.0 primitives and 1.1 primitives
-pub use catalog::{Catalog, MapCatalog};
+pub use catalog::{Catalog, EmptyCatalog, MapCatalog};
 pub use element::builders::{SequenceBuilder, StructBuilder};
 pub use element::{
     element_writer::ElementWriter, reader::ElementReader, Annotations, Element,
@@ -164,7 +164,7 @@ pub use crate::text::text_formatter::{FmtValueFormatter, IoValueFormatter};
 
 // Private modules that serve to organize implementation details.
 pub(crate) mod binary;
-mod catalog;
+pub(crate) mod catalog;
 mod constants;
 mod ion_data;
 mod raw_symbol_ref;
@@ -189,7 +189,7 @@ pub mod ion_hash;
 mod lazy;
 mod write_config;
 
-pub use crate::lazy::any_encoding::AnyEncoding as Any;
+pub use crate::lazy::any_encoding::AnyEncoding;
 pub use crate::lazy::decoder::{HasRange, HasSpan};
 pub use crate::lazy::span::Span;
 pub use crate::write_config::WriteConfig;
@@ -206,7 +206,6 @@ macro_rules! v1_x_reader_writer {
             lazy::encoder::write_as_ion::WriteAsIon,
             lazy::encoder::writer::Writer,
             lazy::reader::Reader,
-            lazy::reader::IonReader,
             raw_symbol_ref::RawSymbolRef,
             symbol_table::SymbolTable,
             lazy::value::LazyValue,
@@ -223,7 +222,6 @@ macro_rules! v1_0_reader_writer {
         #[allow(unused_imports)]
         $visibility use crate::{
             lazy::encoder::writer::{BinaryWriter_1_0 as BinaryWriter, TextWriter_1_0 as TextWriter},
-            lazy::reader::{BinaryReader_1_0 as BinaryReader, TextReader_1_0 as TextReader},
         };
     };
 }
@@ -234,7 +232,6 @@ macro_rules! v1_1_reader_writer {
         $visibility use crate::{
             lazy::encoder::writer::{BinaryWriter_1_1 as BinaryWriter, TextWriter_1_1 as TextWriter},
             lazy::encoding::{BinaryEncoding_1_1 as Binary, TextEncoding_1_1 as Text},
-            lazy::reader::{BinaryReader_1_1 as BinaryReader, TextReader_1_1 as TextReader},
         };
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //! # }
 //! ```
 //!
-//! [Element::read_all] will read any number of Ion values and return them as a `Vec<Element>`.
+//! [Element::read_all] will read any number of Ion values and return them as a [`Sequence`].
 //!
 //! [Element::read_first] will read the first Ion value without requiring that the stream have
 //! exactly one value.

--- a/src/read_config.rs
+++ b/src/read_config.rs
@@ -1,9 +1,55 @@
-use crate::lazy::encoding::Encoding;
-use crate::Catalog;
-use std::marker::PhantomData;
+use crate::catalog::EmptyCatalog;
+use crate::lazy::any_encoding::AnyEncoding;
+use crate::lazy::encoding::{
+    BinaryEncoding_1_0, BinaryEncoding_1_1, TextEncoding_1_0, TextEncoding_1_1,
+};
+use crate::{Catalog, Decoder};
 
 /// Provides configuration details for reader construction.
-pub struct ReadConfig<E: Encoding> {
+pub struct ReadConfig<D: Decoder> {
     pub(crate) catalog: Box<dyn Catalog>,
-    phantom_data: PhantomData<E>,
+    encoding: D,
+}
+
+impl<D: Decoder> ReadConfig<D> {
+    fn new(encoding: D) -> Self {
+        ReadConfig {
+            catalog: Box::new(EmptyCatalog),
+            encoding,
+        }
+    }
+
+    pub fn encoding(&self) -> D {
+        self.encoding
+    }
+}
+
+impl From<TextEncoding_1_0> for ReadConfig<TextEncoding_1_0> {
+    fn from(encoding: TextEncoding_1_0) -> Self {
+        ReadConfig::new(encoding)
+    }
+}
+
+impl From<TextEncoding_1_1> for ReadConfig<TextEncoding_1_1> {
+    fn from(encoding: TextEncoding_1_1) -> Self {
+        ReadConfig::new(encoding)
+    }
+}
+
+impl From<BinaryEncoding_1_0> for ReadConfig<BinaryEncoding_1_0> {
+    fn from(encoding: BinaryEncoding_1_0) -> Self {
+        ReadConfig::new(encoding)
+    }
+}
+
+impl From<BinaryEncoding_1_1> for ReadConfig<BinaryEncoding_1_1> {
+    fn from(encoding: BinaryEncoding_1_1) -> Self {
+        ReadConfig::new(encoding)
+    }
+}
+
+impl From<AnyEncoding> for ReadConfig<AnyEncoding> {
+    fn from(encoding: AnyEncoding) -> Self {
+        ReadConfig::new(encoding)
+    }
 }

--- a/src/read_config.rs
+++ b/src/read_config.rs
@@ -13,8 +13,12 @@ pub struct ReadConfig<D: Decoder> {
 
 impl<D: Decoder> ReadConfig<D> {
     fn new(encoding: D) -> Self {
+        ReadConfig::new_with_catalog(encoding, EmptyCatalog)
+    }
+
+    pub(crate) fn new_with_catalog(encoding: D, catalog: impl Catalog + 'static) -> Self {
         ReadConfig {
-            catalog: Box::new(EmptyCatalog),
+            catalog: Box::new(catalog),
             encoding,
         }
     }

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -19,7 +19,7 @@ where
     T: DeserializeOwned,
     I: IonInput,
 {
-    let mut reader = Reader::new(input)?;
+    let mut reader = Reader::new(AnyEncoding, input)?;
     let value = reader.expect_next()?;
     let value_deserializer = ValueDeserializer::new(&value);
     T::deserialize(value_deserializer)

--- a/tests/ion_hash_tests.rs
+++ b/tests/ion_hash_tests.rs
@@ -4,7 +4,7 @@
 use digest::consts::U4096;
 use digest::{FixedOutput, Reset, Update};
 use ion_rs::ion_hash::IonHasher;
-use ion_rs::{Element, IonResult, Sequence, Struct};
+use ion_rs::{AnyEncoding, Element, IonResult, Sequence, Struct};
 
 use ion_rs::IonError;
 use ion_rs::Reader;
@@ -122,7 +122,7 @@ fn ion_hash_tests() -> IonHashTestResult<()> {
 
 fn test_file(file_name: &str) -> IonHashTestResult<()> {
     let data = read(file_name).map_err(IonError::from)?;
-    let mut reader = Reader::new(data)?;
+    let mut reader = Reader::new(AnyEncoding, data)?;
     let mut elems = Vec::new();
     while let Some(value) = reader.next()? {
         // Similar logic to skip test cases with a name on the skip list also appears in the


### PR DESCRIPTION
Issue: #776.

> [!TIP]
> A large chunk of this PR's diff comes from mechanical renaming/refactoring that occurred in cf6aacc422970758960eb4b7699d012d6c26ee53. I suggest skimming that one and then reviewing the changes in efd8e22504a401756224f8174c7bd746384e248a more closely.

The recently removed `IonReader` API's `SystemReader` had the ability to import shared symbol tables from a given `Catalog` implementation. This PR adds the same functionality to the lazy reader API's `SystemReader`.

It also normalizes the constructors used for `Reader` and `Writer`. There are no longer exported type aliases for `BinaryReader`, `TextReader`, etc. They are all `Reader<D: Decoder, I: IonInput>`. As part of this change, `Reader::new` now accepts an `Into<ReadConfig<D>>` that allows the user to specify the decoder, `Catalog`, and other settings to use.

For example:
```rust
let mut reader = Reader::new(AnyEncoding, ion_data)?;
```
or
```rust
let mut reader = Reader::new(v1_1::Text.with_catalog(my_catalog), ion_data)?;
```

This arrangement mirrors `Writer`'s constructors:
```rust
let mut writer = Writer::new(v1_1::Text.with_format(TextFormat::Pretty), output)?;
```

The patch reworks the `PendingLst` type to hold `Symbol` instances instead of `Option<String>`. Storing `Option<String>` meant that we would heap-allocate a `String` for every symbol, and then later heap-allocate an `Arc<str>` when we added it to the symbol table. In the new arrangement, the `PendingLst` creates `Symbol` instances backed by `Arc<str>`s from the start, halving the allocations required.

Finally, this PR adds methods to the `SystemReader` that will allow tooling to "see" the symbols that are going to be added to the symbol table while the reader is parked on the LST. Without this, the reader would need to advance to the next top level value in the stream to see the updated symbol table (or manually interpret the `$ion_symbol_table::{...}` to learn what would be added). This is helpful for programs like `ion inspect`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
