### PR TITLE
Enables the StreamingRawReader to detect incomplete text

### DIFF
--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -384,13 +384,7 @@ impl<'data> LazyRawReader<'data, AnyEncoding> for LazyRawAnyReader<'data> {
 
     #[inline]
     fn save_state(&self) -> <AnyEncoding as Decoder>::ReaderSavedState {
-        use RawReaderKind::*;
-        match &self.encoding {
-            Text_1_0(_) => IonEncoding::Text_1_0,
-            Binary_1_0(_) => IonEncoding::Binary_1_0,
-            Text_1_1(_) => IonEncoding::Text_1_1,
-            Binary_1_1(_) => IonEncoding::Binary_1_1,
-        }
+        self.encoding()
     }
 
     fn position(&self) -> usize {
@@ -400,6 +394,16 @@ impl<'data> LazyRawReader<'data, AnyEncoding> for LazyRawAnyReader<'data> {
             Binary_1_0(r) => r.position(),
             Text_1_1(r) => r.position(),
             Binary_1_1(r) => r.position(),
+        }
+    }
+
+    fn encoding(&self) -> IonEncoding {
+        use RawReaderKind::*;
+        match &self.encoding {
+            Text_1_0(_) => IonEncoding::Text_1_0,
+            Binary_1_0(_) => IonEncoding::Binary_1_0,
+            Text_1_1(_) => IonEncoding::Text_1_1,
+            Binary_1_1(_) => IonEncoding::Binary_1_1,
         }
     }
 }

--- a/src/lazy/binary/raw/reader.rs
+++ b/src/lazy/binary/raw/reader.rs
@@ -8,6 +8,7 @@ use crate::lazy::raw_stream_item::{EndPosition, LazyRawStreamItem, RawStreamItem
 use crate::result::IonFailure;
 use crate::IonResult;
 
+use crate::lazy::any_encoding::IonEncoding;
 use bumpalo::Bump as BumpAllocator;
 
 /// A binary Ion 1.0 reader that yields [`LazyRawBinaryValue_1_0`]s representing the top level values found
@@ -134,6 +135,10 @@ impl<'data> LazyRawReader<'data, BinaryEncoding_1_0> for LazyRawBinaryReader_1_0
 
     fn position(&self) -> usize {
         self.data.buffer.offset() + self.data.bytes_to_skip
+    }
+
+    fn encoding(&self) -> IonEncoding {
+        IonEncoding::Binary_1_0
     }
 }
 

--- a/src/lazy/binary/raw/v1_1/reader.rs
+++ b/src/lazy/binary/raw/v1_1/reader.rs
@@ -9,6 +9,7 @@ use crate::lazy::raw_stream_item::{EndPosition, LazyRawStreamItem, RawStreamItem
 use crate::result::IonFailure;
 use crate::IonResult;
 
+use crate::lazy::any_encoding::IonEncoding;
 use bumpalo::Bump as BumpAllocator;
 
 pub struct LazyRawBinaryReader_1_1<'data> {
@@ -163,6 +164,10 @@ impl<'data> LazyRawReader<'data, BinaryEncoding_1_1> for LazyRawBinaryReader_1_1
 
     fn position(&self) -> usize {
         self.data.offset() + self.bytes_to_skip
+    }
+
+    fn encoding(&self) -> IonEncoding {
+        IonEncoding::Binary_1_1
     }
 }
 

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -258,7 +258,7 @@ impl<'a, 'top> EncodedBinaryValueData_1_0<'a, 'top> {
     /// value's body (that is: the content of the value that follows its opcode and length).
     pub fn body_range(&self) -> Range<usize> {
         let encoded = &self.value.encoded_value;
-        let body_offset = encoded.header_length();
+        let body_offset = encoded.annotations_header_length as usize + encoded.header_length();
         let body_length = encoded.value_body_length();
         let start = self.range().start + body_offset;
         let end = start + body_length;

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -258,7 +258,7 @@ impl<'a, 'top> EncodedBinaryValueData_1_0<'a, 'top> {
     /// value's body (that is: the content of the value that follows its opcode and length).
     pub fn body_range(&self) -> Range<usize> {
         let encoded = &self.value.encoded_value;
-        let body_offset = encoded.annotations_header_length as usize + encoded.header_length();
+        let body_offset = encoded.header_length();
         let body_length = encoded.value_body_length();
         let start = self.range().start + body_offset;
         let end = start + body_length;
@@ -268,11 +268,11 @@ impl<'a, 'top> EncodedBinaryValueData_1_0<'a, 'top> {
     /// Returns the encoded bytes representing the value's body (that is: the content of the value
     /// that follows its opcode and length).
     pub fn body_span(&self) -> Span<'top> {
-        let stream_range = self.body_range();
-        let offset = self.value.input.offset();
-        let local_range = stream_range.start - offset..stream_range.end - offset;
-        let bytes = &self.span().bytes()[local_range];
-        Span::with_offset(stream_range.start, bytes)
+        let body_range = self.body_range();
+        let body_length = body_range.len();
+        let value_bytes = self.span().bytes();
+        let body_bytes = &value_bytes[value_bytes.len() - body_length..];
+        Span::with_offset(body_range.start, body_bytes)
     }
 }
 

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -3,6 +3,7 @@ use std::ops::Range;
 
 use bumpalo::Bump as BumpAllocator;
 
+use crate::lazy::any_encoding::IonEncoding;
 use crate::lazy::encoding::{BinaryEncoding_1_0, RawValueLiteral, TextEncoding_1_0};
 use crate::lazy::expanded::macro_evaluator::RawEExpression;
 use crate::lazy::raw_stream_item::LazyRawStreamItem;
@@ -348,6 +349,7 @@ pub trait LazyRawReader<'data, D: Decoder>: Sized {
 
     fn resume_at_offset(data: &'data [u8], offset: usize, saved_state: D::ReaderSavedState)
         -> Self;
+
     fn next<'top>(
         &'top mut self,
         allocator: &'top BumpAllocator,
@@ -363,6 +365,8 @@ pub trait LazyRawReader<'data, D: Decoder>: Sized {
     /// This position is not necessarily the first byte of the next value; it may be (e.g.) a NOP,
     /// a comment, or whitespace that the reader will traverse as part of matching the next item.
     fn position(&self) -> usize;
+
+    fn encoding(&self) -> IonEncoding;
 }
 
 pub trait LazyRawContainer<'top, D: Decoder> {

--- a/src/lazy/encoder/text/v1_0/value_writer.rs
+++ b/src/lazy/encoder/text/v1_0/value_writer.rs
@@ -111,7 +111,11 @@ pub struct TextAnnotatedValueWriter_1_0<'value, W: Write> {
 }
 
 impl<'value, W: Write> TextAnnotatedValueWriter_1_0<'value, W> {
-    fn encode_annotations(self) -> IonResult<TextValueWriter_1_0<'value, W>> {
+    fn encode_annotations(mut self) -> IonResult<TextValueWriter_1_0<'value, W>> {
+        // The inner ValueWriter knows the indentation depth; we'll have it write the indentation
+        // before we write the value, then set the body's indentation to 0 to avoid re-indenting.
+        self.value_writer.write_indentation()?;
+        self.value_writer.depth = 0;
         let output = &mut self.value_writer.writer.output;
         for annotation in self.annotations {
             match annotation.as_raw_symbol_token_ref() {

--- a/src/lazy/text/buffer.rs
+++ b/src/lazy/text/buffer.rs
@@ -327,7 +327,16 @@ impl<'top> TextBufferView<'top> {
         terminated(
             whitespace_and_then(match_and_span(Self::match_symbol)),
             whitespace_and_then(terminated(
-                complete_tag("::"),
+                // The complete_tag/tag pair allows the parser to recognize that:
+                //
+                //     foo::bar::baz:
+                //
+                // is incomplete while:
+                //
+                //     foo::bar::baz
+                //
+                // is a symbol with two annotations.
+                pair(complete_tag(":"), tag(":")),
                 Self::match_optional_comments_and_whitespace,
             )),
         )(self)


### PR DESCRIPTION
In binary encodings, stream items contain enough data for the reader to tell whether they are complete. In text encodings, it's possible for the buffer to end with data that looks like a complete item but is not. The only way to be certain is to try to read again from the input source to confirm there's no more data. Consider the following examples in which Ion is being pulled from a `File` into a `Vec<u8>`:
```
foo /* comment */   ::bar::baz::1000
└────────┬───────┘ └────────┬───────┘
  buffer contents   remaining in File

              $ion _1_0
└────────┬───────┘ └────────┬───────┘
  buffer contents   remaining in File

               75 1.20
────────┬───────┘ └────────┬───────┘
  buffer contents   remaining in File
```
To avoid misinterpreting the data, the `StreamingRawReader` now performs a final check for text readers who have emptied their buffer: it does not consider the item complete unless the input source is exhausted.

Other changes:
* Fixes an indentation issue that affected annotated values emitted by the text writer.
* Makes `IonStream` a public part of the `experimental-reader-writer` API.
* Fixes a bug in the tooling access API `EncodedBinaryValueData_1_0::body_span` that caused it to fail if the value in question was annotated.

The three commits are each self-contained; reviewing them separately may be helpful.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
