### PR TITLE
[serde] Implement serde Serializer/Deserializer::is_human_readable

### DIFF
--- a/src/lazy/encoder/binary/v1_0/container_writers.rs
+++ b/src/lazy/encoder/binary/v1_0/container_writers.rs
@@ -335,6 +335,8 @@ impl<'value, 'top> MakeValueWriter for BinaryStructWriter_1_0<'value, 'top> {
 }
 
 impl<'value, 'top> StructWriter for BinaryStructWriter_1_0<'value, 'top> {
+    const IS_HUMAN_READABLE: bool = false;
+
     fn close(self) -> IonResult<()> {
         self.container_writer.end()
     }

--- a/src/lazy/encoder/binary/v1_0/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_0/value_writer.rs
@@ -288,6 +288,7 @@ impl<'value, 'top> ValueWriter for BinaryValueWriter_1_0<'value, 'top> {
     type StructWriter = BinaryStructWriter_1_0<'value, 'top>;
 
     type EExpWriter = Never;
+    const IS_HUMAN_READABLE: bool = false;
 
     delegate_value_writer_to_self!();
 }
@@ -411,6 +412,7 @@ impl<'value, 'top> ValueWriter for BinaryAnnotatedValueWriter_1_0<'value, 'top> 
     type SExpWriter = BinarySExpWriter_1_0<'value, 'top>;
     type StructWriter = BinaryStructWriter_1_0<'value, 'top>;
 
+    const IS_HUMAN_READABLE: bool = false;
     // Ion 1.0
     type EExpWriter = Never;
 

--- a/src/lazy/encoder/binary/v1_1/container_writers.rs
+++ b/src/lazy/encoder/binary/v1_1/container_writers.rs
@@ -345,6 +345,7 @@ impl<'value, 'top> MakeValueWriter for BinaryStructWriter_1_1<'value, 'top> {
 }
 
 impl<'value, 'top> StructWriter for BinaryStructWriter_1_1<'value, 'top> {
+    const IS_HUMAN_READABLE: bool = false;
     fn close(mut self) -> IonResult<()> {
         if let ContainerEncodingKind::Delimited(_) = &mut self.container_writer.encoder {
             // Write the FlexSym escape (FlexUInt 0). The container writer can emit the closing

--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -664,6 +664,8 @@ impl<'value, 'top> ValueWriter for BinaryValueWriter_1_1<'value, 'top> {
 
     type EExpWriter = BinaryEExpWriter_1_1<'value, 'top>;
 
+    const IS_HUMAN_READABLE: bool = false;
+
     delegate_value_writer_to_self!();
 }
 
@@ -766,6 +768,8 @@ impl<'value, 'top> ValueWriter for BinaryAnnotatedValueWriter_1_1<'value, 'top> 
     type SExpWriter = BinarySExpWriter_1_1<'value, 'top>;
     type StructWriter = BinaryStructWriter_1_1<'value, 'top>;
     type EExpWriter = BinaryEExpWriter_1_1<'value, 'top>;
+
+    const IS_HUMAN_READABLE: bool = false;
 
     annotate_and_delegate_1_1!(
         IonType => write_null,

--- a/src/lazy/encoder/text/v1_0/value_writer.rs
+++ b/src/lazy/encoder/text/v1_0/value_writer.rs
@@ -443,6 +443,7 @@ impl<'value, W: Write> MakeValueWriter for TextStructWriter_1_0<'value, W> {
 }
 
 impl<'value, W: Write> StructWriter for TextStructWriter_1_0<'value, W> {
+    const IS_HUMAN_READABLE: bool = true;
     fn close(self) -> IonResult<()> {
         self.end()
     }
@@ -473,6 +474,8 @@ impl<'value, W: Write + 'value> ValueWriter for TextAnnotatedValueWriter_1_0<'va
     // Ion 1.0 does not support macros
     type EExpWriter = Never;
 
+    const IS_HUMAN_READABLE: bool = true;
+
     delegate_value_writer_to!(fallible closure |self_: Self| self_.encode_annotations());
 }
 
@@ -497,6 +500,8 @@ impl<'value, W: Write> ValueWriter for TextValueWriter_1_0<'value, W> {
     type ListWriter = TextListWriter_1_0<'value, W>;
     type SExpWriter = TextSExpWriter_1_0<'value, W>;
     type StructWriter = TextStructWriter_1_0<'value, W>;
+
+    const IS_HUMAN_READABLE: bool = true;
 
     // Ion 1.0 does not support macros
     type EExpWriter = Never;

--- a/src/lazy/encoder/text/v1_1/value_writer.rs
+++ b/src/lazy/encoder/text/v1_1/value_writer.rs
@@ -46,6 +46,8 @@ impl<'value, W: Write + 'value> ValueWriter for TextValueWriter_1_1<'value, W> {
     type StructWriter = TextStructWriter_1_1<'value, W>;
     type EExpWriter = TextEExpWriter_1_1<'value, W>;
 
+    const IS_HUMAN_READABLE: bool = true;
+
     // For all of the scalars, delegate to the existing 1.0 writing logic.
     delegate! {
         to self.value_writer_1_0 {
@@ -121,6 +123,7 @@ impl<'value, W: Write + 'value> ValueWriter for TextAnnotatedValueWriter_1_1<'va
     type SExpWriter = TextSExpWriter_1_1<'value, W>;
     type StructWriter = TextStructWriter_1_1<'value, W>;
     type EExpWriter = TextEExpWriter_1_1<'value, W>;
+    const IS_HUMAN_READABLE: bool = true;
     // For all of the scalars, delegate to the existing 1.0 writing logic.
     delegate! {
         to self.value_writer_1_0 {
@@ -227,6 +230,7 @@ impl<'value, W: Write> MakeValueWriter for TextStructWriter_1_1<'value, W> {
 }
 
 impl<'value, W: Write> StructWriter for TextStructWriter_1_1<'value, W> {
+    const IS_HUMAN_READABLE: bool = true;
     fn close(self) -> IonResult<()> {
         self.writer_1_0.close()
     }

--- a/src/lazy/encoder/value_writer.rs
+++ b/src/lazy/encoder/value_writer.rs
@@ -53,6 +53,7 @@ pub trait ValueWriter: AnnotatableWriter + Sized {
     type SExpWriter: SequenceWriter<Resources = ()>;
     type StructWriter: StructWriter;
     type EExpWriter: EExpWriter<Resources = ()>;
+    const IS_HUMAN_READABLE: bool;
 
     fn write_null(self, ion_type: IonType) -> IonResult<()>;
     fn write_bool(self, value: bool) -> IonResult<()>;
@@ -236,6 +237,7 @@ impl<'field, StructWriterType: StructWriter> ValueWriter for FieldWriter<'field,
         <<StructWriterType as MakeValueWriter>::ValueWriter<'field> as ValueWriter>::StructWriter;
     type EExpWriter =
         <<StructWriterType as MakeValueWriter>::ValueWriter<'field> as ValueWriter>::EExpWriter;
+    const IS_HUMAN_READABLE: bool = StructWriterType::IS_HUMAN_READABLE;
 
     delegate_value_writer_to!(fallible closure |self_: Self| {
         self_.struct_writer.encode_field_name(self_.name)?;
@@ -287,6 +289,8 @@ impl<'field, StructWriterType: StructWriter> AnnotatableWriter
 impl<'field, StructWriterType: StructWriter> ValueWriter
     for AnnotatedFieldWriter<'field, StructWriterType>
 {
+    const IS_HUMAN_READABLE: bool = StructWriterType::IS_HUMAN_READABLE;
+
     type ListWriter =
         <<<StructWriterType as MakeValueWriter>::ValueWriter<'field> as AnnotatableWriter>::AnnotatedValueWriter<'field> as ValueWriter>::ListWriter;
     type SExpWriter =
@@ -304,6 +308,7 @@ impl<'field, StructWriterType: StructWriter> ValueWriter
 }
 
 pub trait StructWriter: FieldEncoder + MakeValueWriter + Sized {
+    const IS_HUMAN_READABLE: bool;
     /// Writes a struct field using the provided name/value pair.
     fn write<A: AsRawSymbolRef, V: WriteAsIon>(
         &mut self,

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -251,6 +251,7 @@ impl<'value, V: ValueWriter> ValueWriter for ApplicationValueWriter<'value, V> {
     type SExpWriter = ApplicationSExpWriter<'value, V>;
     type StructWriter = ApplicationStructWriter<'value, V>;
     type EExpWriter = ApplicationEExpWriter<'value, V>;
+    const IS_HUMAN_READABLE: bool = V::IS_HUMAN_READABLE;
 
     delegate! {
         to self.raw_value_writer {
@@ -403,6 +404,7 @@ impl<'value, V: ValueWriter> FieldEncoder for ApplicationStructWriter<'value, V>
 }
 
 impl<'value, V: ValueWriter> StructWriter for ApplicationStructWriter<'value, V> {
+    const IS_HUMAN_READABLE: bool = V::IS_HUMAN_READABLE;
     fn close(self) -> IonResult<()> {
         self.raw_struct_writer.close()
     }

--- a/src/lazy/never.rs
+++ b/src/lazy/never.rs
@@ -68,6 +68,7 @@ impl FieldEncoder for Never {
 }
 
 impl StructWriter for Never {
+    const IS_HUMAN_READABLE: bool = false;
     fn close(self) -> IonResult<()> {
         unreachable!("StructWriter::end in Never")
     }
@@ -102,6 +103,7 @@ impl ValueWriter for Never {
     type SExpWriter = Never;
     type StructWriter = Never;
     type EExpWriter = Never;
+    const IS_HUMAN_READABLE: bool = false;
 
     delegate_value_writer_to_self!();
 }

--- a/src/lazy/reader.rs
+++ b/src/lazy/reader.rs
@@ -9,7 +9,7 @@ use crate::lazy::text::raw::v1_1::reader::MacroAddress;
 use crate::lazy::value::LazyValue;
 use crate::read_config::ReadConfig;
 use crate::result::IonFailure;
-use crate::{IonError, IonResult};
+use crate::{AnyEncoding, IonEncoding, IonError, IonResult};
 
 /// A binary reader that only reads each value that it visits upon request (that is: lazily).
 ///
@@ -71,6 +71,12 @@ pub(crate) enum NextApplicationValue<'top, D: Decoder> {
     EndOfStream,
 }
 
+impl<Input: IonInput> Reader<AnyEncoding, Input> {
+    pub fn detected_encoding(&self) -> IonEncoding {
+        self.system_reader.detected_encoding()
+    }
+}
+
 impl<Encoding: Decoder, Input: IonInput> Reader<Encoding, Input> {
     /// Returns the next top-level value in the input stream as `Ok(Some(lazy_value))`.
     /// If there are no more top-level values in the stream, returns `Ok(None)`.
@@ -121,7 +127,7 @@ impl<Encoding: Decoder, Input: IonInput> Reader<Encoding, Input> {
         config: impl Into<ReadConfig<Encoding>>,
         ion_data: Input,
     ) -> IonResult<Reader<Encoding, Input>> {
-        let system_reader = SystemReader::new(config, ion_data);
+        let system_reader = SystemReader::new(config, ion_data)?;
         Ok(Reader { system_reader })
     }
 }

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -306,6 +306,10 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
                 .struct_writer()?,
         })
     }
+
+    fn is_human_readable(&self) -> bool {
+        V::IS_HUMAN_READABLE
+    }
 }
 
 pub struct SeqWriter<V: ValueWriter> {


### PR DESCRIPTION
Will return true for text encodings, false for binary. is_human_readable is used to determine whether Serialize implementations should serialize in human-readable form.

Some types have a human-readable form that may be somewhat expensive to construct, as well as a binary form that is compact and efficient.

Fixes issue 790

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
