### PR TITLE
Additional tooling access methods, trait impls, and a bug fix

### DIFF
--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -117,6 +117,22 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_1> for LazyRawBinaryValue_1_1<'to
     fn read(&self) -> IonResult<RawValueRef<'top, BinaryEncoding_1_1>> {
         self.read()
     }
+
+    fn annotations_span(&self) -> Span<'top> {
+        let Some(range) = self.encoded_value.annotations_range() else {
+            // If there are no annotations, return an empty slice positioned at the opcode
+            return Span::with_offset(self.encoded_value.header_offset, &[]);
+        };
+        // Subtract the `offset()` of the ImmutableBuffer to get the local indexes for start/end
+        let local_range = (range.start - self.input.offset())..(range.end - self.input.offset());
+        Span::with_offset(range.start, &self.input.bytes()[local_range])
+    }
+
+    fn value_span(&self) -> Span<'top> {
+        let range = self.encoded_value.unannotated_value_range();
+        let local_range = (range.start - self.input.offset())..(range.end - self.input.offset());
+        Span::with_offset(range.start, &self.input.bytes()[local_range])
+    }
 }
 
 impl<'top> LazyRawBinaryValue_1_1<'top> {

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -115,6 +115,21 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_0> for LazyRawBinaryValue_1_0<'to
     fn read(&self) -> IonResult<RawValueRef<'top, BinaryEncoding_1_0>> {
         self.read()
     }
+
+    fn annotations_span(&self) -> Span<'top> {
+        let Some(range) = self.encoded_value.annotations_range() else {
+            // If there are no annotations, return an empty slice positioned at the opcode
+            return Span::with_offset(self.encoded_value.header_offset, &[]);
+        };
+        let local_range = (range.start - self.input.offset())..(range.end - self.input.offset());
+        Span::with_offset(range.start, &self.input.bytes()[local_range])
+    }
+
+    fn value_span(&self) -> Span<'top> {
+        let range = self.encoded_value.unannotated_value_range();
+        let local_range = (range.start - self.input.offset())..(range.end - self.input.offset());
+        Span::with_offset(range.start, &self.input.bytes()[local_range])
+    }
 }
 
 #[derive(Copy, Clone)]

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -376,6 +376,10 @@ pub trait LazyRawValue<'top, D: Decoder>:
     fn is_null(&self) -> bool;
     fn annotations(&self) -> D::AnnotationsIterator<'top>;
     fn read(&self) -> IonResult<RawValueRef<'top, D>>;
+
+    fn annotations_span(&self) -> Span<'top>;
+
+    fn value_span(&self) -> Span<'top>;
 }
 
 pub trait LazyRawSequence<'top, D: Decoder>:

--- a/src/lazy/encoder/binary/v1_0/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_0/value_writer.rs
@@ -180,6 +180,13 @@ impl<'value, 'top> BinaryValueWriter_1_0<'value, 'top> {
             return Ok(());
         }
 
+        // See if this value can be losslessly encoded in 4 bytes instead of 8
+        let float32 = value as f32;
+        if float32 as f64 == value {
+            // No data lost during cast; write it as an f32 instead.
+            return self.write_f32(float32);
+        }
+
         self.push_byte(0x48);
         self.push_bytes(&value.to_be_bytes());
         Ok(())

--- a/src/lazy/encoding.rs
+++ b/src/lazy/encoding.rs
@@ -3,7 +3,7 @@
 use std::fmt::Debug;
 use std::io;
 
-use crate::lazy::any_encoding::LazyRawAnyValue;
+use crate::lazy::any_encoding::{IonEncoding, LazyRawAnyValue};
 use crate::lazy::binary::raw::annotations_iterator::RawBinaryAnnotationsIterator;
 use crate::lazy::binary::raw::r#struct::{LazyRawBinaryFieldName_1_0, LazyRawBinaryStruct_1_0};
 use crate::lazy::binary::raw::reader::LazyRawBinaryReader_1_0;
@@ -60,6 +60,8 @@ pub trait Encoding: Encoder + Decoder {
     ) -> IonResult<W> {
         Self::default_write_config().encode_all_to(output, values)
     }
+
+    fn encoding(&self) -> IonEncoding;
     fn name() -> &'static str;
     fn default_write_config() -> WriteConfig<Self>;
 }
@@ -119,6 +121,10 @@ impl TextEncoding_1_1 {
 impl Encoding for BinaryEncoding_1_0 {
     type Output = Vec<u8>;
 
+    fn encoding(&self) -> IonEncoding {
+        IonEncoding::Binary_1_0
+    }
+
     fn name() -> &'static str {
         "binary Ion v1.0"
     }
@@ -129,6 +135,10 @@ impl Encoding for BinaryEncoding_1_0 {
 impl Encoding for BinaryEncoding_1_1 {
     type Output = Vec<u8>;
 
+    fn encoding(&self) -> IonEncoding {
+        IonEncoding::Binary_1_1
+    }
+
     fn name() -> &'static str {
         "binary Ion v1.1"
     }
@@ -138,6 +148,11 @@ impl Encoding for BinaryEncoding_1_1 {
 }
 impl Encoding for TextEncoding_1_0 {
     type Output = String;
+
+    fn encoding(&self) -> IonEncoding {
+        IonEncoding::Text_1_0
+    }
+
     fn name() -> &'static str {
         "text Ion v1.0"
     }
@@ -147,6 +162,11 @@ impl Encoding for TextEncoding_1_0 {
 }
 impl Encoding for TextEncoding_1_1 {
     type Output = String;
+
+    fn encoding(&self) -> IonEncoding {
+        IonEncoding::Text_1_1
+    }
+
     fn name() -> &'static str {
         "text Ion v1.1"
     }

--- a/src/lazy/sequence.rs
+++ b/src/lazy/sequence.rs
@@ -67,12 +67,12 @@ impl<'top, D: Decoder> LazyList<'top, D> {
     }
 
     #[cfg(feature = "experimental-tooling-apis")]
-    pub fn lower(&self) -> LazyExpandedList<'top, D> {
+    pub fn expanded(&self) -> LazyExpandedList<'top, D> {
         self.expanded_list
     }
 
     #[cfg(not(feature = "experimental-tooling-apis"))]
-    pub(crate) fn lower(&self) -> LazyExpandedList<'top, D> {
+    pub(crate) fn expanded(&self) -> LazyExpandedList<'top, D> {
         self.expanded_list
     }
 
@@ -148,6 +148,15 @@ impl<'a, 'top, 'data: 'top, D: Decoder> IntoIterator for &'a LazyList<'top, D> {
     }
 }
 
+impl<'top, 'data: 'top, D: Decoder> IntoIterator for LazyList<'top, D> {
+    type Item = IonResult<LazyValue<'top, D>>;
+    type IntoIter = ListIterator<'top, D>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 pub struct ListIterator<'top, D: Decoder> {
     expanded_list_iter: ExpandedListIterator<'top, D>,
 }
@@ -199,7 +208,13 @@ impl<'top, D: Decoder> Debug for LazySExp<'top, D> {
 }
 
 impl<'top, D: Decoder> LazySExp<'top, D> {
-    pub fn lower(&self) -> LazyExpandedSExp<'top, D> {
+    #[cfg(feature = "experimental-tooling-apis")]
+    pub fn expanded(&self) -> LazyExpandedSExp<'top, D> {
+        self.expanded_sexp
+    }
+
+    #[cfg(not(feature = "experimental-tooling-apis"))]
+    pub(crate) fn expanded(&self) -> LazyExpandedSExp<'top, D> {
         self.expanded_sexp
     }
 
@@ -274,6 +289,15 @@ impl<'top, D: Decoder> TryFrom<LazySExp<'top, D>> for Element {
 }
 
 impl<'a, 'top, 'data: 'top, D: Decoder> IntoIterator for &'a LazySExp<'top, D> {
+    type Item = IonResult<LazyValue<'top, D>>;
+    type IntoIter = SExpIterator<'top, D>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'top, 'data: 'top, D: Decoder> IntoIterator for LazySExp<'top, D> {
     type Item = IonResult<LazyValue<'top, D>>;
     type IntoIter = SExpIterator<'top, D>;
 

--- a/src/lazy/streaming_raw_reader.rs
+++ b/src/lazy/streaming_raw_reader.rs
@@ -58,9 +58,11 @@ impl<Encoding: Decoder, Input: IonInput> StreamingRawReader<Encoding, Input> {
     }
 
     /// Gets a reference to the data source and tries to fill its buffer.
-    // This is a separate method to better encapsulate its use of `unsafe`
     #[inline]
     fn pull_more_data_from_source(&mut self) -> IonResult<usize> {
+        // SAFETY: `self.input` is an `UnsafeCell<Input::DataSource>`, which prevents the borrow
+        //         checker from governing its contents. Because this method has a mutable reference
+        //         to `self`, it is safe to modify `self`'s contents.
         let input = unsafe { &mut *self.input.get() };
         input.fill_buffer()
     }
@@ -68,6 +70,9 @@ impl<Encoding: Decoder, Input: IonInput> StreamingRawReader<Encoding, Input> {
     /// Returns true if the input buffer is empty.
     #[inline]
     fn buffer_is_empty(&self) -> bool {
+        // SAFETY: `self.input` is an `UnsafeCell<Input::DataSource>`, which prevents the borrow
+        //         checker from governing its contents. Because this method has an immutable reference
+        //         to `self`, it is safe to read `self`'s contents.
         let input = unsafe { &*self.input.get() };
         input.buffer().is_empty()
     }

--- a/src/lazy/streaming_raw_reader.rs
+++ b/src/lazy/streaming_raw_reader.rs
@@ -1,12 +1,14 @@
 use std::cell::UnsafeCell;
 use std::fs::File;
+use std::io;
 use std::io::{BufReader, Read, StdinLock};
 
 use bumpalo::Bump as BumpAllocator;
 
+use crate::lazy::any_encoding::IonEncoding;
 use crate::lazy::decoder::{Decoder, LazyRawReader};
 use crate::lazy::raw_stream_item::LazyRawStreamItem;
-use crate::{IonError, IonResult};
+use crate::{AnyEncoding, IonError, IonResult};
 
 /// Wraps an implementation of [`IonDataSource`] and reads one top level value at a time from the input.
 pub struct StreamingRawReader<Encoding: Decoder, Input: IonInput> {
@@ -55,11 +57,34 @@ impl<Encoding: Decoder, Input: IonInput> StreamingRawReader<Encoding, Input> {
         }
     }
 
+    /// Gets a reference to the data source and tries to fill its buffer.
+    // This is a separate method to better encapsulate its use of `unsafe`
+    #[inline]
+    fn pull_more_data_from_source(&mut self) -> IonResult<usize> {
+        let input = unsafe { &mut *self.input.get() };
+        input.fill_buffer()
+    }
+
+    /// Returns true if the input buffer is empty.
+    #[inline]
+    fn buffer_is_empty(&self) -> bool {
+        let input = unsafe { &*self.input.get() };
+        input.buffer().is_empty()
+    }
+
     pub fn next<'top>(
         &'top mut self,
         allocator: &'top BumpAllocator,
     ) -> IonResult<LazyRawStreamItem<'top, Encoding>> {
         loop {
+            // If the input buffer is empty, try to pull more data from the source before proceeding.
+            // It's important that we do this _before_ reading from the buffer; any item returned
+            // from a successful `slice_reader.next()` will hold a reference to the buffer. We cannot
+            // modify it once we have that item.
+            if self.buffer_is_empty() {
+                self.pull_more_data_from_source()?;
+            }
+
             let available_bytes = unsafe { &*self.input.get() }.buffer();
             let unsafe_cell_reader = UnsafeCell::new(<Encoding::Reader<'top> as LazyRawReader<
                 'top,
@@ -83,11 +108,13 @@ impl<Encoding: Decoder, Input: IonInput> StreamingRawReader<Encoding, Input> {
 
             let bytes_read = end_position - starting_position;
             let input = unsafe { &mut *self.input.get() };
-            // If we've exhausted the buffer...
-            if bytes_read >= available_bytes.len() || matches!(result, Err(IonError::Incomplete(_)))
-            {
-                // ...try to pull more data from the data source. If we get more data, try again.
+            // If we ran out of data before we could get a result...
+            if matches!(result, Err(IonError::Incomplete(_))) {
+                // ...try to pull more data from the data source. It's ok to modify the buffer in
+                // this case because `result` (which holds a reference to the buffer) will be
+                // discarded.
                 if input.fill_buffer()? > 0 {
+                    // If we get more data, try again.
                     continue;
                 }
                 // If there's nothing available, return the result we got.
@@ -100,6 +127,12 @@ impl<Encoding: Decoder, Input: IonInput> StreamingRawReader<Encoding, Input> {
 
             return result;
         }
+    }
+}
+
+impl<Input: IonInput> StreamingRawReader<AnyEncoding, Input> {
+    pub fn encoding(&self) -> IonEncoding {
+        self.saved_state
     }
 }
 
@@ -312,6 +345,14 @@ impl<R: Read> IonInput for BufReader<R> {
 }
 
 impl<'a> IonInput for StdinLock<'a> {
+    type DataSource = IonStream<Self>;
+
+    fn into_data_source(self) -> Self::DataSource {
+        IonStream::new(self)
+    }
+}
+
+impl<T: Read, U: Read> IonInput for io::Chain<T, U> {
     type DataSource = IonStream<Self>;
 
     fn into_data_source(self) -> Self::DataSource {

--- a/src/lazy/struct.rs
+++ b/src/lazy/struct.rs
@@ -81,12 +81,12 @@ impl<'top, D: Decoder> LazyStruct<'top, D> {
     }
 
     #[cfg(feature = "experimental-tooling-apis")]
-    pub fn lower(&self) -> LazyExpandedStruct<'top, D> {
+    pub fn expanded(&self) -> LazyExpandedStruct<'top, D> {
         self.expanded_struct
     }
 
     #[cfg(not(feature = "experimental-tooling-apis"))]
-    pub(crate) fn lower(&self) -> LazyExpandedStruct<'top, D> {
+    pub(crate) fn expanded(&self) -> LazyExpandedStruct<'top, D> {
         self.expanded_struct
     }
 
@@ -273,6 +273,7 @@ impl<'top, D: Decoder> LazyStruct<'top, D> {
 }
 
 /// A single field within a [`LazyStruct`].
+#[derive(Copy, Clone)]
 pub struct LazyField<'top, D: Decoder> {
     pub(crate) expanded_field: LazyExpandedField<'top, D>,
 }
@@ -351,6 +352,15 @@ impl<'top, D: Decoder> TryFrom<LazyStruct<'top, D>> for Element {
 }
 
 impl<'a, 'top, 'data: 'top, D: Decoder> IntoIterator for &'a LazyStruct<'top, D> {
+    type Item = IonResult<LazyField<'top, D>>;
+    type IntoIter = StructIterator<'top, D>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'top, 'data: 'top, D: Decoder> IntoIterator for LazyStruct<'top, D> {
     type Item = IonResult<LazyField<'top, D>>;
     type IntoIter = StructIterator<'top, D>;
 

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -1,5 +1,6 @@
 #![allow(non_camel_case_types)]
 
+use crate::lazy::any_encoding::IonEncoding;
 use crate::lazy::decoder::Decoder;
 use crate::lazy::expanded::{ExpandedValueRef, ExpandingReader, LazyExpandedValue};
 use crate::lazy::streaming_raw_reader::{IonInput, StreamingRawReader};
@@ -8,8 +9,8 @@ use crate::lazy::value::LazyValue;
 use crate::read_config::ReadConfig;
 use crate::result::IonFailure;
 use crate::{
-    Catalog, Int, IonError, IonResult, IonType, LazyExpandedField, RawSymbolRef, Symbol,
-    SymbolTable,
+    AnyEncoding, Catalog, Int, IonError, IonResult, IonType, LazyExpandedField, RawSymbolRef,
+    Symbol, SymbolTable,
 };
 use std::ops::Deref;
 use std::sync::Arc;
@@ -114,9 +115,7 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
         let expanding_reader = ExpandingReader::new(raw_reader, config.catalog);
         SystemReader { expanding_reader }
     }
-}
 
-impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
     // Returns `true` if the provided [`LazyRawValue`] is a struct whose first annotation is
     // `$ion_symbol_table`.
     pub(crate) fn is_symbol_table_struct(
@@ -337,6 +336,12 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
         }
 
         Ok(())
+    }
+}
+
+impl<Input: IonInput> SystemReader<AnyEncoding, Input> {
+    pub fn detected_encoding(&self) -> IonEncoding {
+        self.expanding_reader.detected_encoding()
     }
 }
 

--- a/src/lazy/system_stream_item.rs
+++ b/src/lazy/system_stream_item.rs
@@ -98,14 +98,14 @@ impl<'top, D: Decoder> SystemStreamItem<'top, D> {
             SystemStreamItem::VersionMarker(marker) => RawStreamItem::VersionMarker(*marker),
             SystemStreamItem::SymbolTable(symtab) => {
                 use ExpandedValueSource::*;
-                match symtab.as_value().lower().source {
+                match symtab.as_value().expanded().source {
                     ValueLiteral(literal) => RawStreamItem::Value(literal),
                     Template(..) | Constructed(..) => return None,
                 }
             }
             SystemStreamItem::Value(value) => {
                 use ExpandedValueSource::*;
-                match value.lower().source {
+                match value.expanded().source {
                     ValueLiteral(literal) => RawStreamItem::Value(literal),
                     Template(..) | Constructed(..) => return None,
                 }

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -1,0 +1,44 @@
+pub(crate) enum FloatRepr {
+    Zero,
+    // TODO: Half(f16)
+    Single(f32),
+    Double(f64),
+}
+
+/// Finds the smallest valid Ion encoding for a given floating point value.
+pub trait SmallestFloatRepr {
+    /// Returns the smallest variant of [`FloatRepr`] that can losslessly represent
+    /// the implementor's data.
+    fn smallest_repr(self) -> FloatRepr;
+}
+
+impl SmallestFloatRepr for f32 {
+    #[inline]
+    fn smallest_repr(self) -> FloatRepr {
+        if self == 0f32 && self.is_sign_positive() {
+            return FloatRepr::Zero;
+        }
+
+        // TODO: See if we can scale down to Half(f16)
+
+        FloatRepr::Single(self)
+    }
+}
+
+impl SmallestFloatRepr for f64 {
+    #[inline]
+    fn smallest_repr(self) -> FloatRepr {
+        if self == 0f64 && self.is_sign_positive() {
+            return FloatRepr::Zero;
+        }
+
+        // TODO: See if we can scale down to Half(f16)
+        // `f64::is_finite` returns false for `NaN`, `+inf`, and `-inf`
+        let is_special_value = !self.is_finite();
+        let value_f32 = self as f32;
+        if is_special_value || value_f32 as f64 == self {
+            return FloatRepr::Single(value_f32);
+        }
+        FloatRepr::Double(self)
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -5,7 +5,7 @@
 pub type SymbolId = usize;
 
 mod bytes;
-pub(crate) mod decimal;
+pub mod decimal;
 pub(crate) mod float;
 pub(crate) mod integer;
 mod list;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -5,7 +5,8 @@
 pub type SymbolId = usize;
 
 mod bytes;
-pub mod decimal;
+pub(crate) mod decimal;
+pub(crate) mod float;
 pub(crate) mod integer;
 mod list;
 mod lob;


### PR DESCRIPTION
This PR includes a variety of small fixes and improvements that I found myself needing as I went to upgrade the `ion-cli` to `HEAD`. I'd like to include these in the v1.0-rc4 release. I have completed the `ion-cli` upgrade in my local workspace using this branch, so I'm reasonably confident that these are the last items I need to get in.

* Renames the `RawReaderType` enum to `IonEncoding` because it is generally useful in other contexts too.
* Adds the ability for system and raw readers using `AnyEncoding` to report the encoding they're currently using.
* Adds `value_span` and `annotations_span` methods to `LazyValue`. It already had a `span` method whose bytes included both the annotations and the value.
* The binary 1.0 and 1.1 writers will now write `f64`s as `f32`s to save space when it can be done losslessly.
* Adds `WriteAsIon` implementations for `LazyList`, `LazySExp`, and `LazyStruct`.
* Adds `IntoIterator` impls for `LazyList`, `LazySExp` and `LazyStruct`. Previously, they only existed for borrowed (`&`) references to those types.
* Fixes a bug in the `StreamingRawReader` that could cause a value's annotations span to be overwritten if reading that value consumed all of the data remaining in the buffer.
* Renames the feature-gated `LazyValue::lower` method (which returns a `LazyExpandedValue`) to `LazyValue::expanded()` so I could add a `raw()` method alongside it that returns the underlying `LazyRawValue` when applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
