### PR TITLE
Prevent writing empty annotations sequences

### DIFF
--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -724,6 +724,16 @@ impl<'top> LazyRawValue<'top, AnyEncoding> for LazyRawAnyValue<'top> {
         }
     }
 
+    fn has_annotations(&self) -> bool {
+        use LazyRawValueKind::*;
+        match &self.encoding {
+            Text_1_0(v) => v.has_annotations(),
+            Binary_1_0(v) => v.has_annotations(),
+            Text_1_1(v) => v.has_annotations(),
+            Binary_1_1(v) => v.has_annotations(),
+        }
+    }
+
     fn annotations(&self) -> RawAnyAnnotationsIterator<'top> {
         use LazyRawValueKind::*;
         match &self.encoding {

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -110,6 +110,10 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_1> for LazyRawBinaryValue_1_1<'to
         self.is_null()
     }
 
+    fn has_annotations(&self) -> bool {
+        self.encoded_value.has_annotations()
+    }
+
     fn annotations(&self) -> <BinaryEncoding_1_1 as Decoder>::AnnotationsIterator<'top> {
         self.annotations()
     }

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -108,6 +108,10 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_0> for LazyRawBinaryValue_1_0<'to
         self.is_null()
     }
 
+    fn has_annotations(&self) -> bool {
+        self.has_annotations()
+    }
+
     fn annotations(&self) -> RawBinaryAnnotationsIterator<'top> {
         self.annotations()
     }

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -374,6 +374,7 @@ pub trait LazyRawValue<'top, D: Decoder>:
 {
     fn ion_type(&self) -> IonType;
     fn is_null(&self) -> bool;
+    fn has_annotations(&self) -> bool;
     fn annotations(&self) -> D::AnnotationsIterator<'top>;
     fn read(&self) -> IonResult<RawValueRef<'top, D>>;
 

--- a/src/lazy/encoder/write_as_ion.rs
+++ b/src/lazy/encoder/write_as_ion.rs
@@ -273,12 +273,16 @@ impl WriteAsIon for Value {
 
 impl<'a, D: Decoder> WriteAsIon for LazyValue<'a, D> {
     fn write_as_ion<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
-        let mut annotations = AnnotationsVec::new();
-        for annotation in self.annotations() {
-            annotations.push(annotation?.into());
+        if self.has_annotations() {
+            let mut annotations = AnnotationsVec::new();
+            for annotation in self.annotations() {
+                annotations.push(annotation?.into());
+            }
+            self.read()?
+                .write_as_ion(writer.with_annotations(annotations)?)
+        } else {
+            self.read()?.write_as_ion(writer)
         }
-        self.read()?
-            .write_as_ion(writer.with_annotations(annotations)?)
     }
 }
 

--- a/src/lazy/text/value.rs
+++ b/src/lazy/text/value.rs
@@ -181,6 +181,10 @@ impl<'top, E: TextEncoding<'top>> LazyRawValue<'top, E> for LazyRawTextValue<'to
         self.encoded_value.is_null()
     }
 
+    fn has_annotations(&self) -> bool {
+        self.has_annotations() // Inherent impl
+    }
+
     fn annotations(&self) -> <E as Decoder>::AnnotationsIterator<'top> {
         let range = self
             .encoded_value


### PR DESCRIPTION
Prior to this change, when a `ValueWriter` explicitly called `with_annotations()` and provided an empty array, the writer would write an empty annotations sequence which is not legal. This change detects that case and skips writing any sequence at all. It also adds a `has_annotations()` convenience method to the `LazyRawValue` trait.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
