### PR TITLE
Support for encoding directives, arg groups, length-prefixed e-expressions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ edition = "2021"
 # We need at least 1.65 for GATs[1] and 1.67 for `ilog`[2]
 # [1] https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html
 # [2] https://blog.rust-lang.org/2023/01/26/Rust-1.67.0.html#stabilized-apis
-rust-version = "1.67"
+rust-version = "1.77"
 
 [features]
 default = []
@@ -63,6 +63,7 @@ smallvec = { version = "1.9.0", features = ["const_generics"] }
 bumpalo = { version = "3.15.3", features = ["collections", "std"] }
 digest = { version = "0.9", optional = true }
 ice_code = "0.1.4"
+rustc-hash = "2.0.0"
 sha2 = { version = "0.9", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_with = { version = "3.7.0", optional = true }

--- a/benches/read_many_structs.rs
+++ b/benches/read_many_structs.rs
@@ -44,7 +44,7 @@ fn maximally_compact_1_1_data(num_values: usize) -> TestData_1_1 {
         )
     "#.to_owned();
 
-    let text_1_1_data = r#"(:event 1670446800245 418 "6" "1" "18b4fa" (: "region 4" "2022-12-07T20:59:59.744000Z"))"#.repeat(num_values);
+    let text_1_1_data = r#"(:event 1670446800245 418 "6" "1" "abc-123" (: "region 4" "2022-12-07T20:59:59.744000Z"))"#.repeat(num_values);
 
     let mut binary_1_1_data = vec![0xE0u8, 0x01, 0x01, 0xEA]; // IVM
     #[rustfmt::skip]
@@ -60,7 +60,7 @@ fn maximally_compact_1_1_data(num_values: usize) -> TestData_1_1 {
         0x91, // 1-byte string (`client_num` param)
         0x31,
         0x96, // 6-byte string (`host_id` param)
-        0x31, 0x38, 0x62, 0x34, 0x66, 0x61,
+        0x61, 0x62, 0x63, 0x31, 0x32, 0x33,
         0x4D, // Arg group length prefix
         0x98, // 8-byte string
         0x72, 0x65, 0x67, 0x69,
@@ -107,7 +107,7 @@ fn moderately_compact_1_1_data(num_values: usize) -> TestData_1_1 {
         )
     "#;
 
-    let text_1_1_data = r#"(:event 1670446800245 418 "scheduler-thread-6" "example-client-1" "aws-us-east-5f-18b4fa" (: "region 4" "2022-12-07T20:59:59.744000Z"))"#.repeat(num_values);
+    let text_1_1_data = r#"(:event 1670446800245 418 "scheduler-thread-6" "example-client-1" "aws-us-east-5f-abc-123" (: "region 4" "2022-12-07T20:59:59.744000Z"))"#.repeat(num_values);
     let mut binary_1_1_data = vec![0xE0u8, 0x01, 0x01, 0xEA]; // IVM
     #[rustfmt::skip]
     let mut binary_1_1_data_body: Vec<u8> = vec![
@@ -127,11 +127,10 @@ fn moderately_compact_1_1_data(num_values: usize) -> TestData_1_1 {
         0x65, 0x78, 0x61, 0x6D, 0x70, 0x6C, 0x65, 0x2D, 0x63, 0x6C, 0x69, 0x65, 0x6E, 0x74, 0x2D, 0x31,
         0xF9, // long-form string (`host_id` param)
         0x2B, // FlexUInt byte length 21
-        // "aws-us-east-5f-18b4fa"
+        // "aws-us-east-5f-abc-123"
         0x61, 0x77, 0x73, 0x2D, 0x75, 0x73,
         0x2D, 0x65, 0x61, 0x73, 0x74, 0x2D,
-        0x35, 0x66, 0x2D, 0x31, 0x38, 0x62,
-        0x34, 0x66, 0x61,
+        0x35, 0x66, 0x2D, 0x61, 0x62, 0x63, 0x31, 0x32, 0x33,
         0x4D, // Arg group length prefix
         0x98, // 8-byte string
         0x72, 0x65, 0x67, 0x69,
@@ -179,7 +178,7 @@ fn length_prefixed_moderately_compact_1_1_data(num_values: usize) -> TestData_1_
         )
     "#;
 
-    let text_1_1_data = r#"(:event 1670446800245 418 "scheduler-thread-6" "example-client-1" "aws-us-east-5f-18b4fa" (: "region 4" "2022-12-07T20:59:59.744000Z"))"#.repeat(num_values);
+    let text_1_1_data = r#"(:event 1670446800245 418 "scheduler-thread-6" "example-client-1" "aws-us-east-5f-abc-123" (: "region 4" "2022-12-07T20:59:59.744000Z"))"#.repeat(num_values);
     let mut binary_1_1_data = vec![0xE0u8, 0x01, 0x01, 0xEA]; // IVM
     #[rustfmt::skip]
     let mut binary_1_1_data_body: Vec<u8> = vec![
@@ -201,11 +200,10 @@ fn length_prefixed_moderately_compact_1_1_data(num_values: usize) -> TestData_1_
         0x65, 0x78, 0x61, 0x6D, 0x70, 0x6C, 0x65, 0x2D, 0x63, 0x6C, 0x69, 0x65, 0x6E, 0x74, 0x2D, 0x31,
         0xF9, // long-form string (`host_id` param)
         0x2B, // FlexUInt byte length 21
-        // "aws-us-east-5f-18b4fa"
+        // "aws-us-east-5f-abc-123"
         0x61, 0x77, 0x73, 0x2D, 0x75, 0x73,
         0x2D, 0x65, 0x61, 0x73, 0x74, 0x2D,
-        0x35, 0x66, 0x2D, 0x31, 0x38, 0x62,
-        0x34, 0x66, 0x61,
+        0x35, 0x66, 0x2D, 0x61, 0x62, 0x63, 0x31, 0x32, 0x33,
         0x4D, // Arg group length prefix
         0x98, // 8-byte string
         0x72, 0x65, 0x67, 0x69,
@@ -304,7 +302,7 @@ mod benchmark {
             'loggerName': "com.example.organization.product.component.ClassName",
             'logLevel': INFO,
             'format': "Request status: {} Client ID: {} Client Host: {} Client Region: {} Timestamp: {}",
-            'parameters': ["SUCCESS","example-client-1","aws-us-east-5f-18b4fa","region 4","2022-12-07T20:59:59.744000Z",],
+            'parameters': ["SUCCESS","example-client-1","aws-us-east-5f-abc-123","region 4","2022-12-07T20:59:59.744000Z",],
         }"#.repeat(num_values);
         let text_1_0_data = rewrite_as(&pretty_data_1_0, v1_0::Text).unwrap();
         let binary_1_0_data = rewrite_as(&pretty_data_1_0, v1_0::Binary).unwrap();

--- a/benches/read_many_structs.rs
+++ b/benches/read_many_structs.rs
@@ -3,27 +3,262 @@ use criterion::{criterion_group, criterion_main};
 #[cfg(not(feature = "experimental"))]
 mod benchmark {
     use criterion::Criterion;
+
     pub fn criterion_benchmark(_c: &mut Criterion) {
         panic!("This benchmark requires the 'experimental' feature to work; try again with `--features experimental`");
+    }
+}
+
+/// An Ion 1.1 test stream to benchmark. Each instance of this type contains data that was encoded
+/// with different settings; for example, using more or fewer macros, or using length-prefixing.
+#[allow(non_camel_case_types)]
+pub struct TestData_1_1 {
+    name: String,
+    template_definition_text: String,
+    text_data: String,
+    binary_data: Vec<u8>,
+}
+
+/// Produces an Ion 1.1 stream with `num_values` top-level e-expressions. Each e-expression invokes
+/// a template that makes more extensive use of macros to minimize the size of each invocation. This
+/// makes the stream much more compact, but comes at the expense of evaluation overhead when the
+/// stream is read. If only a subset of the fields are read from each value, this overhead will be
+/// minimal.
+fn maximally_compact_1_1_data(num_values: usize) -> TestData_1_1 {
+    let template_definition_text: String = r#"
+        (macro event (timestamp thread_id thread_name client_num host_id parameters*)
+            {
+                'timestamp': timestamp,
+                'threadId': thread_id,
+                'threadName': (make_string "scheduler-thread-" thread_name),
+                'loggerName': "com.example.organization.product.component.ClassName",
+                'logLevel': (literal INFO),
+                'format': "Request status: {} Client ID: {} Client Host: {} Client Region: {} Timestamp: {}",
+                'parameters': [
+                    "SUCCESS",
+                    (make_string "example-client-" client_num),
+                    (make_string "aws-us-east-5f-" host_id),
+                    parameters
+                ]
+            }
+        )
+    "#.to_owned();
+
+    let text_1_1_data = r#"(:event 1670446800245 418 "6" "1" "18b4fa" (: "region 4" "2022-12-07T20:59:59.744000Z"))"#.repeat(num_values);
+
+    let mut binary_1_1_data = vec![0xE0u8, 0x01, 0x01, 0xEA]; // IVM
+    #[rustfmt::skip]
+    let mut binary_1_1_data_body: Vec<u8> = vec![
+        0x03, // Macro ID 3
+        0b10, // [NOTE: `0b`] `parameters*` arg is an arg group
+        0x66, // 6-byte integer (`timestamp` param)
+        0x75, 0x5D, 0x63, 0xEE, 0x84, 0x01,
+        0x62, // 2-byte integer (`thread_id` param)
+        0xA2, 0x01,
+        0x91, // 1-byte string (`thread_name` param)
+        0x36,
+        0x91, // 1-byte string (`client_num` param)
+        0x31,
+        0x96, // 6-byte string (`host_id` param)
+        0x31, 0x38, 0x62, 0x34, 0x66, 0x61,
+        0x4D, // Arg group length prefix
+        0x98, // 8-byte string
+        0x72, 0x65, 0x67, 0x69,
+        0x6F, 0x6E, 0x20, 0x34,
+        0xF9, // Long-form, 27-byte string
+        0x37, 0x32, 0x30, 0x32,
+        0x32, 0x2D, 0x31, 0x32,
+        0x2D, 0x30, 0x37, 0x54,
+        0x32, 0x30, 0x3A, 0x35,
+        0x39, 0x3A, 0x35, 0x39,
+        0x2E, 0x37, 0x34, 0x34,
+        0x30, 0x30, 0x30, 0x5A,
+    ].repeat(num_values);
+    binary_1_1_data.append(&mut binary_1_1_data_body);
+    TestData_1_1 {
+        name: "maximally compact".to_owned(),
+        template_definition_text,
+        text_data: text_1_1_data,
+        binary_data: binary_1_1_data,
+    }
+}
+
+/// Produces an Ion 1.1 stream with `num_values` top-level e-expressions. Each e-expression invokes
+/// a template that does not use additional macros. This makes the stream compact relative to its
+/// Ion 1.0 equivalent, but not as compact as it is in the "maximally compact" configuration above.
+/// The lighter use of macros means that there is less evaluation overhead at read time.
+fn moderately_compact_1_1_data(num_values: usize) -> TestData_1_1 {
+    let template_definition_text = r#"
+        (macro event (timestamp thread_id thread_name client_num host_id parameters*)
+            {
+                'timestamp': timestamp,
+                'threadId': thread_id,
+                'threadName': thread_name,
+                'loggerName': "com.example.organization.product.component.ClassName",
+                'logLevel': (literal INFO),
+                'format': "Request status: {} Client ID: {} Client Host: {} Client Region: {} Timestamp: {}",
+                'parameters': [
+                    "SUCCESS",
+                    client_num,
+                    host_id,
+                    parameters
+                ]
+            }
+        )
+    "#;
+
+    let text_1_1_data = r#"(:event 1670446800245 418 "scheduler-thread-6" "example-client-1" "aws-us-east-5f-18b4fa" (: "region 4" "2022-12-07T20:59:59.744000Z"))"#.repeat(num_values);
+    let mut binary_1_1_data = vec![0xE0u8, 0x01, 0x01, 0xEA]; // IVM
+    #[rustfmt::skip]
+    let mut binary_1_1_data_body: Vec<u8> = vec![
+        0x03,
+        0b10, // [NOTE: `0b` prefix] `parameters*` arg is an arg group
+        0x66, // 6-byte integer (`timestamp` param)
+        0x75, 0x5D, 0x63, 0xEE, 0x84, 0x01,
+        0x62, // 2-byte integer (`thread_id` param)
+        0xA2, 0x01,
+        0xF9, // long-form string (`thread_name` param)
+        0x25, // FlexUInt byte length 18
+        // "scheduler-thread-6"
+        0x73, 0x63, 0x68, 0x65, 0x64, 0x75, 0x6C, 0x65, 0x72, 0x2D, 0x74, 0x68, 0x72, 0x65, 0x61, 0x64, 0x2D, 0x36,
+        0xF9, // 1-byte string (`client_num` param)
+        0x21, // FlexUInt byte length 16
+         // "example-client-1"
+        0x65, 0x78, 0x61, 0x6D, 0x70, 0x6C, 0x65, 0x2D, 0x63, 0x6C, 0x69, 0x65, 0x6E, 0x74, 0x2D, 0x31,
+        0xF9, // long-form string (`host_id` param)
+        0x2B, // FlexUInt byte length 21
+        // "aws-us-east-5f-18b4fa"
+        0x61, 0x77, 0x73, 0x2D, 0x75, 0x73,
+        0x2D, 0x65, 0x61, 0x73, 0x74, 0x2D,
+        0x35, 0x66, 0x2D, 0x31, 0x38, 0x62,
+        0x34, 0x66, 0x61,
+        0x4D, // Arg group length prefix
+        0x98, // 8-byte string
+        0x72, 0x65, 0x67, 0x69,
+        0x6F, 0x6E, 0x20, 0x34,
+        0xF9, // Long-form, 27-byte string
+        0x37, 0x32, 0x30, 0x32,
+        0x32, 0x2D, 0x31, 0x32,
+        0x2D, 0x30, 0x37, 0x54,
+        0x32, 0x30, 0x3A, 0x35,
+        0x39, 0x3A, 0x35, 0x39,
+        0x2E, 0x37, 0x34, 0x34,
+        0x30, 0x30, 0x30, 0x5A,
+    ].repeat(num_values);
+
+    binary_1_1_data.append(&mut binary_1_1_data_body);
+    TestData_1_1 {
+        name: "moderately compact".to_owned(),
+        template_definition_text: template_definition_text.to_owned(),
+        text_data: text_1_1_data,
+        binary_data: binary_1_1_data,
+    }
+}
+
+/// Like `moderately_compact_1_1_data` above, but each top-level e-expression in the stream is
+/// length-prefixed. This allows the reader to step over e-expressions without fully parsing them,
+/// making top-level skip-scanning highly efficient at the expense of 1-2 extra bytes per
+/// e-expression.
+fn length_prefixed_moderately_compact_1_1_data(num_values: usize) -> TestData_1_1 {
+    let template_definition_text = r#"
+        (macro event (timestamp thread_id thread_name client_num host_id parameters*)
+            {
+                'timestamp': timestamp,
+                'threadId': thread_id,
+                'threadName': thread_name,
+                'loggerName': "com.example.organization.product.component.ClassName",
+                'logLevel': (literal INFO),
+                'format': "Request status: {} Client ID: {} Client Host: {} Client Region: {} Timestamp: {}",
+                'parameters': [
+                    "SUCCESS",
+                    client_num,
+                    host_id,
+                    parameters
+                ]
+            }
+        )
+    "#;
+
+    let text_1_1_data = r#"(:event 1670446800245 418 "scheduler-thread-6" "example-client-1" "aws-us-east-5f-18b4fa" (: "region 4" "2022-12-07T20:59:59.744000Z"))"#.repeat(num_values);
+    let mut binary_1_1_data = vec![0xE0u8, 0x01, 0x01, 0xEA]; // IVM
+    #[rustfmt::skip]
+    let mut binary_1_1_data_body: Vec<u8> = vec![
+        0xF5, // LP invocation
+        0x07, // Macro ID 3
+        0xDF, // Length prefix: FlexUInt 111
+        0b10, // [NOTE: `0b` prefix] `parameters*` arg is an arg group
+        0x66, // 6-byte integer (`timestamp` param)
+        0x75, 0x5D, 0x63, 0xEE, 0x84, 0x01,
+        0x62, // 2-byte integer (`thread_id` param)
+        0xA2, 0x01,
+        0xF9, // long-form string (`thread_name` param)
+        0x25, // FlexUInt byte length 18
+        // "scheduler-thread-6"
+        0x73, 0x63, 0x68, 0x65, 0x64, 0x75, 0x6C, 0x65, 0x72, 0x2D, 0x74, 0x68, 0x72, 0x65, 0x61, 0x64, 0x2D, 0x36,
+        0xF9, // 1-byte string (`client_num` param)
+        0x21, // FlexUInt byte length 16
+        // "example-client-1"
+        0x65, 0x78, 0x61, 0x6D, 0x70, 0x6C, 0x65, 0x2D, 0x63, 0x6C, 0x69, 0x65, 0x6E, 0x74, 0x2D, 0x31,
+        0xF9, // long-form string (`host_id` param)
+        0x2B, // FlexUInt byte length 21
+        // "aws-us-east-5f-18b4fa"
+        0x61, 0x77, 0x73, 0x2D, 0x75, 0x73,
+        0x2D, 0x65, 0x61, 0x73, 0x74, 0x2D,
+        0x35, 0x66, 0x2D, 0x31, 0x38, 0x62,
+        0x34, 0x66, 0x61,
+        0x4D, // Arg group length prefix
+        0x98, // 8-byte string
+        0x72, 0x65, 0x67, 0x69,
+        0x6F, 0x6E, 0x20, 0x34,
+        0xF9, // Long-form, 27-byte string
+        0x37, 0x32, 0x30, 0x32,
+        0x32, 0x2D, 0x31, 0x32,
+        0x2D, 0x30, 0x37, 0x54,
+        0x32, 0x30, 0x3A, 0x35,
+        0x39, 0x3A, 0x35, 0x39,
+        0x2E, 0x37, 0x34, 0x34,
+        0x30, 0x30, 0x30, 0x5A,
+    ].repeat(num_values);
+
+    binary_1_1_data.append(&mut binary_1_1_data_body);
+    TestData_1_1 {
+        name: "moderately compact w/length-prefixed top level".to_owned(),
+        template_definition_text: template_definition_text.to_owned(),
+        text_data: text_1_1_data,
+        binary_data: binary_1_1_data,
     }
 }
 
 #[cfg(feature = "experimental")]
 mod benchmark {
     use criterion::{black_box, Criterion};
-    use ion_rs::{v1_0, v1_1, ElementReader, Encoding, IonData, Reader, WriteConfig};
+
+    use crate::{
+        length_prefixed_moderately_compact_1_1_data, maximally_compact_1_1_data,
+        moderately_compact_1_1_data, TestData_1_1,
+    };
+    use ion_rs::{
+        v1_0, v1_1, ElementReader, Encoding, EncodingContext, IonData, IonVersion,
+        LazyRawBinaryReader_1_1, RawEExpression, RawStreamItem, Reader, Sequence, TemplateCompiler,
+        ValueExpr, WriteConfig,
+    };
     use ion_rs::{Decoder, Element, IonResult, LazyStruct, LazyValue, ValueRef};
 
-    fn rewrite_as<E: Encoding>(
-        pretty_ion: &str,
-        config: impl Into<WriteConfig<E>>,
-    ) -> IonResult<Vec<u8>> {
-        let values = Element::read_all(pretty_ion).unwrap();
-        let mut buffer = Vec::new();
-        values.encode_to(&mut buffer, config)?;
-        Ok(buffer)
+    /// The entrypoint for the benchmark.
+    pub fn criterion_benchmark(c: &mut Criterion) {
+        const NUM_VALUES: usize = 10_000;
+        let seq_1_0 = benchmark_1_0(c, NUM_VALUES).unwrap();
+        benchmark_1_1(c, &seq_1_0, maximally_compact_1_1_data(NUM_VALUES)).unwrap();
+        benchmark_1_1(c, &seq_1_0, moderately_compact_1_1_data(NUM_VALUES)).unwrap();
+        benchmark_1_1(
+            c,
+            &seq_1_0,
+            length_prefixed_moderately_compact_1_1_data(NUM_VALUES),
+        )
+        .unwrap();
     }
 
+    /// Reads this value and, if it's a container, any nested values. Returns the number of values read.
     fn count_value_and_children<D: Decoder>(lazy_value: &LazyValue<'_, D>) -> IonResult<usize> {
         use ValueRef::*;
         let child_count = match lazy_value.read()? {
@@ -38,6 +273,7 @@ mod benchmark {
         Ok(1 + child_count)
     }
 
+    /// Reads the child values of a list or s-expression. Returns the number of values read.
     fn count_sequence_children<'a, D: Decoder>(
         lazy_sequence: impl Iterator<Item = IonResult<LazyValue<'a, D>>>,
     ) -> IonResult<usize> {
@@ -48,6 +284,7 @@ mod benchmark {
         Ok(count)
     }
 
+    /// Reads the field values of a struct. Returns the number of values read.
     fn count_struct_children<D: Decoder>(lazy_struct: &LazyStruct<'_, D>) -> IonResult<usize> {
         let mut count = 0;
         for field in lazy_struct {
@@ -56,8 +293,10 @@ mod benchmark {
         Ok(count)
     }
 
-    pub fn criterion_benchmark(c: &mut Criterion) {
-        const NUM_VALUES: usize = 10_000;
+    /// Constructs and benchmarks the 'baseline' Ion 1.0 data stream with `num_values` top-level values.
+    /// Returns the materialized `Sequence` representation of the stream so other benchmarks can
+    /// confirm that they are reading Ion-equivalent data.
+    pub fn benchmark_1_0(c: &mut Criterion, num_values: usize) -> IonResult<Sequence> {
         let pretty_data_1_0 = r#"{
             'timestamp': 1670446800245,
             'threadId': 418,
@@ -66,47 +305,54 @@ mod benchmark {
             'logLevel': INFO,
             'format': "Request status: {} Client ID: {} Client Host: {} Client Region: {} Timestamp: {}",
             'parameters': ["SUCCESS","example-client-1","aws-us-east-5f-18b4fa","region 4","2022-12-07T20:59:59.744000Z",],
-        }"#.repeat(NUM_VALUES);
+        }"#.repeat(num_values);
         let text_1_0_data = rewrite_as(&pretty_data_1_0, v1_0::Text).unwrap();
         let binary_1_0_data = rewrite_as(&pretty_data_1_0, v1_0::Binary).unwrap();
-        let template_text = r#"
-            (macro event (timestamp thread_id thread_name client_num host_id parameters)
-                {
-                    'timestamp': timestamp,
-                    'threadId': thread_id,
-                    'threadName': (make_string "scheduler-thread-" thread_name),
-                    'loggerName': "com.example.organization.product.component.ClassName",
-                    'logLevel': (quote INFO),
-                    'format': "Request status: {} Client ID: {} Client Host: {} Client Region: {} Timestamp: {}",
-                    'parameters': [
-                        "SUCCESS",
-                        (make_string "example-client-" client_num),
-                        (make_string "aws-us-east-5f-" host_id),
-                        parameters
-                    ]
-                }
-            )
-        "#;
 
-        let text_1_1_data = r#"(:event 1670446800245 418 "6" "1" "18b4fa" (:values "region 4" "2022-12-07T20:59:59.744000Z"))"#.repeat(NUM_VALUES);
-
-        println!("Bin  Ion 1.0 data size: {} bytes", binary_1_0_data.len());
         println!("Text Ion 1.0 data size: {} bytes", text_1_0_data.len());
-        println!("Text Ion 1.1 data size: {} bytes", text_1_1_data.len());
+        println!("Bin  Ion 1.0 data size: {} bytes", binary_1_0_data.len());
 
-        // As a sanity check, materialize the data from both the Ion 1.0 and 1.1 streams and make sure
-        // that they are equivalent before we start measuring the time needed to read them.
+        // Load the Ion 1.0 values into a Sequence. We'll compare our Ion 1.1 streams' data to this
+        // sequence to make sure that all of the tests are working on equivalent data.
         let seq_1_0 = Reader::new(v1_1::Text, text_1_0_data.as_slice())
             .unwrap()
-            .read_all_elements()
-            .unwrap();
-        let mut reader_1_1 = Reader::new(v1_1::Text, text_1_1_data.as_bytes()).unwrap();
-        reader_1_1.register_template(template_text).unwrap();
-        let seq_1_1 = reader_1_1.read_all_elements().unwrap();
-        assert!(
-            IonData::eq(&seq_1_0, &seq_1_1),
-            "Ion 1.0 sequence was not equal to the Ion 1.1 sequence"
-        );
+            .read_all_elements()?;
+
+        let mut text_1_0_group = c.benchmark_group("text 1.0");
+        // Visit each top level value in the stream without reading it.
+        text_1_0_group.bench_function("scan all", |b| {
+            b.iter(|| {
+                let mut reader = Reader::new(v1_1::Text, text_1_0_data.as_slice()).unwrap();
+                while let Some(item) = reader.next().unwrap() {
+                    black_box(item);
+                }
+            })
+        });
+        // Read every value in the stream, however deeply nested.
+        text_1_0_group.bench_function("read all", |b| {
+            b.iter(|| {
+                let mut reader = Reader::new(v1_1::Text, text_1_0_data.as_slice()).unwrap();
+                let mut num_values = 0usize;
+                while let Some(item) = reader.next().unwrap() {
+                    num_values += count_value_and_children(&item).unwrap();
+                }
+                let _ = black_box(num_values);
+            })
+        });
+        // Read the 'format' field from each top-level struct in the stream.
+        text_1_0_group.bench_function("read 'format' field", |b| {
+            b.iter(|| {
+                let mut reader = Reader::new(v1_1::Text, text_1_0_data.as_slice()).unwrap();
+                let mut num_values = 0usize;
+                while let Some(value) = reader.next().unwrap() {
+                    let s = value.read().unwrap().expect_struct().unwrap();
+                    let parameters_list = s.find_expected("format").unwrap();
+                    num_values += count_value_and_children(&parameters_list).unwrap();
+                }
+                let _ = black_box(num_values);
+            })
+        });
+        text_1_0_group.finish();
 
         let mut binary_1_0_group = c.benchmark_group("binary 1.0");
         binary_1_0_group.bench_function("scan all", |b| {
@@ -127,30 +373,9 @@ mod benchmark {
                 let _ = black_box(num_values);
             })
         });
-        binary_1_0_group.finish();
-
-        let mut text_1_0_group = c.benchmark_group("text 1.0");
-        text_1_0_group.bench_function("scan all", |b| {
+        binary_1_0_group.bench_function("read 'format' field", |b| {
             b.iter(|| {
-                let mut reader = Reader::new(v1_1::Text, text_1_0_data.as_slice()).unwrap();
-                while let Some(item) = reader.next().unwrap() {
-                    black_box(item);
-                }
-            })
-        });
-        text_1_0_group.bench_function("read all", |b| {
-            b.iter(|| {
-                let mut reader = Reader::new(v1_1::Text, text_1_0_data.as_slice()).unwrap();
-                let mut num_values = 0usize;
-                while let Some(item) = reader.next().unwrap() {
-                    num_values += count_value_and_children(&item).unwrap();
-                }
-                let _ = black_box(num_values);
-            })
-        });
-        text_1_0_group.bench_function("read 'format' field", |b| {
-            b.iter(|| {
-                let mut reader = Reader::new(v1_1::Text, text_1_0_data.as_slice()).unwrap();
+                let mut reader = Reader::new(v1_0::Binary, binary_1_0_data.as_slice()).unwrap();
                 let mut num_values = 0usize;
                 while let Some(value) = reader.next().unwrap() {
                     let s = value.read().unwrap().expect_struct().unwrap();
@@ -160,13 +385,153 @@ mod benchmark {
                 let _ = black_box(num_values);
             })
         });
-        text_1_0_group.finish();
+        binary_1_0_group.finish();
 
-        let mut text_1_1_group = c.benchmark_group("text 1.1");
+        Ok(seq_1_0)
+    }
+
+    /// Benchmarks reading the provided Ion 1.1-encoded test data using various access patterns.
+    /// Before benchmarking begins, tests to make sure that the Ion 1.1 data is Ion-equivalent to
+    /// the Ion 1.0-encoded sequence `seq_1_0`.
+    pub fn benchmark_1_1(
+        c: &mut Criterion,
+        seq_1_0: &Sequence,
+        test_data_1_1: TestData_1_1,
+    ) -> IonResult<()> {
+        let text_1_1_data = test_data_1_1.text_data.as_str();
+        let binary_1_1_data = test_data_1_1.binary_data.as_slice();
+        let name = test_data_1_1.name.as_str();
+
+        let empty_context = EncodingContext::for_ion_version(IonVersion::v1_1);
+        let compiled_macro = TemplateCompiler::compile_from_text(
+            empty_context.get_ref(),
+            &test_data_1_1.template_definition_text,
+        )
+        .unwrap();
+
+        println!("=== v1.1: {name} ===");
+        println!("Binary data size: {} bytes", binary_1_1_data.len());
+        println!("Text   data size: {} bytes", text_1_1_data.len());
+
+        // === Binary equivalence check ===
+        let mut reader_1_1 = Reader::new(v1_1::Binary, binary_1_1_data).unwrap();
+        reader_1_1.register_template(compiled_macro.clone())?;
+        let seq_1_1 = reader_1_1.read_all_elements().unwrap();
+        assert!(
+            IonData::eq(seq_1_0, &seq_1_1),
+            "{name} binary Ion 1.1 sequence was not equal to the original Ion 1.0 sequence"
+        );
+
+        // === Text equivalence check ===
+        let mut reader_1_1 = Reader::new(v1_1::Text, text_1_1_data).unwrap();
+        reader_1_1
+            .register_template(compiled_macro.clone())
+            .unwrap();
+        let seq_1_1 = reader_1_1.read_all_elements().unwrap();
+        assert!(
+            IonData::eq(seq_1_0, &seq_1_1),
+            "{name} text Ion 1.1 sequence was not equal to the original Ion 1.0 sequence"
+        );
+
+        // Reads each raw top-level e-expression in full without performing evaluation. This is an
+        // optional "fast path" for macros that are known at compile time; a program can access their
+        // component values without performing evaluation.
+        // TODO: The macro table should have a reasonable interface for 'intercepting' e-expressions
+        //       before they are evaluated when a type knows how to interpret them without evaluation.
+        let mut binary_1_1_group = c.benchmark_group(format!("{name} binary 1.1"));
+        binary_1_1_group.bench_function("read all from eexp", |b| {
+            let mut context = EncodingContext::for_ion_version(IonVersion::v1_1);
+            context
+                .macro_table_mut()
+                .add_macro(compiled_macro.clone())
+                .unwrap();
+            let context_ref = context.get_ref();
+            b.iter(|| {
+                // We don't have an API for doing this with the application-level reader yet, so
+                // for now we use a manually configured context and a raw reader.
+                let mut reader = LazyRawBinaryReader_1_1::new(binary_1_1_data);
+                let mut num_top_level_values: usize = 0;
+                // Skip past the IVM
+                reader.next(context_ref).unwrap().expect_ivm().unwrap();
+                // Expect every top-level item to be an e-expression.
+                while let RawStreamItem::EExp(raw_eexp) = reader.next(context_ref).unwrap() {
+                    num_top_level_values += 1;
+                    // Look up the e-expression's invoked macro ID in the encoding context.
+                    let eexp = raw_eexp.resolve(context_ref).unwrap();
+                    // Visit and read all of the e-expression's arguments.
+                    for arg in eexp.arguments() {
+                        match arg.unwrap() {
+                            // If the argument is a value literal, read it.
+                            ValueExpr::ValueLiteral(value) => {
+                                black_box(value.read_resolved().unwrap());
+                            }
+                            // TODO: Support macro invocations (not just arg groups) as arguments in the benchmark
+                            ValueExpr::MacroInvocation(macro_expr) => {
+                                use ion_rs::MacroExprKind::*;
+                                match macro_expr.kind() {
+                                    // If the argument is a group, read all of its contained expressions.
+                                    EExpArgGroup(group) => {
+                                        for expr in group.expressions() {
+                                            match expr.unwrap() {
+                                                ValueExpr::ValueLiteral(value) => {
+                                                    black_box(value.read_resolved().unwrap());
+                                                }
+                                                ValueExpr::MacroInvocation(_) => {
+                                                    todo!("arg groups of macro invocations in benchmark")
+                                                }
+                                            }
+                                        }
+                                    }
+                                    _ => todo!("other macro types as e-expr args in benchmark"),
+                                }
+                            }
+                        };
+                    }
+                }
+                assert_eq!(num_top_level_values, seq_1_1.len());
+                black_box(num_top_level_values);
+            })
+        });
+        binary_1_1_group.bench_function("scan all", |b| {
+            b.iter(|| {
+                let mut reader = Reader::new(v1_1::Binary, binary_1_1_data).unwrap();
+                reader.register_template(compiled_macro.clone()).unwrap();
+                while let Some(item) = reader.next().unwrap() {
+                    black_box(item);
+                }
+            })
+        });
+        binary_1_1_group.bench_function("read all", |b| {
+            b.iter(|| {
+                let mut reader = Reader::new(v1_1::Binary, binary_1_1_data).unwrap();
+                reader.register_template(compiled_macro.clone()).unwrap();
+                let mut num_values = 0usize;
+                while let Some(item) = reader.next().unwrap() {
+                    num_values += count_value_and_children(&item).unwrap();
+                }
+                let _ = black_box(num_values);
+            })
+        });
+        binary_1_1_group.bench_function("read 'format' field", |b| {
+            b.iter(|| {
+                let mut reader = Reader::new(v1_1::Binary, binary_1_1_data).unwrap();
+                reader.register_template(compiled_macro.clone()).unwrap();
+                let mut num_values = 0usize;
+                while let Some(value) = reader.next().unwrap() {
+                    let s = value.read().unwrap().expect_struct().unwrap();
+                    let format_field_value = s.find_expected("format").unwrap();
+                    num_values += count_value_and_children(&format_field_value).unwrap();
+                }
+                let _ = black_box(num_values);
+            })
+        });
+        binary_1_1_group.finish();
+
+        let mut text_1_1_group = c.benchmark_group(format!("{} text 1.1", &test_data_1_1.name));
         text_1_1_group.bench_function("scan all", |b| {
             b.iter(|| {
                 let mut reader = Reader::new(v1_1::Text, text_1_1_data.as_bytes()).unwrap();
-                reader.register_template(template_text).unwrap();
+                reader.register_template(compiled_macro.clone()).unwrap();
                 while let Some(item) = reader.next().unwrap() {
                     black_box(item);
                 }
@@ -175,7 +540,7 @@ mod benchmark {
         text_1_1_group.bench_function("read all", |b| {
             b.iter(|| {
                 let mut reader = Reader::new(v1_1::Text, text_1_1_data.as_bytes()).unwrap();
-                reader.register_template(template_text).unwrap();
+                reader.register_template(compiled_macro.clone()).unwrap();
                 let mut num_values = 0usize;
                 while let Some(item) = reader.next().unwrap() {
                     num_values += count_value_and_children(&item).unwrap();
@@ -186,7 +551,7 @@ mod benchmark {
         text_1_1_group.bench_function("read 'format' field", |b| {
             b.iter(|| {
                 let mut reader = Reader::new(v1_1::Text, text_1_1_data.as_bytes()).unwrap();
-                reader.register_template(template_text).unwrap();
+                reader.register_template(compiled_macro.clone()).unwrap();
                 let mut num_values = 0usize;
                 while let Some(value) = reader.next().unwrap() {
                     let s = value.read().unwrap().expect_struct().unwrap();
@@ -197,6 +562,18 @@ mod benchmark {
             })
         });
         text_1_1_group.finish();
+        Ok(())
+    }
+
+    /// Transcodes the provided text Ion using the specified `WriteConfig`.
+    fn rewrite_as<E: Encoding>(
+        pretty_ion: &str,
+        config: impl Into<WriteConfig<E>>,
+    ) -> IonResult<Vec<u8>> {
+        let values = Element::read_all(pretty_ion).unwrap();
+        let mut buffer = Vec::new();
+        values.encode_to(&mut buffer, config)?;
+        Ok(buffer)
     }
 }
 

--- a/benches/write_many_structs.rs
+++ b/benches/write_many_structs.rs
@@ -42,7 +42,7 @@ mod benchmark {
                 &[
                     black_box("SUCCESS"),
                     black_box("example-client-1"),
-                    black_box("aws-us-east-5f-18b4fa"),
+                    black_box("aws-us-east-5f-abc-123"),
                     black_box("region 4"),
                     black_box("2022-12-07T20:59:59.744000Z"),
                 ],
@@ -73,7 +73,7 @@ mod benchmark {
                     symbol_id(black_box(21)),
                     // $22 = example-client-1
                     symbol_id(black_box(22)),
-                    // $23 = aws-us-east-5f-18b4fa
+                    // $23 = aws-us-east-5f-abc-123
                     symbol_id(black_box(23)),
                     // $24 = region 4
                     symbol_id(black_box(24)),
@@ -92,7 +92,7 @@ mod benchmark {
             // them wouldn't be beneficial.
             .write(black_box("6"))? // thread_name
             .write(black_box("1"))? // client_num
-            .write(symbol_id(black_box(10)))?; // host_id: "18b4fa" ($10)
+            .write(symbol_id(black_box(10)))?; // host_id: "abc-123" ($10)
         let mut nested_eexp = eexp.eexp_writer(1)?;
         nested_eexp
             // $11 = region 4
@@ -109,7 +109,7 @@ mod benchmark {
             .write(black_box(418))? // thread_id
             .write(black_box("6"))? // thread_name
             .write(black_box("1"))? // client_num
-            .write(black_box("18b4fa"))?; // host_id
+            .write(black_box("abc-123"))?; // host_id
         let mut nested_eexp = eexp.eexp_writer(1)?;
         nested_eexp
             .write(black_box("region 4"))?

--- a/src/element/sequence.rs
+++ b/src/element/sequence.rs
@@ -6,15 +6,32 @@ use crate::lazy::encoding::Encoding;
 use crate::write_config::WriteConfig;
 use crate::IonResult;
 use std::cmp::Ordering;
+use std::fmt::{Debug, Formatter};
 use std::io;
 
 /// An iterable, addressable series of Ion [`Element`]s.
 ///
 /// A `Sequence` is not itself an Ion value type, but can represent a series of Ion values appearing
 /// in a [`List`](crate::List), a [`SExp`](crate::SExp), or at the top level.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Sequence {
     elements: Vec<Element>,
+}
+
+impl Debug for Sequence {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Sequence<")?;
+        let mut is_first = true;
+        for element in self {
+            if is_first {
+                write!(f, "{element}")?;
+            } else {
+                write!(f, ", {element}")?;
+                is_first = false;
+            }
+        }
+        write!(f, ">")
+    }
 }
 
 impl Sequence {

--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -11,7 +11,9 @@ use crate::lazy::binary::raw::reader::LazyRawBinaryReader_1_0;
 use crate::lazy::binary::raw::sequence::{
     LazyRawBinaryList_1_0, LazyRawBinarySExp_1_0, RawBinarySequenceIterator_1_0,
 };
-use crate::lazy::binary::raw::v1_1::e_expression::RawBinaryEExpression_1_1;
+use crate::lazy::binary::raw::v1_1::e_expression::{
+    BinaryEExpArgGroup, BinaryEExpArgGroupIterator, RawBinaryEExpression_1_1,
+};
 use crate::lazy::binary::raw::v1_1::r#struct::{
     LazyRawBinaryFieldName_1_1, LazyRawBinaryStruct_1_1, RawBinaryStructIterator_1_1,
 };
@@ -33,7 +35,11 @@ use crate::lazy::decoder::{
 use crate::lazy::encoding::{
     BinaryEncoding_1_0, BinaryEncoding_1_1, TextEncoding_1_0, TextEncoding_1_1,
 };
-use crate::lazy::expanded::macro_evaluator::RawEExpression;
+use crate::lazy::expanded::e_expression::ArgGroup;
+use crate::lazy::expanded::macro_evaluator::{
+    EExpArgGroupIterator, EExpressionArgGroup, RawEExpression,
+};
+use crate::lazy::expanded::template::ParameterEncoding;
 use crate::lazy::expanded::EncodingContextRef;
 use crate::lazy::raw_stream_item::LazyRawStreamItem;
 use crate::lazy::raw_value_ref::RawValueRef;
@@ -45,16 +51,19 @@ use crate::lazy::text::raw::reader::LazyRawTextReader_1_0;
 use crate::lazy::text::raw::sequence::{
     LazyRawTextList_1_0, LazyRawTextSExp_1_0, RawTextListIterator_1_0, RawTextSExpIterator_1_0,
 };
+use crate::lazy::text::raw::v1_1::arg_group::{
+    EExpArg, EExpArgExpr, TextEExpArgGroup, TextEExpArgGroupIterator,
+};
 use crate::lazy::text::raw::v1_1::reader::{
     LazyRawTextFieldName_1_1, LazyRawTextList_1_1, LazyRawTextReader_1_1, LazyRawTextSExp_1_1,
-    LazyRawTextStruct_1_1, MacroIdRef, RawTextEExpression_1_1, RawTextSequenceCacheIterator_1_1,
-    RawTextStructCacheIterator_1_1,
+    LazyRawTextStruct_1_1, MacroIdRef, RawTextSequenceCacheIterator_1_1,
+    RawTextStructCacheIterator_1_1, TextEExpression_1_1,
 };
 use crate::lazy::text::value::{
     LazyRawTextValue_1_0, LazyRawTextValue_1_1, LazyRawTextVersionMarker_1_0,
     LazyRawTextVersionMarker_1_1, RawTextAnnotationsIterator,
 };
-use crate::{Encoding, IonResult, IonType, RawSymbolRef};
+use crate::{try_next, Encoding, IonResult, IonType, RawStreamItem, RawSymbolRef};
 
 /// An implementation of the `LazyDecoder` trait that can read any encoding of Ion.
 #[derive(Debug, Clone, Copy)]
@@ -65,7 +74,6 @@ pub struct AnyEncoding;
 // underlying type.
 impl Decoder for AnyEncoding {
     type Reader<'data> = LazyRawAnyReader<'data>;
-    type ReaderSavedState = IonEncoding;
     type Value<'top> = LazyRawAnyValue<'top>;
     type SExp<'top> = LazyRawAnySExp<'top>;
     type List<'top> = LazyRawAnyList<'top>;
@@ -126,13 +134,23 @@ impl<'top> HasRange for LazyRawAnyVersionMarker<'top> {
 }
 
 impl<'top> RawVersionMarker<'top> for LazyRawAnyVersionMarker<'top> {
-    fn version(&self) -> (u8, u8) {
+    fn major_minor(&self) -> (u8, u8) {
         use LazyRawAnyVersionMarkerKind::*;
         match self.encoding {
-            Text_1_0(marker) => marker.version(),
-            Binary_1_0(marker) => marker.version(),
-            Text_1_1(marker) => marker.version(),
-            Binary_1_1(marker) => marker.version(),
+            Text_1_0(marker) => marker.major_minor(),
+            Binary_1_0(marker) => marker.major_minor(),
+            Text_1_1(marker) => marker.major_minor(),
+            Binary_1_1(marker) => marker.major_minor(),
+        }
+    }
+
+    fn old_encoding(&self) -> IonEncoding {
+        use LazyRawAnyVersionMarkerKind::*;
+        match self.encoding {
+            Text_1_0(_) => IonEncoding::Text_1_0,
+            Binary_1_0(_) => IonEncoding::Binary_1_0,
+            Text_1_1(_) => IonEncoding::Text_1_1,
+            Binary_1_1(_) => IonEncoding::Binary_1_1,
         }
     }
 }
@@ -173,8 +191,8 @@ pub struct LazyRawAnyEExpression<'top> {
 
 #[derive(Debug, Copy, Clone)]
 pub enum LazyRawAnyEExpressionKind<'top> {
-    Text_1_1(RawTextEExpression_1_1<'top>),
-    Binary_1_1(RawBinaryEExpression_1_1<'top>),
+    Text_1_1(TextEExpression_1_1<'top>),
+    Binary_1_1(&'top RawBinaryEExpression_1_1<'top>),
 }
 
 impl<'top> LazyRawAnyEExpression<'top> {
@@ -187,15 +205,15 @@ impl<'top> LazyRawAnyEExpression<'top> {
     }
 }
 
-impl<'top> From<RawTextEExpression_1_1<'top>> for LazyRawAnyEExpression<'top> {
-    fn from(text_invocation: RawTextEExpression_1_1<'top>) -> Self {
+impl<'top> From<TextEExpression_1_1<'top>> for LazyRawAnyEExpression<'top> {
+    fn from(text_invocation: TextEExpression_1_1<'top>) -> Self {
         LazyRawAnyEExpression {
             encoding: LazyRawAnyEExpressionKind::Text_1_1(text_invocation),
         }
     }
 }
-impl<'top> From<RawBinaryEExpression_1_1<'top>> for LazyRawAnyEExpression<'top> {
-    fn from(binary_invocation: RawBinaryEExpression_1_1<'top>) -> Self {
+impl<'top> From<&'top RawBinaryEExpression_1_1<'top>> for LazyRawAnyEExpression<'top> {
+    fn from(binary_invocation: &'top RawBinaryEExpression_1_1<'top>) -> Self {
         LazyRawAnyEExpression {
             encoding: LazyRawAnyEExpressionKind::Binary_1_1(binary_invocation),
         }
@@ -223,76 +241,179 @@ impl<'top> HasRange for LazyRawAnyEExpression<'top> {
 }
 
 impl<'top> RawEExpression<'top, AnyEncoding> for LazyRawAnyEExpression<'top> {
-    type RawArgumentsIterator<'a> = LazyRawAnyMacroArgsIterator<'top,>  where Self: 'a;
+    type RawArgumentsIterator = AnyEExpArgsIterator<'top>;
+    type ArgGroup = AnyEExpArgGroup<'top>;
 
-    fn id(&self) -> MacroIdRef<'top> {
+    fn id(self) -> MacroIdRef<'top> {
         use LazyRawAnyEExpressionKind::*;
         match self.encoding {
             Text_1_1(ref m) => m.id(),
-            Binary_1_1(ref m) => m.id(),
+            Binary_1_1(m) => m.id(),
         }
     }
 
-    fn raw_arguments(&self) -> Self::RawArgumentsIterator<'_> {
+    fn raw_arguments(&self) -> Self::RawArgumentsIterator {
         use LazyRawAnyEExpressionKind::*;
         match self.encoding {
-            Text_1_1(e) => LazyRawAnyMacroArgsIterator {
-                encoding: LazyRawAnyMacroArgsIteratorKind::Text_1_1(e.raw_arguments()),
+            Text_1_1(e) => AnyEExpArgsIterator {
+                encoding: LazyRawAnyEExpArgsIteratorKind::Text_1_1(e.raw_arguments()),
             },
-            Binary_1_1(e) => LazyRawAnyMacroArgsIterator {
-                encoding: LazyRawAnyMacroArgsIteratorKind::Binary_1_1(e.raw_arguments()),
+            Binary_1_1(e) => AnyEExpArgsIterator {
+                encoding: LazyRawAnyEExpArgsIteratorKind::Binary_1_1(e.raw_arguments()),
             },
         }
     }
 }
 
-pub enum LazyRawAnyMacroArgsIteratorKind<'top> {
-    Text_1_1(
-        <RawTextEExpression_1_1<'top> as RawEExpression<
-                'top,
-                TextEncoding_1_1,
-            >>::RawArgumentsIterator<'top>,
-    ),
-    Binary_1_1(
-        <RawBinaryEExpression_1_1<'top> as RawEExpression<
-            'top,
-            BinaryEncoding_1_1,
-        >>::RawArgumentsIterator<'top>,
-    ),
-}
-pub struct LazyRawAnyMacroArgsIterator<'top> {
-    encoding: LazyRawAnyMacroArgsIteratorKind<'top>,
+#[derive(Copy, Clone, Debug)]
+pub struct AnyEExpArgGroup<'top> {
+    kind: AnyEExpArgGroupKind<'top>,
 }
 
-impl<'top> Iterator for LazyRawAnyMacroArgsIterator<'top> {
+#[derive(Copy, Clone, Debug)]
+pub enum AnyEExpArgGroupKind<'top> {
+    Text_1_1(TextEExpArgGroup<'top>),
+    Binary_1_1(BinaryEExpArgGroup<'top>),
+}
+
+impl<'top> HasRange for AnyEExpArgGroup<'top> {
+    fn range(&self) -> Range<usize> {
+        match self.kind {
+            AnyEExpArgGroupKind::Text_1_1(group) => group.range(),
+            AnyEExpArgGroupKind::Binary_1_1(group) => group.range(),
+        }
+    }
+}
+
+impl<'top> HasSpan<'top> for AnyEExpArgGroup<'top> {
+    fn span(&self) -> Span<'top> {
+        match self.kind {
+            AnyEExpArgGroupKind::Text_1_1(group) => group.span(),
+            AnyEExpArgGroupKind::Binary_1_1(group) => group.span(),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct AnyEExpArgGroupIterator<'top> {
+    kind: AnyEExpArgGroupIteratorKind<'top>,
+}
+
+impl<
+        'top,
+        D: Decoder<Value<'top> = LazyRawAnyValue<'top>, EExp<'top> = LazyRawAnyEExpression<'top>>,
+    > EExpArgGroupIterator<'top, D> for AnyEExpArgGroupIterator<'top>
+{
+    fn is_exhausted(&self) -> bool {
+        match self.kind {
+            AnyEExpArgGroupIteratorKind::Text_1_1(ref i) => i.is_exhausted(),
+            AnyEExpArgGroupIteratorKind::Binary_1_1(ref i) => i.is_exhausted(),
+        }
+    }
+}
+
+impl<'top> IntoIterator for AnyEExpArgGroup<'top> {
+    type Item = IonResult<LazyRawValueExpr<'top, AnyEncoding>>;
+    type IntoIter = AnyEExpArgGroupIterator<'top>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self.kind {
+            AnyEExpArgGroupKind::Text_1_1(group) => AnyEExpArgGroupIterator {
+                kind: AnyEExpArgGroupIteratorKind::Text_1_1(group.into_iter()),
+            },
+            AnyEExpArgGroupKind::Binary_1_1(group) => AnyEExpArgGroupIterator {
+                kind: AnyEExpArgGroupIteratorKind::Binary_1_1(group.into_iter()),
+            },
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum AnyEExpArgGroupIteratorKind<'top> {
+    Text_1_1(TextEExpArgGroupIterator<'top>),
+    Binary_1_1(BinaryEExpArgGroupIterator<'top>),
+}
+
+impl<'top> Iterator for AnyEExpArgGroupIterator<'top> {
     type Item = IonResult<LazyRawValueExpr<'top, AnyEncoding>>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        match self.kind {
+            AnyEExpArgGroupIteratorKind::Text_1_1(ref mut i) => {
+                Some(Ok(try_next!(i.next()).into()))
+            }
+            AnyEExpArgGroupIteratorKind::Binary_1_1(ref mut i) => {
+                Some(Ok(try_next!(i.next()).into()))
+            }
+        }
+    }
+}
+
+impl<'top> EExpressionArgGroup<'top, AnyEncoding> for AnyEExpArgGroup<'top> {
+    type Iterator = AnyEExpArgGroupIterator<'top>;
+
+    fn encoding(&self) -> ParameterEncoding {
+        match self.kind {
+            AnyEExpArgGroupKind::Text_1_1(g) => g.encoding(),
+            AnyEExpArgGroupKind::Binary_1_1(g) => g.encoding(),
+        }
+    }
+
+    fn resolve(self, context: EncodingContextRef<'top>) -> ArgGroup<'top, AnyEncoding> {
+        ArgGroup::new(self, context)
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum LazyRawAnyEExpArgsIteratorKind<'top> {
+    Text_1_1(
+        <TextEExpression_1_1<'top> as RawEExpression<
+                'top,
+                TextEncoding_1_1,
+            >>::RawArgumentsIterator,
+    ),
+    Binary_1_1(
+        <&'top RawBinaryEExpression_1_1<'top> as RawEExpression<
+            'top,
+            BinaryEncoding_1_1,
+        >>::RawArgumentsIterator,
+    ),
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct AnyEExpArgsIterator<'top> {
+    encoding: LazyRawAnyEExpArgsIteratorKind<'top>,
+}
+
+impl<'top> Iterator for AnyEExpArgsIterator<'top> {
+    type Item = IonResult<EExpArg<'top, AnyEncoding>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
         match &mut self.encoding {
-            LazyRawAnyMacroArgsIteratorKind::Text_1_1(ref mut iter) => match iter.next() {
-                Some(Ok(RawValueExpr::ValueLiteral(value))) => {
-                    Some(Ok(RawValueExpr::ValueLiteral(LazyRawAnyValue::from(value))))
-                }
-                Some(Ok(RawValueExpr::EExp(invocation))) => {
-                    Some(Ok(RawValueExpr::EExp(LazyRawAnyEExpression {
-                        encoding: LazyRawAnyEExpressionKind::Text_1_1(invocation),
-                    })))
-                }
-                Some(Err(e)) => Some(Err(e)),
-                None => None,
-            },
-            LazyRawAnyMacroArgsIteratorKind::Binary_1_1(ref mut iter) => match iter.next() {
-                Some(Ok(RawValueExpr::ValueLiteral(value))) => {
-                    Some(Ok(RawValueExpr::ValueLiteral(LazyRawAnyValue::from(value))))
-                }
-                Some(Ok(RawValueExpr::EExp(invocation))) => {
-                    Some(Ok(RawValueExpr::EExp(LazyRawAnyEExpression {
-                        encoding: LazyRawAnyEExpressionKind::Binary_1_1(invocation),
-                    })))
-                }
-                Some(Err(e)) => Some(Err(e)),
-                None => None,
-            },
+            LazyRawAnyEExpArgsIteratorKind::Text_1_1(ref mut iter) => {
+                let arg = try_next!(iter.next());
+                use EExpArgExpr::*;
+                let any_expr = match arg.expr() {
+                    ValueLiteral(v) => ValueLiteral(LazyRawAnyValue::from(*v)),
+                    EExp(e) => EExp(LazyRawAnyEExpression::from(*e)),
+                    ArgGroup(g) => ArgGroup(AnyEExpArgGroup {
+                        kind: AnyEExpArgGroupKind::Text_1_1(*g),
+                    }),
+                };
+                Some(Ok(EExpArg::new(arg.encoding(), any_expr)))
+            }
+            LazyRawAnyEExpArgsIteratorKind::Binary_1_1(ref mut iter) => {
+                let arg = try_next!(iter.next());
+                use EExpArgExpr::*;
+                let any_expr = match arg.expr() {
+                    ValueLiteral(v) => ValueLiteral(LazyRawAnyValue::from(*v)),
+                    EExp(e) => EExp(LazyRawAnyEExpression::from(*e)),
+                    ArgGroup(g) => ArgGroup(AnyEExpArgGroup {
+                        kind: AnyEExpArgGroupKind::Binary_1_1(*g),
+                    }),
+                };
+                Some(Ok(EExpArg::new(arg.encoding(), any_expr)))
+            }
         }
     }
 }
@@ -301,7 +422,11 @@ impl<'top> Iterator for LazyRawAnyMacroArgsIterator<'top> {
 
 /// A lazy raw reader that can decode both text and binary Ion.
 pub struct LazyRawAnyReader<'data> {
-    encoding: RawReaderKind<'data>,
+    // If the reader encounters an IVM that changes the encoding, the new encoding will be stored
+    // here until `next()` is called again, at which point the reader will be swapped out for one
+    // that can read the new encoding.
+    new_encoding: Option<IonEncoding>,
+    encoding_reader: RawReaderKind<'data>,
 }
 
 impl<'data> LazyRawAnyReader<'data> {
@@ -316,6 +441,15 @@ impl<'data> LazyRawAnyReader<'data> {
     }
 }
 
+impl<'data> From<RawReaderKind<'data>> for LazyRawAnyReader<'data> {
+    fn from(encoding: RawReaderKind<'data>) -> Self {
+        Self {
+            new_encoding: None,
+            encoding_reader: encoding,
+        }
+    }
+}
+
 pub enum RawReaderKind<'data> {
     Text_1_0(LazyRawTextReader_1_0<'data>),
     Binary_1_0(LazyRawBinaryReader_1_0<'data>),
@@ -323,7 +457,39 @@ pub enum RawReaderKind<'data> {
     Binary_1_1(LazyRawBinaryReader_1_1<'data>),
 }
 
-#[derive(Default, Debug, Copy, Clone)]
+impl<'data> RawReaderKind<'data> {
+    fn resume_at_offset(
+        data: &'data [u8],
+        stream_offset: usize,
+        encoding_hint: IonEncoding,
+    ) -> RawReaderKind {
+        use IonEncoding::*;
+        match encoding_hint {
+            Text_1_0 => RawReaderKind::Text_1_0(LazyRawTextReader_1_0::resume_at_offset(
+                data,
+                stream_offset,
+                encoding_hint,
+            )),
+            Binary_1_0 => RawReaderKind::Binary_1_0(LazyRawBinaryReader_1_0::resume_at_offset(
+                data,
+                stream_offset,
+                encoding_hint,
+            )),
+            Text_1_1 => RawReaderKind::Text_1_1(LazyRawTextReader_1_1::resume_at_offset(
+                data,
+                stream_offset,
+                encoding_hint,
+            )),
+            Binary_1_1 => RawReaderKind::Binary_1_1(LazyRawBinaryReader_1_1::resume_at_offset(
+                data,
+                stream_offset,
+                encoding_hint,
+            )),
+        }
+    }
+}
+
+#[derive(Default, Debug, Copy, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum IonEncoding {
     // In the absence of a binary IVM, readers must assume Ion 1.0 text data until a
@@ -356,77 +522,97 @@ impl IonEncoding {
         }
     }
 
-    pub fn version(&self) -> (u8, u8) {
+    pub fn version(&self) -> IonVersion {
         use IonEncoding::*;
         match self {
-            Text_1_0 | Binary_1_0 => (1, 0),
-            Text_1_1 | Binary_1_1 => (1, 1),
+            Text_1_0 | Binary_1_0 => IonVersion::v1_0,
+            Text_1_1 | Binary_1_1 => IonVersion::v1_1,
+        }
+    }
+}
+
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+pub enum IonVersion {
+    #[default]
+    v1_0,
+    v1_1,
+}
+
+impl IonVersion {
+    pub fn major_minor(&self) -> (u8, u8) {
+        use IonVersion::*;
+        match self {
+            v1_0 => (1, 0),
+            v1_1 => (1, 1),
         }
     }
 }
 
 impl<'data> From<LazyRawTextReader_1_0<'data>> for LazyRawAnyReader<'data> {
     fn from(reader: LazyRawTextReader_1_0<'data>) -> Self {
-        LazyRawAnyReader {
-            encoding: RawReaderKind::Text_1_0(reader),
-        }
+        RawReaderKind::Text_1_0(reader).into()
     }
 }
 
 impl<'data> From<LazyRawTextReader_1_1<'data>> for LazyRawAnyReader<'data> {
     fn from(reader: LazyRawTextReader_1_1<'data>) -> Self {
-        LazyRawAnyReader {
-            encoding: RawReaderKind::Text_1_1(reader),
-        }
+        RawReaderKind::Text_1_1(reader).into()
     }
 }
 
 impl<'data> From<LazyRawBinaryReader_1_0<'data>> for LazyRawAnyReader<'data> {
     fn from(reader: LazyRawBinaryReader_1_0<'data>) -> Self {
-        LazyRawAnyReader {
-            encoding: RawReaderKind::Binary_1_0(reader),
-        }
+        RawReaderKind::Binary_1_0(reader).into()
     }
 }
 
 impl<'data> From<LazyRawBinaryReader_1_1<'data>> for LazyRawAnyReader<'data> {
     fn from(reader: LazyRawBinaryReader_1_1<'data>) -> Self {
-        LazyRawAnyReader {
-            encoding: RawReaderKind::Binary_1_1(reader),
-        }
+        RawReaderKind::Binary_1_1(reader).into()
     }
 }
 
 impl<'data> LazyRawReader<'data, AnyEncoding> for LazyRawAnyReader<'data> {
     fn new(data: &'data [u8]) -> Self {
-        let reader_type = Self::detect_encoding(data);
-        Self::resume_at_offset(data, 0, reader_type)
+        Self::resume_at_offset(data, 0, IonEncoding::default())
     }
 
-    fn resume_at_offset(
-        data: &'data [u8],
-        offset: usize,
-        mut raw_reader_type: IonEncoding,
-    ) -> Self {
+    fn resume_at_offset(data: &'data [u8], offset: usize, mut encoding_hint: IonEncoding) -> Self {
         if offset == 0 {
             // If we're at the beginning of the stream, the provided `raw_reader_type` may be a
             // default. We need to inspect the bytes to see if we should override it.
-            raw_reader_type = Self::detect_encoding(data);
+            encoding_hint = Self::detect_encoding(data);
         }
-        match raw_reader_type {
+        match encoding_hint {
             IonEncoding::Text_1_0 => {
-                LazyRawTextReader_1_0::resume_at_offset(data, offset, ()).into()
+                LazyRawTextReader_1_0::resume_at_offset(data, offset, encoding_hint).into()
             }
             IonEncoding::Binary_1_0 => {
-                LazyRawBinaryReader_1_0::resume_at_offset(data, offset, ()).into()
+                LazyRawBinaryReader_1_0::resume_at_offset(data, offset, encoding_hint).into()
             }
             IonEncoding::Text_1_1 => {
-                LazyRawTextReader_1_0::resume_at_offset(data, offset, ()).into()
+                LazyRawTextReader_1_1::resume_at_offset(data, offset, encoding_hint).into()
             }
             IonEncoding::Binary_1_1 => {
-                LazyRawBinaryReader_1_1::resume_at_offset(data, offset, ()).into()
+                LazyRawBinaryReader_1_1::resume_at_offset(data, offset, encoding_hint).into()
             }
         }
+    }
+
+    fn stream_data(&self) -> (&'data [u8], usize, IonEncoding) {
+        use RawReaderKind::*;
+        let (remaining_data, stream_offset, mut encoding) = match &self.encoding_reader {
+            Text_1_0(r) => r.stream_data(),
+            Binary_1_0(r) => r.stream_data(),
+            Text_1_1(r) => r.stream_data(),
+            Binary_1_1(r) => r.stream_data(),
+        };
+        // If we hit an IVM that changed the encoding but we haven't changed our reader yet,
+        // we still want to report the new encoding.
+        if let Some(new_encoding) = self.new_encoding {
+            encoding = new_encoding;
+        }
+        (remaining_data, stream_offset, encoding)
     }
 
     fn next<'top>(
@@ -436,23 +622,41 @@ impl<'data> LazyRawReader<'data, AnyEncoding> for LazyRawAnyReader<'data> {
     where
         'data: 'top,
     {
-        use RawReaderKind::*;
-        match &mut self.encoding {
-            Text_1_0(r) => Ok(r.next(context)?.into()),
-            Binary_1_0(r) => Ok(r.next()?.into()),
-            Text_1_1(r) => Ok(r.next(context)?.into()),
-            Binary_1_1(r) => Ok(r.next(context)?.into()),
+        // If we previously ran into an IVM that changed the stream encoding, replace our reader
+        // with one that can read the new encoding.
+        if let Some(new_encoding) = self.new_encoding.take() {
+            let (remaining_data, stream_offset, _) = self.stream_data();
+            let new_encoding_reader =
+                RawReaderKind::resume_at_offset(remaining_data, stream_offset, new_encoding);
+            self.encoding_reader = new_encoding_reader;
         }
-    }
 
-    #[inline]
-    fn save_state(&self) -> <AnyEncoding as Decoder>::ReaderSavedState {
-        self.encoding()
+        use RawReaderKind::*;
+        let item: LazyRawStreamItem<AnyEncoding> = match &mut self.encoding_reader {
+            Text_1_0(r) => r.next(context)?.into(),
+            Binary_1_0(r) => r.next()?.into(),
+            Text_1_1(r) => r.next(context)?.into(),
+            Binary_1_1(r) => r.next(context)?.into(),
+        };
+
+        // If this item is an IVM:
+        //   * the encoding context will be reset, but this is handled by higher-level readers.
+        //   * the encoding itself may change, and we need to handle that at this level.
+        if let RawStreamItem::VersionMarker(ivm) = item {
+            let ivm_old_encoding = ivm.old_encoding();
+            let ivm_new_encoding = ivm.new_encoding()?;
+            if ivm_new_encoding != ivm_old_encoding {
+                // Save the new encoding; when `next()` is called again, we'll make a new reader.
+                self.new_encoding = Some(ivm_new_encoding);
+            }
+        }
+
+        Ok(item)
     }
 
     fn position(&self) -> usize {
         use RawReaderKind::*;
-        match &self.encoding {
+        match &self.encoding_reader {
             Text_1_0(r) => r.position(),
             Binary_1_0(r) => r.position(),
             Text_1_1(r) => r.position(),
@@ -462,7 +666,16 @@ impl<'data> LazyRawReader<'data, AnyEncoding> for LazyRawAnyReader<'data> {
 
     fn encoding(&self) -> IonEncoding {
         use RawReaderKind::*;
-        match &self.encoding {
+        // If we hit an IVM that changed the encoding but we haven't changed our reader yet,
+        // we still want to report the new encoding. This is a niche case -- it can only arise
+        // when the reader has hit an IVM (in which case `next()` mutably borrowed the reader
+        // and `reader.encoding()` cannot be called) and then dropped the IVM. At that point,
+        // the reader is available again and has moved beyond the IVM, so the new encoding is in
+        // effect even though we have not encountered our first item in the new encoding.
+        if let Some(new_encoding) = self.new_encoding {
+            return new_encoding;
+        }
+        match &self.encoding_reader {
             Text_1_0(_) => IonEncoding::Text_1_0,
             Binary_1_0(_) => IonEncoding::Binary_1_0,
             Text_1_1(_) => IonEncoding::Text_1_1,
@@ -501,7 +714,7 @@ pub enum LazyRawValueKind<'top> {
     Text_1_0(LazyRawTextValue_1_0<'top>),
     Binary_1_0(LazyRawBinaryValue_1_0<'top>),
     Text_1_1(LazyRawTextValue_1_1<'top>),
-    Binary_1_1(LazyRawBinaryValue_1_1<'top>),
+    Binary_1_1(&'top LazyRawBinaryValue_1_1<'top>),
 }
 
 impl<'top> From<LazyRawTextValue_1_0<'top>> for LazyRawAnyValue<'top> {
@@ -528,8 +741,8 @@ impl<'top> From<LazyRawTextValue_1_1<'top>> for LazyRawAnyValue<'top> {
     }
 }
 
-impl<'top> From<LazyRawBinaryValue_1_1<'top>> for LazyRawAnyValue<'top> {
-    fn from(value: LazyRawBinaryValue_1_1<'top>) -> Self {
+impl<'top> From<&'top LazyRawBinaryValue_1_1<'top>> for LazyRawAnyValue<'top> {
+    fn from(value: &'top LazyRawBinaryValue_1_1<'top>) -> Self {
         LazyRawAnyValue {
             encoding: LazyRawValueKind::Binary_1_1(value),
         }
@@ -681,7 +894,7 @@ impl<'top> From<LazyRawStreamItem<'top, TextEncoding_1_0>>
             LazyRawStreamItem::<TextEncoding_1_0>::Value(value) => {
                 LazyRawStreamItem::<AnyEncoding>::Value(value.into())
             }
-            LazyRawStreamItem::<TextEncoding_1_0>::EExpression(_) => {
+            LazyRawStreamItem::<TextEncoding_1_0>::EExp(_) => {
                 unreachable!("Ion 1.0 does not support macro invocations")
             }
             LazyRawStreamItem::<TextEncoding_1_0>::EndOfStream(end) => {
@@ -702,7 +915,7 @@ impl<'top> From<LazyRawStreamItem<'top, BinaryEncoding_1_0>>
             LazyRawStreamItem::<BinaryEncoding_1_0>::Value(value) => {
                 LazyRawStreamItem::<AnyEncoding>::Value(value.into())
             }
-            LazyRawStreamItem::<BinaryEncoding_1_0>::EExpression(_) => {
+            LazyRawStreamItem::<BinaryEncoding_1_0>::EExp(_) => {
                 unreachable!("Ion 1.0 does not support macro invocations")
             }
             LazyRawStreamItem::<BinaryEncoding_1_0>::EndOfStream(end) => {
@@ -723,8 +936,8 @@ impl<'top> From<LazyRawStreamItem<'top, TextEncoding_1_1>>
             LazyRawStreamItem::<TextEncoding_1_1>::Value(value) => {
                 LazyRawStreamItem::<AnyEncoding>::Value(value.into())
             }
-            LazyRawStreamItem::<TextEncoding_1_1>::EExpression(invocation) => {
-                LazyRawStreamItem::<AnyEncoding>::EExpression(LazyRawAnyEExpression {
+            LazyRawStreamItem::<TextEncoding_1_1>::EExp(invocation) => {
+                LazyRawStreamItem::<AnyEncoding>::EExp(LazyRawAnyEExpression {
                     encoding: LazyRawAnyEExpressionKind::Text_1_1(invocation),
                 })
             }
@@ -746,8 +959,8 @@ impl<'top> From<LazyRawStreamItem<'top, BinaryEncoding_1_1>>
             LazyRawStreamItem::<BinaryEncoding_1_1>::Value(value) => {
                 LazyRawStreamItem::<AnyEncoding>::Value(value.into())
             }
-            LazyRawStreamItem::<BinaryEncoding_1_1>::EExpression(eexp) => {
-                LazyRawStreamItem::<AnyEncoding>::EExpression(eexp.into())
+            LazyRawStreamItem::<BinaryEncoding_1_1>::EExp(eexp) => {
+                LazyRawStreamItem::<AnyEncoding>::EExp(eexp.into())
             }
             LazyRawStreamItem::<BinaryEncoding_1_1>::EndOfStream(end) => {
                 LazyRawStreamItem::<AnyEncoding>::EndOfStream(end)
@@ -1258,7 +1471,7 @@ impl<'top> HasRange for LazyRawAnyFieldName<'top> {
     }
 }
 
-impl<'top> LazyRawFieldName<'top> for LazyRawAnyFieldName<'top> {
+impl<'top> LazyRawFieldName<'top, AnyEncoding> for LazyRawAnyFieldName<'top> {
     fn read(&self) -> IonResult<RawSymbolRef<'top>> {
         use LazyRawFieldNameKind::*;
         match self.encoding {
@@ -1501,7 +1714,7 @@ mod tests {
             let context = encoding_context.get_ref();
 
             let mut reader = LazyRawAnyReader::new(data);
-            assert_eq!(reader.next(context)?.expect_ivm()?.version(), (1, 0));
+            assert_eq!(reader.next(context)?.expect_ivm()?.major_minor(), (1, 0));
             let _strukt = reader
                 .next(context)?
                 .expect_value()?
@@ -1566,6 +1779,162 @@ mod tests {
 
         test_input(text_data.as_bytes())?;
         test_input(&binary_data)?;
+
+        Ok(())
+    }
+
+    fn expect_version_change(
+        context_ref: EncodingContextRef,
+        reader: &mut LazyRawAnyReader,
+        encoding_before: IonEncoding,
+        encoding_after: IonEncoding,
+    ) -> IonResult<()> {
+        // The reader is using the expected encoding before we hit the IVM
+        assert_eq!(reader.encoding(), encoding_before);
+        // The next item is an IVM
+        let ivm = reader.next(context_ref)?.expect_ivm()?;
+        // The IVM correctly reports the expected before/after encodings
+        assert_eq!(ivm.old_encoding(), encoding_before);
+        assert_eq!(ivm.new_encoding()?, encoding_after);
+        // The reader is now using the new encoding
+        assert_eq!(reader.encoding(), encoding_after);
+        Ok(())
+    }
+
+    fn expect_int(
+        context_ref: EncodingContextRef,
+        reader: &mut LazyRawAnyReader,
+        expected_encoding: IonEncoding,
+        expected_int: i64,
+    ) -> IonResult<()> {
+        let value = reader.next(context_ref)?.expect_value()?;
+        let actual_int = value.read()?.expect_i64()?;
+        assert_eq!(actual_int, expected_int);
+        assert_eq!(reader.encoding(), expected_encoding);
+        Ok(())
+    }
+
+    #[test]
+    fn switch_text_versions() -> IonResult<()> {
+        const DATA: &str = r#"
+            1
+            $ion_1_0
+            2
+            $ion_1_1
+            3
+            $ion_1_1
+            4
+            $ion_1_0
+            5
+        "#;
+
+        let mut reader = LazyRawAnyReader::new(DATA.as_bytes());
+        let encoding_context = EncodingContext::empty();
+        let context_ref = encoding_context.get_ref();
+
+        expect_int(context_ref, &mut reader, IonEncoding::Text_1_0, 1)?;
+
+        // This IVM doesn't change the encoding.
+        expect_version_change(
+            context_ref,
+            &mut reader,
+            IonEncoding::Text_1_0,
+            IonEncoding::Text_1_0,
+        )?;
+
+        expect_int(context_ref, &mut reader, IonEncoding::Text_1_0, 2)?;
+
+        // This IVM changes the encoding from 1.0 text to 1.1 text
+        expect_version_change(
+            context_ref,
+            &mut reader,
+            IonEncoding::Text_1_0,
+            IonEncoding::Text_1_1,
+        )?;
+
+        expect_int(context_ref, &mut reader, IonEncoding::Text_1_1, 3)?;
+
+        // This IVM doesn't change the encoding.
+        expect_version_change(
+            context_ref,
+            &mut reader,
+            IonEncoding::Text_1_1,
+            IonEncoding::Text_1_1,
+        )?;
+
+        expect_int(context_ref, &mut reader, IonEncoding::Text_1_1, 4)?;
+
+        // This IVM changes the encoding from 1.1 text to 1.0 text
+        expect_version_change(
+            context_ref,
+            &mut reader,
+            IonEncoding::Text_1_1,
+            IonEncoding::Text_1_0,
+        )?;
+
+        expect_int(context_ref, &mut reader, IonEncoding::Text_1_0, 5)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn switch_binary_versions() -> IonResult<()> {
+        const DATA: &[u8] = &[
+            0xE0, 0x01, 0x00, 0xEA, // $ion_1_0
+            0x21, 0x02, // 2
+            0xE0, 0x01, 0x01, 0xEA, // $ion_1_1
+            0x61, 0x03, // 3
+            0xE0, 0x01, 0x01, 0xEA, // $ion_1_1
+            0x61, 0x04, // 4
+            0xE0, 0x01, 0x00, 0xEA, // $ion_1_0
+            0x21, 0x05, // 5
+        ];
+
+        let mut reader = LazyRawAnyReader::new(DATA);
+        let encoding_context = EncodingContext::empty();
+        let context_ref = encoding_context.get_ref();
+
+        // When the reader is constructed it peeks at the leading bytes to see if they're an IVM.
+        // In this case, they were a binary Ion v1.0 IVM, so the reader is already expecting to see
+        // binary 1.0 data. Reading the binary version marker tells the reader to switch encodings.
+        expect_version_change(
+            context_ref,
+            &mut reader,
+            IonEncoding::Binary_1_0,
+            IonEncoding::Binary_1_0,
+        )?;
+
+        expect_int(context_ref, &mut reader, IonEncoding::Binary_1_0, 2)?;
+
+        // This IVM changes the encoding from 1.0 binary to 1.1 binary
+        expect_version_change(
+            context_ref,
+            &mut reader,
+            IonEncoding::Binary_1_0,
+            IonEncoding::Binary_1_1,
+        )?;
+
+        expect_int(context_ref, &mut reader, IonEncoding::Binary_1_1, 3)?;
+
+        // This IVM doesn't change the encoding.
+        expect_version_change(
+            context_ref,
+            &mut reader,
+            IonEncoding::Binary_1_1,
+            IonEncoding::Binary_1_1,
+        )?;
+
+        expect_int(context_ref, &mut reader, IonEncoding::Binary_1_1, 4)?;
+
+        // This IVM changes the encoding from 1.1 binary to 1.0 binary
+        expect_version_change(
+            context_ref,
+            &mut reader,
+            IonEncoding::Binary_1_1,
+            IonEncoding::Binary_1_0,
+        )?;
+
+        expect_int(context_ref, &mut reader, IonEncoding::Binary_1_0, 5)?;
 
         Ok(())
     }

--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -12,7 +12,7 @@ use crate::lazy::binary::raw::sequence::{
     LazyRawBinaryList_1_0, LazyRawBinarySExp_1_0, RawBinarySequenceIterator_1_0,
 };
 use crate::lazy::binary::raw::v1_1::e_expression::{
-    BinaryEExpArgGroup, BinaryEExpArgGroupIterator, RawBinaryEExpression_1_1,
+    BinaryEExpArgGroup, BinaryEExpArgGroupIterator, BinaryEExpression_1_1,
 };
 use crate::lazy::binary::raw::v1_1::r#struct::{
     LazyRawBinaryFieldName_1_1, LazyRawBinaryStruct_1_1, RawBinaryStructIterator_1_1,
@@ -192,7 +192,7 @@ pub struct LazyRawAnyEExpression<'top> {
 #[derive(Debug, Copy, Clone)]
 pub enum LazyRawAnyEExpressionKind<'top> {
     Text_1_1(TextEExpression_1_1<'top>),
-    Binary_1_1(&'top RawBinaryEExpression_1_1<'top>),
+    Binary_1_1(&'top BinaryEExpression_1_1<'top>),
 }
 
 impl<'top> LazyRawAnyEExpression<'top> {
@@ -212,8 +212,8 @@ impl<'top> From<TextEExpression_1_1<'top>> for LazyRawAnyEExpression<'top> {
         }
     }
 }
-impl<'top> From<&'top RawBinaryEExpression_1_1<'top>> for LazyRawAnyEExpression<'top> {
-    fn from(binary_invocation: &'top RawBinaryEExpression_1_1<'top>) -> Self {
+impl<'top> From<&'top BinaryEExpression_1_1<'top>> for LazyRawAnyEExpression<'top> {
+    fn from(binary_invocation: &'top BinaryEExpression_1_1<'top>) -> Self {
         LazyRawAnyEExpression {
             encoding: LazyRawAnyEExpressionKind::Binary_1_1(binary_invocation),
         }
@@ -373,7 +373,7 @@ pub enum LazyRawAnyEExpArgsIteratorKind<'top> {
             >>::RawArgumentsIterator,
     ),
     Binary_1_1(
-        <&'top RawBinaryEExpression_1_1<'top> as RawEExpression<
+        <&'top BinaryEExpression_1_1<'top> as RawEExpression<
             'top,
             BinaryEncoding_1_1,
         >>::RawArgumentsIterator,

--- a/src/lazy/binary/encoded_value.rs
+++ b/src/lazy/binary/encoded_value.rs
@@ -72,11 +72,15 @@ pub(crate) struct EncodedValue<HeaderType: EncodedHeader> {
     // We store the offset for the header byte because it is guaranteed to be present for all values.
     // Annotations appear earlier in the stream but are optional.
 
-    // The number of bytes used to encode the annotations wrapper (if present) preceding the Ion
-    // value. If `annotations` is empty, `annotations_header_length` will be zero. The annotations
-    // wrapper contains several fields: an opcode, a wrapper length, a sequence length, and the
-    // sequence itself.
-    pub annotations_header_length: u16,
+    // The number of bytes used to encode the header of the annotations wrapper preceding the Ion
+    // value. If the value has no annotations, `annotations_header_length` will be zero.
+    //
+    // In Ion 1.0, the annotations header contains several fields: an opcode, a wrapper length, and
+    // the length of the sequence itself. It does not include the actual sequence of annotations.
+    //
+    // In Ion 1.1, the annotations header contains an opcode and (in the case of opcode 0xE9) a
+    // FlexUInt length.
+    pub annotations_header_length: u8,
     // The number of bytes used to encode the series of symbol IDs inside the annotations wrapper.
     pub annotations_sequence_length: u16,
     // Whether the annotations sequence is encoded as `FlexSym`s or as symbol addresses.
@@ -154,37 +158,47 @@ impl<HeaderType: EncodedHeader> EncodedValue<HeaderType> {
         self.annotations_header_length > 0
     }
 
-    /// Returns the number of bytes used to encode this value's annotations, if any.
-    /// While annotations envelope the value that they decorate, this function does not include
-    /// the length of the value itself.
-    pub fn annotations_header_length(&self) -> Option<usize> {
-        if self.annotations_header_length == 0 {
-            return None;
-        }
-        Some(self.annotations_header_length as usize)
+    /// Returns the number of bytes used to encode this value's annotations header, if any.
+    ///
+    /// In Ion 1.0, the annotations header contains several fields: an opcode, a wrapper length, and
+    /// the length of the sequence itself. It does not include the actual sequence of annotations.
+    ///
+    /// In Ion 1.1, the annotations header contains an opcode and (in the case of opcode 0xE9) a
+    /// FlexUInt representing the sequence length.
+    pub fn annotations_header_length(&self) -> usize {
+        self.annotations_header_length as usize
     }
 
-    /// Returns the number of bytes used to encode the series of VarUInt annotation symbol IDs, if
+    /// Returns the number of bytes used to encode the series of encoded annotation symbols, if
     /// any.
     ///
     /// See: <https://amazon-ion.github.io/ion-docs/docs/binary.html#annotations>
-    pub fn annotations_sequence_length(&self) -> Option<usize> {
-        if self.annotations_header_length == 0 {
-            return None;
-        }
-        Some(self.annotations_sequence_length as usize)
+    pub fn annotations_sequence_length(&self) -> usize {
+        self.annotations_sequence_length as usize
     }
 
+    /// Returns the combined length of the annotations header and sequence.
+    pub fn annotations_total_length(&self) -> usize {
+        self.annotations_header_length() + self.annotations_sequence_length()
+    }
+
+    /// Returns the offset range of the bytes in the stream that encoded the value's annotations
+    /// sequence.
     pub fn annotations_sequence_range(&self) -> Option<Range<usize>> {
         let wrapper_offset = self.annotations_offset()?;
         let wrapper_exclusive_end = wrapper_offset + self.annotations_header_length as usize;
         let sequence_length = self.annotations_sequence_length as usize;
-        let sequence_offset = wrapper_exclusive_end - sequence_length;
-        Some(sequence_offset..wrapper_exclusive_end)
+        let sequence_offset = wrapper_exclusive_end;
+        let sequence_exclusive_end = sequence_offset + sequence_length;
+        debug_assert!(sequence_exclusive_end == self.header_offset);
+        Some(sequence_offset..sequence_exclusive_end)
     }
 
     pub fn annotations_sequence_offset(&self) -> Option<usize> {
-        Some(self.annotations_sequence_range()?.start)
+        if self.annotations_header_length() == 0 {
+            return None;
+        }
+        Some(self.header_offset - self.annotations_sequence_length())
     }
 
     /// Returns the offset of the beginning of the annotations wrapper, if present.
@@ -192,15 +206,15 @@ impl<HeaderType: EncodedHeader> EncodedValue<HeaderType> {
         if self.annotations_header_length == 0 {
             return None;
         }
-        Some(self.header_offset - self.annotations_header_length as usize)
+        Some(self.header_offset - self.annotations_total_length())
     }
 
-    /// Returns an offset Range that includes the bytes used to encode this value's annotations,
-    /// if any. While annotations envelope the value that they modify, this function does not
-    /// include the bytes of the encoded value itself.
+    /// Returns an offset Range that includes the bytes used to encode this value's annotations
+    /// (including both the header and sequence), if any.
     pub fn annotations_range(&self) -> Option<Range<usize>> {
         if let Some(start) = self.annotations_offset() {
-            let end = start + self.annotations_header_length as usize;
+            // The annotations sequence always ends at the value's opcode.
+            let end = self.header_offset();
             return Some(start..end);
         }
         None
@@ -217,7 +231,7 @@ impl<HeaderType: EncodedHeader> EncodedValue<HeaderType> {
     /// complete encoding, including annotations.
     pub fn annotated_value_range(&self) -> Range<usize> {
         // [ annotations? | header (type descriptor) | header_length? | value ]
-        let start = self.header_offset - self.annotations_header_length as usize;
+        let start = self.header_offset - self.annotations_total_length();
         let end = start + self.total_length;
         start..end
     }
@@ -227,7 +241,7 @@ impl<HeaderType: EncodedHeader> EncodedValue<HeaderType> {
     pub fn unannotated_value_range(&self) -> Range<usize> {
         // [ annotations? | header (type descriptor) | header_length? | value ]
         let start = self.header_offset;
-        let end = start + self.total_length - self.annotations_header_length as usize;
+        let end = start + self.total_length - self.annotations_total_length();
         start..end
     }
 
@@ -253,7 +267,7 @@ mod tests {
                 ion_type_code: IonTypeCode::String,
                 length_code: 3,
             },
-            annotations_header_length: 3,
+            annotations_header_length: 2,
             annotations_sequence_length: 1,
             annotations_encoding: AnnotationsEncoding::SymbolAddress,
             header_offset: 200,
@@ -275,9 +289,9 @@ mod tests {
         assert_eq!(value.header_range(), 200..201);
         assert!(value.has_annotations());
         assert_eq!(value.annotations_range(), Some(197..200));
-        assert_eq!(value.annotations_header_length(), Some(3));
+        assert_eq!(value.annotations_header_length(), 2);
         assert_eq!(value.annotations_sequence_offset(), Some(199));
-        assert_eq!(value.annotations_sequence_length(), Some(1));
+        assert_eq!(value.annotations_sequence_length(), 1);
         assert_eq!(value.annotations_sequence_range(), Some(199..200));
         assert_eq!(value.value_body_length(), 3);
         assert_eq!(value.value_body_offset(), 201);

--- a/src/lazy/binary/encoded_value.rs
+++ b/src/lazy/binary/encoded_value.rs
@@ -169,7 +169,7 @@ impl<HeaderType: EncodedHeader> EncodedValue<HeaderType> {
         self.annotations_header_length as usize
     }
 
-    /// Returns the number of bytes used to encode the series of encoded annotation symbols, if
+    /// Returns the number of bytes used to encode the series of annotation symbols, if
     /// any.
     ///
     /// See: <https://amazon-ion.github.io/ion-docs/docs/binary.html#annotations>

--- a/src/lazy/binary/encoded_value.rs
+++ b/src/lazy/binary/encoded_value.rs
@@ -184,14 +184,16 @@ impl<HeaderType: EncodedHeader> EncodedValue<HeaderType> {
 
     /// Returns the offset range of the bytes in the stream that encoded the value's annotations
     /// sequence.
-    pub fn annotations_sequence_range(&self) -> Option<Range<usize>> {
-        let wrapper_offset = self.annotations_offset()?;
+    pub fn annotations_sequence_range(&self) -> Range<usize> {
+        let wrapper_offset = self
+            .annotations_offset()
+            .unwrap_or_else(|| self.header_offset());
         let wrapper_exclusive_end = wrapper_offset + self.annotations_header_length as usize;
         let sequence_length = self.annotations_sequence_length as usize;
         let sequence_offset = wrapper_exclusive_end;
         let sequence_exclusive_end = sequence_offset + sequence_length;
         debug_assert!(sequence_exclusive_end == self.header_offset);
-        Some(sequence_offset..sequence_exclusive_end)
+        sequence_offset..sequence_exclusive_end
     }
 
     pub fn annotations_sequence_offset(&self) -> Option<usize> {
@@ -292,7 +294,7 @@ mod tests {
         assert_eq!(value.annotations_header_length(), 2);
         assert_eq!(value.annotations_sequence_offset(), Some(199));
         assert_eq!(value.annotations_sequence_length(), 1);
-        assert_eq!(value.annotations_sequence_range(), Some(199..200));
+        assert_eq!(value.annotations_sequence_range(), 199..200);
         assert_eq!(value.value_body_length(), 3);
         assert_eq!(value.value_body_offset(), 201);
         assert_eq!(value.value_body_range(), 201..204);

--- a/src/lazy/binary/raw/struct.rs
+++ b/src/lazy/binary/raw/struct.rs
@@ -134,7 +134,7 @@ impl<'top> HasRange for LazyRawBinaryFieldName_1_0<'top> {
     }
 }
 
-impl<'top> LazyRawFieldName<'top> for LazyRawBinaryFieldName_1_0<'top> {
+impl<'top> LazyRawFieldName<'top, BinaryEncoding_1_0> for LazyRawBinaryFieldName_1_0<'top> {
     fn read(&self) -> IonResult<RawSymbolRef<'top>> {
         Ok(RawSymbolRef::SymbolId(self.field_id))
     }

--- a/src/lazy/binary/raw/v1_1/e_expression.rs
+++ b/src/lazy/binary/raw/v1_1/e_expression.rs
@@ -18,8 +18,6 @@ use crate::lazy::text::raw::v1_1::arg_group::{EExpArg, EExpArgExpr};
 use crate::lazy::text::raw::v1_1::reader::MacroIdRef;
 use crate::{try_or_some_err, v1_1, Environment, HasRange, HasSpan, IonResult, Span};
 
-use bumpalo::collections::Vec as BumpVec;
-
 #[derive(Copy, Clone)]
 pub struct BinaryEExpHeader {
     // The number of bytes that were used to encode the e-expression's opcode and address.
@@ -152,13 +150,7 @@ impl<'top> RawEExpression<'top, v1_1::Binary> for &'top BinaryEExpression_1_1<'t
         // a mutable reference to `self` and getting one would be a non-trivial change. However,
         // in the vast majority of use cases, e-expressions are not evaluated more than once, which
         // means that populating the cache would be of little value.
-        let allocator = context.allocator();
-        let num_args = self.macro_ref.signature().len();
-        let mut env_exprs = BumpVec::with_capacity_in(num_args, allocator);
-        for expr in self.raw_arguments() {
-            env_exprs.push(expr?.resolve(context)?);
-        }
-        Ok(Environment::new(env_exprs.into_bump_slice()))
+        Environment::for_eexp(context, *self)
     }
 }
 

--- a/src/lazy/binary/raw/v1_1/e_expression.rs
+++ b/src/lazy/binary/raw/v1_1/e_expression.rs
@@ -255,6 +255,7 @@ pub struct BinaryEExpArgsInputIter<'top> {
 impl<'top> Iterator for BinaryEExpArgsInputIter<'top> {
     type Item = IonResult<EExpArg<'top, v1_1::Binary>>;
 
+    #[inline(always)]
     fn next(&mut self) -> Option<IonResult<EExpArg<'top, v1_1::Binary>>> {
         // We cannot read the arguments of a binary e-expression without first looking at the
         // corresponding parameter's encoding and cardinality to know what bytes to expect.

--- a/src/lazy/binary/raw/v1_1/e_expression.rs
+++ b/src/lazy/binary/raw/v1_1/e_expression.rs
@@ -327,7 +327,7 @@ impl<'top> Iterator for BinaryEExpArgsInputIter<'top> {
     }
 }
 
-/// At iterator that visits already-resolved `ValueExpr`s stored in an array.
+/// An iterator that visits already-resolved `ValueExpr`s stored in an array.
 #[derive(Debug, Copy, Clone)]
 pub struct BinaryEExpArgsCacheIter<'top> {
     initial_offset: usize,

--- a/src/lazy/binary/raw/v1_1/e_expression.rs
+++ b/src/lazy/binary/raw/v1_1/e_expression.rs
@@ -44,6 +44,7 @@ impl BinaryEExpHeader {
     }
 }
 
+/// An e-expression which has been parsed from a binary Ion 1.1 stream.
 #[derive(Copy, Clone)]
 pub struct BinaryEExpression_1_1<'top> {
     // The arguments to the e-expression are parsed either:

--- a/src/lazy/binary/raw/v1_1/e_expression.rs
+++ b/src/lazy/binary/raw/v1_1/e_expression.rs
@@ -3,77 +3,439 @@
 use std::fmt::{Debug, Formatter};
 use std::ops::Range;
 
-use crate::lazy::binary::raw::v1_1::immutable_buffer::ImmutableBuffer;
+use crate::lazy::binary::raw::v1_1::immutable_buffer::{
+    ArgGrouping, ArgGroupingBitmapIterator, ImmutableBuffer,
+};
 use crate::lazy::decoder::LazyRawValueExpr;
-use crate::lazy::expanded::macro_evaluator::RawEExpression;
+use crate::lazy::encoding::BinaryEncoding_1_1;
+use crate::lazy::expanded::e_expression::ArgGroup;
+use crate::lazy::expanded::macro_evaluator::{EExpArgGroupIterator, MacroExprKind};
+use crate::lazy::expanded::macro_evaluator::{EExpressionArgGroup, RawEExpression, ValueExpr};
+use crate::lazy::expanded::macro_table::MacroRef;
+use crate::lazy::expanded::template::{MacroSignature, Parameter, ParameterEncoding};
+use crate::lazy::expanded::EncodingContextRef;
+use crate::lazy::text::raw::v1_1::arg_group::{EExpArg, EExpArgExpr};
 use crate::lazy::text::raw::v1_1::reader::MacroIdRef;
-use crate::{v1_1, HasRange, HasSpan, IonResult, Span};
+use crate::{try_or_some_err, v1_1, Environment, HasRange, HasSpan, IonResult, Span};
+
+use bumpalo::collections::Vec as BumpVec;
 
 #[derive(Copy, Clone)]
-pub struct EncodedBinaryEExp {
-    // The number of bytes that were used to encode the e-expression's header (including its ID)
-    header_length: u16,
+pub struct BinaryEExpHeader {
+    // The number of bytes that were used to encode the e-expression's opcode and address.
+    opcode_and_address_length: u8,
+    // The number of bytes that were used to encode the e-expression's arg grouping bitmap, if any.
+    bitmap_length: u8,
 }
 
-impl EncodedBinaryEExp {
-    pub fn new(header_length: u16) -> Self {
-        Self { header_length }
+impl BinaryEExpHeader {
+    pub fn new(opcode_length: u8, bitmap_length: u8) -> Self {
+        Self {
+            opcode_and_address_length: opcode_length,
+            bitmap_length,
+        }
+    }
+    pub fn address_and_opcode_length(&self) -> usize {
+        self.opcode_and_address_length as usize
+    }
+    pub fn bitmap_length(&self) -> usize {
+        self.bitmap_length as usize
+    }
+    pub fn header_length(&self) -> usize {
+        self.address_and_opcode_length() + self.bitmap_length()
     }
 }
 
 #[derive(Copy, Clone)]
 pub struct RawBinaryEExpression_1_1<'top> {
-    pub(crate) encoded_expr: EncodedBinaryEExp,
+    // The arguments to the e-expression are parsed either:
+    //
+    //   1. when the e-expression is first encountered, if it is not length-prefixed.
+    //     OR
+    //   2. when the e-expression is being evaluated, to populate its evaluation environment.
+    //
+    // In case #1, we store the parsed arguments in the bump allocator so that we don't have to
+    // re-parse them at evaluation time. We _could_ store the `LazyRawValueExpr<'top, BinaryEncoding_1_1>`
+    // representations of the expressions, but then we would need to make a separate array of the
+    // resolved versions of those expressions (`ValueExpr<'top, BinaryEncoding_1_1>`) to populate
+    // the environment. As an optimization, we store the fully resolved version of the arguments
+    // so that populating the environment is very close to a no-op. In the uncommon case that we need
+    // to iterate over the raw argument expressions (usually for tooling), we can do so by
+    // "unpacking" their resolved representations. See `make_evaluation_environment` for details.
+    cache: Option<&'top [ValueExpr<'top, BinaryEncoding_1_1>]>,
+    macro_ref: MacroRef<'top>,
+    bitmap_bits: u64,
+    // The index of `input` at which the bitmap can be found. If there is no bitmap, this index
+    // will be the beginning of the encoded arguments.
+    bitmap_offset: u8,
+    // The index at which the arguments to the e-expression begin within `input`. This index is
+    // the first position after the opcode, address, length, and bitmap.
+    args_offset: u8,
+
     pub(crate) input: ImmutableBuffer<'top>,
-    pub(crate) id: MacroIdRef<'top>,
-    pub(crate) arg_expr_cache: &'top [LazyRawValueExpr<'top, v1_1::Binary>],
 }
 
 impl<'top> RawBinaryEExpression_1_1<'top> {
     pub fn new(
-        id: MacroIdRef<'top>,
-        encoded_expr: EncodedBinaryEExp,
+        macro_ref: MacroRef<'top>,
+        bitmap_bits: u64,
         input: ImmutableBuffer<'top>,
-        arg_expr_cache: &'top [LazyRawValueExpr<'top, v1_1::Binary>],
+        bitmap_offset: u8,
+        args_offset: u8,
     ) -> Self {
         Self {
-            encoded_expr,
+            bitmap_bits,
             input,
-            id,
-            arg_expr_cache,
+            macro_ref,
+            bitmap_offset,
+            args_offset,
+            cache: None,
         }
+    }
+
+    pub fn with_arg_expr_cache(
+        mut self,
+        cache: &'top [ValueExpr<'top, BinaryEncoding_1_1>],
+    ) -> Self {
+        self.cache = Some(cache);
+        self
     }
 }
 
-impl<'top> HasSpan<'top> for RawBinaryEExpression_1_1<'top> {
+impl<'top> HasSpan<'top> for &'top RawBinaryEExpression_1_1<'top> {
     fn span(&self) -> Span<'top> {
         Span::with_offset(self.input.offset(), self.input.bytes())
     }
 }
 
-impl<'top> HasRange for RawBinaryEExpression_1_1<'top> {
+impl<'top> HasRange for &'top RawBinaryEExpression_1_1<'top> {
     fn range(&self) -> Range<usize> {
         self.input.range()
     }
 }
 
-impl<'top> Debug for RawBinaryEExpression_1_1<'top> {
+impl<'top> Debug for &'top RawBinaryEExpression_1_1<'top> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "<e-expression invoking id '{}'>", self.id())
     }
 }
 
-impl<'top> RawEExpression<'top, v1_1::Binary> for RawBinaryEExpression_1_1<'top> {
-    type RawArgumentsIterator<'a> = RawBinarySequenceCacheIterator_1_1<'top>
-    where
-        Self: 'a;
+impl<'top> RawEExpression<'top, v1_1::Binary> for &'top RawBinaryEExpression_1_1<'top> {
+    type RawArgumentsIterator = BinaryEExpArgsIterator_1_1<'top>;
+    type ArgGroup = BinaryEExpArgGroup<'top>;
 
-    fn id(&self) -> MacroIdRef<'top> {
-        self.id
+    fn id(self) -> MacroIdRef<'top> {
+        MacroIdRef::LocalAddress(self.macro_ref.address())
     }
 
-    fn raw_arguments(&self) -> Self::RawArgumentsIterator<'top> {
-        RawBinarySequenceCacheIterator_1_1::new(self.arg_expr_cache)
+    fn raw_arguments(&self) -> Self::RawArgumentsIterator {
+        let signature = self.macro_ref.signature();
+        let args_input = self.input.consume(self.args_offset as usize);
+        if let Some(cache) = self.cache {
+            return BinaryEExpArgsIterator_1_1::for_cache(signature, args_input.offset(), cache);
+        }
+        let bitmap_iterator =
+            ArgGroupingBitmapIterator::new(signature.parameters().len(), self.bitmap_bits);
+        BinaryEExpArgsIterator_1_1::for_input(bitmap_iterator, args_input, signature)
+    }
+
+    fn make_evaluation_environment(
+        &self,
+        context: EncodingContextRef<'top>,
+    ) -> IonResult<Environment<'top, BinaryEncoding_1_1>> {
+        // If we've already parsed and resolved the e-expression's arguments, use our cache as the
+        // new environment.
+        if let Some(cache) = self.cache {
+            return Ok(Environment::new(cache));
+        }
+        // Otherwise, we parse the arguments and add them to a new environment as we go.
+        // Note that (as currently designed) we cannot then populate the cache as we do not have
+        // a mutable reference to `self` and getting one would be a non-trivial change. However,
+        // in the vast majority of use cases, e-expressions are not evaluated more than once, which
+        // means that populating the cache would be of little value.
+        let allocator = context.allocator();
+        let num_args = self.macro_ref.signature().parameters().len();
+        let mut env_exprs = BumpVec::with_capacity_in(num_args, allocator);
+        for expr in self.raw_arguments() {
+            env_exprs.push(expr?.resolve(context)?);
+        }
+        Ok(Environment::new(env_exprs.into_bump_slice()))
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct BinaryEExpArgsIterator_1_1<'top> {
+    source: BinaryEExpArgsSource<'top>,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct BinaryEExpArgsInputIter<'top> {
+    bitmap_iter: ArgGroupingBitmapIterator,
+    remaining_args_buffer: ImmutableBuffer<'top>,
+    param_index: usize,
+    signature: &'top MacroSignature,
+}
+
+impl<'top> Iterator for BinaryEExpArgsInputIter<'top> {
+    type Item = IonResult<EExpArg<'top, v1_1::Binary>>;
+
+    fn next(&mut self) -> Option<IonResult<EExpArg<'top, v1_1::Binary>>> {
+        // We cannot read the arguments of a binary e-expression without first looking at the
+        // corresponding parameter's encoding and cardinality to know what bytes to expect.
+        // First, get the parameter from the signature. If `get` returns `None`, we've reached the
+        // end of the signature and can early-return.
+        let parameter = self.signature.parameters().get(self.param_index)?;
+        let arg_grouping = if parameter.is_variadic() {
+            // If it's a variadic parameter (that is: `?`, `*`, or `+`), pull two bits from the
+            // argument encoding bitmap to see how it was encoded.
+            try_or_some_err!(self.bitmap_iter.next().unwrap())
+        } else {
+            // If it's a required parameter (`!`, or no modifier), there's no corresponding entry in the
+            // argument encoding bitmap.
+            ArgGrouping::ValueExprLiteral
+        };
+        // TODO: Tagless encodings
+        let (arg_expr, remaining_input) = match arg_grouping {
+            // If the encoding is `empty`, there's nothing to do. Make an empty slice at the current
+            // offset and build an empty BinaryEExpArgGroup with it.
+            ArgGrouping::Empty => {
+                let input = self.remaining_args_buffer.slice(0, 0);
+                let expr = EExpArgExpr::ArgGroup(BinaryEExpArgGroup::new(parameter, input, 0));
+                (EExpArg::new(parameter, expr), self.remaining_args_buffer)
+            }
+            // If it's a tagged value expression, parse it as usual.
+            ArgGrouping::ValueExprLiteral => {
+                let (expr, remaining) = try_or_some_err! {
+                    self
+                        .remaining_args_buffer
+                        .expect_eexp_arg_expr("reading tagged e-expr arg")
+                };
+                (EExpArg::new(parameter, expr), remaining)
+            }
+            // If it's an argument group...
+            ArgGrouping::ArgGroup => {
+                //...then it starts with a FlexUInt that indicates whether the group is length-prefixed
+                // or delimited.
+                let (group_header_flex_uint, _remaining_args_input) =
+                    try_or_some_err!(self.remaining_args_buffer.read_flex_uint());
+                let bytes_to_read = match group_header_flex_uint.value() {
+                    0 => todo!("delimited argument groups"),
+                    n_bytes => n_bytes as usize,
+                };
+                // If it's length-prefixed, we don't need to inspect its contents. We can build an
+                // ArgGroup using the unexamined bytes; we'll parse them later if they get evaluated.
+                let arg_group_length = group_header_flex_uint.size_in_bytes() + bytes_to_read;
+                let arg_group = BinaryEExpArgGroup::new(
+                    parameter,
+                    self.remaining_args_buffer.slice(0, arg_group_length),
+                    group_header_flex_uint.size_in_bytes() as u8,
+                );
+                (
+                    EExpArg::new(parameter, EExpArgExpr::ArgGroup(arg_group)),
+                    self.remaining_args_buffer.consume(arg_group_length),
+                )
+            }
+        };
+
+        self.param_index += 1;
+        self.remaining_args_buffer = remaining_input;
+        Some(Ok(arg_expr))
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct BinaryEExpArgsCacheIter<'top> {
+    initial_offset: usize,
+    cache_exprs: &'top [ValueExpr<'top, BinaryEncoding_1_1>],
+    expr_index: usize,
+    signature: &'top MacroSignature,
+}
+
+impl<'top> BinaryEExpArgsCacheIter<'top> {
+    pub fn next(&mut self) -> Option<IonResult<EExpArg<'top, v1_1::Binary>>> {
+        let parameter = self.signature.parameters().get(self.expr_index)?;
+        let cache_entry = self.cache_exprs.get(self.expr_index).unwrap();
+        self.expr_index += 1;
+        let next_expr = match cache_entry {
+            ValueExpr::ValueLiteral(value) => {
+                // We know that every ValueExpr in the cache is the resolved version of a raw value
+                // literal, so we can safely `unwrap` here.
+                let value_literal = value.expect_value_literal().unwrap();
+                EExpArg::new(parameter, EExpArgExpr::ValueLiteral(value_literal))
+            }
+            ValueExpr::MacroInvocation(invocation) => {
+                use MacroExprKind::*;
+                let expr = match invocation.source() {
+                    TemplateMacro(_) => {
+                        unreachable!("e-expression cannot be a TDL macro invocation")
+                    }
+                    EExp(eexp) => EExpArgExpr::EExp(eexp.raw_invocation),
+                    EExpArgGroup(group) => EExpArgExpr::ArgGroup(group.raw_arg_group()),
+                };
+                EExpArg::new(parameter, expr)
+            }
+        };
+        Some(Ok(next_expr))
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum BinaryEExpArgsSource<'top> {
+    Input(BinaryEExpArgsInputIter<'top>),
+    Cache(BinaryEExpArgsCacheIter<'top>),
+}
+
+impl<'top> BinaryEExpArgsIterator_1_1<'top> {
+    pub fn for_input(
+        groupings_iter: ArgGroupingBitmapIterator,
+        remaining_args_buffer: ImmutableBuffer<'top>,
+        signature: &'top MacroSignature,
+    ) -> Self {
+        Self {
+            source: BinaryEExpArgsSource::Input(BinaryEExpArgsInputIter {
+                bitmap_iter: groupings_iter,
+                remaining_args_buffer,
+                param_index: 0,
+                signature,
+            }),
+        }
+    }
+
+    pub fn for_cache(
+        signature: &'top MacroSignature,
+        initial_offset: usize,
+        cache: &'top [ValueExpr<'top, BinaryEncoding_1_1>],
+    ) -> Self {
+        Self {
+            source: BinaryEExpArgsSource::Cache(BinaryEExpArgsCacheIter {
+                cache_exprs: cache,
+                initial_offset,
+                expr_index: 0,
+                signature,
+            }),
+        }
+    }
+
+    pub fn offset(&self) -> usize {
+        match &self.source {
+            BinaryEExpArgsSource::Input(i) => i.remaining_args_buffer.offset(),
+            // If there weren't any args, then the iterator's position is where it started.
+            BinaryEExpArgsSource::Cache(c) if c.cache_exprs.is_empty() => c.initial_offset,
+            BinaryEExpArgsSource::Cache(c) => {
+                match c.cache_exprs.get(c.expr_index) {
+                    Some(value_expr) => value_expr.range().unwrap().end,
+                    // If the iterator is exhausted, then its offset is the end of the last arg expr.
+                    None => c.cache_exprs[c.expr_index - 1].range().unwrap().end,
+                }
+            }
+        }
+    }
+}
+
+impl<'top> Iterator for BinaryEExpArgsIterator_1_1<'top> {
+    type Item = IonResult<EExpArg<'top, v1_1::Binary>>;
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.source {
+            BinaryEExpArgsSource::Input(ref mut input_iter) => input_iter.next(),
+            BinaryEExpArgsSource::Cache(ref mut cache_iter) => cache_iter.next(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let signature = match self.source {
+            BinaryEExpArgsSource::Input(i) => i.signature,
+            BinaryEExpArgsSource::Cache(i) => i.signature,
+        };
+        let num_args = signature.parameters().len();
+        // Tells the macro evaluator how much space to allocate to hold these arguments
+        (num_args, Some(num_args))
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct BinaryEExpArgGroup<'top> {
+    parameter: &'top Parameter,
+    input: ImmutableBuffer<'top>,
+    header_size: u8,
+}
+
+impl<'top> BinaryEExpArgGroup<'top> {
+    pub fn new(parameter: &'top Parameter, input: ImmutableBuffer<'top>, header_size: u8) -> Self {
+        Self {
+            parameter,
+            input,
+            header_size,
+        }
+    }
+}
+
+impl<'top> HasRange for BinaryEExpArgGroup<'top> {
+    fn range(&self) -> Range<usize> {
+        self.input.range()
+    }
+}
+
+impl<'top> HasSpan<'top> for BinaryEExpArgGroup<'top> {
+    fn span(&self) -> Span<'top> {
+        Span::with_offset(self.input.offset(), self.input.bytes())
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct BinaryEExpArgGroupIterator<'top> {
+    parameter: &'top Parameter,
+    remaining_args_buffer: ImmutableBuffer<'top>,
+}
+
+impl<'top> EExpArgGroupIterator<'top, BinaryEncoding_1_1> for BinaryEExpArgGroupIterator<'top> {
+    fn is_exhausted(&self) -> bool {
+        self.remaining_args_buffer.is_empty()
+    }
+}
+
+impl<'top> Iterator for BinaryEExpArgGroupIterator<'top> {
+    type Item = IonResult<LazyRawValueExpr<'top, BinaryEncoding_1_1>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining_args_buffer.is_empty() {
+            return None;
+        }
+        let (expr, remaining) = try_or_some_err! {
+            // TODO: Other encodings
+            self.remaining_args_buffer.expect_sequence_value_expr("eexp arg group subarg")
+        };
+        self.remaining_args_buffer = remaining;
+        Some(Ok(expr))
+    }
+}
+
+impl<'top> IntoIterator for BinaryEExpArgGroup<'top> {
+    type Item = IonResult<LazyRawValueExpr<'top, BinaryEncoding_1_1>>;
+    type IntoIter = BinaryEExpArgGroupIterator<'top>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        BinaryEExpArgGroupIterator {
+            parameter: self.parameter,
+            remaining_args_buffer: self.input.consume(self.header_size as usize),
+        }
+    }
+}
+
+impl<'top> EExpressionArgGroup<'top, BinaryEncoding_1_1> for BinaryEExpArgGroup<'top> {
+    type Iterator = BinaryEExpArgGroupIterator<'top>;
+
+    fn encoding(&self) -> ParameterEncoding {
+        self.parameter.encoding()
+    }
+
+    fn resolve(self, context: EncodingContextRef<'top>) -> ArgGroup<'top, BinaryEncoding_1_1> {
+        ArgGroup::new(self, context)
+    }
+
+    fn iter(self) -> Self::Iterator {
+        self.into_iter()
     }
 }
 

--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -58,8 +58,11 @@ impl<'a> Debug for ImmutableBuffer<'a> {
 
 impl<'a> PartialEq for ImmutableBuffer<'a> {
     fn eq(&self, other: &Self) -> bool {
-        // A definition of equality that ignores the `context` field
+        // A definition of equality that ignores the `context` field.
         self.offset == other.offset && self.data == other.data
+        // An argument could be made that two buffers are not equal if they're holding references to
+        // different contexts, but this is a very low-level, feature-gated construct so it's probably
+        // fine if the implementation is arguably imperfect.
     }
 }
 

--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -7,7 +7,7 @@ use bumpalo::collections::Vec as BumpVec;
 use crate::binary::constants::v1_1::IVM;
 use crate::lazy::binary::encoded_value::EncodedValue;
 use crate::lazy::binary::raw::v1_1::e_expression::{
-    BinaryEExpArgsIterator_1_1, RawBinaryEExpression_1_1,
+    BinaryEExpArgsIterator_1_1, BinaryEExpression_1_1,
 };
 use crate::lazy::binary::raw::v1_1::value::{
     LazyRawBinaryValue_1_1, LazyRawBinaryVersionMarker_1_1,
@@ -346,7 +346,7 @@ impl<'a> ImmutableBuffer<'a> {
         // Like RawValueExpr, but doesn't use references.
         enum ParseValueExprResult<'top> {
             Value(ParseResult<'top, LazyRawBinaryValue_1_1<'top>>),
-            EExp(ParseResult<'top, RawBinaryEExpression_1_1<'top>>),
+            EExp(ParseResult<'top, BinaryEExpression_1_1<'top>>),
         }
 
         use OpcodeType::*;
@@ -576,10 +576,7 @@ impl<'a> ImmutableBuffer<'a> {
     }
 
     #[inline]
-    pub fn read_e_expression(
-        self,
-        opcode: Opcode,
-    ) -> ParseResult<'a, RawBinaryEExpression_1_1<'a>> {
+    pub fn read_e_expression(self, opcode: Opcode) -> ParseResult<'a, BinaryEExpression_1_1<'a>> {
         use OpcodeType::*;
         match opcode.opcode_type {
             EExpressionWithAddress => return self.read_eexp_with_address_in_opcode(opcode),
@@ -592,7 +589,7 @@ impl<'a> ImmutableBuffer<'a> {
     fn read_eexp_with_address_in_opcode(
         self,
         opcode: Opcode,
-    ) -> ParseResult<'a, RawBinaryEExpression_1_1<'a>> {
+    ) -> ParseResult<'a, BinaryEExpression_1_1<'a>> {
         let input_after_opcode = self.consume(1);
         let macro_address = opcode.byte as usize;
 
@@ -639,7 +636,7 @@ impl<'a> ImmutableBuffer<'a> {
         let args_offset = input_after_bitmap.offset() - self.offset();
         Ok((
             {
-                RawBinaryEExpression_1_1::new(
+                BinaryEExpression_1_1::new(
                     MacroRef::new(macro_address, macro_ref),
                     bitmap_bits,
                     matched_eexp_bytes,
@@ -655,7 +652,7 @@ impl<'a> ImmutableBuffer<'a> {
     fn read_eexp_with_length_prefix(
         self,
         _opcode: Opcode,
-    ) -> ParseResult<'a, RawBinaryEExpression_1_1<'a>> {
+    ) -> ParseResult<'a, BinaryEExpression_1_1<'a>> {
         let input_after_opcode = self.consume(1);
         let (macro_address_flex_uint, input_after_address) = input_after_opcode.read_flex_uint()?;
         let (args_length_flex_uint, input_after_length) = input_after_address.read_flex_uint()?;
@@ -682,7 +679,7 @@ impl<'a> ImmutableBuffer<'a> {
         let args_offset = bitmap_offset + macro_ref.signature().bitmap_size_in_bytes() as u8;
         let remaining_input = self.consume(total_length);
         return Ok((
-            RawBinaryEExpression_1_1::new(
+            BinaryEExpression_1_1::new(
                 MacroRef::new(macro_address, macro_ref),
                 bitmap_bits,
                 matched_bytes,

--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -290,8 +290,7 @@ impl<'a> ImmutableBuffer<'a> {
         }
     }
 
-    /// Reads a value without a field name from the buffer. This is applicable in lists, s-expressions,
-    /// and at the top level.
+    /// Reads a single expression (value literal or e-expression) as an argument to an e-expression.
     #[inline]
     pub(crate) fn expect_eexp_arg_expr(
         self,

--- a/src/lazy/binary/raw/v1_1/struct.rs
+++ b/src/lazy/binary/raw/v1_1/struct.rs
@@ -46,7 +46,7 @@ impl<'top> HasRange for LazyRawBinaryFieldName_1_1<'top> {
     }
 }
 
-impl<'top> LazyRawFieldName<'top> for LazyRawBinaryFieldName_1_1<'top> {
+impl<'top> LazyRawFieldName<'top, BinaryEncoding_1_1> for LazyRawBinaryFieldName_1_1<'top> {
     fn read(&self) -> IonResult<RawSymbolRef<'top>> {
         Ok(self.field_name)
     }
@@ -54,7 +54,7 @@ impl<'top> LazyRawFieldName<'top> for LazyRawBinaryFieldName_1_1<'top> {
 
 #[derive(Copy, Clone)]
 pub struct LazyRawBinaryStruct_1_1<'top> {
-    pub(crate) value: LazyRawBinaryValue_1_1<'top>,
+    pub(crate) value: &'top LazyRawBinaryValue_1_1<'top>,
 }
 
 impl<'a, 'top> IntoIterator for &'a LazyRawBinaryStruct_1_1<'top> {
@@ -85,9 +85,7 @@ impl<'top> LazyRawBinaryStruct_1_1<'top> {
     }
 
     pub fn iter(&self) -> RawBinaryStructIterator_1_1<'top> {
-        // Get as much of the struct's body as is available in the input buffer.
-        // Reading a child value may fail as `Incomplete`
-        let buffer_slice = self.value.available_body();
+        let buffer_slice = self.value.value_body_buffer();
         RawBinaryStructIterator_1_1::new(
             self.value.encoded_value.header.ion_type_code,
             buffer_slice,
@@ -96,7 +94,7 @@ impl<'top> LazyRawBinaryStruct_1_1<'top> {
 }
 
 impl<'top> LazyContainerPrivate<'top, BinaryEncoding_1_1> for LazyRawBinaryStruct_1_1<'top> {
-    fn from_value(value: LazyRawBinaryValue_1_1<'top>) -> Self {
+    fn from_value(value: &'top LazyRawBinaryValue_1_1<'top>) -> Self {
         LazyRawBinaryStruct_1_1 { value }
     }
 }
@@ -197,7 +195,7 @@ impl<'top> RawBinaryStructIterator_1_1<'top> {
     fn peek_value(
         buffer: ImmutableBuffer<'top>,
     ) -> IonResult<(Option<LazyRawBinaryValue_1_1<'top>>, ImmutableBuffer<'top>)> {
-        let opcode = buffer.peek_opcode()?;
+        let opcode = buffer.expect_opcode()?;
         if opcode.is_nop() {
             let after_nops = buffer.consume_nop_padding(opcode)?.1;
             if after_nops.is_empty() {
@@ -208,7 +206,7 @@ impl<'top> RawBinaryStructIterator_1_1<'top> {
         } else {
             buffer
                 .read_value(opcode)
-                .map(|v| (Some(v), v.input.consume(v.encoded_value.total_length)))
+                .map(|(v, remaining)| (Some(v), remaining))
         }
     }
 
@@ -243,7 +241,7 @@ impl<'top> RawBinaryStructIterator_1_1<'top> {
                     buffer = after;
                     continue; // No value for this field, loop to try next field.
                 }
-                (Some(value), after) => (value, after),
+                (Some(value), after) => (&*after.context().allocator().alloc_with(|| value), after),
             };
 
             let bytes_to_skip = after_value.offset() - self.source.offset();

--- a/src/lazy/binary/raw/v1_1/type_code.rs
+++ b/src/lazy/binary/raw/v1_1/type_code.rs
@@ -29,22 +29,22 @@ pub enum OpcodeType {
     Struct,           // 0xD2-0xDF -
     IonVersionMarker, // 0xE0      -
 
-    SymbolAddress,               // 0xE1-0xE3 -
-    AnnotationSymAddress,        // 0xE4-0xE6 -
-    AnnotationFlexSym,           // 0xE7-0xE9 -
-    NullNull,                    // 0xEA      -
-    TypedNull,                   // 0xEB      -
-    Nop,                         // 0xEC-0xED -
-    EExpressionWithLengthPrefix, // 0xF5
+    SymbolAddress,        // 0xE1-0xE3 -
+    AnnotationSymAddress, // 0xE4-0xE6 -
+    AnnotationFlexSym,    // 0xE7-0xE9 -
+    NullNull,             // 0xEA      -
+    TypedNull,            // 0xEB      -
+    Nop,                  // 0xEC-0xED -
     // Reserved
     SystemMacroInvoke, // 0xEF      -
     // 0xF0 delimited container end
     // 0xF1 delimited list start
     // 0xF2 delimited s-expression start
     // 0xF3 delimited struct start
-    LargeInteger, // 0xF6 - Integer preceded by FlexUInt length
-    Blob,         // 0xFE -
-    Clob,         // 0xFF -
+    EExpressionWithLengthPrefix, // 0xF5
+    LargeInteger,                // 0xF6 - Integer preceded by FlexUInt length
+    Blob,                        // 0xFE -
+    Clob,                        // 0xFF -
     // 0xF8 Long decimal
     TimestampLong, // 0xF8 - Long-form Timestamp
     // 0xF9 - Long string

--- a/src/lazy/binary/raw/v1_1/type_code.rs
+++ b/src/lazy/binary/raw/v1_1/type_code.rs
@@ -29,12 +29,13 @@ pub enum OpcodeType {
     Struct,           // 0xD2-0xDF -
     IonVersionMarker, // 0xE0      -
 
-    SymbolAddress,        // 0xE1-0xE3 -
-    AnnotationSymAddress, // 0xE4-0xE6 -
-    AnnotationFlexSym,    // 0xE7-0xE9 -
-    NullNull,             // 0xEA      -
-    TypedNull,            // 0xEB      -
-    Nop,                  // 0xEC-0xED -
+    SymbolAddress,               // 0xE1-0xE3 -
+    AnnotationSymAddress,        // 0xE4-0xE6 -
+    AnnotationFlexSym,           // 0xE7-0xE9 -
+    NullNull,                    // 0xEA      -
+    TypedNull,                   // 0xEB      -
+    Nop,                         // 0xEC-0xED -
+    EExpressionWithLengthPrefix, // 0xF5
     // Reserved
     SystemMacroInvoke, // 0xEF      -
     // 0xF0 delimited container end

--- a/src/lazy/binary/raw/v1_1/type_descriptor.rs
+++ b/src/lazy/binary/raw/v1_1/type_descriptor.rs
@@ -76,6 +76,7 @@ impl Opcode {
             (0xE, 0xA) => (NullNull, low_nibble, Some(IonType::Null)),
             (0xE, 0xB) => (TypedNull, low_nibble, Some(IonType::Null)),
             (0xE, 0xC..=0xD) => (Nop, low_nibble, None),
+            (0xF, 0x5) => (EExpressionWithLengthPrefix, low_nibble, None),
             (0xF, 0x6) => (LargeInteger, low_nibble, Some(IonType::Int)),
             (0xF, 0x7) => (Decimal, 0xFF, Some(IonType::Decimal)),
             (0xF, 0x8) => (TimestampLong, low_nibble, Some(IonType::Timestamp)),
@@ -96,6 +97,10 @@ impl Opcode {
         }
     }
 
+    pub fn ion_type(&self) -> Option<IonType> {
+        self.ion_type
+    }
+
     pub fn is_null(&self) -> bool {
         self.opcode_type == OpcodeType::NullNull || self.opcode_type == OpcodeType::TypedNull
     }
@@ -108,7 +113,7 @@ impl Opcode {
         use OpcodeType::*;
         matches!(
             self.opcode_type,
-            EExpressionWithAddress | EExpressionAddressFollows
+            EExpressionWithAddress | EExpressionAddressFollows | EExpressionWithLengthPrefix
         )
     }
 

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -85,7 +85,7 @@ impl<'top> RawVersionMarker<'top> for LazyRawBinaryVersionMarker_1_1<'top> {
         (self.major, self.minor)
     }
 
-    fn old_encoding(&self) -> IonEncoding {
+    fn stream_encoding_before_marker(&self) -> IonEncoding {
         IonEncoding::Binary_1_1
     }
 }

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -190,21 +190,6 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_1> for &'top LazyRawBinaryValue_1
         }
     }
 
-    #[inline]
-    fn read_int(&self) -> IonResult<Int> {
-        LazyRawBinaryValue_1_1::read_int(self)
-    }
-
-    #[inline]
-    fn read_string(&self) -> IonResult<StrRef<'top>> {
-        LazyRawBinaryValue_1_1::read_string(self)
-    }
-
-    #[inline]
-    fn read_symbol(&self) -> IonResult<RawSymbolRef<'top>> {
-        LazyRawBinaryValue_1_1::read_symbol(self)
-    }
-
     fn annotations_span(&self) -> Span<'top> {
         let Some(range) = self.encoded_value.annotations_range() else {
             // If there are no annotations, return an empty slice positioned at the opcode

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -3,8 +3,13 @@
 use std::fmt::Debug;
 use std::ops::Range;
 
+use crate::lazy::binary::raw::v1_1::r#struct::LazyRawBinaryStruct_1_1;
+use crate::lazy::binary::raw::v1_1::sequence::{LazyRawBinaryList_1_1, LazyRawBinarySExp_1_1};
+use crate::lazy::bytes_ref::BytesRef;
 use crate::lazy::decoder::{HasRange, HasSpan, RawVersionMarker};
+use crate::lazy::expanded::EncodingContextRef;
 use crate::lazy::span::Span;
+use crate::lazy::str_ref::StrRef;
 use crate::{
     lazy::{
         binary::{
@@ -25,7 +30,8 @@ use crate::{
     },
     result::IonFailure,
     types::{HasMinute, SymbolId, Timestamp, TimestampBuilder},
-    IonError, IonResult, IonType, RawSymbolRef,
+    Decimal, Int, IonEncoding, IonError, IonResult, IonType, LazyExpandedList, LazyExpandedSExp,
+    LazyExpandedStruct, LazyList, LazySExp, LazyStruct, RawSymbolRef, SymbolRef, ValueRef,
 };
 use num_traits::PrimInt;
 
@@ -75,8 +81,12 @@ impl<'top> HasRange for LazyRawBinaryVersionMarker_1_1<'top> {
 }
 
 impl<'top> RawVersionMarker<'top> for LazyRawBinaryVersionMarker_1_1<'top> {
-    fn version(&self) -> (u8, u8) {
+    fn major_minor(&self) -> (u8, u8) {
         (self.major, self.minor)
+    }
+
+    fn old_encoding(&self) -> IonEncoding {
+        IonEncoding::Binary_1_1
     }
 }
 
@@ -86,7 +96,7 @@ pub struct LazyRawBinaryValue_1_1<'top> {
     pub(crate) input: ImmutableBuffer<'top>,
 }
 
-impl<'top> HasSpan<'top> for LazyRawBinaryValue_1_1<'top> {
+impl<'top> HasSpan<'top> for &'top LazyRawBinaryValue_1_1<'top> {
     fn span(&self) -> Span<'top> {
         let range = self.range();
         let local_range = (range.start - self.input.offset())..(range.end - self.input.offset());
@@ -95,19 +105,19 @@ impl<'top> HasSpan<'top> for LazyRawBinaryValue_1_1<'top> {
     }
 }
 
-impl<'top> HasRange for LazyRawBinaryValue_1_1<'top> {
+impl<'top> HasRange for &'top LazyRawBinaryValue_1_1<'top> {
     fn range(&self) -> Range<usize> {
         self.encoded_value.annotated_value_range()
     }
 }
 
-impl<'top> LazyRawValue<'top, BinaryEncoding_1_1> for LazyRawBinaryValue_1_1<'top> {
+impl<'top> LazyRawValue<'top, BinaryEncoding_1_1> for &'top LazyRawBinaryValue_1_1<'top> {
     fn ion_type(&self) -> IonType {
-        self.ion_type()
+        self.encoded_value.ion_type()
     }
 
     fn is_null(&self) -> bool {
-        self.is_null()
+        self.encoded_value.header().is_null()
     }
 
     fn has_annotations(&self) -> bool {
@@ -115,11 +125,84 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_1> for LazyRawBinaryValue_1_1<'to
     }
 
     fn annotations(&self) -> <BinaryEncoding_1_1 as Decoder>::AnnotationsIterator<'top> {
-        self.annotations()
+        RawBinaryAnnotationsIterator_1_1::new(
+            self.annotations_sequence(),
+            self.encoded_value.annotations_encoding,
+        )
     }
 
     fn read(&self) -> IonResult<RawValueRef<'top, BinaryEncoding_1_1>> {
-        self.read()
+        if self.is_null() {
+            let ion_type = if self.encoded_value.header.ion_type_code == OpcodeType::TypedNull {
+                let body = self.value_body();
+                ION_1_1_TYPED_NULL_TYPES[body[0] as usize]
+            } else {
+                IonType::Null
+            };
+            return Ok(RawValueRef::Null(ion_type));
+        }
+
+        match self.ion_type() {
+            IonType::Null => unreachable!("all null types handled above"),
+            IonType::Bool => Ok(RawValueRef::Bool(self.read_bool()?)),
+            IonType::Int => Ok(RawValueRef::Int(self.read_int()?)),
+            IonType::Float => Ok(RawValueRef::Float(self.read_float()?)),
+            IonType::Decimal => Ok(RawValueRef::Decimal(self.read_decimal()?)),
+            IonType::Timestamp => Ok(RawValueRef::Timestamp(self.read_timestamp()?)),
+            IonType::Symbol => Ok(RawValueRef::Symbol(self.read_symbol()?)),
+            IonType::String => Ok(RawValueRef::String(self.read_string()?)),
+            IonType::Clob => Ok(RawValueRef::Clob(self.read_clob()?)),
+            IonType::Blob => Ok(RawValueRef::Blob(self.read_blob()?)),
+            IonType::List => Ok(RawValueRef::List(self.read_list()?)),
+            IonType::SExp => Ok(RawValueRef::SExp(self.read_sexp()?)),
+            IonType::Struct => Ok(RawValueRef::Struct(self.read_struct()?)),
+        }
+    }
+
+    /// This is a fast path for reading values that we know need to be resolved.
+    ///
+    /// When a `LazyValue` wrapping a raw binary value calls `read()`, it's clear that the `RawValueRef` will
+    /// need to be resolved into a `ValueRef` before it is returned to the application. If `LazyValue::read`
+    /// (indirectly) calls `RawLazyValue::read`, the raw level will dispatch on the Ion type of the current
+    /// value to find the correct decoder. It will then return the `RawValueRef` to the `LazyValue`, which
+    /// will dispatch on the Ion type again to resolve it into a `ValueRef`. These two identical dispatch steps
+    /// over 13 Ion types happen far enough away from each other in the code that they cannot be consolidated
+    /// into a single dispatch by the compiler.
+    ///
+    /// This method exists to perform the read and resolve steps in the same locale, allowing the compiler
+    /// to optimize it more effectively.
+    #[inline(always)]
+    fn read_resolved(
+        &self,
+        context: EncodingContextRef<'top>,
+    ) -> IonResult<ValueRef<'top, BinaryEncoding_1_1>> {
+        if self.is_null() {
+            return Ok(ValueRef::Null(self.ion_type()));
+        }
+        // Anecdotally, string and integer values are very common in Ion streams. This `match` creates
+        // an inlineable fast path for them while other types go through the general case impl.
+        // NOTE: We can and should change the subset of types this optimizes for when we have data to
+        //       better inform our decision.
+        match self.ion_type() {
+            IonType::String => Ok(ValueRef::String(self.read_string()?)),
+            IonType::Int => Ok(ValueRef::Int(self.read_int()?)),
+            _ => self.read_resolved_general_case(context),
+        }
+    }
+
+    #[inline]
+    fn read_int(&self) -> IonResult<Int> {
+        LazyRawBinaryValue_1_1::read_int(self)
+    }
+
+    #[inline]
+    fn read_string(&self) -> IonResult<StrRef<'top>> {
+        LazyRawBinaryValue_1_1::read_string(self)
+    }
+
+    #[inline]
+    fn read_symbol(&self) -> IonResult<RawSymbolRef<'top>> {
+        LazyRawBinaryValue_1_1::read_symbol(self)
     }
 
     fn annotations_span(&self) -> Span<'top> {
@@ -142,17 +225,17 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_1> for LazyRawBinaryValue_1_1<'to
 impl<'top> LazyRawBinaryValue_1_1<'top> {
     /// Indicates the Ion data type of this value. Calling this method does not require additional
     /// parsing of the input stream.
-    pub fn ion_type(&self) -> IonType {
-        self.encoded_value.ion_type()
+    pub fn ion_type(&'top self) -> IonType {
+        <&'top Self as LazyRawValue<'top, BinaryEncoding_1_1>>::ion_type(&self)
     }
 
-    pub fn is_null(&self) -> bool {
-        self.encoded_value.header().is_null()
+    pub fn is_null(&'top self) -> bool {
+        <&'top Self as LazyRawValue<'top, BinaryEncoding_1_1>>::is_null(&self)
     }
 
     /// Returns `true` if this value has a non-empty annotations sequence; otherwise, returns `false`.
-    fn has_annotations(&self) -> bool {
-        self.encoded_value.has_annotations()
+    fn has_annotations(&'top self) -> bool {
+        <&'top Self as LazyRawValue<'top, BinaryEncoding_1_1>>::has_annotations(&self)
     }
 
     /// Returns an `ImmutableBuffer` that contains the bytes comprising this value's encoded
@@ -160,81 +243,84 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
     fn annotations_sequence(&self) -> ImmutableBuffer<'top> {
         let annotations_header_length = self.encoded_value.annotations_header_length as usize;
         let sequence_length = self.encoded_value.annotations_sequence_length as usize;
-        let sequence = self
-            .input
-            .slice(annotations_header_length - sequence_length, sequence_length);
+        let sequence = self.input.slice(annotations_header_length, sequence_length);
         sequence
     }
 
     /// Returns an iterator over this value's unresolved annotation symbols.
-    pub fn annotations(&self) -> RawBinaryAnnotationsIterator_1_1<'top> {
-        RawBinaryAnnotationsIterator_1_1::new(
-            self.annotations_sequence(),
-            self.encoded_value.annotations_encoding,
-        )
+    pub fn annotations(&'top self) -> RawBinaryAnnotationsIterator_1_1<'top> {
+        <&'top Self as LazyRawValue<'top, BinaryEncoding_1_1>>::annotations(&self)
     }
 
     /// Reads this value's data, returning it as a [`RawValueRef`]. If this value is a container,
     /// calling this method will not read additional data; the `RawValueRef` will provide a
     /// [`LazyRawBinarySequence_1_1`](crate::lazy::binary::raw::v1_1::sequence::LazyRawBinarySequence_1_1)
-    /// or [`LazyStruct`](crate::lazy::struct::LazyStruct) that can be traversed to access the container's contents.
-    pub fn read(&self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
+    /// or [`LazyStruct`] that can be traversed to access the container's contents.
+    pub fn read(&'top self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
+        <&'top Self as LazyRawValue<'top, BinaryEncoding_1_1>>::read(&self)
+    }
+
+    fn read_resolved_general_case(
+        &'top self,
+        context: EncodingContextRef<'top>,
+    ) -> IonResult<ValueRef<'top, BinaryEncoding_1_1>> {
         if self.is_null() {
-            let ion_type = if self.encoded_value.header.ion_type_code == OpcodeType::TypedNull {
-                let body = self.value_body()?;
-                ION_1_1_TYPED_NULL_TYPES[body[0] as usize]
-            } else {
-                IonType::Null
-            };
-            return Ok(RawValueRef::Null(ion_type));
+            return Ok(ValueRef::Null(self.ion_type()));
         }
 
-        match self.ion_type() {
-            IonType::Null => unreachable!("all null types handled above"),
-            IonType::Bool => self.read_bool(),
-            IonType::Int => self.read_int(),
-            IonType::Float => self.read_float(),
-            IonType::Decimal => self.read_decimal(),
-            IonType::Timestamp => self.read_timestamp(),
-            IonType::Symbol => self.read_symbol(),
-            IonType::String => self.read_string(),
-            IonType::Clob => self.read_clob(),
-            IonType::Blob => self.read_blob(),
-            IonType::List => self.read_list(),
-            IonType::SExp => self.read_sexp(),
-            IonType::Struct => self.read_struct(),
-        }
+        let value_ref = match self.ion_type() {
+            IonType::Bool => ValueRef::Bool(self.read_bool()?),
+            IonType::Int => ValueRef::Int(self.read_int()?),
+            IonType::Float => ValueRef::Float(self.read_float()?),
+            IonType::Decimal => ValueRef::Decimal(self.read_decimal()?),
+            IonType::Timestamp => ValueRef::Timestamp(self.read_timestamp()?),
+            IonType::String => ValueRef::String(self.read_string()?),
+            IonType::Symbol => {
+                let raw_symbol: RawSymbolRef = self.read_symbol()?;
+                let symbol: SymbolRef = raw_symbol.resolve(context)?;
+                ValueRef::Symbol(symbol)
+            }
+            IonType::Blob => ValueRef::Blob(self.read_blob()?),
+            IonType::Clob => ValueRef::Clob(self.read_clob()?),
+            IonType::List => ValueRef::List(LazyList::from(LazyExpandedList::from_literal(
+                context,
+                self.read_list()?,
+            ))),
+            IonType::SExp => ValueRef::SExp(LazySExp::from(LazyExpandedSExp::from_literal(
+                context,
+                self.read_sexp()?,
+            ))),
+            IonType::Struct => ValueRef::Struct(LazyStruct::from(
+                LazyExpandedStruct::from_literal(context, self.read_struct()?),
+            )),
+            IonType::Null => unreachable!("already handled"),
+        };
+        Ok(value_ref)
     }
 
     /// Returns the encoded byte slice representing this value's data.
-    pub(crate) fn value_body(&self) -> IonResult<&'top [u8]> {
+    /// For this raw value to have been created, lexing had to indicate that the complete value
+    /// was available. Because of that invariant, this method will always succeed.
+    #[inline]
+    pub(crate) fn value_body(&self) -> &'top [u8] {
         let value_total_length = self.encoded_value.total_length();
-        if self.input.len() < value_total_length {
-            return IonResult::incomplete(
-                "only part of the requested value is available in the buffer",
-                self.input.offset(),
-            );
-        }
         let value_body_length = self.encoded_value.value_body_length();
         let value_offset = value_total_length - value_body_length;
-        Ok(self.input.bytes_range(value_offset, value_body_length))
+        self.input.bytes_range(value_offset, value_body_length)
     }
 
-    /// Returns an [`ImmutableBuffer`] containing whatever bytes of this value's body are currently
-    /// available. This method is used to construct lazy containers, which are not required to be
-    /// fully buffered before reading begins.
-    pub(crate) fn available_body(&self) -> ImmutableBuffer<'top> {
+    /// Returns an [`ImmutableBuffer`] representing this value's data.
+    /// For this raw value to have been created, lexing had to indicate that the complete value
+    /// was available. Because of that invariant, this method will always succeed.
+    pub(crate) fn value_body_buffer(&self) -> ImmutableBuffer<'top> {
         let value_total_length = self.encoded_value.total_length();
         let value_body_length = self.encoded_value.value_body_length();
         let value_offset = value_total_length - value_body_length;
-
-        let bytes_needed = std::cmp::min(self.input.len() - value_offset, value_body_length);
-        let buffer_slice = self.input.slice(value_offset, bytes_needed);
-        buffer_slice
+        self.input.slice(value_offset, value_body_length)
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a bool.
-    fn read_bool(&self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
+    fn read_bool(&'top self) -> IonResult<bool> {
         debug_assert!(self.encoded_value.ion_type() == IonType::Bool);
         let header = &self.encoded_value.header();
         let representation = header.type_code();
@@ -243,46 +329,43 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
             (OpcodeType::Boolean, 0xF) => false,
             _ => unreachable!("found a boolean value with an illegal length code."),
         };
-        Ok(RawValueRef::Bool(value))
+        Ok(value)
     }
 
-    /// Helper method called by [`Self::read`]. Reads the current value as an int.
-    fn read_int(&self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
+    #[inline(always)]
+    fn read_int(&self) -> IonResult<Int> {
         debug_assert!(self.encoded_value.ion_type() == IonType::Int);
-
+        debug_assert!(!self.is_null());
         let header = &self.encoded_value.header();
-        let representation = header.type_code();
-        let value = match (representation, header.low_nibble as usize) {
-            (OpcodeType::Integer, 0x0) => 0.into(),
-            (OpcodeType::Integer, n) => {
-                // We have n bytes following that make up our integer.
-                self.available_body().read_fixed_int(n)?.0.into()
-            }
-            (OpcodeType::LargeInteger, 0x6) => {
-                // We have a FlexUInt size, then big int.
-                let value_bytes = self.value_body()?;
-                FixedInt::read(value_bytes, value_bytes.len(), 0)?.into()
-            }
-            _ => unreachable!("integer encoding with illegal length_code found"),
-        };
-        Ok(RawValueRef::Int(value))
+        if header.type_code() == OpcodeType::LargeInteger {
+            return self.read_large_int();
+        }
+        // Otherwise, this is an int of 0-8 bytes.
+        let num_bytes = header.low_nibble;
+        Ok(*FixedInt::read(self.value_body(), num_bytes as usize, self.input.offset())?.value())
+    }
+
+    #[inline(never)]
+    fn read_large_int(&self) -> IonResult<Int> {
+        let body_bytes = self.value_body();
+        Ok(FixedInt::read(body_bytes, body_bytes.len(), 0)?.into())
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a float.
-    fn read_float(&self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
+    fn read_float(&'top self) -> IonResult<f64> {
         debug_assert!(self.encoded_value.ion_type() == IonType::Float);
 
         let value = match self.encoded_value.value_body_length {
             8 => {
                 let mut buffer = [0; 8];
-                let val_bytes = self.available_body().bytes_range(0, 8);
+                let val_bytes = self.value_body_buffer().bytes_range(0, 8);
                 buffer[..8].copy_from_slice(val_bytes);
 
                 f64::from_le_bytes(buffer)
             }
             4 => {
                 let mut buffer = [0; 4];
-                let val_bytes = self.available_body().bytes_range(0, 4);
+                let val_bytes = self.value_body_buffer().bytes_range(0, 4);
                 buffer[..4].copy_from_slice(val_bytes);
 
                 f32::from_le_bytes(buffer).into()
@@ -291,11 +374,11 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
             0 => 0.0f64,
             _ => unreachable!("found a float value with illegal byte size"),
         };
-        Ok(RawValueRef::Float(value))
+        Ok(value)
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a decimal.
-    fn read_decimal(&self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
+    fn read_decimal(&'top self) -> IonResult<Decimal> {
         use crate::types::decimal::*;
 
         debug_assert!(self.encoded_value.ion_type() == IonType::Decimal);
@@ -304,7 +387,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
         } else {
             use crate::lazy::encoder::binary::v1_1::flex_int::FlexInt;
 
-            let value_bytes = self.value_body()?;
+            let value_bytes = self.value_body();
             let exponent = FlexInt::read(value_bytes, 0)?;
             let coefficient_size = self.encoded_value.value_body_length - exponent.size_in_bytes();
             let coefficient = FixedInt::read(
@@ -321,16 +404,16 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
             }
         };
 
-        Ok(RawValueRef::Decimal(decimal))
+        Ok(decimal)
     }
 
     // Helper method called by [`Self::read_timestamp_short`]. Reads the time information from a
     // timestamp with Unknown or UTC offset.
     fn read_timestamp_short_no_offset_after_minute(
-        &self,
+        &'top self,
         value_bytes: &[u8],
         ts_builder: TimestampBuilder<HasMinute>,
-    ) -> ValueParseResult<'top, BinaryEncoding_1_1> {
+    ) -> IonResult<Timestamp> {
         const SECONDS_MASK_16BIT: u16 = 0x03_F0;
         const MILLISECONDS_MASK_16BIT: u16 = 0x0F_FC;
         const MICROSECONDS_MASK_32BIT: u32 = 0x3F_FF_FC_00;
@@ -347,7 +430,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
                 ts_builder.build()?
             };
 
-            return Ok(RawValueRef::Timestamp(timestamp));
+            return Ok(timestamp);
         }
 
         // Read Second
@@ -363,7 +446,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
                 ts_builder.build()?
             };
 
-            return Ok(RawValueRef::Timestamp(timestamp));
+            return Ok(timestamp);
         }
 
         // Millisecond Precision
@@ -377,7 +460,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
                 ts_builder.build()?
             };
 
-            return Ok(RawValueRef::Timestamp(timestamp));
+            return Ok(timestamp);
         }
 
         // Microsecond Precision
@@ -391,7 +474,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
                 ts_builder.build()?
             };
 
-            return Ok(RawValueRef::Timestamp(timestamp));
+            return Ok(timestamp);
         }
 
         // Nanosecond Precision
@@ -404,7 +487,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
                 ts_builder.build()?
             };
 
-            return Ok(RawValueRef::Timestamp(timestamp));
+            return Ok(timestamp);
         }
 
         unreachable!("invalid length code for short-form timestamp");
@@ -413,10 +496,10 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
     // Helper method callsed by [`Self::read_timestamp_short`]. Reads the time information from a
     // timestamp with a provided offset.
     fn read_timestamp_short_offset_after_minute(
-        &self,
+        &'top self,
         value_bytes: &[u8],
         ts_builder: TimestampBuilder<HasMinute>,
-    ) -> ValueParseResult<'top, BinaryEncoding_1_1> {
+    ) -> IonResult<Timestamp> {
         const OFFSET_MASK_16BIT: u16 = 0x03_F8;
         const MILLISECOND_MASK_16BIT: u16 = 0x03_FF;
         const MICROSECOND_MASK_32BIT: u32 = 0x0F_FF_00;
@@ -433,7 +516,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
         // Hour and Minutes at known offset
         if length_code == 8 {
             let ts_builder = ts_builder.with_offset(offset);
-            return Ok(RawValueRef::Timestamp(ts_builder.build()?));
+            return ts_builder.build();
         }
 
         // Read seconds
@@ -443,7 +526,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
         // Seconds precision at known offset.
         if length_code == 9 {
             let ts_builder = ts_builder.with_offset(offset);
-            return Ok(RawValueRef::Timestamp(ts_builder.build()?));
+            return ts_builder.build();
         }
 
         // Opcodes 7A, 7B, and 7C, differ in subsecond precision.
@@ -455,7 +538,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
                 .with_milliseconds(millisecond.into())
                 .with_offset(offset);
 
-            return Ok(RawValueRef::Timestamp(ts_builder.build()?));
+            return ts_builder.build();
         } else if length_code == 0xB {
             // Read microseconds
             let microsecond = u32::from_le_bytes(value_bytes[4..=7].try_into().unwrap())
@@ -464,14 +547,14 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
                 .with_microseconds(microsecond)
                 .with_offset(offset);
 
-            return Ok(RawValueRef::Timestamp(ts_builder.build()?));
+            return ts_builder.build();
         } else if length_code == 0xC {
             // Read nanoseconds
             let nanoseconds =
                 u32::from_le_bytes(value_bytes[5..=8].try_into().unwrap()) & NANOSECOND_MASK_32BIT;
             let ts_builder = ts_builder.with_nanoseconds(nanoseconds).with_offset(offset);
 
-            return Ok(RawValueRef::Timestamp(ts_builder.build()?));
+            return ts_builder.build();
         }
 
         unreachable!();
@@ -479,18 +562,18 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
 
     // Helper method called by [`Self::read_timestamp`]. Reads the time information from a
     // timestamp encoded in short form.
-    fn read_timestamp_short(&self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
+    fn read_timestamp_short(&'top self) -> IonResult<Timestamp> {
         const MONTH_MASK_16BIT: u16 = 0x07_80;
 
         let length_code = self.encoded_value.header.low_nibble();
-        let value_bytes = self.value_body()?;
+        let value_bytes = self.value_body();
 
         // Year is biased offset by 1970, and is held in the lower 7 bits of the first byte.
         let ts_builder = Timestamp::with_year((value_bytes[0] & 0x7F) as u32 + 1970);
 
         // Year Precision.
         if length_code == 0 {
-            return Ok(RawValueRef::Timestamp(ts_builder.build()?));
+            return ts_builder.build();
         }
 
         // Read month..
@@ -501,7 +584,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
 
         // Month Precision
         if length_code == 1 {
-            return Ok(RawValueRef::Timestamp(ts_builder.build()?));
+            return ts_builder.build();
         }
 
         // Read day.
@@ -510,7 +593,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
 
         // Day Precision
         if length_code == 2 {
-            return Ok(RawValueRef::Timestamp(ts_builder.build()?));
+            return ts_builder.build();
         }
 
         // Hour and Minute
@@ -532,7 +615,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
 
     // Helper method called by [`Self::read_timestamp`]. Reads the time information from a
     // timestamp encoded in long form.
-    fn read_timestamp_long(&self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
+    fn read_timestamp_long(&'top self) -> IonResult<Timestamp> {
         use crate::lazy::encoder::binary::v1_1::fixed_uint::FixedUInt;
         use crate::lazy::encoder::binary::v1_1::flex_uint::FlexUInt;
         use crate::types::decimal::{coefficient::Coefficient, *};
@@ -545,7 +628,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
         const SECOND_MASK_16BIT: u16 = 0x0F_C0;
         const OFFSET_MASK_16BIT: u16 = 0x3F_FC;
 
-        let value_bytes = self.value_body()?;
+        let value_bytes = self.value_body();
         let value_length = self.encoded_value.value_body_length;
 
         if value_length < 2 || value_length == 4 || value_length == 5 {
@@ -555,7 +638,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
         let year = u16::from_le_bytes(value_bytes[0..=1].try_into().unwrap()) & YEAR_MASK_16BIT;
         let ts_builder = Timestamp::with_year(year.into());
         if value_length == 2 {
-            return Ok(RawValueRef::Timestamp(ts_builder.build()?));
+            return ts_builder.build();
         }
 
         let month = u16::from_le_bytes(value_bytes[1..=2].try_into().unwrap())
@@ -563,12 +646,12 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
         let day = value_bytes[2].extract_bitmask(DAY_MASK_8BIT);
         let ts_builder = ts_builder.with_month(month.into());
         if value_length == 3 && day == 0 {
-            return Ok(RawValueRef::Timestamp(ts_builder.build()?));
+            return ts_builder.build();
         }
 
         let ts_builder = ts_builder.with_day(day as u32);
         if value_length == 3 {
-            return Ok(RawValueRef::Timestamp(ts_builder.build()?));
+            return ts_builder.build();
         }
 
         let hour = u16::from_le_bytes(value_bytes[2..=3].try_into().unwrap())
@@ -588,9 +671,9 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
         if value_length == 6 {
             if let Some(offset) = offset {
                 let ts_builder = ts_builder.with_offset(offset);
-                return Ok(RawValueRef::Timestamp(ts_builder.build()?));
+                return ts_builder.build();
             }
-            return Ok(RawValueRef::Timestamp(ts_builder.build()?));
+            return ts_builder.build();
         }
 
         let second = u16::from_le_bytes(value_bytes[5..=6].try_into().unwrap())
@@ -600,9 +683,9 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
         if value_length == 7 {
             if let Some(offset) = offset {
                 let ts_builder = ts_builder.with_offset(offset);
-                return Ok(RawValueRef::Timestamp(ts_builder.build()?));
+                return ts_builder.build();
             }
-            return Ok(RawValueRef::Timestamp(ts_builder.build()?));
+            return ts_builder.build();
         }
 
         let scale = FlexUInt::read(&value_bytes[7..], 0)?;
@@ -617,14 +700,14 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
         let ts_builder = ts_builder.with_fractional_seconds(frac_sec);
         if let Some(offset) = offset {
             let ts_builder = ts_builder.with_offset(offset);
-            Ok(RawValueRef::Timestamp(ts_builder.build()?))
+            ts_builder.build()
         } else {
-            Ok(RawValueRef::Timestamp(ts_builder.build()?))
+            ts_builder.build()
         }
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a timestamp.
-    fn read_timestamp(&self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
+    fn read_timestamp(&'top self) -> IonResult<Timestamp> {
         debug_assert!(self.encoded_value.ion_type() == IonType::Timestamp);
 
         match self.encoded_value.header.type_code() {
@@ -634,12 +717,24 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
         }
     }
 
+    #[inline]
+    fn read_string(&self) -> IonResult<StrRef<'top>> {
+        debug_assert!(self.encoded_value.ion_type() == IonType::String);
+        debug_assert!(!self.is_null());
+        let raw_bytes = self.value_body();
+        let text = std::str::from_utf8(raw_bytes)
+            .map_err(|_| IonError::decoding_error("found string with invalid UTF-8 data"))?;
+        Ok(StrRef::from(text))
+    }
+
     /// Helper method called by [`Self::read_symbol`]. Reads the current value as a symbol ID.
-    fn read_symbol_id(&self) -> IonResult<SymbolId> {
+    fn read_symbol_id(&'top self) -> IonResult<SymbolId> {
         let biases: [usize; 3] = [0, 256, 65792];
         let length_code = self.encoded_value.header.low_nibble;
         if (1..=3).contains(&length_code) {
-            let (id, _) = self.available_body().read_fixed_uint(length_code.into())?;
+            let (id, _) = self
+                .value_body_buffer()
+                .read_fixed_uint(length_code.into())?;
             let id = usize::try_from(id.value())?;
             Ok(id + biases[(length_code - 1) as usize])
         } else {
@@ -648,71 +743,58 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a symbol.
-    fn read_symbol(&self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
+    fn read_symbol(&'top self) -> IonResult<RawSymbolRef<'top>> {
         debug_assert!(self.encoded_value.ion_type() == IonType::Symbol);
         let type_code = self.encoded_value.header.ion_type_code;
         if type_code == OpcodeType::InlineSymbol {
-            let raw_bytes = self.value_body()?;
+            let raw_bytes = self.value_body();
             let text = std::str::from_utf8(raw_bytes)
                 .map_err(|_| IonError::decoding_error("found symbol with invalid UTF-8 data"))?;
-            Ok(RawValueRef::Symbol(RawSymbolRef::from(text)))
+            Ok(RawSymbolRef::from(text))
         } else if type_code == OpcodeType::SymbolAddress {
             let symbol_id = self.read_symbol_id()?;
-            Ok(RawValueRef::Symbol(RawSymbolRef::SymbolId(symbol_id)))
+            Ok(RawSymbolRef::SymbolId(symbol_id))
         } else {
             unreachable!("invalid Opcode type found for symbol");
         }
     }
 
-    /// Helper method called by [`Self::read`]. Reads the current value as a string.
-    fn read_string(&self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
-        use crate::lazy::str_ref::StrRef;
-
-        debug_assert!(self.encoded_value.ion_type() == IonType::String);
-        let raw_bytes = self.value_body()?;
-        let text = std::str::from_utf8(raw_bytes)
-            .map_err(|_| IonError::decoding_error("found string with invalid UTF-8 data"))?;
-        Ok(RawValueRef::String(StrRef::from(text)))
-    }
-
     /// Helper method called by [`Self::read`]. Reads the current value as a blob.
-    fn read_blob(&self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
+    fn read_blob(&self) -> IonResult<BytesRef<'top>> {
         debug_assert!(self.encoded_value.ion_type() == IonType::Blob);
 
-        let raw_bytes = self.value_body()?;
-        Ok(RawValueRef::Blob(raw_bytes.into()))
+        let raw_bytes = self.value_body();
+        Ok(raw_bytes.into())
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a clob.
-    fn read_clob(&self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
+    fn read_clob(&'top self) -> IonResult<BytesRef<'top>> {
         debug_assert!(self.encoded_value.ion_type() == IonType::Clob);
 
-        let raw_bytes = self.value_body()?;
-        Ok(RawValueRef::Clob(raw_bytes.into()))
+        let raw_bytes = self.value_body();
+        Ok(raw_bytes.into())
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as an S-expression.
-    fn read_sexp(&self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
+    fn read_sexp(&'top self) -> IonResult<LazyRawBinarySExp_1_1<'top>> {
         use crate::lazy::binary::raw::v1_1::sequence::LazyRawBinarySExp_1_1;
         use crate::lazy::decoder::private::LazyContainerPrivate;
         debug_assert!(self.encoded_value.ion_type() == IonType::SExp);
-        Ok(RawValueRef::SExp(LazyRawBinarySExp_1_1::from_value(*self)))
+        Ok(LazyRawBinarySExp_1_1::from_value(self))
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a list.
-    fn read_list(&self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
+    fn read_list(&'top self) -> IonResult<LazyRawBinaryList_1_1<'top>> {
         use crate::lazy::binary::raw::v1_1::sequence::LazyRawBinaryList_1_1;
         use crate::lazy::decoder::private::LazyContainerPrivate;
         debug_assert!(self.encoded_value.ion_type() == IonType::List);
-        Ok(RawValueRef::List(LazyRawBinaryList_1_1::from_value(*self)))
+        Ok(LazyRawBinaryList_1_1::from_value(self))
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a struct.
-    fn read_struct(&self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
+    fn read_struct(&'top self) -> IonResult<LazyRawBinaryStruct_1_1<'top>> {
         use crate::lazy::binary::raw::v1_1::r#struct::LazyRawBinaryStruct_1_1;
         use crate::lazy::decoder::private::LazyContainerPrivate;
-        Ok(RawValueRef::Struct(LazyRawBinaryStruct_1_1::from_value(
-            *self,
-        )))
+        Ok(LazyRawBinaryStruct_1_1::from_value(self))
     }
 }

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -336,19 +336,8 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
     fn read_int(&self) -> IonResult<Int> {
         debug_assert!(self.encoded_value.ion_type() == IonType::Int);
         debug_assert!(!self.is_null());
-        let header = &self.encoded_value.header();
-        if header.type_code() == OpcodeType::LargeInteger {
-            return self.read_large_int();
-        }
-        // Otherwise, this is an int of 0-8 bytes.
-        let num_bytes = header.low_nibble;
-        Ok(*FixedInt::read(self.value_body(), num_bytes as usize, self.input.offset())?.value())
-    }
-
-    #[inline(never)]
-    fn read_large_int(&self) -> IonResult<Int> {
         let body_bytes = self.value_body();
-        Ok(FixedInt::read(body_bytes, body_bytes.len(), 0)?.into())
+        Ok(*FixedInt::read(body_bytes, body_bytes.len(), self.input.offset())?.value())
     }
 
     /// Helper method called by [`Self::read`]. Reads the current value as a float.

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -183,17 +183,17 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_1> for &'top LazyRawBinaryValue_1
         // an inlineable fast path for them while other types go through the general case impl.
         // NOTE: We can and should change the subset of types this optimizes for when we have data to
         //       better inform our decision.
-        match self.ion_type() {
+        return match self.ion_type() {
             IonType::String => Ok(ValueRef::String(self.read_string()?)),
             IonType::Int => Ok(ValueRef::Int(self.read_int()?)),
             _ => read_resolved_general_case(self, context),
-        }
+        };
 
         // The 'general case' function that we fall back to for nulls and less common types
-        fn read_resolved_general_case(
-            value: &'top Self,
-            context: EncodingContextRef<'top>,
-        ) -> IonResult<ValueRef<'top, BinaryEncoding_1_1>> {
+        fn read_resolved_general_case<'a>(
+            value: &'a LazyRawBinaryValue_1_1<'a>,
+            context: EncodingContextRef<'a>,
+        ) -> IonResult<ValueRef<'a, BinaryEncoding_1_1>> {
             if value.is_null() {
                 return Ok(ValueRef::Null(value.ion_type()));
             }

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -56,7 +56,7 @@ impl<'top> RawVersionMarker<'top> for LazyRawBinaryVersionMarker_1_0<'top> {
         (self.major, self.minor)
     }
 
-    fn old_encoding(&self) -> IonEncoding {
+    fn stream_encoding_before_marker(&self) -> IonEncoding {
         IonEncoding::Binary_1_0
     }
 }

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -17,7 +17,7 @@ use crate::lazy::span::Span;
 use crate::lazy::str_ref::StrRef;
 use crate::result::IonFailure;
 use crate::types::SymbolId;
-use crate::{Decimal, Int, IonError, IonResult, IonType, RawSymbolRef, Timestamp};
+use crate::{Decimal, Int, IonEncoding, IonError, IonResult, IonType, RawSymbolRef, Timestamp};
 use std::fmt::{Debug, Formatter};
 use std::ops::Range;
 use std::{fmt, mem};
@@ -52,8 +52,12 @@ impl<'top> HasRange for LazyRawBinaryVersionMarker_1_0<'top> {
 }
 
 impl<'top> RawVersionMarker<'top> for LazyRawBinaryVersionMarker_1_0<'top> {
-    fn version(&self) -> (u8, u8) {
+    fn major_minor(&self) -> (u8, u8) {
         (self.major, self.minor)
+    }
+
+    fn old_encoding(&self) -> IonEncoding {
+        IonEncoding::Binary_1_0
     }
 }
 
@@ -312,12 +316,7 @@ impl<'top> LazyRawBinaryValue_1_0<'top> {
         let offset_and_length = self
             .encoded_value
             .annotations_sequence_offset()
-            .map(|offset| {
-                (
-                    offset,
-                    self.encoded_value.annotations_sequence_length().unwrap(),
-                )
-            });
+            .map(|offset| (offset, self.encoded_value.annotations_sequence_length()));
         let (sequence_offset, sequence_length) = match offset_and_length {
             None => {
                 // If there are no annotations, return an empty slice positioned on the type

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -14,11 +14,10 @@ use crate::lazy::expanded::{EncodingContext, EncodingContextRef};
 use crate::lazy::raw_stream_item::LazyRawStreamItem;
 use crate::lazy::raw_value_ref::RawValueRef;
 use crate::lazy::span::Span;
-use crate::lazy::str_ref::StrRef;
 use crate::read_config::ReadConfig;
 use crate::result::IonFailure;
 use crate::{
-    v1_0, v1_1, Catalog, Encoding, Int, IonResult, IonType, LazyExpandedFieldName, LazyRawWriter,
+    v1_0, v1_1, Catalog, Encoding, IonResult, IonType, LazyExpandedFieldName, LazyRawWriter,
     RawSymbolRef, ValueRef,
 };
 
@@ -570,17 +569,6 @@ pub trait LazyRawValue<'top, D: Decoder>:
     fn read(&self) -> IonResult<RawValueRef<'top, D>>;
     fn read_resolved(&self, context: EncodingContextRef<'top>) -> IonResult<ValueRef<'top, D>> {
         self.read()?.resolve(context)
-    }
-    fn read_string(&self) -> IonResult<StrRef<'top>> {
-        self.read()?.expect_string()
-    }
-
-    fn read_symbol(&self) -> IonResult<RawSymbolRef<'top>> {
-        self.read()?.expect_symbol()
-    }
-
-    fn read_int(&self) -> IonResult<Int> {
-        self.read()?.expect_int()
     }
 
     fn annotations_span(&self) -> Span<'top>;

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -1,16 +1,26 @@
 use std::fmt::Debug;
+use std::io::Write;
 use std::ops::Range;
 
-use crate::lazy::any_encoding::IonEncoding;
-use crate::lazy::encoding::{BinaryEncoding_1_0, RawValueLiteral, TextEncoding_1_0};
+use crate::lazy::any_encoding::{IonEncoding, IonVersion};
+use crate::lazy::encoder::text::v1_0::writer::LazyRawTextWriter_1_0;
+use crate::lazy::encoder::text::v1_1::writer::LazyRawTextWriter_1_1;
+use crate::lazy::encoder::write_as_ion::{WriteableEExp, WriteableRawValue};
+use crate::lazy::encoding::{
+    BinaryEncoding, BinaryEncoding_1_0, RawValueLiteral, TextEncoding_1_0,
+};
 use crate::lazy::expanded::macro_evaluator::RawEExpression;
-use crate::lazy::expanded::EncodingContextRef;
+use crate::lazy::expanded::{EncodingContext, EncodingContextRef};
 use crate::lazy::raw_stream_item::LazyRawStreamItem;
 use crate::lazy::raw_value_ref::RawValueRef;
 use crate::lazy::span::Span;
+use crate::lazy::str_ref::StrRef;
 use crate::read_config::ReadConfig;
 use crate::result::IonFailure;
-use crate::{Catalog, IonResult, IonType, RawSymbolRef};
+use crate::{
+    v1_0, v1_1, Catalog, Encoding, Int, IonResult, IonType, LazyExpandedFieldName, LazyRawWriter,
+    RawSymbolRef, ValueRef,
+};
 
 pub trait HasSpan<'top>: HasRange {
     fn span(&self) -> Span<'top>;
@@ -18,6 +28,15 @@ pub trait HasSpan<'top>: HasRange {
 
 pub trait HasRange {
     fn range(&self) -> Range<usize>;
+
+    /// Returns the number of bytes this encoded item occupies.
+    ///
+    /// This method is equivalent to calling `.range().len()`, but types have the option to
+    /// override its implementation if the length can be found more quickly without computing the
+    /// range first.
+    fn byte_length(&self) -> usize {
+        self.range().len()
+    }
 }
 
 /// A family of types that collectively comprise the lazy reader API for an Ion serialization
@@ -30,11 +49,6 @@ pub trait HasRange {
 pub trait Decoder: 'static + Sized + Debug + Clone + Copy {
     /// A lazy reader that yields [`Self::Value`]s representing the top level values in its input.
     type Reader<'data>: LazyRawReader<'data, Self>;
-    /// Additional data (beyond the offset) that the reader will need in order to resume reading
-    /// from a different point in the stream.
-    // At the moment this feature is only used by `LazyAnyRawReader`, which needs to remember what
-    // encoding the stream was using during earlier read operations.
-    type ReaderSavedState: Copy + Default;
     /// A value (at any depth) in the input. This can be further inspected to access either its
     /// scalar data or, if it is a container, to view it as [`Self::List`], [`Self::SExp`] or
     /// [`Self::Struct`].  
@@ -46,7 +60,7 @@ pub trait Decoder: 'static + Sized + Debug + Clone + Copy {
     /// A struct whose fields may be accessed iteratively or by field name.
     type Struct<'top>: LazyRawStruct<'top, Self>;
     /// A symbol token representing the name of a field within a struct.
-    type FieldName<'top>: LazyRawFieldName<'top>;
+    type FieldName<'top>: LazyRawFieldName<'top, Self>;
     /// An iterator over the annotations on the input stream's values.
     type AnnotationsIterator<'top>: Iterator<Item = IonResult<RawSymbolRef<'top>>>;
     /// An e-expression invoking a macro. (Ion 1.1+)
@@ -60,13 +74,73 @@ pub trait Decoder: 'static + Sized + Debug + Clone + Copy {
 }
 
 pub trait RawVersionMarker<'top>: Debug + Copy + Clone + HasSpan<'top> {
+    /// Returns the major version of the Ion encoding to which the stream is switching.
     fn major(&self) -> u8 {
-        self.version().0
+        self.major_minor().0
     }
+
+    /// Returns the minor version of the Ion encoding to which the stream is switching.
     fn minor(&self) -> u8 {
-        self.version().1
+        self.major_minor().1
     }
-    fn version(&self) -> (u8, u8);
+
+    /// Returns a tuple representing the `(major, minor)` version pair for the Ion encoding
+    /// to which the stream is switching.
+    fn major_minor(&self) -> (u8, u8);
+
+    /// If this marker is encoded in binary Ion, returns `true`. Otherwise, returns `false`.
+    ///
+    /// Ion streams can switch versions (for example: from v1.0 to v1.1 or vice-versa), but they
+    /// cannot change formats (for example: from binary to text or vice-versa). Therefore the value
+    /// returned by this method will be true for the stream prior to the IVM _and_ for the stream
+    /// that follows the IVM.
+    fn is_binary(&self) -> bool {
+        self.old_encoding().is_binary()
+    }
+
+    /// If this marker is encoded in text Ion, returns `true`. Otherwise, returns `false`.
+    ///
+    /// Ion streams can switch versions (for example: from v1.0 to v1.1 or vice-versa), but they
+    /// cannot change formats (for example: from binary to text or vice-versa). Therefore, the value
+    /// returned by this method will be true for the stream prior to the IVM _and_ for the stream
+    /// that follows the IVM.
+    fn is_text(&self) -> bool {
+        self.old_encoding().is_text()
+    }
+
+    /// The `IonVersion` that was used to encode this IVM.
+    fn old_version(&self) -> IonVersion {
+        self.old_encoding().version()
+    }
+
+    /// If this marker's `(major, minor)` version pair represents a supported Ion version,
+    /// returns `Ok(ion_version)`. Otherwise, returns a decoding error. To access the marker's
+    /// version without confirming it is supported, see [`major_minor`](Self::major_minor).
+    fn new_version(&self) -> IonResult<IonVersion> {
+        match self.major_minor() {
+            (1, 0) => Ok(IonVersion::v1_0),
+            (1, 1) => Ok(IonVersion::v1_1),
+            (major, minor) => {
+                IonResult::decoding_error(format!("Ion version {major}.{minor} is not supported"))
+            }
+        }
+    }
+
+    fn old_encoding(&self) -> IonEncoding;
+
+    /// If this marker's `(major, minor)` version pair represents a supported Ion version,
+    /// returns `Ok(ion_encoding)`. Otherwise, returns a decoding error. To access the marker's
+    /// encoding information without confirming it is supported, see [`major_minor`](Self::major_minor) and
+    /// [`is_binary`](Self::is_binary)/[`is_text`](Self::is_text).
+    fn new_encoding(&self) -> IonResult<IonEncoding> {
+        let encoding = match (self.is_binary(), self.new_version()?) {
+            (true, IonVersion::v1_0) => IonEncoding::Binary_1_0,
+            (false, IonVersion::v1_0) => IonEncoding::Text_1_0,
+            (true, IonVersion::v1_1) => IonEncoding::Binary_1_1,
+            (false, IonVersion::v1_1) => IonEncoding::Text_1_1,
+        };
+        Ok(encoding)
+    }
 }
 
 /// An expression found in value position in either serialized Ion or a template.
@@ -272,9 +346,10 @@ impl<'top, D: Decoder> HasRange for LazyRawFieldExpr<'top, D> {
 // internal code that is defined in terms of `LazyRawField` to call the private `into_value()`
 // function while also preventing users from seeing or depending on it.
 pub(crate) mod private {
+    use crate::lazy::expanded::macro_evaluator::{MacroExpr, RawEExpression};
     use crate::lazy::expanded::r#struct::UnexpandedField;
     use crate::lazy::expanded::EncodingContextRef;
-    use crate::IonResult;
+    use crate::{try_next, try_or_some_err, IonResult, LazyExpandedValue, LazyRawFieldName};
 
     use super::{Decoder, LazyRawFieldExpr, LazyRawStruct};
 
@@ -309,16 +384,24 @@ pub(crate) mod private {
         type Item = IonResult<UnexpandedField<'top, D>>;
 
         fn next(&mut self) -> Option<Self::Item> {
-            let field: LazyRawFieldExpr<'top, D> = match self.raw_fields.next() {
-                Some(Ok(field)) => field,
-                Some(Err(e)) => return Some(Err(e)),
-                None => return None,
-            };
+            let field: LazyRawFieldExpr<'top, D> = try_next!(self.raw_fields.next());
             use LazyRawFieldExpr::*;
             let unexpanded_field = match field {
-                NameValue(name, value) => UnexpandedField::RawNameValue(self.context, name, value),
-                NameEExp(name, eexp) => UnexpandedField::RawNameEExp(self.context, name, eexp),
-                EExp(eexp) => UnexpandedField::RawEExp(self.context, eexp),
+                NameValue(name, value) => UnexpandedField::NameValue(
+                    name.resolve(self.context),
+                    LazyExpandedValue::from_literal(self.context, value),
+                ),
+                NameEExp(name, raw_eexp) => {
+                    let eexp = try_or_some_err!(raw_eexp.resolve(self.context));
+                    UnexpandedField::NameMacro(
+                        name.resolve(self.context),
+                        MacroExpr::from_eexp(eexp),
+                    )
+                }
+                EExp(raw_eexp) => {
+                    let eexp = try_or_some_err!(raw_eexp.resolve(self.context));
+                    UnexpandedField::Macro(MacroExpr::from_eexp(eexp))
+                }
             };
             Some(Ok(unexpanded_field))
         }
@@ -342,12 +425,23 @@ pub(crate) mod private {
 }
 
 pub trait LazyRawReader<'data, D: Decoder>: Sized {
+    /// Constructs a new raw reader using decoder `D` that will read from `data`.
+    /// `data` must be the beginning of the stream. To continue reading from the middle of a
+    /// stream, see [`resume_at_offset`](Self::resume_at_offset).
     fn new(data: &'data [u8]) -> Self {
-        Self::resume_at_offset(data, 0, D::ReaderSavedState::default())
+        Self::resume_at_offset(data, 0, IonEncoding::default())
     }
 
-    fn resume_at_offset(data: &'data [u8], offset: usize, saved_state: D::ReaderSavedState)
-        -> Self;
+    /// Constructs a new raw reader using decoder `D` that will read from `data`.
+    ///
+    /// Automatically detecting the stream's encoding is only possible when `offset` is zero.
+    /// If offset is not zero, the caller must supply an `encoding_hint` indicating the expected
+    /// encoding. Encoding-specific raw readers will ignore this hint--the stream's encoding must be
+    /// the one that they support--but the `LazyRawAnyReader` will use it.
+    fn resume_at_offset(data: &'data [u8], offset: usize, encoding_hint: IonEncoding) -> Self;
+
+    /// Deconstructs this reader, returning a tuple of `(remaining_data, stream_offset, encoding)`.
+    fn stream_data(&self) -> (&'data [u8], usize, IonEncoding);
 
     fn next<'top>(
         &'top mut self,
@@ -356,16 +450,110 @@ pub trait LazyRawReader<'data, D: Decoder>: Sized {
     where
         'data: 'top;
 
-    fn save_state(&self) -> D::ReaderSavedState {
-        D::ReaderSavedState::default()
-    }
-
     /// The stream byte offset at which the reader will begin parsing the next item to return.
     /// This position is not necessarily the first byte of the next value; it may be (e.g.) a NOP,
     /// a comment, or whitespace that the reader will traverse as part of matching the next item.
     fn position(&self) -> usize;
 
+    /// The Ion encoding of the stream that the reader has been processing.
+    ///
+    /// Note that:
+    /// * Before any items have been read from the stream, the encoding defaults
+    ///   to [`IonEncoding::Text_1_0`].
+    /// * When an IVM is encountered, the Ion version reported afterward can be different but the
+    ///   format (text vs binary) will remain the same.
     fn encoding(&self) -> IonEncoding;
+}
+
+/// Allows writers to specify which Ion encodings they can losslessly transcribe from.
+///
+/// TODO: At the moment, this implementation does not process encoding directives in the
+///       input stream, which means it only works for very simple use cases. A better solution
+///       would be to take a `&mut SystemReader<_>` that can maintain the encoding context while
+///       also only paying attention to stream literals.
+pub trait TranscribeRaw<E: Encoding> {
+    fn transcribe<'a, R: LazyRawReader<'a, E>>(&mut self, reader: &mut R) -> IonResult<()>
+    where
+        Self: 'a;
+}
+
+impl<W: Write> TranscribeRaw<v1_1::Binary> for LazyRawTextWriter_1_1<W> {
+    fn transcribe<'a, R: LazyRawReader<'a, v1_1::Binary>>(
+        &mut self,
+        reader: &mut R,
+    ) -> IonResult<()>
+    where
+        Self: 'a,
+    {
+        transcribe_raw_binary_to_text(reader, self)
+    }
+}
+
+impl<W: Write> TranscribeRaw<v1_0::Binary> for LazyRawTextWriter_1_1<W> {
+    fn transcribe<'a, R: LazyRawReader<'a, v1_0::Binary>>(
+        &mut self,
+        reader: &mut R,
+    ) -> IonResult<()>
+    where
+        Self: 'a,
+    {
+        transcribe_raw_binary_to_text(reader, self)
+    }
+}
+
+impl<W: Write> TranscribeRaw<v1_0::Binary> for LazyRawTextWriter_1_0<W> {
+    fn transcribe<'a, R: LazyRawReader<'a, v1_0::Binary>>(
+        &mut self,
+        reader: &mut R,
+    ) -> IonResult<()>
+    where
+        Self: 'a,
+    {
+        transcribe_raw_binary_to_text(reader, self)
+    }
+}
+
+fn transcribe_raw_binary_to_text<
+    'a,
+    W: Write + 'a,
+    InputEncoding: BinaryEncoding<'a>,
+    Reader: LazyRawReader<'a, InputEncoding>,
+    Writer: LazyRawWriter<W>,
+>(
+    reader: &mut Reader,
+    writer: &mut Writer,
+) -> IonResult<()> {
+    const FLUSH_EVERY_N: usize = 100;
+    let encoding_context = EncodingContext::for_ion_version(IonVersion::v1_1);
+    let context_ref = encoding_context.get_ref();
+    let mut item_number: usize = 0;
+    loop {
+        let item = reader.next(context_ref)?;
+        use crate::RawStreamItem::*;
+        match item {
+            VersionMarker(_m) if item_number == 0 => {
+                // The writer automatically emits an IVM at the head of the output.
+            }
+            VersionMarker(_m) => {
+                // If the reader surfaces another IVM, write a matching one in the output.
+                writer.write_version_marker()?
+            }
+            Value(v) => {
+                writer.write(WriteableRawValue::new(v))?;
+            }
+            EExp(e) => {
+                writer.write(WriteableEExp::new(e))?;
+            }
+            EndOfStream(_) => {
+                writer.flush()?;
+                return Ok(());
+            }
+        }
+        item_number += 1;
+        if item_number % FLUSH_EVERY_N == 0 {
+            writer.flush()?;
+        }
+    }
 }
 
 pub trait LazyRawContainer<'top, D: Decoder> {
@@ -380,6 +568,20 @@ pub trait LazyRawValue<'top, D: Decoder>:
     fn has_annotations(&self) -> bool;
     fn annotations(&self) -> D::AnnotationsIterator<'top>;
     fn read(&self) -> IonResult<RawValueRef<'top, D>>;
+    fn read_resolved(&self, context: EncodingContextRef<'top>) -> IonResult<ValueRef<'top, D>> {
+        self.read()?.resolve(context)
+    }
+    fn read_string(&self) -> IonResult<StrRef<'top>> {
+        self.read()?.expect_string()
+    }
+
+    fn read_symbol(&self) -> IonResult<RawSymbolRef<'top>> {
+        self.read()?.expect_symbol()
+    }
+
+    fn read_int(&self) -> IonResult<Int> {
+        self.read()?.expect_int()
+    }
 
     fn annotations_span(&self) -> Span<'top>;
 
@@ -410,6 +612,12 @@ pub trait LazyRawStruct<'top, D: Decoder>:
     fn iter(&self) -> Self::Iterator;
 }
 
-pub trait LazyRawFieldName<'top>: HasSpan<'top> + Copy + Debug + Clone {
+pub trait LazyRawFieldName<'top, D: Decoder<FieldName<'top> = Self>>:
+    HasSpan<'top> + Copy + Debug + Clone
+{
     fn read(&self) -> IonResult<RawSymbolRef<'top>>;
+
+    fn resolve(&self, context: EncodingContextRef<'top>) -> LazyExpandedFieldName<'top, D> {
+        LazyExpandedFieldName::RawName(context, *self)
+    }
 }

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -94,7 +94,7 @@ pub trait RawVersionMarker<'top>: Debug + Copy + Clone + HasSpan<'top> {
     /// returned by this method will be true for the stream prior to the IVM _and_ for the stream
     /// that follows the IVM.
     fn is_binary(&self) -> bool {
-        self.old_encoding().is_binary()
+        self.stream_encoding_before_marker().is_binary()
     }
 
     /// If this marker is encoded in text Ion, returns `true`. Otherwise, returns `false`.
@@ -104,18 +104,18 @@ pub trait RawVersionMarker<'top>: Debug + Copy + Clone + HasSpan<'top> {
     /// returned by this method will be true for the stream prior to the IVM _and_ for the stream
     /// that follows the IVM.
     fn is_text(&self) -> bool {
-        self.old_encoding().is_text()
+        self.stream_encoding_before_marker().is_text()
     }
 
     /// The `IonVersion` that was used to encode this IVM.
-    fn old_version(&self) -> IonVersion {
-        self.old_encoding().version()
+    fn stream_version_before_marker(&self) -> IonVersion {
+        self.stream_encoding_before_marker().version()
     }
 
     /// If this marker's `(major, minor)` version pair represents a supported Ion version,
     /// returns `Ok(ion_version)`. Otherwise, returns a decoding error. To access the marker's
     /// version without confirming it is supported, see [`major_minor`](Self::major_minor).
-    fn new_version(&self) -> IonResult<IonVersion> {
+    fn stream_version_after_marker(&self) -> IonResult<IonVersion> {
         match self.major_minor() {
             (1, 0) => Ok(IonVersion::v1_0),
             (1, 1) => Ok(IonVersion::v1_1),
@@ -125,14 +125,14 @@ pub trait RawVersionMarker<'top>: Debug + Copy + Clone + HasSpan<'top> {
         }
     }
 
-    fn old_encoding(&self) -> IonEncoding;
+    fn stream_encoding_before_marker(&self) -> IonEncoding;
 
     /// If this marker's `(major, minor)` version pair represents a supported Ion version,
     /// returns `Ok(ion_encoding)`. Otherwise, returns a decoding error. To access the marker's
     /// encoding information without confirming it is supported, see [`major_minor`](Self::major_minor) and
     /// [`is_binary`](Self::is_binary)/[`is_text`](Self::is_text).
-    fn new_encoding(&self) -> IonResult<IonEncoding> {
-        let encoding = match (self.is_binary(), self.new_version()?) {
+    fn stream_encoding_after_marker(&self) -> IonResult<IonEncoding> {
+        let encoding = match (self.is_binary(), self.stream_version_after_marker()?) {
             (true, IonVersion::v1_0) => IonEncoding::Binary_1_0,
             (false, IonVersion::v1_0) => IonEncoding::Text_1_0,
             (true, IonVersion::v1_1) => IonEncoding::Binary_1_1,

--- a/src/lazy/encoder/binary/v1_0/writer.rs
+++ b/src/lazy/encoder/binary/v1_0/writer.rs
@@ -13,7 +13,7 @@ use crate::lazy::encoder::LazyRawWriter;
 use crate::lazy::encoding::Encoding;
 use crate::unsafe_helpers::{mut_ref_to_ptr, ptr_to_mut_ref};
 use crate::write_config::{WriteConfig, WriteConfigKind};
-use crate::IonResult;
+use crate::{IonEncoding, IonResult};
 
 /// A "raw"-level streaming binary Ion writer. This writer does not provide symbol table
 /// management; symbol-related operations (e.g. setting field IDs and annotations or writing symbol
@@ -125,18 +125,27 @@ impl<W: Write> LazyRawWriter<W> for LazyRawBinaryWriter_1_0<W> {
         }
     }
 
+    fn output(&self) -> &W {
+        &self.output
+    }
+
     delegate! {
         to self {
             fn flush(&mut self) -> IonResult<()>;
         }
     }
 
-    fn output(&self) -> &W {
-        &self.output
-    }
-
     fn output_mut(&mut self) -> &mut W {
         &mut self.output
+    }
+
+    fn write_version_marker(&mut self) -> IonResult<()> {
+        self.output.write_all(&[0xE0, 0x01, 0x00, 0xEA])?;
+        Ok(())
+    }
+
+    fn encoding(&self) -> IonEncoding {
+        IonEncoding::Binary_1_0
     }
 }
 

--- a/src/lazy/encoder/binary/v1_1/flex_uint.rs
+++ b/src/lazy/encoder/binary/v1_1/flex_uint.rs
@@ -56,8 +56,8 @@ impl FlexUInt {
         // FlexUInt we find requires more than 8 bytes to represent, we'll fall back to the general
         // case.
         if input.len() < COMMON_CASE_INPUT_BYTES_NEEDED || input[0] == 0 {
-            // `read_flex_uint_slow` is marked #[cold] to discourage inlining it, which keeps
-            // this method small enough that the code for the common case can be inlined.
+            // Calling `read_flex_primitive_as_uint_no_inline` keeps this method small enough that
+            // the code for the common case can be inlined.
             return Self::read_flex_primitive_as_uint_no_inline(
                 input,
                 offset,

--- a/src/lazy/encoder/binary/v1_1/flex_uint.rs
+++ b/src/lazy/encoder/binary/v1_1/flex_uint.rs
@@ -58,7 +58,12 @@ impl FlexUInt {
         if input.len() < COMMON_CASE_INPUT_BYTES_NEEDED || input[0] == 0 {
             // `read_flex_uint_slow` is marked #[cold] to discourage inlining it, which keeps
             // this method small enough that the code for the common case can be inlined.
-            return Self::read_flex_primitive_as_uint(input, offset, "reading a FlexUInt", false);
+            return Self::read_flex_primitive_as_uint_no_inline(
+                input,
+                offset,
+                "reading a FlexUInt",
+                false,
+            );
         }
 
         let flex_uint = Self::read_small_flex_uint(input);
@@ -88,6 +93,16 @@ impl FlexUInt {
         // to discard via right shifting.
         let value = (encoded_value & mask) >> num_encoded_bytes;
         FlexUInt::new(num_encoded_bytes, value)
+    }
+
+    #[inline(never)]
+    pub(crate) fn read_flex_primitive_as_uint_no_inline(
+        input: &[u8],
+        offset: usize,
+        label: &'static str,
+        support_sign_extension: bool,
+    ) -> IonResult<FlexUInt> {
+        Self::read_flex_primitive_as_uint(input, offset, label, support_sign_extension)
     }
 
     /// Helper method that reads a flex-encoded primitive from the buffer, returning it as a `FlexUInt`.

--- a/src/lazy/encoder/binary/v1_1/writer.rs
+++ b/src/lazy/encoder/binary/v1_1/writer.rs
@@ -13,7 +13,7 @@ use crate::lazy::encoder::LazyRawWriter;
 use crate::lazy::encoding::Encoding;
 use crate::unsafe_helpers::{mut_ref_to_ptr, ptr_to_mut_ref};
 use crate::write_config::{WriteConfig, WriteConfigKind};
-use crate::IonResult;
+use crate::{IonEncoding, IonResult};
 
 /// A "raw"-level streaming binary Ion 1.1 writer. This writer does not provide encoding module
 /// management; symbol- and macro- related operations require the caller to perform their own
@@ -146,6 +146,15 @@ impl<W: Write> LazyRawWriter<W> for LazyRawBinaryWriter_1_1<W> {
 
     fn output_mut(&mut self) -> &mut W {
         &mut self.output
+    }
+
+    fn write_version_marker(&mut self) -> IonResult<()> {
+        self.output.write_all(&[0xE0, 0x01, 0x01, 0xEA])?;
+        Ok(())
+    }
+
+    fn encoding(&self) -> IonEncoding {
+        IonEncoding::Binary_1_1
     }
 }
 

--- a/src/lazy/encoder/mod.rs
+++ b/src/lazy/encoder/mod.rs
@@ -7,7 +7,7 @@ use value_writer::SequenceWriter;
 
 use crate::lazy::encoding::Encoding;
 use crate::write_config::WriteConfig;
-use crate::IonResult;
+use crate::{IonEncoding, IonResult};
 
 pub mod annotate;
 pub mod annotation_seq;
@@ -57,6 +57,7 @@ pub trait LazyRawWriter<W: Write>: SequenceWriter<Resources = W> {
     fn new(output: W) -> IonResult<Self>
     where
         Self: Sized;
+
     fn build<E: Encoding>(config: WriteConfig<E>, output: W) -> IonResult<Self>
     where
         Self: Sized;
@@ -65,6 +66,10 @@ pub trait LazyRawWriter<W: Write>: SequenceWriter<Resources = W> {
     fn output(&self) -> &W;
 
     fn output_mut(&mut self) -> &mut W;
+
+    fn write_version_marker(&mut self) -> IonResult<()>;
+
+    fn encoding(&self) -> IonEncoding;
 }
 
 #[cfg(test)]

--- a/src/lazy/encoder/text/v1_0/value_writer.rs
+++ b/src/lazy/encoder/text/v1_0/value_writer.rs
@@ -1,3 +1,8 @@
+use std::fmt::Formatter;
+use std::io::Write;
+
+use delegate::delegate;
+
 use crate::lazy::encoder::annotation_seq::{AnnotationSeq, AnnotationsVec};
 use crate::lazy::encoder::private::Sealed;
 use crate::lazy::encoder::text::v1_0::writer::LazyRawTextWriter_1_0;
@@ -14,9 +19,6 @@ use crate::text::text_formatter::{FmtValueFormatter, IoValueFormatter};
 use crate::text::whitespace_config::WhitespaceConfig;
 use crate::types::{ContainerType, ParentType};
 use crate::{Decimal, Int, IonResult, IonType, RawSymbolRef, Timestamp};
-use delegate::delegate;
-use std::fmt::Formatter;
-use std::io::Write;
 
 pub struct TextValueWriter_1_0<'value, W: Write + 'value> {
     pub(crate) writer: &'value mut LazyRawTextWriter_1_0<W>,

--- a/src/lazy/encoder/text/v1_0/writer.rs
+++ b/src/lazy/encoder/text/v1_0/writer.rs
@@ -13,7 +13,7 @@ use crate::text::whitespace_config::{
 };
 use crate::types::ParentType;
 use crate::write_config::WriteConfigKind;
-use crate::{IonResult, TextFormat, WriteConfig};
+use crate::{IonEncoding, IonResult, TextFormat, WriteConfig};
 
 /// A raw text Ion 1.0 writer.
 pub struct LazyRawTextWriter_1_0<W: Write> {
@@ -112,6 +112,16 @@ impl<W: Write> LazyRawWriter<W> for LazyRawTextWriter_1_0<W> {
 
     fn output_mut(&mut self) -> &mut W {
         &mut self.output
+    }
+
+    fn write_version_marker(&mut self) -> IonResult<()> {
+        let space_between = self.whitespace_config.space_between_top_level_values;
+        write!(self.output, "$ion_1_0{space_between}")?;
+        Ok(())
+    }
+
+    fn encoding(&self) -> IonEncoding {
+        IonEncoding::Text_1_0
     }
 }
 

--- a/src/lazy/encoding.rs
+++ b/src/lazy/encoding.rs
@@ -34,7 +34,7 @@ use crate::lazy::text::value::{
     LazyRawTextVersionMarker_1_1, RawTextAnnotationsIterator,
 };
 
-use crate::lazy::binary::raw::v1_1::e_expression::RawBinaryEExpression_1_1;
+use crate::lazy::binary::raw::v1_1::e_expression::BinaryEExpression_1_1;
 use crate::{IonResult, TextFormat, WriteConfig};
 
 /// Marker trait for types that represent an Ion encoding.
@@ -272,7 +272,7 @@ impl Decoder for BinaryEncoding_1_1 {
     type Struct<'top> = LazyRawBinaryStruct_1_1<'top>;
     type FieldName<'top> = LazyRawBinaryFieldName_1_1<'top>;
     type AnnotationsIterator<'top> = RawBinaryAnnotationsIterator_1_1<'top>;
-    type EExp<'top> = &'top RawBinaryEExpression_1_1<'top>;
+    type EExp<'top> = &'top BinaryEExpression_1_1<'top>;
     type VersionMarker<'top> = LazyRawBinaryVersionMarker_1_1<'top>;
 }
 

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -245,7 +245,7 @@ impl TemplateCompiler {
         Self::expect_keyword("macro", &mut values)?;
 
         // TODO: Enforce 'identifier' syntax subset of symbol
-        // TODO: Syntactic support for address IDs like `(:14 ...)`
+        // TODO: Syntactic support for address IDs like `(14 ...)`
         let template_name =
             Self::expect_nullable_name("a macro name", &mut values)?.map(|name| name.to_owned());
 

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -1,13 +1,14 @@
 //! Compiles template definition language (TDL) expressions into a form suitable for fast incremental
 //! evaluation.
-use std::collections::HashMap;
 use std::ops::Range;
+
+use rustc_hash::FxHashMap;
 
 use crate::lazy::decoder::Decoder;
 use crate::lazy::expanded::template::{
-    ExprRange, MacroSignature, Parameter, ParameterEncoding, TemplateBody, TemplateBodyElement,
-    TemplateBodyMacroInvocation, TemplateBodyValueExpr, TemplateMacro, TemplateStructIndex,
-    TemplateValue,
+    ExprRange, MacroSignature, Parameter, ParameterCardinality, ParameterEncoding,
+    RestSyntaxPolicy, TemplateBody, TemplateBodyElement, TemplateBodyExpr, TemplateMacro,
+    TemplateStructIndex, TemplateValue,
 };
 use crate::lazy::expanded::EncodingContextRef;
 use crate::lazy::r#struct::LazyStruct;
@@ -18,7 +19,64 @@ use crate::result::IonFailure;
 use crate::symbol_ref::AsSymbolRef;
 use crate::{v1_1, IonError, IonResult, IonType, Reader, SymbolRef};
 
-/// Validates a given TDL expression and compiles it into a [`TemplateMacro`] that can be added
+/// Information inferred about a template's expansion at compile time.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct ExpansionAnalysis {
+    pub(crate) could_produce_system_value: bool,
+    pub(crate) must_produce_exactly_one_value: bool,
+    // A memoized combination of the above flags.
+    pub(crate) can_be_lazily_evaluated_at_top_level: bool,
+    pub(crate) expansion_singleton: Option<ExpansionSingleton>,
+}
+
+impl ExpansionAnalysis {
+    pub fn could_produce_system_value(&self) -> bool {
+        self.could_produce_system_value
+    }
+
+    pub fn must_produce_exactly_one_value(&self) -> bool {
+        self.must_produce_exactly_one_value
+    }
+
+    pub fn can_be_lazily_evaluated_at_top_level(&self) -> bool {
+        self.can_be_lazily_evaluated_at_top_level
+    }
+
+    pub fn expansion_singleton(&self) -> Option<ExpansionSingleton> {
+        self.expansion_singleton
+    }
+}
+
+/// When static analysis can detect that a template body will always expand to a single value,
+/// information inferred about that value is stored in this type. When this template backs a
+/// lazy value, having these fields available allows the lazy value to answer basic queries without
+/// needing to fully evaluate the template.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct ExpansionSingleton {
+    pub(crate) is_null: bool,
+    pub(crate) ion_type: IonType,
+    pub(crate) num_annotations: u8,
+}
+
+impl ExpansionSingleton {
+    pub fn is_null(&self) -> bool {
+        self.is_null
+    }
+
+    pub fn ion_type(&self) -> IonType {
+        self.ion_type
+    }
+
+    pub fn has_annotations(&self) -> bool {
+        self.num_annotations > 0
+    }
+
+    pub fn num_annotations(&self) -> usize {
+        self.num_annotations as usize
+    }
+}
+
+/// Validates a given TDL expression and compiles it into a `TemplateMacro` that can be added
 /// to a [`MacroTable`](crate::lazy::expanded::macro_table::MacroTable).
 pub struct TemplateCompiler {}
 
@@ -29,35 +87,39 @@ impl TemplateCompiler {
     /// ```
     /// and compiles it into a [`TemplateMacro`].
     ///
-    /// The [`TemplateMacro`] stores a sequence of [`TemplateBodyValueExpr`]s that need to be evaluated
+    /// The [`TemplateMacro`] stores a sequence of [`TemplateBodyExpr`]s that need to be evaluated
     /// in turn. Each step is either a value literal, a reference to one of the parameters (that is:
     /// a variable), or a macro invocation.
     ///
-    /// Expressions that contain other expressions (i.e. containers and macro invocations) each
-    /// store the range of subexpressions that they contain, allowing a reader to skip the entire
-    /// parent expression as desired. For example, in this macro:
+    /// A `TemplateBodyExpr` can be made up of more than one expression. Each `TemplateBodyExpr`
+    /// stores the number of expressions that it includes. For example, scalar value
+    /// literals are always a single expression and so will have `num_expressions=1`. However,
+    /// container value literals can have nested expressions, and macro invocations can take
+    /// expressions as arguments; in both these cases, `num_expressions` can be `1` or higher.
+    /// This arrangement--expressions storing their composite expression count--enables the reader
+    /// to skip the entire parent expression as desired. For example, in this macro:
     ///
     /// ```ion_1_1
     /// (macro foo ()
     ///                  // Template body expressions
-    ///     [            // #0, contains expressions 1..=4
-    ///         1,       // #1
-    ///         (values  // #2, contains expressions 3..=4
-    ///             2    // #3
-    ///             3    // #4
+    ///     [            // #0, num_expressions=5, range=0..5
+    ///         1,       // #1, num_expressions=1, range=1..2
+    ///         (values  // #2, num_expressions=3, range=2..5
+    ///             2    // #3, num_expressions=1, range=3..4
+    ///             3    // #4, num_expressions=1, range=4..5
     ///         )
     ///     ]
     /// )
     /// ```
     ///
-    /// the step corresponding to `(values 2 3)` would store the range `3..=4`, indicating that
-    /// it contains template body expressions number `3` and `4`. A reader wishing to skip that call
-    /// to `values` could do so by moving ahead to expression number `5`. The outer
-    /// list (`[1, (values 2 3)]`) would store a `1..=4`, indicating that it contains the `1`,
-    /// the a macro invocation `values`, and the two arguments that belong to `values`.
+    /// the step corresponding to `(values 2 3)` would store the range `2..5`, indicating that
+    /// it includes not only template body expression #2, but #3 and #4 as well. A reader wishing to
+    /// skip that call to `values` could do so by moving ahead to expression number `5`. The outer
+    /// list (`[1, (values 2 3)]`) would store a `0..5`, indicating that it contains the `1`,
+    /// the macro invocation `values`, and the two arguments that belong to `values`.
     ///
-    /// The compiler recognizes the `(quote expr1 expr2 [...] exprN)` form, adding each subexpression
-    /// to the template without interpretation. `(quote ...)` does not appear in the compiled
+    /// The compiler recognizes the `(literal expr1 expr2 [...] exprN)` form, adding each subexpression
+    /// to the template without interpretation. `(literal ...)` does not appear in the compiled
     /// template as there is nothing more for it to do at expansion time.
     pub fn compile_from_text(
         context: EncodingContextRef,
@@ -66,52 +128,195 @@ impl TemplateCompiler {
         // TODO: This is a rudimentary implementation that panics instead of performing thorough
         //       validation. Where it does surface errors, the messages are too terse.
         let mut reader = Reader::new(v1_1::Text, expression.as_bytes())?;
-        let invocation = reader.expect_next()?.read()?.expect_sexp()?;
-        let mut values = invocation.iter();
+        let macro_def_sexp = reader.expect_next()?.read()?.expect_sexp()?;
 
-        let macro_keyword = values.next().expect("macro ID")?.read()?.expect_symbol()?;
-        if macro_keyword != "macro" {
-            return IonResult::decoding_error(
-                "macro compilation expects a sexp starting with the keyword `macro`",
-            );
-        }
+        Self::compile_from_sexp(context, macro_def_sexp)
+    }
 
-        // TODO: Enforce 'identifier' syntax subset of symbol
-        // TODO: Syntactic support address IDs like `(:14 ...)`
-        let template_name = match values.next().expect("template name")?.read()? {
-            ValueRef::Symbol(s) if s.text().is_none() => {
-                return IonResult::decoding_error("$0 is not a valid macro name")
-            }
-            ValueRef::Symbol(s) => Some(s.text().unwrap().to_owned()),
-            ValueRef::Null(IonType::Symbol | IonType::Null) => None,
-            other => {
+    /// Pulls the next value from the provided source and confirms that it is a symbol whose
+    /// text matches the `keyword` string.
+    fn expect_keyword<'a, Encoding: Decoder>(
+        keyword: &str,
+        source: &mut impl Iterator<Item = IonResult<LazyValue<'a, Encoding>>>,
+    ) -> IonResult<()> {
+        let value = match source.next() {
+            None => {
                 return IonResult::decoding_error(format!(
-                    "expected identifier as macro name but found: {other:?}"
+                    "expected keyword '{keyword}', but found nothing"
                 ))
             }
+            Some(Err(e)) => {
+                return IonResult::decoding_error(format!(
+                    "expected keyword '{keyword}', but encountered an error: {e:?}"
+                ))
+            }
+            Some(Ok(value)) => value,
         };
+        match value.read()? {
+            ValueRef::Symbol(s) if s.text() == Some(keyword) => Ok(()),
+            value_ref => IonResult::decoding_error(format!(
+                "expected keyword '{keyword}', but found {value_ref:?}"
+            )),
+        }
+    }
 
-        let params = values
-            .next()
-            .expect("parameters sexp")?
-            .read()?
-            .expect_sexp()?;
+    /// Confirms that the provided `value` is a symbol with known text. If so, returns `Ok(text)`.
+    /// If not, returns a decoding error containing the specified label.
+    fn expect_symbol_text<'a, Encoding: Decoder>(
+        label: &str,
+        value: LazyValue<'a, Encoding>,
+    ) -> IonResult<&'a str> {
+        match value.read()? {
+            ValueRef::Symbol(s) => {
+                if let Some(text) = s.text() {
+                    Ok(text)
+                } else {
+                    IonResult::decoding_error(format!(
+                        "expected {label}, but found a symbol with no text"
+                    ))
+                }
+            }
+            value_ref => {
+                IonResult::decoding_error(format!("expected {label}, but found a(n) {value_ref:?}"))
+            }
+        }
+    }
+
+    /// Tries to pull the next `LazyValue` from the provided iterator. If the iterator is empty,
+    /// returns a `IonError::Decoding` that includes the specified label.
+    fn expect_next<'a, Encoding: Decoder>(
+        label: &str,
+        source: &mut impl Iterator<Item = IonResult<LazyValue<'a, Encoding>>>,
+    ) -> IonResult<LazyValue<'a, Encoding>> {
+        match source.next() {
+            None => IonResult::decoding_error(format!("expected {label} but found nothing")),
+            Some(Err(e)) => IonResult::decoding_error(format!(
+                "expected {label} but encountered an error: {e:?}"
+            )),
+            Some(Ok(value)) => Ok(value),
+        }
+    }
+
+    /// Tries to pull the next `LazyValue` from the provided iterator, confirming that it is
+    /// a symbol with text.
+    fn expect_name<'a, Encoding: Decoder>(
+        label: &str,
+        source: &mut impl Iterator<Item = IonResult<LazyValue<'a, Encoding>>>,
+    ) -> IonResult<&'a str> {
+        let value = Self::expect_next(label, source)?;
+        Self::expect_symbol_text(label, value)
+    }
+
+    /// Tries to pull the next `LazyValue` from the provided iterator, confirming that it is
+    /// either a symbol with text, `null`, or `null.symbol`.
+    fn expect_nullable_name<'a, Encoding: Decoder>(
+        label: &str,
+        source: &mut impl Iterator<Item = IonResult<LazyValue<'a, Encoding>>>,
+    ) -> IonResult<Option<&'a str>> {
+        let value = Self::expect_next(label, source)?;
+        if value.is_null() && matches!(value.ion_type(), IonType::Null | IonType::Symbol) {
+            Ok(None)
+        } else {
+            Ok(Some(Self::expect_symbol_text(label, value)?))
+        }
+    }
+
+    /// Tries to pull the next `LazyValue` from the provided iterator, confirming that it is
+    /// an s-expression.
+    fn expect_sexp<'a, Encoding: Decoder>(
+        label: &str,
+        source: &mut impl Iterator<Item = IonResult<LazyValue<'a, Encoding>>>,
+    ) -> IonResult<LazySExp<'a, Encoding>> {
+        let value = Self::expect_next(label, source)?;
+        match value.read()? {
+            ValueRef::SExp(clause) => Ok(clause),
+            other => {
+                IonResult::decoding_error(format!("expected {label}, but found a(n) {other:?}"))
+            }
+        }
+    }
+
+    pub fn compile_from_sexp<'a, Encoding: Decoder>(
+        context: EncodingContextRef<'a>,
+        macro_def_sexp: LazySExp<'a, Encoding>,
+    ) -> Result<TemplateMacro, IonError> {
+        let mut values = macro_def_sexp.iter();
+
+        Self::expect_keyword("macro", &mut values)?;
+
+        // TODO: Enforce 'identifier' syntax subset of symbol
+        // TODO: Syntactic support for address IDs like `(:14 ...)`
+        let template_name =
+            Self::expect_nullable_name("a macro name", &mut values)?.map(|name| name.to_owned());
+
+        // The `params` clause of the macro definition is an s-expression enumerating the parameters
+        // that the macro accepts. For example: `(flex_uint::x, y*, z?)`.
+        let params_clause = Self::expect_sexp("an s-expression defining parameters", &mut values)?;
 
         let mut compiled_params = Vec::new();
-        for param_result in &params {
+        // `param_items` is a peekable iterator over the Ion values in `params_clause`. Because it
+        // is peekable, we can look ahead at each step to see if there are more values. This is
+        // important because special syntax rules apply to `*` and `+` parameters in tail position.
+        let mut param_items = params_clause.iter().peekable();
+
+        let mut is_final_parameter = false;
+        // TODO: Reuseable function for "Expect labeled symbol with text"
+        while let Some(item) = param_items.next().transpose()? {
+            is_final_parameter |= param_items.peek().is_none();
+            let name = Self::expect_symbol_text("a parameter name", item)?.to_owned();
+
+            use ParameterCardinality::*;
+            let mut cardinality = ExactlyOne;
+            if let Some(next_item_result) = param_items.peek() {
+                let next_item = match next_item_result {
+                    Ok(item_ref) => *item_ref,
+                    // Because we are borrowing the peek()ed result, we must clone the error
+                    Err(e) => return Err(e.clone()),
+                };
+                let text = Self::expect_symbol_text("a cardinality modifier", next_item)?;
+                cardinality = match text {
+                    "!" => ExactlyOne,
+                    "?" => ZeroOrOne,
+                    "*" => ZeroOrMore,
+                    "+" => OneOrMore,
+                    // The next item doesn't appear to be a cardinality specifier, it's probably a parameter.
+                    // Finish processing this parameter, then move on to the next item.
+                    _ => {
+                        // We know there are more items in the signature, so this isn't the last parameter.
+                        // Therefore, rest syntax is not allowed.
+                        let compiled_param = Parameter::new(
+                            name,
+                            ParameterEncoding::Tagged,
+                            cardinality,
+                            RestSyntaxPolicy::NotAllowed,
+                        );
+                        compiled_params.push(compiled_param);
+                        continue;
+                    }
+                };
+                // If we reach this point, the item was a cardinality specifier and we're done
+                // processing it. We can discard the item and continue on to the next parameter.
+                let _cardinality_specifier = param_items.next().unwrap();
+                is_final_parameter |= param_items.peek().is_none();
+            }
+
+            let rest_syntax_policy = if is_final_parameter && cardinality != ExactlyOne {
+                RestSyntaxPolicy::Allowed
+            } else {
+                RestSyntaxPolicy::NotAllowed
+            };
+
             let compiled_param = Parameter::new(
-                param_result?
-                    .read()?
-                    .expect_symbol()?
-                    .text()
-                    .unwrap()
-                    .to_string(),
+                name,
                 ParameterEncoding::Tagged,
+                cardinality,
+                rest_syntax_policy,
             );
             compiled_params.push(compiled_param);
         }
-        let signature = MacroSignature::new(compiled_params);
-        let body = values.next().expect("template body")?;
+        let signature = MacroSignature::new(compiled_params)?;
+        let body = Self::expect_next("the template body", &mut values)?;
+        let expansion_analysis = Self::analyze_body_expr(body);
         let mut compiled_body = TemplateBody {
             expressions: Vec::new(),
             annotations_storage: Vec::new(),
@@ -120,26 +325,84 @@ impl TemplateCompiler {
             context,
             &signature,
             &mut compiled_body,
-            /*is_quoted=*/ false,
+            /*is_literal=*/ false,
             body,
         )?;
         let template_macro = TemplateMacro {
             name: template_name,
             signature,
             body: compiled_body,
+            expansion_analysis,
         };
         Ok(template_macro)
     }
 
-    /// Recursively visits all of the expressions in `lazy_value` and adds their corresponding
-    /// [`TemplateBodyValueExpr`] sequences to the `TemplateBody`.
+    fn analyze_body_expr<D: Decoder>(body_expr: LazyValue<D>) -> ExpansionAnalysis {
+        let could_produce_system_value = Self::body_expr_could_produce_system_values(body_expr);
+        let must_produce_exactly_one_value =
+            Self::body_expr_must_produce_exactly_one_value(body_expr);
+        let num_annotations = u8::try_from(body_expr.annotations().count())
+            .expect("template body expression can only have up to 255 annotations");
+        let expansion_singleton = if must_produce_exactly_one_value {
+            Some(ExpansionSingleton {
+                ion_type: body_expr.ion_type(),
+                num_annotations,
+                is_null: body_expr.is_null(),
+            })
+        } else {
+            None
+        };
+        ExpansionAnalysis {
+            could_produce_system_value,
+            must_produce_exactly_one_value,
+            can_be_lazily_evaluated_at_top_level: must_produce_exactly_one_value
+                && !could_produce_system_value,
+            expansion_singleton,
+        }
+    }
+
+    /// Indicates whether the provided expression *could* produce a system value (e.g. a symbol table
+    /// or encoding directive) when expanded.
     ///
-    /// If `is_quoted` is true, nested symbols and s-expressions will not be interpreted.
+    /// If the expression is guaranteed to never produce a system value, returns `false`.
+    /// If the expression *could* produce one, returns `true`.
+    ///
+    /// For the time being, this is a simple, lightweight heuristic.
+    fn body_expr_could_produce_system_values<D: Decoder>(body_expr: LazyValue<D>) -> bool {
+        use IonType::*;
+        match body_expr.ion_type() {
+            // If the expression is an s-expression, it could expand to anything. If desired, we could
+            // inspect the macro it invokes to see if it's a `make_string`, `make_struct`, etc.
+            // For now, we simply say "Producing a system value is possible."
+            SExp => true,
+            // If the value is a struct, it would need to be annotated with `$ion_symbol_table`
+            // to produce a system value.
+            Struct => {
+                matches!(body_expr.annotations().next(), Some(Ok(s)) if s.text() == Some("$ion_symbol_table"))
+            }
+            _ => false,
+        }
+    }
+
+    /// Indicates whether the provided expression is guaranteed to produce exactly one Ion value
+    /// when expanded.
+    ///
+    /// If the expression will always produce a single value, returns `true`.
+    /// If the expression could potentially produce an empty stream or a stream with multiple
+    /// values, returns `false`.
+    fn body_expr_must_produce_exactly_one_value<D: Decoder>(body_expr: LazyValue<D>) -> bool {
+        body_expr.ion_type() != IonType::SExp
+    }
+
+    /// Recursively visits all of the expressions in `lazy_value` and adds their corresponding
+    /// [`TemplateBodyExprKind`](crate::TemplateBodyExprKind) sequences to the `TemplateBody`.
+    ///
+    /// If `is_literal` is true, nested symbols and s-expressions will not be interpreted.
     fn compile_value<'top, D: Decoder>(
         context: EncodingContextRef<'top>,
         signature: &MacroSignature,
         definition: &mut TemplateBody,
-        is_quoted: bool,
+        is_literal: bool,
         lazy_value: LazyValue<'top, D>,
     ) -> IonResult<()> {
         let annotations_range_start = definition.annotations_storage.len();
@@ -158,7 +421,7 @@ impl TemplateCompiler {
             ValueRef::Decimal(d) => TemplateValue::Decimal(d),
             ValueRef::Timestamp(t) => TemplateValue::Timestamp(t),
             ValueRef::String(s) => TemplateValue::String(s.to_owned()),
-            ValueRef::Symbol(s) if is_quoted => TemplateValue::Symbol(s.to_owned()),
+            ValueRef::Symbol(s) if is_literal => TemplateValue::Symbol(s.to_owned()),
             ValueRef::Symbol(s) => {
                 return Self::compile_variable_reference(
                     context,
@@ -175,7 +438,7 @@ impl TemplateCompiler {
                     context,
                     signature,
                     definition,
-                    is_quoted,
+                    is_literal,
                     annotations_range.clone(),
                     s,
                 );
@@ -185,7 +448,7 @@ impl TemplateCompiler {
                     context,
                     signature,
                     definition,
-                    is_quoted,
+                    is_literal,
                     annotations_range.clone(),
                     l,
                 )
@@ -195,14 +458,17 @@ impl TemplateCompiler {
                     context,
                     signature,
                     definition,
-                    is_quoted,
+                    is_literal,
                     annotations_range.clone(),
                     s,
                 )
             }
         };
+        // At this point, we're only looking at scalars.
+        let scalar_expr_index = definition.expressions().len();
         definition.push_element(
             TemplateBodyElement::with_value(value).with_annotations(annotations_range),
+            ExprRange::new(scalar_expr_index..scalar_expr_index + 1),
         );
         Ok(())
     }
@@ -212,26 +478,26 @@ impl TemplateCompiler {
         context: EncodingContextRef<'top>,
         signature: &MacroSignature,
         definition: &mut TemplateBody,
-        is_quoted: bool,
+        is_literal: bool,
         annotations_range: Range<usize>,
         lazy_list: LazyList<'top, D>,
     ) -> IonResult<()> {
         let list_element_index = definition.expressions.len();
-        // Assume the list contains zero expressions to start, we'll update this at the end
-        let list_element = TemplateBodyElement::with_value(TemplateValue::List(ExprRange::empty()));
-        definition.push_element(list_element);
-        let list_children_start = definition.expressions.len();
+        let list_element = TemplateBodyElement::with_value(TemplateValue::List);
+        // Use an empty range for now. When we finish reading the list, we'll overwrite the empty
+        // range with the correct one.
+        definition.push_element(list_element, ExprRange::empty());
         for value_result in &lazy_list {
             let value = value_result?;
-            Self::compile_value(context, signature, definition, is_quoted, value)?;
+            Self::compile_value(context, signature, definition, is_literal, value)?;
         }
         let list_children_end = definition.expressions.len();
         // Update the list entry to reflect the number of child expressions it contains
-        let list_element = TemplateBodyElement::with_value(TemplateValue::List(ExprRange::new(
-            list_children_start..list_children_end,
-        )))
-        .with_annotations(annotations_range);
-        definition.expressions[list_element_index] = TemplateBodyValueExpr::Element(list_element);
+        let list_element = TemplateBodyElement::with_value(TemplateValue::List)
+            .with_annotations(annotations_range);
+        let list_expr_range = ExprRange::new(list_element_index..list_children_end);
+        definition.expressions[list_element_index] =
+            TemplateBodyExpr::element(list_element, list_expr_range);
         Ok(())
     }
 
@@ -240,12 +506,12 @@ impl TemplateCompiler {
         context: EncodingContextRef<'top>,
         signature: &MacroSignature,
         definition: &mut TemplateBody,
-        is_quoted: bool,
+        is_literal: bool,
         annotations_range: Range<usize>,
         lazy_sexp: LazySExp<'top, D>,
     ) -> IonResult<()> {
-        if is_quoted {
-            // If `is_quoted` is true, this s-expression is nested somewhere inside a `(quote ...)`
+        if is_literal {
+            // If `is_literal` is true, this s-expression is nested somewhere inside a `(literal ...)`
             // macro invocation. The sexp and its child expressions can be added to the TemplateBody
             // without interpretation.
             Self::compile_quoted_sexp(context, signature, definition, annotations_range, lazy_sexp)
@@ -255,8 +521,8 @@ impl TemplateCompiler {
             if !annotations_range.is_empty() {
                 return IonResult::decoding_error("found annotations on a macro invocation");
             }
-            // Peek at the first expression in the sexp. If it's the symbol `quoted`...
-            if Self::sexp_is_quote_macro(&lazy_sexp)? {
+            // Peek at the first expression in the sexp. If it's the symbol `literal`...
+            if Self::sexp_is_literal_macro(&lazy_sexp)? {
                 // ...then we set `is_quoted` to true and compile all of its child expressions.
                 Self::compile_quoted_elements(context, signature, definition, lazy_sexp)
             } else {
@@ -288,7 +554,6 @@ impl TemplateCompiler {
         // Assume the macro contains zero argument expressions to start, we'll update
         // this at the end of the function.
         definition.push_macro_invocation(macro_address, ExprRange::empty());
-        let arguments_start = definition.expressions.len();
         for argument_result in expressions {
             let argument = argument_result?;
             Self::compile_value(
@@ -298,12 +563,9 @@ impl TemplateCompiler {
         let arguments_end = definition.expressions.len();
         // Update the macro step to reflect the macro's address and number of child expressions it
         // contains
-        let template_macro_invocation = TemplateBodyMacroInvocation::new(
-            macro_address,
-            ExprRange::new(arguments_start..arguments_end),
-        );
+        let invocation_expr_range = ExprRange::new(macro_step_index..arguments_end);
         definition.expressions[macro_step_index] =
-            TemplateBodyValueExpr::MacroInvocation(template_macro_invocation);
+            TemplateBodyExpr::macro_invocation(macro_address, invocation_expr_range);
         Ok(())
     }
 
@@ -381,10 +643,9 @@ impl TemplateCompiler {
         lazy_sexp: LazySExp<'top, D>,
     ) -> IonResult<()> {
         let sexp_element_index = definition.expressions.len();
-        // Assume the sexp contains zero expressions to start, we'll update this at the end
-        let sexp_element = TemplateBodyElement::with_value(TemplateValue::SExp(ExprRange::empty()));
-        definition.push_element(sexp_element);
-        let sexp_children_start = definition.expressions.len();
+        let sexp_element = TemplateBodyElement::with_value(TemplateValue::SExp);
+        // Use an empty range for now; we'll overwrite it with the correct one later.
+        definition.push_element(sexp_element, ExprRange::empty());
         for value_result in &lazy_sexp {
             let value = value_result?;
             Self::compile_value(
@@ -392,26 +653,28 @@ impl TemplateCompiler {
             )?;
         }
         let sexp_children_end = definition.expressions.len();
-        let sexp_element = TemplateBodyElement::with_value(TemplateValue::SExp(ExprRange::new(
-            sexp_children_start..sexp_children_end,
-        )))
-        .with_annotations(annotations_range);
+        let sexp_element = TemplateBodyElement::with_value(TemplateValue::SExp)
+            .with_annotations(annotations_range);
+        let sexp_expr_range = ExprRange::new(sexp_element_index..sexp_children_end);
         // Update the sexp entry to reflect the number of child expressions it contains
-        definition.expressions[sexp_element_index] = TemplateBodyValueExpr::Element(sexp_element);
+        definition.expressions[sexp_element_index] =
+            TemplateBodyExpr::element(sexp_element, sexp_expr_range);
         Ok(())
     }
 
-    /// Returns `Ok(true)` if the first child value in the `LazySexp` is the symbol `quote`.
-    /// This method should only be called in an unquoted context.
-    fn sexp_is_quote_macro<D: Decoder>(sexp: &LazySExp<D>) -> IonResult<bool> {
+    /// Returns `Ok(true)` if the first child value in the `LazySexp` is the symbol `literal`.
+    /// This method should only be called in a non-literal context.
+    fn sexp_is_literal_macro<D: Decoder>(sexp: &LazySExp<D>) -> IonResult<bool> {
         let first_expr = sexp.iter().next();
         match first_expr {
-            // If the sexp is empty and we're not in a quoted context, that's an error.
-            None => IonResult::decoding_error("found an empty s-expression in an unquoted context"),
+            // If the sexp is empty and we're not in a literal context, that's an error.
+            None => {
+                IonResult::decoding_error("found an empty s-expression in a non-literal context")
+            }
             Some(Err(e)) => Err(e),
             Some(Ok(lazy_value)) => {
                 let value = lazy_value.read()?;
-                Ok(value == ValueRef::Symbol("quote".as_symbol_ref()))
+                Ok(value == ValueRef::Symbol("literal".as_symbol_ref()))
             }
         }
     }
@@ -421,30 +684,27 @@ impl TemplateCompiler {
         context: EncodingContextRef<'top>,
         signature: &MacroSignature,
         definition: &mut TemplateBody,
-        is_quoted: bool,
+        is_literal: bool,
         annotations_range: Range<usize>,
         lazy_struct: LazyStruct<'top, D>,
     ) -> IonResult<()> {
         let struct_element_index = definition.expressions.len();
-        let struct_element = TemplateBodyElement::with_value(
-            // Assume the struct contains zero expressions to start, we'll update this entry with
-            // the actual range at the end of the method.
-            TemplateValue::Struct(
-                ExprRange::empty(),
-                // Creating a new HashMap does not allocate; we'll overwrite this value with an
-                // actual map of field names to indexes at the end of the method.
-                HashMap::new(),
-            ),
-        );
-        definition.push_element(struct_element);
+        let struct_element = TemplateBodyElement::with_value(TemplateValue::Struct(
+            // Creating a new HashMap does not allocate; we'll overwrite this value with an
+            // actual map of field names to indexes at the end of the method.
+            FxHashMap::default(),
+        ));
+        // Use an empty range for now; we'll overwrite it with the correct range later.
+        definition.push_element(struct_element, ExprRange::empty());
 
-        let mut fields: TemplateStructIndex = HashMap::new();
-        let struct_start = definition.expressions.len();
+        let mut fields: TemplateStructIndex = FxHashMap::default();
         for field_result in &lazy_struct {
             let field = field_result?;
             let name = field.name()?.to_owned();
+            let name_expr_index = definition.expressions().len();
             let name_element = TemplateBodyElement::with_value(TemplateValue::Symbol(name.clone()));
-            definition.push_element(name_element);
+            let name_expr_range = ExprRange::new(name_expr_index..name_expr_index + 1);
+            definition.push_element(name_element, name_expr_range);
             // If this field name has defined text (which is everything besides `$0` and equivalents),
             // add that text to the fields map. Future queries for `$0` will require a linear scan,
             // but that's a niche use case. If there is call for it, this approach can be revised.
@@ -458,17 +718,15 @@ impl TemplateCompiler {
                 }
             }
 
-            Self::compile_value(context, signature, definition, is_quoted, field.value())?;
+            Self::compile_value(context, signature, definition, is_literal, field.value())?;
         }
         let struct_end = definition.expressions.len();
         // Update the struct entry to reflect the range of expansion steps it contains.
-        let struct_element = TemplateBodyElement::with_value(TemplateValue::Struct(
-            ExprRange::new(struct_start..struct_end),
-            fields,
-        ))
-        .with_annotations(annotations_range);
+        let struct_element = TemplateBodyElement::with_value(TemplateValue::Struct(fields))
+            .with_annotations(annotations_range);
+        let struct_expr_range = ExprRange::new(struct_element_index..struct_end);
         definition.expressions[struct_element_index] =
-            TemplateBodyValueExpr::Element(struct_element);
+            TemplateBodyExpr::element(struct_element, struct_expr_range);
         Ok(())
     }
 
@@ -506,12 +764,11 @@ impl TemplateCompiler {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use rustc_hash::FxHashMap;
 
     use crate::lazy::expanded::compiler::TemplateCompiler;
     use crate::lazy::expanded::template::{
-        ExprRange, TemplateBodyMacroInvocation, TemplateBodyValueExpr,
-        TemplateBodyVariableReference, TemplateMacro, TemplateValue,
+        ExprRange, TemplateBodyExpr, TemplateMacro, TemplateValue,
     };
     use crate::lazy::expanded::{EncodingContext, EncodingContextRef};
     use crate::{Int, IntoAnnotations, IonResult, Symbol};
@@ -528,8 +785,8 @@ mod tests {
             .expressions()
             .get(index)
             .expect("no such expansion step")
-            .expect_element()
-            .unwrap_or_else(|_| panic!("expected value {expected:?}"));
+            .kind()
+            .require_element();
         assert_eq!(actual.value(), &expected);
         Ok(())
     }
@@ -543,11 +800,11 @@ mod tests {
         expect_step(
             definition,
             index,
-            TemplateBodyValueExpr::MacroInvocation(TemplateBodyMacroInvocation::new(
+            TemplateBodyExpr::macro_invocation(
                 expected_address,
-                // The arg range starts just after the macro invocation step and goes for `expected_num_arguments`.
-                ExprRange::new(index + 1..index + 1 + expected_num_arguments),
-            )),
+                // First arg position to last arg position (exclusive)
+                ExprRange::new(index..index + 1 + expected_num_arguments),
+            ),
         )
     }
 
@@ -559,23 +816,24 @@ mod tests {
         expect_step(
             definition,
             index,
-            TemplateBodyValueExpr::Variable(TemplateBodyVariableReference::new(
+            TemplateBodyExpr::variable(
                 expected_signature_index as u16,
-            )),
+                ExprRange::new(index..index + 1),
+            ),
         )
     }
 
     fn expect_step(
         definition: &TemplateMacro,
         index: usize,
-        expected: TemplateBodyValueExpr,
+        expected: TemplateBodyExpr,
     ) -> IonResult<()> {
         let step = definition
             .body()
             .expressions()
             .get(index)
             .expect("no such expansion step");
-        assert_eq!(step, &expected);
+        assert_eq!(step, &expected, "(actual, expected)");
         Ok(())
     }
 
@@ -589,8 +847,8 @@ mod tests {
             .expressions()
             .get(index)
             .expect("requested index does not exist")
-            .expect_element()
-            .unwrap();
+            .kind()
+            .require_element();
         let actual_annotations = definition
             .body
             .annotations_storage()
@@ -641,7 +899,7 @@ mod tests {
         let template = TemplateCompiler::compile_from_text(context.get_ref(), expression)?;
         assert_eq!(template.name(), "foo");
         assert_eq!(template.signature().parameters().len(), 0);
-        expect_value(&template, 0, TemplateValue::List(ExprRange::new(1..4)))?;
+        expect_value(&template, 0, TemplateValue::List)?;
         expect_value(&template, 1, TemplateValue::Int(1.into()))?;
         expect_value(&template, 2, TemplateValue::Int(2.into()))?;
         expect_value(&template, 3, TemplateValue::Int(3.into()))?;
@@ -678,22 +936,18 @@ mod tests {
         let expression = "(macro foo (x y z) [100, [200, a::b::300], x, {y: [true, false, z]}])";
 
         let template = TemplateCompiler::compile_from_text(context.get_ref(), expression)?;
-        expect_value(&template, 0, TemplateValue::List(ExprRange::new(1..12)))?;
+        expect_value(&template, 0, TemplateValue::List)?;
         expect_value(&template, 1, TemplateValue::Int(Int::from(100)))?;
-        expect_value(&template, 2, TemplateValue::List(ExprRange::new(3..5)))?;
+        expect_value(&template, 2, TemplateValue::List)?;
         expect_value(&template, 3, TemplateValue::Int(Int::from(200)))?;
         expect_value(&template, 4, TemplateValue::Int(Int::from(300)))?;
         expect_annotations(&template, 4, ["a", "b"]);
         expect_variable(&template, 5, 0)?;
-        let mut struct_index = HashMap::new();
+        let mut struct_index = FxHashMap::default();
         struct_index.insert(Symbol::from("y"), vec![8]);
-        expect_value(
-            &template,
-            6,
-            TemplateValue::Struct(ExprRange::new(7..12), struct_index),
-        )?;
+        expect_value(&template, 6, TemplateValue::Struct(struct_index))?;
         expect_value(&template, 7, TemplateValue::Symbol(Symbol::from("y")))?;
-        expect_value(&template, 8, TemplateValue::List(ExprRange::new(9..12)))?;
+        expect_value(&template, 8, TemplateValue::List)?;
         expect_value(&template, 9, TemplateValue::Bool(true))?;
         expect_value(&template, 10, TemplateValue::Bool(false))?;
         expect_variable(&template, 11, 2)?;
@@ -715,7 +969,7 @@ mod tests {
     }
 
     #[test]
-    fn quote() -> IonResult<()> {
+    fn literal() -> IonResult<()> {
         let resources = TestResources::new();
         let context = resources.context();
 
@@ -725,8 +979,8 @@ mod tests {
                 (values
                     // This `values` is a macro call that has a single argument: the variable `x`
                     (values x)
-                    // This `quote` call causes the inner `(values x)` to be an uninterpreted s-expression.
-                    (quote 
+                    // This `literal` call causes the inner `(values x)` to be an uninterpreted s-expression.
+                    (literal
                         (values x))))
         "#;
 
@@ -748,9 +1002,9 @@ mod tests {
             1,
         )?;
         expect_variable(&template, 2, 0)?;
-        // Second argument: `(quote (values x))`
-        // Notice that the `quote` is not part of the compiled output, only its arguments
-        expect_value(&template, 3, TemplateValue::SExp(ExprRange::new(4..6)))?;
+        // Second argument: `(literal (values x))`
+        // Notice that the `literal` is not part of the compiled output, only its arguments
+        expect_value(&template, 3, TemplateValue::SExp)?;
         expect_value(&template, 4, TemplateValue::Symbol("values".into()))?;
         expect_value(&template, 5, TemplateValue::Symbol("x".into()))?;
 

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -884,7 +884,7 @@ mod tests {
 
         let template = TemplateCompiler::compile_from_text(context.get_ref(), expression)?;
         assert_eq!(template.name(), "foo");
-        assert_eq!(template.signature().parameters().len(), 0);
+        assert_eq!(template.signature().len(), 0);
         expect_value(&template, 0, TemplateValue::Int(42.into()))?;
         Ok(())
     }
@@ -898,7 +898,7 @@ mod tests {
 
         let template = TemplateCompiler::compile_from_text(context.get_ref(), expression)?;
         assert_eq!(template.name(), "foo");
-        assert_eq!(template.signature().parameters().len(), 0);
+        assert_eq!(template.signature().len(), 0);
         expect_value(&template, 0, TemplateValue::List)?;
         expect_value(&template, 1, TemplateValue::Int(1.into()))?;
         expect_value(&template, 2, TemplateValue::Int(2.into()))?;
@@ -915,7 +915,7 @@ mod tests {
 
         let template = TemplateCompiler::compile_from_text(context.get_ref(), expression)?;
         assert_eq!(template.name(), "foo");
-        assert_eq!(template.signature().parameters().len(), 0);
+        assert_eq!(template.signature().len(), 0);
         expect_macro(
             &template,
             0,
@@ -963,7 +963,7 @@ mod tests {
 
         let template = TemplateCompiler::compile_from_text(context.get_ref(), expression)?;
         assert_eq!(template.name(), "identity");
-        assert_eq!(template.signature().parameters().len(), 1);
+        assert_eq!(template.signature().len(), 1);
         expect_variable(&template, 0, 0)?;
         Ok(())
     }
@@ -986,7 +986,7 @@ mod tests {
 
         let template = TemplateCompiler::compile_from_text(context.get_ref(), expression)?;
         assert_eq!(template.name(), "foo");
-        assert_eq!(template.signature().parameters().len(), 1);
+        assert_eq!(template.signature().len(), 1);
         // Outer `values`
         expect_macro(
             &template,

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -399,7 +399,7 @@ impl TemplateCompiler {
     }
 
     /// Recursively visits all of the expressions in `lazy_value` and adds their corresponding
-    /// [`TemplateBodyExprKind`](crate::TemplateBodyExprKind) sequences to the `TemplateBody`.
+    /// [`TemplateBodyExpr`] sequences to the `TemplateBody`.
     ///
     /// If `is_literal` is true, nested symbols and s-expressions will not be interpreted.
     fn compile_value<'top, D: Decoder>(

--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -65,7 +65,7 @@ impl<'top, D: Decoder> ArgGroup<'top, D> {
     }
     pub fn new_evaluation_environment(&self) -> IonResult<Environment<'top, D>> {
         let allocator = self.context.allocator();
-        let num_args = self.invoked_macro().signature().parameters().len();
+        let num_args = self.invoked_macro().signature().len();
         let mut env_exprs = BumpVec::with_capacity_in(num_args, allocator);
         // Populate the environment by parsing the arguments from input
         for expr in self.raw_arg_group().iter() {

--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -1,14 +1,112 @@
 //! Types and traits representing an e-expression in an Ion stream.
 #![allow(non_camel_case_types)]
 
-use crate::lazy::decoder::{Decoder, LazyRawValueExpr};
-use crate::lazy::encoding::TextEncoding_1_1;
-use crate::lazy::expanded::macro_evaluator::{MacroExpr, RawEExpression, ValueExpr};
-use crate::lazy::expanded::macro_table::MacroRef;
-use crate::lazy::expanded::{EncodingContextRef, LazyExpandedValue};
-use crate::lazy::text::raw::v1_1::reader::MacroIdRef;
-use crate::IonResult;
 use std::fmt::{Debug, Formatter};
+use std::ops::Range;
+
+use bumpalo::collections::Vec as BumpVec;
+
+use crate::lazy::decoder::{Decoder, RawValueExpr};
+use crate::lazy::encoding::TextEncoding_1_1;
+use crate::lazy::expanded::compiler::{ExpansionAnalysis, ExpansionSingleton};
+use crate::lazy::expanded::macro_evaluator::{
+    EExpArgGroupIterator, EExpressionArgGroup, MacroExpansion, MacroExpansionKind, MacroExpr,
+    MacroExprArgsIterator, MakeStringExpansion, RawEExpression, TemplateExpansion, ValueExpr,
+    ValuesExpansion,
+};
+use crate::lazy::expanded::macro_table::{MacroKind, MacroRef};
+use crate::lazy::expanded::template::TemplateMacroRef;
+use crate::lazy::expanded::{EncodingContextRef, LazyExpandedValue};
+use crate::lazy::text::raw::v1_1::arg_group::{EExpArg, EExpArgExpr};
+use crate::lazy::text::raw::v1_1::reader::MacroIdRef;
+use crate::{try_next, Environment, HasRange, HasSpan, IonResult, Span};
+
+/// An `ArgGroup` is a collection of expressions found in e-expression argument position.
+/// They can only appear in positions that correspond with variadic parameters.
+#[derive(Copy, Clone)]
+pub struct ArgGroup<'top, D: Decoder> {
+    context: EncodingContextRef<'top>,
+    raw_arg_group: <D::EExp<'top> as RawEExpression<'top, D>>::ArgGroup,
+    invoked_macro: MacroRef<'top>,
+}
+
+impl<'top, D: Decoder> ArgGroup<'top, D> {
+    pub fn new(
+        raw_arg_group: <D::EExp<'top> as RawEExpression<'top, D>>::ArgGroup,
+        context: EncodingContextRef<'top>,
+    ) -> Self {
+        // While an `ArgGroup` is a distinct syntactic entity with its own role to play in the grammar,
+        // once it has been read off the wire it behaves identically to a call to `(:values ...)`.
+        // Each expression in the group is expanded and the resulting stream is concatenated to that
+        // of the expression that proceeded it.
+        // TODO: Fully qualified, unambiguous ID
+        const VALUES_MACRO_ID: MacroIdRef<'static> = MacroIdRef::LocalAddress(1);
+        let invoked_macro = context
+            .macro_table()
+            .macro_with_id(VALUES_MACRO_ID)
+            .expect("`values` must be available");
+        Self {
+            context,
+            raw_arg_group,
+            invoked_macro,
+        }
+    }
+    pub fn context(&self) -> EncodingContextRef<'top> {
+        self.context
+    }
+    pub fn raw_arg_group(&self) -> <D::EExp<'top> as RawEExpression<'top, D>>::ArgGroup {
+        self.raw_arg_group
+    }
+    pub fn invoked_macro(&self) -> MacroRef<'top> {
+        self.invoked_macro
+    }
+    pub fn expressions(&self) -> ArgGroupIterator<'top, D> {
+        ArgGroupIterator::new(self.context, self.raw_arg_group())
+    }
+    pub fn new_evaluation_environment(&self) -> IonResult<Environment<'top, D>> {
+        let allocator = self.context.allocator();
+        let num_args = self.invoked_macro().signature().parameters().len();
+        let mut env_exprs = BumpVec::with_capacity_in(num_args, allocator);
+        // Populate the environment by parsing the arguments from input
+        for expr in self.raw_arg_group().iter() {
+            let value_expr = match expr? {
+                RawValueExpr::ValueLiteral(value) => {
+                    ValueExpr::ValueLiteral(LazyExpandedValue::from_literal(self.context, value))
+                }
+                RawValueExpr::EExp(eexp) => {
+                    ValueExpr::MacroInvocation(MacroExpr::from_eexp(eexp.resolve(self.context)?))
+                }
+            };
+            env_exprs.push(value_expr);
+        }
+        Ok(Environment::new(env_exprs.into_bump_slice()))
+    }
+
+    pub fn expand(&self, environment: Environment<'top, D>) -> IonResult<MacroExpansion<'top, D>> {
+        let context = self.context();
+        let arguments = MacroExprArgsIterator::from_arg_group(self.expressions());
+        let expansion_kind = MacroExpansionKind::Values(ValuesExpansion::new(arguments));
+        Ok(MacroExpansion::new(context, environment, expansion_kind))
+    }
+}
+
+impl<'top, D: Decoder> HasRange for ArgGroup<'top, D> {
+    fn range(&self) -> Range<usize> {
+        self.raw_arg_group.range()
+    }
+}
+
+impl<'top, D: Decoder> HasSpan<'top> for ArgGroup<'top, D> {
+    fn span(&self) -> Span<'top> {
+        self.raw_arg_group.span()
+    }
+}
+
+impl<'top, D: Decoder> Debug for ArgGroup<'top, D> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ArgGroup {:?}", self.raw_arg_group)
+    }
+}
 
 /// An e-expression (in Ion format `D`) that has been resolved in the current encoding context.
 #[derive(Copy, Clone)]
@@ -28,11 +126,75 @@ impl<'top, D: Decoder> EExpression<'top, D> {
     pub fn invoked_macro(&self) -> MacroRef<'top> {
         self.invoked_macro
     }
+
+    pub(crate) fn new_evaluation_environment(&self) -> IonResult<Environment<'top, D>> {
+        self.raw_invocation
+            .make_evaluation_environment(self.context)
+    }
+
+    pub(crate) fn expand(&self) -> IonResult<MacroExpansion<'top, D>> {
+        let invoked_macro = self.invoked_macro;
+        let arguments = MacroExprArgsIterator::from_eexp(self.arguments());
+
+        let mut environment = Environment::empty();
+        // Initialize a `MacroExpansionKind` with the state necessary to evaluate the requested
+        // macro.
+        let expansion_kind = match invoked_macro.kind() {
+            MacroKind::Void => MacroExpansionKind::Void,
+            MacroKind::Values => MacroExpansionKind::Values(ValuesExpansion::new(arguments)),
+            MacroKind::MakeString => {
+                MacroExpansionKind::MakeString(MakeStringExpansion::new(arguments))
+            }
+            MacroKind::Template(template_body) => {
+                let template_ref = TemplateMacroRef::new(invoked_macro, template_body);
+                environment = self.new_evaluation_environment()?;
+                MacroExpansionKind::Template(TemplateExpansion::new(template_ref))
+            }
+        };
+        Ok(MacroExpansion::new(
+            self.context(),
+            environment,
+            expansion_kind,
+        ))
+    }
+
+    pub(crate) fn expand_to_single_value(&self) -> IonResult<LazyExpandedValue<'top, D>> {
+        let environment = self.new_evaluation_environment()?;
+        MacroExpansion::expand_singleton(MacroExpansion::initialize(
+            environment,
+            MacroExpr::from_eexp(*self),
+        )?)
+    }
+
+    pub fn expansion_analysis(&self) -> ExpansionAnalysis {
+        self.invoked_macro.expansion_analysis()
+    }
+
+    pub fn expansion_singleton(&self) -> Option<ExpansionSingleton> {
+        self.expansion_analysis().expansion_singleton()
+    }
+    /// Caller must guarantee that this e-expression invokes a template and that the template
+    /// has a `ExpansionSingleton`. If these prerequisites are not met, this method will panic.
+    pub fn require_expansion_singleton(&self) -> ExpansionSingleton {
+        self.expansion_singleton().unwrap()
+    }
 }
 
 impl<'top, D: Decoder> Debug for EExpression<'top, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "EExpression {:?}", self.raw_invocation)
+    }
+}
+
+impl<'top, D: Decoder> HasRange for EExpression<'top, D> {
+    fn range(&self) -> Range<usize> {
+        self.raw_invocation.range()
+    }
+}
+
+impl<'top, D: Decoder> HasSpan<'top> for EExpression<'top, D> {
+    fn span(&self) -> Span<'top> {
+        self.raw_invocation.span()
     }
 }
 
@@ -59,44 +221,116 @@ impl<'top, D: Decoder> EExpression<'top, D> {
         EExpressionArgsIterator {
             context: self.context,
             raw_args: self.raw_invocation.raw_arguments(),
+            num_args: self.invoked_macro.signature().len() as u32,
+            index: 0,
         }
     }
 }
 
 impl<'top, D: Decoder> From<EExpression<'top, D>> for MacroExpr<'top, D> {
     fn from(value: EExpression<'top, D>) -> Self {
-        MacroExpr::EExp(value)
+        MacroExpr::from_eexp(value)
     }
 }
 
+#[derive(Copy, Clone, Debug)]
 pub struct EExpressionArgsIterator<'top, D: Decoder> {
     context: EncodingContextRef<'top>,
-    raw_args: <D::EExp<'top> as RawEExpression<'top, D>>::RawArgumentsIterator<'top>,
+    raw_args: <D::EExp<'top> as RawEExpression<'top, D>>::RawArgumentsIterator,
+    // The number of argument expressions that the e-expr expects
+    num_args: u32,
+    // The index of the next argument to consider
+    index: u32,
+}
+
+impl<'top, D: Decoder> EExpressionArgsIterator<'top, D> {
+    pub fn is_exhausted(&self) -> bool {
+        self.index == self.num_args
+    }
 }
 
 impl<'top, D: Decoder> Iterator for EExpressionArgsIterator<'top, D> {
     type Item = IonResult<ValueExpr<'top, D>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let raw_arg: LazyRawValueExpr<'top, D> = match self.raw_args.next()? {
-            Ok(arg) => arg,
-            Err(e) => return Some(Err(e)),
-        };
-
-        let expr = match raw_arg {
-            LazyRawValueExpr::<D>::ValueLiteral(value) => {
-                ValueExpr::ValueLiteral(LazyExpandedValue::from_literal(self.context, value))
+        let raw_arg: EExpArg<'top, D> = match self.raw_args.next()? {
+            Ok(arg) => {
+                debug_assert!(self.index < self.num_args);
+                arg
             }
-            LazyRawValueExpr::<D>::EExp(raw_invocation) => {
+            Err(e) => {
+                debug_assert!(self.index == self.num_args);
+                return Some(Err(e));
+            }
+        };
+        self.index += 1;
+
+        let expr = match raw_arg.expr() {
+            EExpArgExpr::<D>::ValueLiteral(value) => {
+                ValueExpr::ValueLiteral(LazyExpandedValue::from_literal(self.context, *value))
+            }
+            EExpArgExpr::<D>::EExp(raw_invocation) => {
                 let invocation = match raw_invocation.resolve(self.context) {
                     Ok(invocation) => invocation,
                     Err(e) => return Some(Err(e)),
                 };
                 ValueExpr::MacroInvocation(invocation.into())
             }
+            EExpArgExpr::<D>::ArgGroup(group) => {
+                let arg_group = group.resolve(self.context);
+                ValueExpr::MacroInvocation(MacroExpr::from_eexp_arg_group(arg_group))
+            }
         };
         Some(Ok(expr))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.raw_args.size_hint()
     }
 }
 
 pub type TextEExpression_1_1<'top> = EExpression<'top, TextEncoding_1_1>;
+
+#[derive(Copy, Clone, Debug)]
+pub struct ArgGroupIterator<'top, D: Decoder> {
+    context: EncodingContextRef<'top>,
+    expressions: <<<D as Decoder>::EExp<'top> as RawEExpression<'top, D>>::ArgGroup as EExpressionArgGroup<'top, D>>::Iterator,
+}
+
+impl<'top, D: Decoder> ArgGroupIterator<'top, D> {
+    pub fn new(
+        context: EncodingContextRef<'top>,
+        arg_group: <<D as Decoder>::EExp<'top> as RawEExpression<'top, D>>::ArgGroup,
+    ) -> Self {
+        Self {
+            context,
+            expressions: arg_group.iter(),
+        }
+    }
+
+    pub fn is_exhausted(&self) -> bool {
+        self.expressions.is_exhausted()
+    }
+}
+
+impl<'top, D: Decoder> Iterator for ArgGroupIterator<'top, D> {
+    type Item = IonResult<ValueExpr<'top, D>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let expr = try_next!(self.expressions.next());
+        match expr {
+            RawValueExpr::ValueLiteral(v) => Some(Ok(ValueExpr::ValueLiteral(
+                LazyExpandedValue::from_literal(self.context, v),
+            ))),
+            RawValueExpr::EExp(e) => {
+                let resolved_eexp = match e.resolve(self.context) {
+                    Ok(eexp) => eexp,
+                    Err(e) => return Some(Err(e)),
+                };
+                Some(Ok(ValueExpr::MacroInvocation(MacroExpr::from_eexp(
+                    resolved_eexp,
+                ))))
+            }
+        }
+    }
+}

--- a/src/lazy/expanded/encoding_module.rs
+++ b/src/lazy/expanded/encoding_module.rs
@@ -1,0 +1,40 @@
+use crate::lazy::expanded::macro_table::MacroTable;
+use crate::SymbolTable;
+
+#[derive(Debug, Clone)]
+pub struct EncodingModule {
+    name: String,
+    macro_table: MacroTable,
+    symbol_table: SymbolTable,
+}
+
+impl EncodingModule {
+    pub fn new(name: String, macro_table: MacroTable, symbol_table: SymbolTable) -> Self {
+        Self {
+            name,
+            macro_table,
+            symbol_table,
+        }
+    }
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    pub fn macro_table(&self) -> &MacroTable {
+        &self.macro_table
+    }
+    pub fn macro_table_mut(&mut self) -> &mut MacroTable {
+        &mut self.macro_table
+    }
+    pub fn symbol_table(&self) -> &SymbolTable {
+        &self.symbol_table
+    }
+    pub fn symbol_table_mut(&mut self) -> &mut SymbolTable {
+        &mut self.symbol_table
+    }
+    pub fn set_macro_table(&mut self, macro_table: MacroTable) {
+        self.macro_table = macro_table;
+    }
+    pub fn set_symbol_table(&mut self, symbol_table: SymbolTable) {
+        self.symbol_table = symbol_table;
+    }
+}

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -712,7 +712,6 @@ impl<'top, D: Decoder> StackedMacroEvaluator<'top, D> {
     /// current encoding context and push the resulting `MacroExpansion` onto the stack.
     pub fn push(&mut self, invocation: impl Into<MacroExpr<'top, D>>) -> IonResult<()> {
         let macro_expr = invocation.into();
-        // let expansion = match self.initialize_expansion(macro_expr) {
         let expansion = match MacroExpansion::initialize(self.environment(), macro_expr) {
             Ok(expansion) => expansion,
             Err(e) => return Err(e),

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -649,6 +649,10 @@ impl<'top, D: Decoder> MacroEvaluator<'top, D> {
             }
         };
     }
+
+    pub fn set_root_environment(&mut self, environment: Environment<'top, D>) {
+        self.root_environment = environment;
+    }
 }
 
 pub type MacroStack<'top, D> = BumpVec<'top, MacroExpansion<'top, D>>;

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -1117,11 +1117,11 @@ mod tests {
                 eval_template_invocation(
                     "(macro foo (x) (make_string x x))",
                     r#"
-                (:foo (:))
-            "#,
+                        (:foo (:))
+                    "#,
                     r#"
-                // should raise an error
-            "#,
+                        // should raise an error
+                    "#,
                 )
                 .unwrap()
             }
@@ -1162,19 +1162,6 @@ mod tests {
                 ""
                 ""
                 "aa"
-                "aaaa"
-            "#,
-                )
-            }
-
-            #[test]
-            fn narrow() -> IonResult<()> {
-                eval_template_invocation(
-                    "(macro foo (x?) (make_string x x))",
-                    r#"
-                (:foo (:foo a))  // x is `(:foo a)`
-            "#,
-                    r#"
                 "aaaa"
             "#,
                 )
@@ -1515,7 +1502,7 @@ mod tests {
                     418
                     "6"
                     "1"
-                    "18b4fa"
+                    "abc-123"
                     (:values
                         "region 4"
                         "2022-12-07T20:59:59.744000Z"))
@@ -1532,7 +1519,7 @@ mod tests {
                         'parameters': [
                             "SUCCESS",
                             "example-client-1",
-                            "aws-us-east-5f-18b4fa",
+                            "aws-us-east-5f-abc-123",
                             "region 4",
                             "2022-12-07T20:59:59.744000Z",
                         ]

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -1,59 +1,152 @@
-use std::collections::HashMap;
-
-use crate::lazy::expanded::template::{TemplateMacro, TemplateMacroRef};
+use crate::lazy::expanded::compiler::{ExpansionAnalysis, ExpansionSingleton};
+use crate::lazy::expanded::template::{
+    MacroSignature, Parameter, ParameterCardinality, ParameterEncoding, RestSyntaxPolicy,
+    TemplateBody, TemplateMacro, TemplateMacroRef,
+};
 use crate::lazy::text::raw::v1_1::reader::{MacroAddress, MacroIdRef};
 use crate::result::IonFailure;
-use crate::IonResult;
+use crate::{IonResult, IonType};
+use delegate::delegate;
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Macro {
+    name: Option<String>,
+    signature: MacroSignature,
+    kind: MacroKind,
+    // Compile-time heuristics that allow the reader to evaluate e-expressions lazily or using fewer
+    // resources in many cases.
+    //
+    // For the time being, e-expressions that could produce multiple values cannot be lazily evaluated.
+    // This is because the reader gives out lazy value handles for each value in the stream. If it knows
+    // in advance that an expression will produce one value, it can give out a lazy value that is
+    // backed by that e-expression.
+    //
+    // At the top level, e-expressions that both:
+    // 1. Produce a single value
+    //   and
+    // 2. Will not produce a system value
+    // can be lazily evaluated.
+    //
+    // At other levels of nesting, the single-value expansion is the only requirement for lazy
+    // evaluation.
+    expansion_analysis: ExpansionAnalysis,
+}
+
+impl Macro {
+    pub fn named(
+        name: impl Into<String>,
+        signature: MacroSignature,
+        kind: MacroKind,
+        expansion_analysis: ExpansionAnalysis,
+    ) -> Self {
+        Self::new(Some(name.into()), signature, kind, expansion_analysis)
+    }
+
+    pub fn anonymous(
+        signature: MacroSignature,
+        kind: MacroKind,
+        expansion_analysis: ExpansionAnalysis,
+    ) -> Self {
+        Self::new(None, signature, kind, expansion_analysis)
+    }
+
+    pub fn new(
+        name: Option<String>,
+        signature: MacroSignature,
+        kind: MacroKind,
+        expansion_analysis: ExpansionAnalysis,
+    ) -> Self {
+        Self {
+            name,
+            signature,
+            kind,
+            expansion_analysis,
+        }
+    }
+
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+    pub fn signature(&self) -> &MacroSignature {
+        &self.signature
+    }
+    pub fn kind(&self) -> &MacroKind {
+        &self.kind
+    }
+
+    pub fn expansion_analysis(&self) -> ExpansionAnalysis {
+        self.expansion_analysis
+    }
+
+    pub fn can_be_lazily_evaluated_at_top_level(&self) -> bool {
+        self.expansion_analysis()
+            .can_be_lazily_evaluated_at_top_level()
+    }
+
+    pub fn must_produce_exactly_one_value(&self) -> bool {
+        self.expansion_analysis().must_produce_exactly_one_value()
+    }
+}
 
 /// The kinds of macros supported by
-/// [`MacroEvaluator`](crate::lazy::expanded::macro_evaluator::MacroEvaluator).
+/// [`MacroEvaluator`](crate::MacroEvaluator)
 /// This list parallels
-/// [`MacroExpansionKind`](crate::lazy::expanded::macro_evaluator::MacroExpansionKind),
+/// [`MacroExpansionKind`](crate::MacroExpansionKind),
 /// but its variants do not hold any associated state.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum MacroKind {
     Void,
     Values,
     MakeString,
-    Template(TemplateMacro),
+    Template(TemplateBody),
 }
 
-impl MacroKind {
-    fn name(&self) -> &str {
-        match self {
-            MacroKind::Void => "void",
-            MacroKind::Values => "values",
-            MacroKind::MakeString => "make_string",
-            MacroKind::Template(template) => template.name(),
-        }
-    }
-}
-
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct MacroRef<'top> {
     address: MacroAddress,
-    kind: &'top MacroKind,
+    reference: &'top Macro,
 }
 
 impl<'top> MacroRef<'top> {
-    pub fn new(address: MacroAddress, kind: &'top MacroKind) -> Self {
-        Self { address, kind }
+    pub fn new(address: MacroAddress, reference: &'top Macro) -> Self {
+        Self { address, reference }
     }
+
+    pub fn require_template(self) -> TemplateMacroRef<'top> {
+        if let MacroKind::Template(body) = &self.kind() {
+            return TemplateMacroRef::new(self, body);
+        }
+        unreachable!(
+            "caller required a template macro but found {:?}",
+            self.kind()
+        )
+    }
+
+    pub fn id_text(&'top self) -> Cow<'top, str> {
+        self.name()
+            .map(Cow::from)
+            .unwrap_or_else(move || Cow::from(format!("<address={}>", self.address())))
+    }
+
     pub fn address(&self) -> MacroAddress {
         self.address
     }
-    pub fn kind(&self) -> &'top MacroKind {
-        self.kind
+
+    pub fn reference(&self) -> &'top Macro {
+        self.reference
     }
 
-    pub fn expect_template(self) -> IonResult<TemplateMacroRef<'top>> {
-        if let MacroKind::Template(template) = &self.kind {
-            return Ok(TemplateMacroRef::new(self.address, template));
+    delegate! {
+        to self.reference {
+            pub fn name(&'top self) -> Option<&'top str>;
+            pub fn signature(self) -> &'top MacroSignature;
+            pub fn kind(&self) -> &'top MacroKind;
+            pub fn expansion_analysis(&self) -> ExpansionAnalysis;
+            pub fn can_be_lazily_evaluated_at_top_level(&self) -> bool;
+            pub fn must_produce_exactly_one_value(&self) -> bool;
         }
-        IonResult::decoding_error(format!(
-            "expected a template macro but found {:?}",
-            self.kind
-        ))
     }
 }
 
@@ -61,7 +154,7 @@ impl<'top> MacroRef<'top> {
 /// its validity and allowing evaluation to begin.
 #[derive(Debug, Clone)]
 pub struct MacroTable {
-    macros_by_address: Vec<MacroKind>,
+    macros_by_address: Vec<Macro>,
     // Maps names to an address that can be used to query the Vec above.
     macros_by_name: HashMap<String, usize>,
 }
@@ -73,11 +166,74 @@ impl Default for MacroTable {
 }
 
 impl MacroTable {
+    pub const SYSTEM_MACRO_KINDS: &'static [MacroKind] =
+        &[MacroKind::Void, MacroKind::Values, MacroKind::MakeString];
+    pub const NUM_SYSTEM_MACROS: usize = Self::SYSTEM_MACRO_KINDS.len();
+    // When a user defines new macros, this is the first ID that will be assigned. This value
+    // is expected to change as development continues. It is currently used in several unit tests.
+    pub const FIRST_USER_MACRO_ID: usize = 3;
+
     pub fn new() -> Self {
-        let macros_by_id = vec![MacroKind::Void, MacroKind::Values, MacroKind::MakeString];
+        let macros_by_id = vec![
+            Macro::named(
+                "void",
+                MacroSignature::new(vec![]).unwrap(),
+                MacroKind::Void,
+                ExpansionAnalysis {
+                    could_produce_system_value: false,
+                    must_produce_exactly_one_value: false,
+                    // This is false because lazy evaluation requires giving out a LazyValue as a
+                    // handle to eventually read the expression. We cannot give out a `LazyValue`
+                    // for e-expressions that will produce 0 or 2+ values.
+                    can_be_lazily_evaluated_at_top_level: false,
+                    expansion_singleton: None,
+                },
+            ),
+            Macro::named(
+                "values",
+                MacroSignature::new(vec![Parameter::new(
+                    "expr_group",
+                    ParameterEncoding::Tagged,
+                    ParameterCardinality::ZeroOrMore,
+                    RestSyntaxPolicy::Allowed,
+                )])
+                .unwrap(),
+                MacroKind::Values,
+                ExpansionAnalysis {
+                    could_produce_system_value: true,
+                    must_produce_exactly_one_value: false,
+                    can_be_lazily_evaluated_at_top_level: false,
+                    expansion_singleton: None,
+                },
+            ),
+            Macro::named(
+                "make_string",
+                MacroSignature::new(vec![Parameter::new(
+                    "expr_group",
+                    ParameterEncoding::Tagged,
+                    ParameterCardinality::ZeroOrMore,
+                    RestSyntaxPolicy::Allowed,
+                )])
+                .unwrap(),
+                MacroKind::MakeString,
+                ExpansionAnalysis {
+                    could_produce_system_value: false,
+                    must_produce_exactly_one_value: true,
+                    can_be_lazily_evaluated_at_top_level: true,
+                    expansion_singleton: Some(ExpansionSingleton {
+                        is_null: false,
+                        ion_type: IonType::String,
+                        num_annotations: 0,
+                    }),
+                },
+            ),
+        ];
         let mut macros_by_name = HashMap::default();
-        for (id, kind) in macros_by_id.iter().enumerate() {
-            macros_by_name.insert(kind.name().to_string(), id);
+        for (id, mac) in macros_by_id.iter().enumerate() {
+            if let Some(name) = mac.name() {
+                macros_by_name.insert(name.to_owned(), id);
+            }
+            // Anonymous macros are not entered into the macros_by_name lookup table
         }
         Self {
             macros_by_address: macros_by_id,
@@ -89,7 +245,12 @@ impl MacroTable {
         self.macros_by_address.len()
     }
 
-    pub fn macro_with_id(&'_ self, id: MacroIdRef<'_>) -> Option<MacroRef<'_>> {
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn macro_with_id<'a, 'b, I: Into<MacroIdRef<'b>>>(&'a self, id: I) -> Option<MacroRef<'a>> {
+        let id = id.into();
         match id {
             MacroIdRef::LocalName(name) => self.macro_with_name(name),
             MacroIdRef::LocalAddress(address) => self.macro_at_address(address),
@@ -97,28 +258,38 @@ impl MacroTable {
     }
 
     pub fn macro_at_address(&self, address: usize) -> Option<MacroRef<'_>> {
-        let kind = self.macros_by_address.get(address)?;
-        Some(MacroRef { address, kind })
+        let reference = self.macros_by_address.get(address)?;
+        Some(MacroRef { address, reference })
     }
 
     pub fn address_for_name(&self, name: &str) -> Option<usize> {
         self.macros_by_name.get(name).copied()
     }
 
-    pub fn macro_with_name(&self, name: &str) -> Option<MacroRef<'_>> {
+    pub fn macro_with_name<'a>(&'a self, name: &str) -> Option<MacroRef<'a>> {
         let address = *self.macros_by_name.get(name)?;
-        let kind = self.macros_by_address.get(address)?;
-        Some(MacroRef { address, kind })
+        let reference = self.macros_by_address.get(address)?;
+        Some(MacroRef { address, reference })
     }
 
     pub fn add_macro(&mut self, template: TemplateMacro) -> IonResult<usize> {
-        let name = template.name();
-        if self.macros_by_name.contains_key(name) {
-            return IonResult::decoding_error(format!("macro named '{name}' already exists"));
-        }
         let id = self.macros_by_address.len();
-        self.macros_by_name.insert(name.to_owned(), id);
-        self.macros_by_address.push(MacroKind::Template(template));
+        // If the macro has a name, make sure that name is not already in use and then add it.
+        if let Some(name) = template.name.as_deref() {
+            if self.macros_by_name.contains_key(name) {
+                return IonResult::decoding_error(format!("macro named '{name}' already exists"));
+            }
+            self.macros_by_name.insert(name.to_owned(), id);
+        }
+
+        let new_macro = Macro::new(
+            template.name,
+            template.signature,
+            MacroKind::Template(template.body),
+            template.expansion_analysis,
+        );
+
+        self.macros_by_address.push(new_macro);
         Ok(id)
     }
 }

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -449,10 +449,10 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
         &self,
         marker: <Encoding as Decoder>::VersionMarker<'top>,
     ) -> IonResult<SystemStreamItem<'top, Encoding>> {
-        let new_version = marker.new_version()?;
+        let new_version = marker.stream_version_after_marker()?;
         // If this is the first item in the stream or we're changing versions, we need to ensure
         // the encoding context is set up for this version.
-        if marker.range().start == 0 || new_version != marker.old_version() {
+        if marker.range().start == 0 || new_version != marker.stream_version_before_marker() {
             // SAFETY: Version markers do not hold a reference to the symbol table.
             let pending_changes = unsafe { &mut *self.pending_context_changes.get() };
             pending_changes.switch_to_version = Some(new_version);

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -33,40 +33,44 @@
 //! that are ignored by the reader do not incur the cost of symbol table resolution.
 
 use std::cell::{Cell, UnsafeCell};
+use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::iter::empty;
-use std::ops::Deref;
+use std::ops::{Deref, Range};
 
 use bumpalo::Bump as BumpAllocator;
 
 use sequence::{LazyExpandedList, LazyExpandedSExp};
 
 use crate::element::iterators::SymbolsIterator;
-use crate::lazy::any_encoding::IonEncoding;
+use crate::lazy::any_encoding::{IonEncoding, IonVersion};
 use crate::lazy::bytes_ref::BytesRef;
 use crate::lazy::decoder::{Decoder, LazyRawValue};
 use crate::lazy::encoding::RawValueLiteral;
 use crate::lazy::expanded::compiler::TemplateCompiler;
-use crate::lazy::expanded::macro_evaluator::{MacroEvaluator, RawEExpression};
-use crate::lazy::expanded::macro_table::MacroTable;
+use crate::lazy::expanded::e_expression::EExpression;
+use crate::lazy::expanded::encoding_module::EncodingModule;
+use crate::lazy::expanded::macro_evaluator::{
+    MacroEvaluator, MacroExpansion, MacroExpr, RawEExpression,
+};
+use crate::lazy::expanded::macro_table::{Macro, MacroTable};
 use crate::lazy::expanded::r#struct::LazyExpandedStruct;
 use crate::lazy::expanded::sequence::Environment;
-use crate::lazy::expanded::template::{
-    TemplateElement, TemplateMacro, TemplateMacroRef, TemplateValue,
-};
+use crate::lazy::expanded::template::{TemplateElement, TemplateMacro, TemplateValue};
 use crate::lazy::r#struct::LazyStruct;
 use crate::lazy::raw_value_ref::RawValueRef;
 use crate::lazy::sequence::{LazyList, LazySExp};
 use crate::lazy::str_ref::StrRef;
 use crate::lazy::streaming_raw_reader::{IonInput, StreamingRawReader};
-use crate::lazy::system_reader::{PendingLst, SystemReader};
+use crate::lazy::system_reader::{PendingContextChanges, SystemReader};
 use crate::lazy::system_stream_item::SystemStreamItem;
 use crate::lazy::text::raw::v1_1::reader::MacroAddress;
 use crate::lazy::value::LazyValue;
 use crate::raw_symbol_ref::AsRawSymbolRef;
 use crate::result::IonFailure;
 use crate::{
-    AnyEncoding, Catalog, Decimal, Int, IonResult, IonType, RawSymbolRef, SymbolTable, Timestamp,
+    Catalog, Decimal, HasRange, HasSpan, Int, IonResult, IonType, RawSymbolRef, RawVersionMarker,
+    Span, SymbolTable, Timestamp, ValueRef,
 };
 
 // All of these modules (and most of their types) are currently `pub` as the lazy reader is gated
@@ -74,6 +78,7 @@ use crate::{
 // stabilizes.
 pub mod compiler;
 pub mod e_expression;
+pub mod encoding_module;
 pub mod macro_evaluator;
 pub mod macro_table;
 pub mod sequence;
@@ -81,9 +86,6 @@ pub mod r#struct;
 pub mod template;
 
 /// A collection of resources that can be used to encode or decode Ion values.
-/// The `'top` lifetime associated with the [`EncodingContextRef`] reflects the fact that it can only
-/// be used as long as the reader is positioned on the same top level expression (i.e. the symbol and
-/// macro tables are guaranteed not to change).
 //  It should be possible to loosen this definition of `'top` to include several top level values
 //  as long as the macro and symbol tables do not change between them, though this would require
 //  carefully designing the API to emphasize that the sequence of values is either the set that
@@ -92,6 +94,7 @@ pub mod template;
 //  would need to be proved out first.
 #[derive(Debug)]
 pub struct EncodingContext {
+    pub(crate) modules: HashMap<String, EncodingModule>,
     pub(crate) macro_table: MacroTable,
     pub(crate) symbol_table: SymbolTable,
     pub(crate) allocator: BumpAllocator,
@@ -104,18 +107,47 @@ impl EncodingContext {
         allocator: BumpAllocator,
     ) -> Self {
         Self {
+            modules: HashMap::new(),
             macro_table,
             symbol_table,
             allocator,
         }
     }
 
+    pub fn for_ion_version(version: IonVersion) -> Self {
+        Self::new(
+            MacroTable::new(),
+            SymbolTable::new(version),
+            BumpAllocator::new(),
+        )
+    }
+
     pub fn empty() -> Self {
-        Self::new(MacroTable::new(), SymbolTable::new(), BumpAllocator::new())
+        Self::new(
+            MacroTable::new(),
+            SymbolTable::new(IonVersion::default()),
+            BumpAllocator::new(),
+        )
     }
 
     pub fn get_ref(&self) -> EncodingContextRef {
         EncodingContextRef { context: self }
+    }
+
+    pub fn macro_table(&self) -> &MacroTable {
+        &self.macro_table
+    }
+
+    pub fn macro_table_mut(&mut self) -> &mut MacroTable {
+        &mut self.macro_table
+    }
+
+    pub fn symbol_table(&self) -> &SymbolTable {
+        &self.symbol_table
+    }
+
+    pub fn allocator(&self) -> &BumpAllocator {
+        &self.allocator
     }
 }
 
@@ -230,7 +262,7 @@ pub struct ExpandingReader<Encoding: Decoder, Input: IonInput> {
     //
     // Holds information found in symbol tables and encoding directives (TODO) that can be applied
     // to the encoding context the next time the reader is between top-level expressions.
-    pending_lst: UnsafeCell<PendingLst>,
+    pending_context_changes: UnsafeCell<PendingContextChanges>,
     encoding_context: UnsafeCell<EncodingContext>,
     catalog: Box<dyn Catalog>,
 }
@@ -244,15 +276,19 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
             raw_reader: raw_reader.into(),
             evaluator_ptr: None.into(),
             encoding_context: EncodingContext::empty().into(),
-            pending_lst: PendingLst::new().into(),
+            pending_context_changes: PendingContextChanges::new().into(),
             catalog,
         }
     }
 
     // TODO: This method is temporary. It will be removed when the ability to read 1.1 encoding
     //       directives from the input stream is available. Until then, template creation is manual.
-    pub fn register_template(&mut self, template_definition: &str) -> IonResult<MacroAddress> {
+    pub fn register_template_src(&mut self, template_definition: &str) -> IonResult<MacroAddress> {
         let template_macro: TemplateMacro = self.compile_template(template_definition)?;
+        self.register_template(template_macro)
+    }
+
+    pub fn register_template(&mut self, template_macro: TemplateMacro) -> IonResult<MacroAddress> {
         self.add_macro(template_macro)
     }
 
@@ -288,24 +324,26 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
         context.allocator.reset();
     }
 
-    pub fn pending_lst(&self) -> &PendingLst {
+    pub fn pending_context_changes(&self) -> &PendingContextChanges {
         // If the user is able to call this method, the PendingLst is not being modified and it's
         // safe to immutably reference.
-        unsafe { &*self.pending_lst.get() }
+        unsafe { &*self.pending_context_changes.get() }
     }
 
-    pub fn pending_lst_mut(&mut self) -> &mut PendingLst {
+    pub fn pending_lst_mut(&mut self) -> &mut PendingContextChanges {
         // SAFETY: If the caller has a `&mut` reference to `self`, it is the only mutable reference
         //         that can modify `self.pending_lst`.
-        unsafe { &mut *self.pending_lst.get() }
+        unsafe { &mut *self.pending_context_changes.get() }
     }
 
+    #[inline]
     fn ptr_to_mut_ref<'a, T>(ptr: *mut ()) -> &'a mut T {
         let typed_ptr: *mut T = ptr.cast();
         unsafe { &mut *typed_ptr }
     }
 
     /// Dereferences a raw pointer storing the address of the active MacroEvaluator.
+    #[inline]
     fn ptr_to_evaluator<'top>(evaluator_ptr: *mut ()) -> &'top mut MacroEvaluator<'top, Encoding> {
         Self::ptr_to_mut_ref(evaluator_ptr)
     }
@@ -321,47 +359,106 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
         Self::ref_as_ptr(evaluator)
     }
 
-    /// Updates the encoding context with the information stored in the `PendingLst`.
-    // TODO: This only works on Ion 1.0 symbol tables for now, hence the name `PendingLst`
-    fn apply_pending_lst(pending_lst: &mut PendingLst, symbol_table: &mut SymbolTable) {
+    /// Updates the encoding context with the information stored in the `PendingContextChanges`.
+    fn apply_pending_context_changes(
+        pending_changes: &mut PendingContextChanges,
+        symbol_table: &mut SymbolTable,
+        macro_table: &mut MacroTable,
+    ) {
+        if let Some(new_version) = pending_changes.switch_to_version.take() {
+            symbol_table.reset_to_version(new_version);
+            pending_changes.has_changes = false;
+            // If we're switching to a new version, the last stream item was a version marker
+            // and there are no other pending changes. The `take()` above clears the `switch_to_version`.
+            return;
+        }
+
+        if let Some(mut module) = pending_changes.take_new_active_module() {
+            std::mem::swap(symbol_table, module.symbol_table_mut());
+            std::mem::swap(macro_table, module.macro_table_mut());
+            return;
+        }
+
         // If the symbol table's `imports` field had a value of `$ion_symbol_table`, then we're
         // appending the symbols it defined to the end of our existing local symbol table.
         // Otherwise, we need to clear the existing table before appending the new symbols.
-        if !pending_lst.is_lst_append {
+        if !pending_changes.is_lst_append {
             // We're setting the symbols list, not appending to it.
             symbol_table.reset();
         }
         // `drain()` empties the pending `imported_symbols` and `symbols` lists
-        for symbol in pending_lst.imported_symbols.drain(..) {
+        for symbol in pending_changes.imported_symbols.drain(..) {
             symbol_table.add_symbol(symbol);
         }
-        for symbol in pending_lst.symbols.drain(..) {
+        for symbol in pending_changes.symbols.drain(..) {
             symbol_table.add_symbol(symbol);
         }
-        pending_lst.is_lst_append = false;
-        pending_lst.has_changes = false;
+        pending_changes.is_lst_append = false;
+        pending_changes.has_changes = false;
+    }
+
+    #[inline]
+    fn interpret_value<'top>(
+        &self,
+        value: LazyExpandedValue<'top, Encoding>,
+    ) -> IonResult<SystemStreamItem<'top, Encoding>> {
+        if value.has_annotations() && matches!(value.ion_type(), IonType::Struct | IonType::SExp) {
+            self.fully_interpret_value(value)
+        } else {
+            Ok(SystemStreamItem::Value(LazyValue::new(value)))
+        }
     }
 
     /// Inspects a `LazyExpandedValue` to determine whether it is a symbol table or an
     /// application-level value. Returns it as the appropriate variant of `SystemStreamItem`.
-    fn interpret_value<'top>(
+    fn fully_interpret_value<'top>(
         &self,
         value: LazyExpandedValue<'top, Encoding>,
     ) -> IonResult<SystemStreamItem<'top, Encoding>> {
         // If this value is a symbol table...
         if SystemReader::<_, Input>::is_symbol_table_struct(&value)? {
             // ...traverse it and record any new symbols in our `pending_lst`.
-            let pending_lst = unsafe { &mut *self.pending_lst.get() };
-            SystemReader::<_, Input>::process_symbol_table(pending_lst, &*self.catalog, &value)?;
-            pending_lst.has_changes = true;
+            let pending_changes = unsafe { &mut *self.pending_context_changes.get() };
+            SystemReader::<_, Input>::process_symbol_table(
+                pending_changes,
+                &*self.catalog,
+                &value,
+            )?;
+            pending_changes.has_changes = true;
             let lazy_struct = LazyStruct {
                 expanded_struct: value.read()?.expect_struct().unwrap(),
             };
             return Ok(SystemStreamItem::SymbolTable(lazy_struct));
+        } else if self.detected_encoding().version() == IonVersion::v1_1
+            && SystemReader::<_, Input>::is_encoding_directive_sexp(&value)?
+        {
+            let pending_changes = unsafe { &mut *self.pending_context_changes.get() };
+            SystemReader::<_, Input>::process_encoding_directive(pending_changes, value)?;
+            pending_changes.has_changes = true;
+            let lazy_sexp = LazySExp {
+                expanded_sexp: value.read()?.expect_sexp().unwrap(),
+            };
+            return Ok(SystemStreamItem::EncodingDirective(lazy_sexp));
         }
         // Otherwise, it's an application value.
         let lazy_value = LazyValue::new(value);
         return Ok(SystemStreamItem::Value(lazy_value));
+    }
+
+    fn interpret_ivm<'top>(
+        &self,
+        marker: <Encoding as Decoder>::VersionMarker<'top>,
+    ) -> IonResult<SystemStreamItem<'top, Encoding>> {
+        let new_version = marker.new_version()?;
+        // If this is the first item in the stream or we're changing versions, we need to ensure
+        // the encoding context is set up for this version.
+        if marker.range().start == 0 || new_version != marker.old_version() {
+            // SAFETY: Version markers do not hold a reference to the symbol table.
+            let pending_changes = unsafe { &mut *self.pending_context_changes.get() };
+            pending_changes.switch_to_version = Some(new_version);
+            pending_changes.has_changes = true;
+        }
+        Ok(SystemStreamItem::VersionMarker(marker))
     }
 
     /// This method is invoked just before the reader begins reading the next top-level expression
@@ -382,13 +479,16 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
         // If the pending LST has changes to apply, do so.
         // SAFETY: Nothing else holds a reference to the `PendingLst`'s contents, so we can use the
         //         `UnsafeCell` to get a mutable reference to it.
-        let pending_lst: &mut PendingLst = unsafe { &mut *self.pending_lst.get() };
+        let pending_lst: &mut PendingContextChanges =
+            unsafe { &mut *self.pending_context_changes.get() };
         if pending_lst.has_changes {
             // SAFETY: Nothing else holds a reference to the `EncodingContext`'s contents, so we can use the
             //         `UnsafeCell` to get a mutable reference to its symbol table.
             let symbol_table: &mut SymbolTable =
                 &mut unsafe { &mut *self.encoding_context.get() }.symbol_table;
-            Self::apply_pending_lst(pending_lst, symbol_table);
+            let macro_table: &mut MacroTable =
+                &mut unsafe { &mut *self.encoding_context.get() }.macro_table;
+            Self::apply_pending_context_changes(pending_lst, symbol_table, macro_table);
         }
     }
 
@@ -397,19 +497,21 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
     /// This method will consume and process as many system-level values as possible until it
     /// encounters an application-level value or the end of the stream.
     pub fn next_value(&mut self) -> IonResult<Option<LazyValue<Encoding>>> {
+        use SystemStreamItem::*;
         loop {
-            match self.next_item()? {
-                SystemStreamItem::VersionMarker(_marker) => {
-                    // TODO: Handle version changes 1.0 <-> 1.1
-                }
-                SystemStreamItem::SymbolTable(_) => {
-                    // The symbol table is processed by `next_item` before it is returned. There's
-                    // nothing to be done here.
-                }
-                SystemStreamItem::Value(value) => return Ok(Some(value)),
-                SystemStreamItem::EndOfStream(_) => return Ok(None),
-            }
+            match self.next_item() {
+                Ok(Value(value)) => return Ok(Some(value)),
+                Ok(EndOfStream(_)) => return Ok(None),
+                Ok(_) => {}
+                Err(e) => return Err(e),
+            };
         }
+    }
+
+    pub fn detected_encoding(&self) -> IonEncoding {
+        // SAFETY: We have an immutable reference to `self`, so it's legal for us to have an immutable
+        //         reference to one of its fields.
+        unsafe { &*self.raw_reader.get() }.encoding()
     }
 
     /// Returns the next [`SystemStreamItem`] either by continuing to evaluate a macro invocation
@@ -422,8 +524,21 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
 
         // If there's already an active macro evaluator, that means the reader is still in the process
         // of expanding a macro invocation it previously encountered. See if it has a value to give us.
-        if let Some(stream_item) = self.next_from_evaluator()? {
-            return Ok(stream_item);
+        if let Some(ptr) = self.evaluator_ptr.get() {
+            // If there's already an evaluator, dereference the pointer.
+            let evaluator = Self::ptr_to_evaluator(ptr);
+            match evaluator.next() {
+                Ok(Some(value)) => {
+                    if evaluator.is_empty() {
+                        // If the evaluator is empty, unset the pointer so we know not to query it
+                        // further.
+                        self.evaluator_ptr.set(None);
+                    }
+                    return self.interpret_value(value);
+                }
+                Ok(None) => {}
+                Err(e) => return Err(e),
+            }
         }
 
         // Otherwise, we're now between top level expressions. Take this opportunity to apply any
@@ -441,37 +556,55 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
             use crate::lazy::raw_stream_item::RawStreamItem::*;
             let raw_reader = unsafe { &mut *self.raw_reader.get() };
             match raw_reader.next(context_ref)? {
-                VersionMarker(marker) => return Ok(SystemStreamItem::VersionMarker(marker)),
+                VersionMarker(marker) => {
+                    return self.interpret_ivm(marker);
+                }
                 // We got our value; return it.
                 Value(raw_value) => {
                     let value = LazyExpandedValue::from_literal(context_ref, raw_value);
                     return self.interpret_value(value);
                 }
                 // It's another macro invocation, we'll start evaluating it.
-                EExpression(e_exp) => {
+                EExp(e_exp) => {
                     let context = self.context();
-                    let resolved_e_exp = e_exp.resolve(context_ref)?;
+                    let resolved_e_exp = match e_exp.resolve(context_ref) {
+                        Ok(resolved) => resolved,
+                        Err(e) => return Err(e),
+                    };
+
+                    // If this e-expression invokes a template with a non-system, singleton expansion, we can use the
+                    // e-expression to back a LazyExpandedValue. It will only be evaluated if the user calls `read()`.
+                    if let Some(value) = LazyExpandedValue::try_from_e_expression(resolved_e_exp) {
+                        // Because the expansion is guaranteed not to be a system value, we do not need to interpret it.
+                        return Ok(SystemStreamItem::Value(LazyValue::new(value)));
+                    }
+                    let new_evaluator = MacroEvaluator::for_eexp(resolved_e_exp)?;
                     // Get the current evaluator or make a new one
                     let evaluator = match self.evaluator_ptr.get() {
-                        // If there's already an evaluator, dereference the pointer.
-                        Some(ptr) => Self::ptr_to_evaluator(ptr),
-                        // If there's not, make a new one.
-                        None => context
-                            .allocator
-                            // E-expressions always have an empty environment
-                            .alloc_with(move || {
-                                MacroEvaluator::new(context_ref, Environment::empty())
-                            }),
+                        // If there's already an evaluator in the bump, it's empty. Overwrite it with our new one.
+                        Some(ptr) => {
+                            let bump_evaluator_ref = Self::ptr_to_evaluator(ptr);
+                            *bump_evaluator_ref = new_evaluator;
+                            bump_evaluator_ref
+                        }
+                        // If there's not an evaluator in the bump, make a new one.
+                        None => context.allocator.alloc_with(|| new_evaluator),
                     };
-                    // Push the invocation onto the evaluation stack.
-                    evaluator.push(resolved_e_exp)?;
-                    self.evaluator_ptr
-                        .set(Some(Self::evaluator_to_ptr(evaluator)));
 
                     // Try to get a value by starting to evaluate the e-expression.
-                    if let Some(value) = self.next_from_evaluator()? {
+                    let next_value = match evaluator.next() {
+                        Ok(value) => value,
+                        Err(e) => return Err(e),
+                    };
+                    if let Some(value) = next_value {
+                        // If we get a value and the evaluator isn't empty yet, save its pointer
+                        // so we can try to get more out of it when `next_at_or_above_depth` is called again.
+                        if !evaluator.is_empty() {
+                            self.evaluator_ptr
+                                .set(Some(Self::evaluator_to_ptr(evaluator)));
+                        }
                         // If we get a value, return it.
-                        return Ok(value);
+                        return self.interpret_value(value);
                     } else {
                         // If the expression was equivalent to `(:void)`, return to the top of
                         // the loop and get the next expression.
@@ -484,40 +617,6 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
             };
         }
     }
-
-    /// If there is not an evaluation in process, returns `Ok(None)`.
-    /// If there is an evaluation in process but it does not yield another value, returns `Ok(None)`.
-    /// If there is an evaluation in process and it yields another value, returns `Ok(Some(value))`.
-    /// Otherwise, returns `Err`.
-    fn next_from_evaluator(&self) -> IonResult<Option<SystemStreamItem<Encoding>>> {
-        let evaluator_ptr = match self.evaluator_ptr.get() {
-            // There's not currently an evaluator.
-            None => return Ok(None),
-            // There's an evaluator in the process of expanding a macro.
-            Some(ptr) => ptr,
-        };
-        let evaluator = Self::ptr_to_evaluator(evaluator_ptr);
-
-        match evaluator.next() {
-            Ok(Some(value)) => {
-                // See if this value was a symbol table that needs interpretation.
-                self.interpret_value(value).map(Some)
-            }
-            Ok(None) => {
-                // While the evaluator had macros in its stack, they did not produce any more
-                // values. The stack is now empty.
-                Ok(None)
-            }
-            Err(e) => Err(e),
-        }
-    }
-}
-
-impl<Input: IonInput> ExpandingReader<AnyEncoding, Input> {
-    pub fn detected_encoding(&self) -> IonEncoding {
-        let raw_reader = unsafe { &*self.raw_reader.get() };
-        raw_reader.encoding()
-    }
 }
 
 /// The source of data backing a [`LazyExpandedValue`].
@@ -525,6 +624,8 @@ impl<Input: IonInput> ExpandingReader<AnyEncoding, Input> {
 pub enum ExpandedValueSource<'top, D: Decoder> {
     /// This value was a literal in the input stream.
     ValueLiteral(D::Value<'top>),
+    /// This value is backed by an e-expression invoking a macro known to produce a single value.
+    EExp(EExpression<'top, D>),
     /// This value was part of a template definition.
     Template(Environment<'top, D>, TemplateElement<'top>),
     /// This value was the computed result of a macro invocation like `(:make_string `...)`.
@@ -533,14 +634,15 @@ pub enum ExpandedValueSource<'top, D: Decoder> {
         //       it to `Never` and the compiler can eliminate this code path where applicable.
         // Constructed data stored in the bump allocator. Holding references instead of the data
         // itself allows this type (and those that contain it) to impl `Copy`.
-        &'top [&'top str],               // Annotations (if any)
-        &'top ExpandedValueRef<'top, D>, // Value
+        &'top [&'top str],       // Annotations (if any)
+        &'top ValueRef<'top, D>, // Value
     ),
 }
 
 impl<'top, Encoding: Decoder> Debug for ExpandedValueSource<'top, Encoding> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match &self {
+            ExpandedValueSource::EExp(eexp) => write!(f, "{eexp:?}"),
             ExpandedValueSource::ValueLiteral(v) => write!(f, "{v:?}"),
             ExpandedValueSource::Template(_, template_element) => {
                 write!(f, "{:?}", template_element.value())
@@ -563,24 +665,24 @@ impl<'top, V: RawValueLiteral, Encoding: Decoder<Value<'top> = V>> From<V>
 /// A variable found in the body of a template macro.
 #[derive(Debug, Copy, Clone)]
 pub struct TemplateVariableReference<'top> {
-    template: TemplateMacroRef<'top>,
+    macro_ref: &'top Macro,
     signature_index: u16,
 }
 
 impl<'top> TemplateVariableReference<'top> {
-    pub fn new(template: TemplateMacroRef<'top>, signature_index: u16) -> Self {
+    pub fn new(macro_ref: &'top Macro, signature_index: u16) -> Self {
         Self {
-            template,
+            macro_ref,
             signature_index,
         }
     }
 
-    fn name(&self) -> &'top str {
-        self.template.signature.parameters()[self.signature_index()].name()
+    fn name(&self) -> &str {
+        self.macro_ref.signature().parameters()[self.signature_index()].name()
     }
 
-    fn host_template(&self) -> TemplateMacroRef<'top> {
-        self.template
+    fn host_macro(&self) -> &'top Macro {
+        self.macro_ref
     }
 
     fn signature_index(&self) -> usize {
@@ -605,6 +707,23 @@ impl<'top, Encoding: Decoder> Debug for LazyExpandedValue<'top, Encoding> {
 }
 
 impl<'top, Encoding: Decoder> LazyExpandedValue<'top, Encoding> {
+    // If the provided e-expression can be resolved to a template macro that is eligible to back
+    // a lazy value without first being evaluated, returns `Some(lazy_expanded_value)`.
+    // To be eligible, the body of the template macro must be an Ion value literal that is not
+    // a system value.
+    pub(crate) fn try_from_e_expression(eexp: EExpression<'top, Encoding>) -> Option<Self> {
+        let analysis = eexp.expansion_analysis();
+        if !analysis.can_be_lazily_evaluated_at_top_level() {
+            return None;
+        }
+
+        Some(Self {
+            context: eexp.context,
+            source: ExpandedValueSource::EExp(eexp),
+            variable: None,
+        })
+    }
+
     pub(crate) fn from_literal(
         context: EncodingContextRef<'top>,
         value: Encoding::Value<'top>,
@@ -631,7 +750,7 @@ impl<'top, Encoding: Decoder> LazyExpandedValue<'top, Encoding> {
     pub(crate) fn from_constructed(
         context: EncodingContextRef<'top>,
         annotations: &'top [&'top str],
-        value: &'top ExpandedValueRef<'top, Encoding>,
+        value: &'top ValueRef<'top, Encoding>,
     ) -> Self {
         Self {
             context,
@@ -651,6 +770,7 @@ impl<'top, Encoding: Decoder> LazyExpandedValue<'top, Encoding> {
             ValueLiteral(value) => value.ion_type(),
             Template(_, element) => element.value().ion_type(),
             Constructed(_annotations, value) => value.ion_type(),
+            EExp(eexp) => eexp.require_expansion_singleton().ion_type(),
         }
     }
 
@@ -660,8 +780,9 @@ impl<'top, Encoding: Decoder> LazyExpandedValue<'top, Encoding> {
             ValueLiteral(value) => value.is_null(),
             Template(_, element) => element.value().is_null(),
             Constructed(_, value) => {
-                matches!(value, ExpandedValueRef::Null(_))
+                matches!(value, ValueRef::Null(_))
             }
+            EExp(eexp) => eexp.require_expansion_singleton().is_null(),
         }
     }
 
@@ -671,6 +792,7 @@ impl<'top, Encoding: Decoder> LazyExpandedValue<'top, Encoding> {
             ValueLiteral(value) => value.has_annotations(),
             Template(_, element) => !element.annotations().is_empty(),
             Constructed(annotations, _) => !annotations.is_empty(),
+            EExp(eexp) => eexp.require_expansion_singleton().has_annotations(),
         }
     }
 
@@ -690,9 +812,21 @@ impl<'top, Encoding: Decoder> LazyExpandedValue<'top, Encoding> {
                     empty(),
                 )))
             }
+            EExp(eexp) => {
+                let annotations_range = 0..eexp.require_expansion_singleton().num_annotations();
+                let annotations = &eexp
+                    .invoked_macro
+                    .require_template()
+                    .body()
+                    .annotations_storage()[annotations_range];
+                ExpandedAnnotationsIterator::new(ExpandedAnnotationsSource::Template(
+                    SymbolsIterator::new(annotations),
+                ))
+            }
         }
     }
 
+    #[inline]
     pub fn read(&self) -> IonResult<ExpandedValueRef<'top, Encoding>> {
         use ExpandedValueSource::*;
         match &self.source {
@@ -702,8 +836,35 @@ impl<'top, Encoding: Decoder> LazyExpandedValue<'top, Encoding> {
                 *environment,
                 element,
             )),
-            Constructed(_annotations, value) => Ok((*value).clone()),
+            Constructed(_annotations, value) => Ok((**value).as_expanded()),
+            EExp(ref eexp) => eexp.expand_to_single_value()?.read(),
         }
+    }
+
+    #[inline(always)]
+    pub fn read_resolved(&self) -> IonResult<ValueRef<'top, Encoding>> {
+        use ExpandedValueSource::*;
+        match &self.source {
+            ValueLiteral(value) => value.read_resolved(self.context),
+            Template(environment, element) => {
+                Ok(ValueRef::from_template(self.context, *environment, element))
+            }
+            Constructed(_annotations, value) => Ok(**value),
+            EExp(ref eexp) => self.read_resolved_singleton_eexp(eexp),
+        }
+    }
+
+    #[inline(never)]
+    fn read_resolved_singleton_eexp(
+        &self,
+        eexp: &EExpression<'top, Encoding>,
+    ) -> IonResult<ValueRef<'top, Encoding>> {
+        let new_expansion = MacroExpansion::initialize(
+            // The parent environment of an e-expression is always empty.
+            Environment::empty(),
+            MacroExpr::from_eexp(*eexp),
+        )?;
+        new_expansion.expand_singleton()?.read_resolved()
     }
 
     pub fn context(&self) -> EncodingContextRef<'top> {
@@ -712,6 +873,27 @@ impl<'top, Encoding: Decoder> LazyExpandedValue<'top, Encoding> {
 
     pub fn source(&self) -> ExpandedValueSource<'top, Encoding> {
         self.source
+    }
+
+    pub fn expect_value_literal(&self) -> IonResult<Encoding::Value<'top>> {
+        if let ExpandedValueSource::ValueLiteral(literal) = self.source {
+            return Ok(literal);
+        }
+        IonResult::decoding_error("expected LazyExpandedValue to be a literal")
+    }
+
+    pub fn range(&self) -> Option<Range<usize>> {
+        if let ExpandedValueSource::ValueLiteral(value) = &self.source {
+            return Some(value.range());
+        }
+        None
+    }
+
+    pub fn span(&self) -> Option<Span<'top>> {
+        if let ExpandedValueSource::ValueLiteral(value) = &self.source {
+            return Some(value.span());
+        }
+        None
     }
 }
 
@@ -775,12 +957,7 @@ impl<'top, Encoding: Decoder> Iterator for ExpandedAnnotationsIterator<'top, Enc
     }
 }
 
-// TODO: This type does not implement `Copy` because some of its variants can own heap resources.
-//       (Specifically: Int, Decimal, String, Symbol, Blob, Clob.) If we plumb the bump allocator all
-//       the way down to the raw readers, then the situations that require allocation can
-//       hold a 'top reference to a bump allocation instead of a static reference to a heap allocation.
-//       This will enable us to remove several calls to `clone()`, which can be much slower than copies.
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub enum ExpandedValueRef<'top, Encoding: Decoder> {
     Null(IonType),
     Bool(bool),
@@ -1001,26 +1178,20 @@ impl<'top, Encoding: Decoder> ExpandedValueRef<'top, Encoding> {
             Symbol(s) => ExpandedValueRef::Symbol(s.as_raw_symbol_token_ref()),
             Blob(b) => ExpandedValueRef::Blob(BytesRef::from(b.as_ref())),
             Clob(c) => ExpandedValueRef::Clob(BytesRef::from(c.as_ref())),
-            List(s) => ExpandedValueRef::List(LazyExpandedList::from_template(
+            List => ExpandedValueRef::List(LazyExpandedList::from_template(
                 context,
                 environment,
-                element.template(),
-                element.annotations_range(),
-                *s,
+                *element,
             )),
-            SExp(s) => ExpandedValueRef::SExp(LazyExpandedSExp::from_template(
+            SExp => ExpandedValueRef::SExp(LazyExpandedSExp::from_template(
                 context,
                 environment,
-                element.template(),
-                element.annotations_range(),
-                *s,
+                *element,
             )),
-            Struct(s, index) => ExpandedValueRef::Struct(LazyExpandedStruct::from_template(
+            Struct(index) => ExpandedValueRef::Struct(LazyExpandedStruct::from_template(
                 context,
                 environment,
-                element.template(),
-                element.annotations_range(),
-                *s,
+                element,
                 index,
             )),
         }

--- a/src/lazy/expanded/sequence.rs
+++ b/src/lazy/expanded/sequence.rs
@@ -53,6 +53,19 @@ impl<'top, D: Decoder> Environment<'top, D> {
     pub fn expressions(&self) -> &'top [ValueExpr<'top, D>] {
         self.expressions
     }
+    pub fn for_eexp(context: EncodingContextRef<'top>, eexp: D::EExp<'top>) -> IonResult<Self> {
+        use bumpalo::collections::Vec as BumpVec;
+        let allocator = context.allocator();
+        let raw_args = eexp.raw_arguments();
+        let capacity_hint = raw_args.size_hint().0;
+        let mut env_exprs = BumpVec::with_capacity_in(capacity_hint, allocator);
+        // Populate the environment by parsing the arguments from input
+        for expr in raw_args {
+            env_exprs.push(expr?.resolve(context)?);
+        }
+
+        Ok(Environment::new(env_exprs.into_bump_slice()))
+    }
 }
 
 impl<'top, D: Decoder> Default for Environment<'top, D> {

--- a/src/lazy/expanded/sequence.rs
+++ b/src/lazy/expanded/sequence.rs
@@ -1,16 +1,11 @@
-use bumpalo::collections::Vec as BumpVec;
-
 use crate::element::iterators::SymbolsIterator;
 use crate::lazy::decoder::{Decoder, LazyRawSequence, LazyRawValueExpr, RawValueExpr};
 use crate::lazy::expanded::macro_evaluator::{MacroEvaluator, RawEExpression, ValueExpr};
-use crate::lazy::expanded::template::{
-    AnnotationsRange, ExprRange, TemplateMacroRef, TemplateSequenceIterator,
-};
+use crate::lazy::expanded::template::{TemplateElement, TemplateSequenceIterator};
 use crate::lazy::expanded::{
     EncodingContextRef, ExpandedAnnotationsIterator, ExpandedAnnotationsSource, LazyExpandedValue,
 };
-use crate::result::IonFailure;
-use crate::{IonError, IonResult, IonType};
+use crate::{try_or_some_err, IonResult, IonType};
 
 /// A sequence of not-yet-evaluated expressions passed as arguments to a macro invocation.
 ///
@@ -25,7 +20,7 @@ use crate::{IonError, IonResult, IonType};
 /// ```ion_1_1
 ///     (:foo 1 2 (:values 3))
 /// ```
-/// The `Environment` would contain the expressions `1`, `2` and `3`, corresponding to parameters
+/// The `Environment` would contain the expressions `1`, `2` and `(:values 3)`, corresponding to parameters
 /// `x`, `y`, and `z` respectively.
 #[derive(Copy, Clone, Debug)]
 pub struct Environment<'top, D: Decoder> {
@@ -33,34 +28,36 @@ pub struct Environment<'top, D: Decoder> {
 }
 
 impl<'top, D: Decoder> Environment<'top, D> {
-    pub(crate) fn new(args: BumpVec<'top, ValueExpr<'top, D>>) -> Self {
-        Environment {
-            expressions: args.into_bump_slice(),
-        }
+    pub(crate) fn new(args: &'top [ValueExpr<'top, D>]) -> Self {
+        Environment { expressions: args }
     }
 
     /// Returns the expression for the corresponding signature index -- the variable's offset within
-    /// the template's signature. If the requested index is out of bounds, returns `Err`.
-    pub fn get_expected(&self, signature_index: usize) -> IonResult<ValueExpr<'top, D>> {
-        self.expressions()
-            .get(signature_index)
-            .copied()
-            // The TemplateCompiler should detect any invalid variable references prior to evaluation
-            .ok_or_else(|| {
-                IonError::decoding_error(format!(
-                    "reference to variable with signature index {} not valid",
-                    signature_index
-                ))
-            })
+    /// the template's signature.
+    ///
+    /// Panics if the requested index is out of bounds, as the rules of the template compiler
+    /// should make that impossible.
+    #[inline]
+    pub fn require_expr(&self, signature_index: usize) -> ValueExpr<'top, D> {
+        if let Some(expr) = self.expressions().get(signature_index).copied() {
+            return expr;
+        }
+        unreachable!("found a macro signature index reference that was out of bounds")
     }
 
     /// Returns an empty environment without performing any allocations. This is used for evaluating
     /// e-expressions, which never have named parameters.
-    pub fn empty() -> Environment<'top, D> {
+    pub const fn empty() -> Environment<'top, D> {
         Environment { expressions: &[] }
     }
     pub fn expressions(&self) -> &'top [ValueExpr<'top, D>] {
         self.expressions
+    }
+}
+
+impl<'top, D: Decoder> Default for Environment<'top, D> {
+    fn default() -> Self {
+        Self::empty()
     }
 }
 
@@ -70,12 +67,7 @@ pub enum ExpandedListSource<'top, D: Decoder> {
     /// The list was a value literal in the input stream.
     ValueLiteral(D::List<'top>),
     /// The list was part of a template definition.
-    Template(
-        Environment<'top, D>,
-        TemplateMacroRef<'top>,
-        AnnotationsRange,
-        ExprRange,
-    ),
+    Template(Environment<'top, D>, TemplateElement<'top>),
     // TODO: Constructed
 }
 
@@ -99,12 +91,9 @@ impl<'top, D: Decoder> LazyExpandedList<'top, D> {
     pub fn from_template(
         context: EncodingContextRef<'top>,
         environment: Environment<'top, D>,
-        template: TemplateMacroRef<'top>,
-        annotations_range: AnnotationsRange,
-        step_range: ExprRange,
+        element: TemplateElement<'top>,
     ) -> LazyExpandedList<'top, D> {
-        let source =
-            ExpandedListSource::Template(environment, template, annotations_range, step_range);
+        let source = ExpandedListSource::Template(environment, element);
         Self { source, context }
     }
 
@@ -121,12 +110,8 @@ impl<'top, D: Decoder> LazyExpandedList<'top, D> {
             ExpandedListSource::ValueLiteral(value) => ExpandedAnnotationsIterator {
                 source: ExpandedAnnotationsSource::ValueLiteral(value.annotations()),
             },
-            ExpandedListSource::Template(_environment, template, annotations, _sequence) => {
-                let annotations = template
-                    .body
-                    .annotations_storage()
-                    .get(annotations.ops_range())
-                    .unwrap();
+            ExpandedListSource::Template(_environment, element) => {
+                let annotations = element.annotations();
                 ExpandedAnnotationsIterator {
                     source: ExpandedAnnotationsSource::Template(SymbolsIterator::new(annotations)),
                 }
@@ -137,17 +122,16 @@ impl<'top, D: Decoder> LazyExpandedList<'top, D> {
     pub fn iter(&self) -> ExpandedListIterator<'top, D> {
         let source = match &self.source {
             ExpandedListSource::ValueLiteral(list) => {
-                let evaluator = MacroEvaluator::new(self.context, Environment::empty());
-                ExpandedListIteratorSource::ValueLiteral(evaluator, list.iter())
+                ExpandedListIteratorSource::ValueLiteral(MacroEvaluator::new(), list.iter())
             }
-            ExpandedListSource::Template(environment, template, _annotations, steps) => {
-                let steps = template.body.expressions().get(steps.ops_range()).unwrap();
-                let evaluator = MacroEvaluator::new(self.context, *environment);
+            ExpandedListSource::Template(environment, element) => {
+                let nested_expressions = element.nested_expressions();
+                let evaluator = MacroEvaluator::new_with_environment(*environment);
                 ExpandedListIteratorSource::Template(TemplateSequenceIterator::new(
                     self.context,
                     evaluator,
-                    *template,
-                    steps,
+                    element.template(),
+                    nested_expressions,
                 ))
             }
         };
@@ -195,12 +179,7 @@ pub enum ExpandedSExpSource<'top, D: Decoder> {
     /// The SExp was a value literal in the input stream.
     ValueLiteral(D::SExp<'top>),
     /// The SExp was part of a template definition.
-    Template(
-        Environment<'top, D>,
-        TemplateMacroRef<'top>,
-        AnnotationsRange,
-        ExprRange,
-    ),
+    Template(Environment<'top, D>, TemplateElement<'top>),
 }
 
 /// An s-expression that may have come from either a value literal in the input stream or from
@@ -225,12 +204,8 @@ impl<'top, D: Decoder> LazyExpandedSExp<'top, D> {
             ExpandedSExpSource::ValueLiteral(value) => ExpandedAnnotationsIterator {
                 source: ExpandedAnnotationsSource::ValueLiteral(value.annotations()),
             },
-            ExpandedSExpSource::Template(_environment, template, annotations, _sequence) => {
-                let annotations = template
-                    .body
-                    .annotations_storage()
-                    .get(annotations.ops_range())
-                    .unwrap();
+            ExpandedSExpSource::Template(_environment, element) => {
+                let annotations = element.annotations();
                 ExpandedAnnotationsIterator {
                     source: ExpandedAnnotationsSource::Template(SymbolsIterator::new(annotations)),
                 }
@@ -241,17 +216,16 @@ impl<'top, D: Decoder> LazyExpandedSExp<'top, D> {
     pub fn iter(&self) -> ExpandedSExpIterator<'top, D> {
         let source = match &self.source {
             ExpandedSExpSource::ValueLiteral(sexp) => {
-                let evaluator = MacroEvaluator::new(self.context, Environment::empty());
-                ExpandedSExpIteratorSource::ValueLiteral(evaluator, sexp.iter())
+                ExpandedSExpIteratorSource::ValueLiteral(MacroEvaluator::new(), sexp.iter())
             }
-            ExpandedSExpSource::Template(environment, template, _annotations, steps) => {
-                let steps = template.body.expressions().get(steps.ops_range()).unwrap();
-                let evaluator = MacroEvaluator::new(self.context, *environment);
+            ExpandedSExpSource::Template(environment, element) => {
+                let nested_expressions = element.nested_expressions();
+                let evaluator = MacroEvaluator::new_with_environment(*environment);
                 ExpandedSExpIteratorSource::Template(TemplateSequenceIterator::new(
                     self.context,
                     evaluator,
-                    *template,
-                    steps,
+                    element.template(),
+                    nested_expressions,
                 ))
             }
         };
@@ -272,11 +246,9 @@ impl<'top, D: Decoder> LazyExpandedSExp<'top, D> {
     pub fn from_template(
         context: EncodingContextRef<'top>,
         environment: Environment<'top, D>,
-        template: TemplateMacroRef<'top>,
-        annotations: AnnotationsRange,
-        expressions: ExprRange,
+        element: TemplateElement<'top>,
     ) -> LazyExpandedSExp<'top, D> {
-        let source = ExpandedSExpSource::Template(environment, template, annotations, expressions);
+        let source = ExpandedSExpSource::Template(environment, element);
         Self { source, context }
     }
 }
@@ -321,7 +293,7 @@ fn expand_next_sequence_value<'top, D: Decoder>(
 ) -> Option<IonResult<LazyExpandedValue<'top, D>>> {
     loop {
         // If the evaluator's stack is not empty, it's still expanding a macro.
-        if evaluator.macro_stack_depth() > 0 {
+        if !evaluator.is_empty() {
             let value = evaluator.next().transpose();
             if value.is_some() {
                 // The `Some` may contain a value or an error; either way, that's the next return value.
@@ -341,10 +313,7 @@ fn expand_next_sequence_value<'top, D: Decoder>(
                     Ok(resolved) => resolved,
                     Err(e) => return Some(Err(e)),
                 };
-                let begin_expansion_result = evaluator.push(resolved_invocation);
-                if let Err(e) = begin_expansion_result {
-                    return Some(Err(e));
-                }
+                evaluator.push(try_or_some_err!(resolved_invocation.expand()));
                 continue;
             }
             Some(Err(e)) => return Some(Err(e)),

--- a/src/lazy/expanded/struct.rs
+++ b/src/lazy/expanded/struct.rs
@@ -457,9 +457,13 @@ impl<'top, D: Decoder> ExpandedStructIterator<'top, D> {
                     match evaluator.next() {
                         Err(e) => return Some(Err(e)),
                         Ok(Some(next_value)) => {
+                            let field_name = *field_name;
+                            if evaluator.is_empty() {
+                                *state = ReadingFieldFromSource;
+                            }
                             // We got another value from the macro we're evaluating. Emit
                             // it as another field using the same field_name.
-                            return Some(Ok(LazyExpandedField::new(*field_name, next_value)));
+                            return Some(Ok(LazyExpandedField::new(field_name, next_value)));
                         }
                         Ok(None) => {
                             // The macro in the value position is no longer emitting values. Switch

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -105,6 +105,7 @@ impl MacroSignature {
         Ok(self)
     }
 
+    /// Constructs a new instance of a signature with no arguments (the signature of a "constant" template).
     fn constant() -> Self {
         Self::new(Vec::new()).unwrap()
     }
@@ -164,8 +165,8 @@ mod macro_signature_tests {
 
         let signature = MacroSignature::new(Vec::new())?
             .with_parameter("foo", ParameterEncoding::Tagged, ParameterCardinality::ZeroOrOne)?
-            .with_parameter("bar", ParameterEncoding::Tagged, ParameterCardinality::ZeroOrOne)?
-            .with_parameter("baz", ParameterEncoding::Tagged, ParameterCardinality::ZeroOrOne)?;
+            .with_parameter("bar", ParameterEncoding::Tagged, ParameterCardinality::ZeroOrMore)?
+            .with_parameter("baz", ParameterEncoding::Tagged, ParameterCardinality::OneOrMore)?;
         assert_eq!(signature.num_variadic_params(), 3);
         assert_eq!(signature.bitmap_size_in_bytes(), 1);
 
@@ -821,7 +822,6 @@ impl<'top> Debug for TemplateMacroInvocation<'top> {
 impl<'top> TemplateMacroInvocation<'top> {
     pub fn new(
         context: EncodingContextRef<'top>,
-        // host_template_address: TemplateMacroRef<'top>,
         host_template_address: MacroAddress,
         invoked_macro: MacroRef<'top>,
         arg_expressions_range: ExprRange,

--- a/src/lazy/raw_stream_item.rs
+++ b/src/lazy/raw_stream_item.rs
@@ -16,7 +16,7 @@ pub enum RawStreamItem<M: Debug, V: Debug, E: Debug> {
     /// for [`LazyRawBinaryValue`](crate::lazy::binary::raw::value::LazyRawBinaryValue_1_0).
     Value(V),
     /// An Ion 1.1+ macro invocation. Ion 1.0 readers will never return a macro invocation.
-    EExpression(E),
+    EExp(E),
     /// The end of the stream
     EndOfStream(EndPosition),
 }
@@ -32,7 +32,7 @@ impl<'top> LazyRawStreamItem<'top, AnyEncoding> {
         match self {
             LazyRawStreamItem::<AnyEncoding>::VersionMarker(m) => m.encoding(),
             LazyRawStreamItem::<AnyEncoding>::Value(v) => v.encoding(),
-            LazyRawStreamItem::<AnyEncoding>::EExpression(e) => e.encoding(),
+            LazyRawStreamItem::<AnyEncoding>::EExp(e) => e.encoding(),
             LazyRawStreamItem::<AnyEncoding>::EndOfStream(eos) => eos.encoding(),
         }
     }
@@ -46,7 +46,7 @@ impl<M: Debug + HasRange, V: Debug + HasRange, E: Debug + HasRange> HasRange
         match self {
             VersionMarker(marker) => marker.range(),
             Value(value) => value.range(),
-            EExpression(eexp) => eexp.range(),
+            EExp(eexp) => eexp.range(),
             EndOfStream(eos) => eos.range(),
         }
     }
@@ -60,7 +60,7 @@ impl<'top, M: Debug + HasSpan<'top>, V: Debug + HasSpan<'top>, E: Debug + HasSpa
         match self {
             VersionMarker(marker) => marker.span(),
             Value(value) => value.span(),
-            EExpression(eexp) => eexp.span(),
+            EExp(eexp) => eexp.span(),
             EndOfStream(eos) => eos.span(),
         }
     }
@@ -104,15 +104,15 @@ impl<M: Copy + Debug, V: Copy + Debug, E: Copy + Debug> RawStreamItem<M, V, E> {
     }
 
     pub fn as_macro_invocation(&self) -> Option<&E> {
-        if let Self::EExpression(m) = self {
+        if let Self::EExp(m) = self {
             Some(m)
         } else {
             None
         }
     }
 
-    pub fn expect_macro_invocation(self) -> IonResult<E> {
-        if let Self::EExpression(m) = self {
+    pub fn expect_eexp(self) -> IonResult<E> {
+        if let Self::EExp(m) = self {
             Ok(m)
         } else {
             IonResult::decoding_error(format!("expected a macro invocation, found {:?}", self))

--- a/src/lazy/str_ref.rs
+++ b/src/lazy/str_ref.rs
@@ -20,7 +20,7 @@ impl<'data> StrRef<'data> {
         Str::from(self)
     }
 
-    pub fn text(&self) -> &str {
+    pub fn text(&self) -> &'data str {
         self.text
     }
 }

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -1,16 +1,22 @@
 #![allow(non_camel_case_types)]
 
-use crate::lazy::any_encoding::IonEncoding;
+use crate::lazy::any_encoding::{IonEncoding, IonVersion};
 use crate::lazy::decoder::Decoder;
-use crate::lazy::expanded::{ExpandedValueRef, ExpandingReader, LazyExpandedValue};
+use crate::lazy::expanded::compiler::TemplateCompiler;
+use crate::lazy::expanded::encoding_module::EncodingModule;
+use crate::lazy::expanded::macro_table::MacroTable;
+use crate::lazy::expanded::template::TemplateMacro;
+use crate::lazy::expanded::{ExpandingReader, LazyExpandedValue};
+use crate::lazy::sequence::SExpIterator;
 use crate::lazy::streaming_raw_reader::{IonInput, StreamingRawReader};
 use crate::lazy::system_stream_item::SystemStreamItem;
+use crate::lazy::text::raw::v1_1::reader::MacroAddress;
 use crate::lazy::value::LazyValue;
 use crate::read_config::ReadConfig;
 use crate::result::IonFailure;
 use crate::{
-    AnyEncoding, Catalog, Int, IonError, IonResult, IonType, LazyExpandedField, RawSymbolRef,
-    Symbol, SymbolTable,
+    AnyEncoding, Catalog, Int, IonError, IonResult, IonType, LazyField, LazySExp, LazyStruct,
+    RawSymbolRef, Symbol, SymbolTable, ValueRef,
 };
 use std::ops::Deref;
 use std::sync::Arc;
@@ -29,11 +35,11 @@ const SYMBOLS: RawSymbolRef = RawSymbolRef::SymbolId(7);
 ///
 /// Each time [`SystemReader::next_item`] is called, the reader will advance to the next top-level
 /// value in the input stream. Once positioned on a top-level value, users may visit nested values by
-/// calling [`LazyValue::read`] and working with the resulting [`crate::lazy::value_ref::ValueRef`],
+/// calling [`LazyValue::read`] and working with the resulting [`ValueRef`],
 /// which may contain either a scalar value or a lazy container that may itself be traversed.
 ///
 /// The values that the reader yields ([`LazyValue`],
-/// [`LazyList`](crate::LazyList), [`LazySExp`](crate::LazySExp) and [`LazyStruct`](crate::LazyStruct)), are immutable references to the data stream,
+/// [`LazyList`](crate::LazyList), [`LazySExp`] and [`LazyStruct`]), are immutable references to the data stream,
 /// and remain valid until [`SystemReader::next_item`] is called again to advance the reader to
 /// the next top level value. This means that these references can be stored, read, and re-read as
 /// long as the reader remains on the same top-level value.
@@ -81,20 +87,26 @@ pub struct SystemReader<Encoding: Decoder, Input: IonInput> {
 // If the reader encounters a symbol table in the stream, it will store all of the symbols that
 // the table defines in this structure so that they may be applied when the reader next advances.
 #[derive(Default)]
-pub struct PendingLst {
+pub struct PendingContextChanges {
+    pub(crate) switch_to_version: Option<IonVersion>,
     pub(crate) has_changes: bool,
     pub(crate) is_lst_append: bool,
-    pub(crate) symbols: Vec<Symbol>,
     pub(crate) imported_symbols: Vec<Symbol>,
+    pub(crate) symbols: Vec<Symbol>,
+    // A new encoding modules defined in the current encoding directive.
+    // TODO: Support for defining several modules
+    pub(crate) new_active_module: Option<EncodingModule>,
 }
 
-impl PendingLst {
+impl PendingContextChanges {
     pub fn new() -> Self {
         Self {
+            switch_to_version: None,
             has_changes: false,
             is_lst_append: false,
             symbols: Vec::new(),
             imported_symbols: Vec::new(),
+            new_active_module: None,
         }
     }
     pub fn local_symbols(&self) -> &[Symbol] {
@@ -102,6 +114,17 @@ impl PendingLst {
     }
     pub fn imported_symbols(&self) -> &[Symbol] {
         &self.imported_symbols
+    }
+    pub fn has_changes(&self) -> bool {
+        self.has_changes
+    }
+    pub fn new_active_module(&self) -> Option<&EncodingModule> {
+        self.new_active_module.as_ref()
+    }
+    /// If there's a new module defined, returns `Some(new_module)` and sets `self.new_module`
+    /// to `None`. If there is no new module defined, returns `None`.
+    pub(crate) fn take_new_active_module(&mut self) -> Option<EncodingModule> {
+        self.new_active_module.take()
     }
 }
 
@@ -116,26 +139,60 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
         SystemReader { expanding_reader }
     }
 
-    // Returns `true` if the provided [`LazyRawValue`] is a struct whose first annotation is
-    // `$ion_symbol_table`.
+    pub fn register_template_src(&mut self, template_definition: &str) -> IonResult<MacroAddress> {
+        self.expanding_reader
+            .register_template_src(template_definition)
+    }
+
+    pub fn register_template(&mut self, template_macro: TemplateMacro) -> IonResult<MacroAddress> {
+        self.expanding_reader.register_template(template_macro)
+    }
+
+    /// Returns `true` if the provided `LazyRawValue` is a struct whose first annotation is
+    /// `$ion_symbol_table`. Caller is responsible for confirming the struct appeared at the top
+    /// level.
     pub(crate) fn is_symbol_table_struct(
-        lazy_value: &'_ LazyExpandedValue<'_, Encoding>,
+        expanded_value: &'_ LazyExpandedValue<'_, Encoding>,
     ) -> IonResult<bool> {
-        if lazy_value.ion_type() != IonType::Struct {
+        if expanded_value.ion_type() != IonType::Struct || !expanded_value.has_annotations() {
             return Ok(false);
         }
+        let lazy_value = LazyValue::new(*expanded_value);
         if let Some(symbol_ref) = lazy_value.annotations().next() {
-            return Ok(symbol_ref?.matches_sid_or_text(3, "$ion_symbol_table"));
+            return Ok(symbol_ref? == "$ion_symbol_table");
         };
         Ok(false)
+    }
+
+    /// Returns `true` if the provided `LazyRawValue` is an s-expression whose first annotation
+    /// is `$ion_encoding`. Caller is responsible for confirming the sexp appeared at the top
+    /// level AND that this stream is encoded using Ion 1.1.
+    pub(crate) fn is_encoding_directive_sexp(
+        lazy_value: &'_ LazyExpandedValue<'_, Encoding>,
+    ) -> IonResult<bool> {
+        if lazy_value.ion_type() != IonType::SExp {
+            return Ok(false);
+        }
+        if !lazy_value.has_annotations() {
+            return Ok(false);
+        }
+        // At this point, we've confirmed it's an annotated s-expression. We need to see if its
+        // first annotation has the text `$ion_encoding`, which may involve a lookup in the
+        // encoding context. We'll promote this LazyExpandedValue to a LazyValue to enable that.
+        let lazy_value = LazyValue::new(*lazy_value);
+        let first_annotation = lazy_value
+            .annotations()
+            .next()
+            .expect("already confirmed that there are annotations")?;
+        Ok(first_annotation.text() == Some("$ion_encoding"))
     }
 
     pub fn symbol_table(&self) -> &SymbolTable {
         self.expanding_reader.context().symbol_table()
     }
 
-    pub fn pending_symtab_changes(&self) -> &PendingLst {
-        self.expanding_reader.pending_lst()
+    pub fn pending_context_changes(&self) -> &PendingContextChanges {
+        self.expanding_reader.pending_context_changes()
     }
 
     /// Returns the next top-level stream item (IVM, Symbol Table, Value, or Nothing) as a
@@ -158,10 +215,205 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
         })
     }
 
+    pub(crate) fn process_encoding_directive(
+        pending_changes: &mut PendingContextChanges,
+        directive: LazyExpandedValue<'_, Encoding>,
+    ) -> IonResult<()> {
+        // We've already confirmed this is an annotated sexp
+        let directive = directive.read()?.expect_sexp()?;
+        for step in directive.iter() {
+            Self::process_encoding_directive_operation(pending_changes, step?)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn process_encoding_directive_operation(
+        pending_changes: &mut PendingContextChanges,
+        value: LazyExpandedValue<Encoding>,
+    ) -> IonResult<()> {
+        let operation_sexp = LazyValue::new(value).read()?.expect_sexp().map_err(|_| {
+            IonError::decoding_error(format!(
+                "found an encoding directive step that was not an s-expression: {value:?}"
+            ))
+        })?;
+
+        let mut values = operation_sexp.iter();
+        let first_value =
+            Self::expect_next_sexp_value("encoding directive operation name", &mut values)?;
+        let step_name_text =
+            Self::expect_symbol_text("encoding directive operation name", first_value)?;
+
+        match step_name_text {
+            "module" => todo!("defining a new named module"),
+            "symbol_table" => {
+                let symbol_table = Self::process_symbol_table_definition(operation_sexp)?;
+                let new_encoding_module = match pending_changes.take_new_active_module() {
+                    None => EncodingModule::new(
+                        "$ion_encoding".to_owned(),
+                        MacroTable::new(),
+                        symbol_table,
+                    ),
+                    Some(mut module) => {
+                        module.set_symbol_table(symbol_table);
+                        module
+                    }
+                };
+                pending_changes.new_active_module = Some(new_encoding_module);
+            }
+            "macro_table" => {
+                let macro_table = Self::process_macro_table_definition(operation_sexp)?;
+                let new_encoding_module = match pending_changes.take_new_active_module() {
+                    None => EncodingModule::new(
+                        "$ion_encoding".to_owned(),
+                        macro_table,
+                        SymbolTable::new(IonVersion::v1_1),
+                    ),
+                    Some(mut module) => {
+                        module.set_macro_table(macro_table);
+                        module
+                    }
+                };
+                pending_changes.new_active_module = Some(new_encoding_module);
+            }
+            _ => {
+                return IonResult::decoding_error(format!(
+                    "unsupported encoding directive step '{step_name_text}'"
+                ))
+            }
+        }
+        Ok(())
+    }
+
+    fn process_module_definition(
+        _pending_changes: &mut PendingContextChanges,
+        module: LazySExp<Encoding>,
+    ) -> IonResult<()> {
+        let mut args = module.iter();
+        // We've already looked at and validated the `name` to get to this point. We can skip it.
+        let _operation = args.next(); // 'module'
+        let module_name = Self::expect_next_sexp_value("a module name", &mut args)?;
+        let module_name_text = Self::expect_symbol_text("a module name", module_name)?;
+        let symbol_table_value =
+            Self::expect_next_sexp_value("a `symbol_table` operation", &mut args)?;
+        let symbol_table_operation =
+            Self::expect_sexp("a `symbol_table` operation", symbol_table_value)?;
+        let macro_table_value =
+            Self::expect_next_sexp_value("a `macro_table` operation", &mut args)?;
+        let macro_table_operation =
+            Self::expect_sexp("a `macro_table` operation", macro_table_value)?;
+
+        let symbol_table = Self::process_symbol_table_definition(symbol_table_operation)?;
+        let macro_table = Self::process_macro_table_definition(macro_table_operation)?;
+
+        // TODO: Register the new module in `pending_changes`.
+        let _encoding_module =
+            EncodingModule::new(module_name_text.to_owned(), macro_table, symbol_table);
+
+        Ok(())
+    }
+
+    fn process_symbol_table_definition(operation: LazySExp<Encoding>) -> IonResult<SymbolTable> {
+        let mut args = operation.iter();
+        let operation_name_value =
+            Self::expect_next_sexp_value("a `symbol_table` operation name", &mut args)?;
+        let operation_name =
+            Self::expect_symbol_text("the operation name `symbol_table`", operation_name_value)?;
+        if operation_name != "symbol_table" {
+            return IonResult::decoding_error(format!(
+                "expected a symbol table definition operation, but found: {operation:?}"
+            ));
+        }
+        let mut symbol_table = SymbolTable::new(IonVersion::v1_1);
+        for arg in args {
+            let symbol_list = arg?.read()?.expect_list()?;
+            for value in symbol_list {
+                match value?.read()? {
+                    ValueRef::String(s) => symbol_table.add_symbol_for_text(s.text()),
+                    ValueRef::Symbol(s) => symbol_table.add_symbol(s.to_owned()),
+                    other => {
+                        return IonResult::decoding_error(format!(
+                            "found a non-text value in symbols list: {other:?}"
+                        ))
+                    }
+                };
+            }
+        }
+        Ok(symbol_table)
+    }
+
+    fn process_macro_table_definition(operation: LazySExp<Encoding>) -> IonResult<MacroTable> {
+        let mut args = operation.iter();
+        let operation_name_value =
+            Self::expect_next_sexp_value("a `macro_table` operation name", &mut args)?;
+        let operation_name =
+            Self::expect_symbol_text("the operation name `macro_table`", operation_name_value)?;
+        if operation_name != "macro_table" {
+            return IonResult::decoding_error(format!(
+                "expected a macro table definition operation, but found: {operation:?}"
+            ));
+        }
+        let mut macro_table = MacroTable::new();
+        for arg in args {
+            let arg = arg?;
+            let context = operation.expanded_sexp.context;
+            let macro_def_sexp = arg.read()?.expect_sexp().map_err(|_| {
+                IonError::decoding_error(format!(
+                    "macro_table had a non-sexp parameter: {}",
+                    arg.ion_type()
+                ))
+            })?;
+            let new_macro = TemplateCompiler::compile_from_sexp(context, macro_def_sexp)?;
+            macro_table.add_macro(new_macro)?;
+        }
+        Ok(macro_table)
+    }
+
+    fn expect_next_sexp_value<'a>(
+        label: &str,
+        iter: &mut SExpIterator<'a, Encoding>,
+    ) -> IonResult<LazyValue<'a, Encoding>> {
+        iter.next().transpose()?.ok_or_else(|| {
+            IonError::decoding_error(format!(
+                "expected {label} but found no more values in the s-expression"
+            ))
+        })
+    }
+
+    fn expect_sexp<'a>(
+        label: &str,
+        value: LazyValue<'a, Encoding>,
+    ) -> IonResult<LazySExp<'a, Encoding>> {
+        value.read()?.expect_sexp().map_err(|_| {
+            IonError::decoding_error(format!(
+                "expected an s-expression representing {label} but found a {}",
+                value.ion_type()
+            ))
+        })
+    }
+
+    fn expect_symbol_text<'a>(
+        label: &str,
+        lazy_value: LazyValue<'a, Encoding>,
+    ) -> IonResult<&'a str> {
+        lazy_value
+            .read()?
+            .expect_symbol()
+            .map_err(|_| {
+                IonError::decoding_error(format!(
+                    "found {label} with non-symbol type: {}",
+                    lazy_value.ion_type()
+                ))
+            })?
+            .text()
+            .ok_or_else(|| {
+                IonError::decoding_error(format!("found {label} that had undefined text ($0)"))
+            })
+    }
+
     // Traverses a symbol table, processing the `symbols` and `imports` fields as needed to
     // populate the `PendingLst`.
     pub(crate) fn process_symbol_table(
-        pending_lst: &mut PendingLst,
+        pending_lst: &mut PendingContextChanges,
         catalog: &dyn Catalog,
         symbol_table: &LazyExpandedValue<'_, Encoding>,
     ) -> IonResult<()> {
@@ -170,28 +422,41 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
 
         // We're interested in the `imports` field and the `symbols` field. Both are optional;
         // however, it is illegal to specify either field more than once.
-        let mut imports_field: Option<LazyExpandedField<Encoding>> = None;
-        let mut symbols_field: Option<LazyExpandedField<Encoding>> = None;
+        let mut imports_field: Option<LazyField<Encoding>> = None;
+        let mut symbols_field: Option<LazyField<Encoding>> = None;
+
+        let symbol_table = LazyStruct {
+            expanded_struct: symbol_table,
+        };
 
         // Iterate through the fields of the symbol table struct, taking note of `imports` and `symbols`
         // if we encounter them.
         for field_result in symbol_table.iter() {
             let field = field_result?;
-            if field.name().read_raw()?.matches_sid_or_text(6, "imports") {
-                if imports_field.is_some() {
-                    return IonResult::decoding_error(
-                        "found symbol table with multiple 'imports' fields",
-                    );
+            let Some(name) = field.name()?.text() else {
+                // If the field is $0, we don't care about it.
+                continue;
+            };
+            match name {
+                "imports" => {
+                    if imports_field.is_some() {
+                        return IonResult::decoding_error(
+                            "found symbol table with multiple 'imports' fields",
+                        );
+                    }
+                    imports_field = Some(field);
                 }
-                imports_field = Some(field);
-            } else if field.name().read_raw()?.matches_sid_or_text(7, "symbols") {
-                if symbols_field.is_some() {
-                    return IonResult::decoding_error(
-                        "found symbol table with multiple 'symbols' fields",
-                    );
+                "symbols" => {
+                    if symbols_field.is_some() {
+                        return IonResult::decoding_error(
+                            "found symbol table with multiple 'symbols' fields",
+                        );
+                    }
+                    symbols_field = Some(field);
                 }
-                symbols_field = Some(field);
-            }
+                // Other fields are ignored
+                _ => {}
+            };
         }
 
         if let Some(imports_field) = imports_field {
@@ -207,13 +472,12 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
     }
 
     fn clear_pending_lst_if_needed(
-        pending_lst: &mut PendingLst,
-        imports_value: LazyExpandedValue<'_, Encoding>,
+        pending_lst: &mut PendingContextChanges,
+        imports_value: LazyValue<'_, Encoding>,
     ) -> IonResult<()> {
         match imports_value.read()? {
             // If this is an LST append, there's nothing to do.
-            ExpandedValueRef::Symbol(raw_symbol)
-                if raw_symbol.matches_sid_or_text(3, "$ion_symbol_table") => {}
+            ValueRef::Symbol(symbol) if symbol == "$ion_symbol_table" => {}
             // If this is NOT an LST append, it will eventually cause the SymbolTable to reset.
             // However, at this point in the processing the PendingLst may have symbols that have
             // not yet made it to the SymbolTable. This can happen when a single top-level e-expression
@@ -240,12 +504,12 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
 
     // Store any strings defined in the `symbols` field in the `PendingLst` for future application.
     fn process_symbols(
-        pending_lst: &mut PendingLst,
-        symbols: LazyExpandedValue<'_, Encoding>,
+        pending_lst: &mut PendingContextChanges,
+        symbols: LazyValue<'_, Encoding>,
     ) -> IonResult<()> {
-        if let ExpandedValueRef::List(list) = symbols.read()? {
+        if let ValueRef::List(list) = symbols.read()? {
             for symbol_text_result in list.iter() {
-                if let ExpandedValueRef::String(str_ref) = symbol_text_result?.read()? {
+                if let ValueRef::String(str_ref) = symbol_text_result?.read()? {
                     pending_lst
                         .symbols
                         .push(Symbol::shared(Arc::from(str_ref.deref())))
@@ -263,31 +527,29 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
 
     // Check for `imports: $ion_symbol_table`.
     fn process_imports(
-        pending_lst: &mut PendingLst,
+        pending_lst: &mut PendingContextChanges,
         catalog: &dyn Catalog,
-        imports: LazyExpandedValue<'_, Encoding>,
+        imports: LazyValue<'_, Encoding>,
     ) -> IonResult<()> {
         match imports.read()? {
-            ExpandedValueRef::Symbol(symbol_ref) => {
-                if symbol_ref.matches_sid_or_text(3, "$ion_symbol_table") {
-                    pending_lst.is_lst_append = true;
-                }
-                // Any other symbol is ignored
+            // Any symbol other than `$ion_symbol_table` is ignored.
+            ValueRef::Symbol(symbol_ref) if symbol_ref == "$ion_symbol_table" => {
+                pending_lst.is_lst_append = true;
             }
-            ExpandedValueRef::List(list) => {
+            ValueRef::List(list) => {
                 for value in list.iter() {
-                    let ExpandedValueRef::Struct(import) = value?.read()? else {
+                    let ValueRef::Struct(import) = value?.read()? else {
                         // If there's a value in the imports list that isn't a struct, it's malformed.
                         // Ignore that value.
                         continue;
                     };
                     let name = match import.get("name")? {
                         // If `name` is missing, a non-string, or the empty string, ignore this import.
-                        Some(ExpandedValueRef::String(s)) if !s.is_empty() => s,
+                        Some(ValueRef::String(s)) if !s.is_empty() => s,
                         _ => continue,
                     };
                     let version: usize = match import.get("version")? {
-                        Some(ExpandedValueRef::Int(i)) if i > Int::ZERO => usize::try_from(i)
+                        Some(ValueRef::Int(i)) if i > Int::ZERO => usize::try_from(i)
                             .map_err(|_|
                             IonError::decoding_error(format!("found a symbol table import (name='{name}') with a version number too high to support: {i}")),
                         ),
@@ -304,12 +566,13 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
                     };
 
                     let max_id = match import.get("max_id")? {
-                        Some(ExpandedValueRef::Int(i)) if i >= Int::ZERO => usize::try_from(i)
-                            .map_err(|_| {
+                        Some(ValueRef::Int(i)) if i >= Int::ZERO => {
+                            usize::try_from(i).map_err(|_| {
                                 IonError::decoding_error(
                                     "found a `max_id` beyond the range of usize",
                                 )
-                            })?,
+                            })?
+                        }
                         // If the max_id is unspecified, negative, or an invalid data type, we'll import all of the symbols from the requested table.
                         _ => shared_table.symbols().len(),
                     };
@@ -350,7 +613,9 @@ mod tests {
     use crate::lazy::binary::test_utilities::to_binary_ion;
     use crate::lazy::decoder::RawVersionMarker;
     use crate::lazy::system_stream_item::SystemStreamItem;
-    use crate::{v1_0::Binary, AnyEncoding, Catalog, IonResult, SymbolRef};
+    use crate::{
+        v1_0, AnyEncoding, Catalog, IonResult, SequenceWriter, SymbolRef, ValueWriter, Writer,
+    };
 
     use super::*;
 
@@ -368,13 +633,16 @@ mod tests {
         hello
         "#,
         )?;
-        let mut system_reader = SystemReader::new(Binary, ion_data);
+        let mut system_reader = SystemReader::new(v1_0::Binary, ion_data);
         loop {
             match system_reader.next_item()? {
                 SystemStreamItem::VersionMarker(marker) => {
                     println!("ivm => v{}.{}", marker.major(), marker.minor())
                 }
                 SystemStreamItem::SymbolTable(ref s) => println!("symtab => {:?}", s),
+                SystemStreamItem::EncodingDirective(ref s) => {
+                    println!("encoding directive => {:?}", s)
+                }
                 SystemStreamItem::Value(ref v) => println!("value => {:?}", v.read()?),
                 SystemStreamItem::EndOfStream(_) => break,
             }
@@ -393,7 +661,7 @@ mod tests {
         )
         "#,
         )?;
-        let mut system_reader = SystemReader::new(Binary, ion_data);
+        let mut system_reader = SystemReader::new(v1_0::Binary, ion_data);
         loop {
             match system_reader.next_item()? {
                 SystemStreamItem::Value(value) => {
@@ -420,7 +688,7 @@ mod tests {
         }
         "#,
         )?;
-        let mut system_reader = SystemReader::new(Binary, ion_data);
+        let mut system_reader = SystemReader::new(v1_0::Binary, ion_data);
         loop {
             match system_reader.next_item()? {
                 SystemStreamItem::Value(value) => {
@@ -438,6 +706,8 @@ mod tests {
 
     // === Shared Symbol Tables ===
 
+    use crate::lazy::encoder::binary::v1_1::writer::LazyRawBinaryWriter_1_1;
+    use crate::lazy::encoder::value_writer::AnnotatableWriter;
     use crate::{MapCatalog, SharedSymbolTable};
 
     fn system_reader_for<I: IonInput>(ion: I) -> SystemReader<AnyEncoding, I> {
@@ -521,7 +791,7 @@ mod tests {
         // The reader has analyzed the symtab struct and identified what symbols will be added when
         // it advances beyond it.
         assert_eq!(
-            reader.pending_symtab_changes().local_symbols()[0].text(),
+            reader.pending_context_changes().local_symbols()[0].text(),
             Some("potato salad")
         );
 
@@ -531,11 +801,11 @@ mod tests {
         assert_eq!(reader.symbol_table().text_for(10), Some("potato salad"));
         // We can peak at the symbols that will be added by the second LST before they are applied.
         assert_eq!(
-            reader.pending_symtab_changes().imported_symbols(),
+            reader.pending_context_changes().imported_symbols(),
             &[Symbol::from("foo"), Symbol::from("bar")]
         );
         assert_eq!(
-            reader.pending_symtab_changes().local_symbols(),
+            reader.pending_context_changes().local_symbols(),
             &[Symbol::from("local_symbol")]
         );
         // Now we advance to the application data, confirming that the symbol IDs align with the
@@ -579,9 +849,9 @@ mod tests {
             .as_slice(),
             map_catalog,
         );
-        assert_eq!(reader.next_item()?.expect_ivm()?.version(), (1, 0));
+        assert_eq!(reader.next_item()?.expect_ivm()?.major_minor(), (1, 0));
         let _symtab = reader.next_item()?.expect_symbol_table()?;
-        let pending_imported_symbols = reader.pending_symtab_changes().imported_symbols();
+        let pending_imported_symbols = reader.pending_context_changes().imported_symbols();
         // This symbol table imports the symbols 'name' and 'foo'.
         assert_eq!(pending_imported_symbols[0].text(), Some("name"));
         assert_eq!(pending_imported_symbols[1].text(), Some("foo"));
@@ -691,6 +961,143 @@ mod tests {
         assert_eq!(reader.expect_next_value()?.read()?.expect_symbol()?, "foo");
         assert_eq!(reader.expect_next_value()?.read()?.expect_symbol()?, "bar");
         assert_eq!(reader.expect_next_value()?.read()?.expect_symbol()?, "quuz");
+        Ok(())
+    }
+
+    #[test]
+    fn detect_encoding_directive_text() -> IonResult<()> {
+        let text = r#"
+            $ion_1_1
+            $ion_encoding::((symbol_table ["foo", "bar", "baz"]))
+        "#;
+
+        let mut reader = SystemReader::new(AnyEncoding, text);
+        assert_eq!(reader.next_item()?.expect_ivm()?.major_minor(), (1, 1));
+        reader.next_item()?.expect_encoding_directive()?;
+        Ok(())
+    }
+
+    #[test]
+    fn detect_encoding_directive_binary() -> IonResult<()> {
+        let mut writer = LazyRawBinaryWriter_1_1::new(Vec::new())?;
+        let mut directive = writer
+            .value_writer()
+            .with_annotations("$ion_encoding")?
+            .sexp_writer()?;
+        let mut symbol_table = directive.sexp_writer()?;
+        symbol_table.write_symbol("symbol_table")?;
+        symbol_table.write_list(["foo", "bar", "baz"])?;
+        symbol_table.close()?;
+        directive.close()?;
+        let binary_ion = writer.close()?;
+
+        let mut reader = SystemReader::new(AnyEncoding, binary_ion);
+        assert_eq!(reader.next_item()?.expect_ivm()?.major_minor(), (1, 1));
+        reader.next_item()?.expect_encoding_directive()?;
+        Ok(())
+    }
+
+    #[test]
+    fn ignore_encoding_directive_text_1_0() -> IonResult<()> {
+        let text = r#"
+            $ion_1_0
+            // In Ion 1.0, this is just an annotated s-expression.
+            $ion_encoding::((symbol_table ["foo", "bar", "baz"]))
+        "#;
+
+        let mut reader = SystemReader::new(AnyEncoding, text);
+        assert_eq!(reader.next_item()?.expect_ivm()?.major_minor(), (1, 0));
+        let sexp = reader.next_item()?.expect_value()?.read()?.expect_sexp()?;
+        assert!(sexp.annotations().are(["$ion_encoding"])?);
+        Ok(())
+    }
+
+    #[test]
+    fn ignore_encoding_directive_binary_1_0() -> IonResult<()> {
+        let mut writer = Writer::new(v1_0::Binary, Vec::new())?;
+        let mut directive = writer
+            .value_writer()
+            .with_annotations("$ion_encoding")?
+            .sexp_writer()?;
+        let mut symbol_table = directive.sexp_writer()?;
+        symbol_table.write_symbol("symbol_table")?;
+        symbol_table.write_list(["foo", "bar", "baz"])?;
+        symbol_table.close()?;
+        directive.close()?;
+        let bytes = writer.close()?;
+
+        let mut reader = SystemReader::new(AnyEncoding, bytes);
+        assert_eq!(reader.next_item()?.expect_ivm()?.major_minor(), (1, 0));
+        let _ = reader.next_item()?.expect_symbol_table()?;
+        let sexp = reader.next_item()?.expect_value()?.read()?.expect_sexp()?;
+        assert!(sexp.annotations().are(["$ion_encoding"])?);
+        Ok(())
+    }
+
+    #[test]
+    fn read_encoding_directive_new_active_module() -> IonResult<()> {
+        let ion = r#"
+            $ion_1_1
+            $ion_encoding::(
+                (symbol_table ["foo", "bar", "baz"])
+                (macro_table
+                    (macro seventeen () 17)
+                    (macro twelve () 12)))
+            (:seventeen)
+            (:twelve)
+        "#;
+        let mut reader = SystemReader::new(AnyEncoding, ion);
+        // Before reading any data, the reader defaults to expecting the Text v1.0 encoding,
+        // the only encoding that doesn't have to start with an IVM.
+        assert_eq!(reader.detected_encoding(), IonEncoding::Text_1_0);
+
+        // The first thing the reader encounters is an IVM. Verify that all of its accessors report
+        // the expected values.
+        let ivm = reader.next_item()?.expect_ivm()?;
+        assert_eq!(ivm.major_minor(), (1, 1));
+        assert_eq!(ivm.old_encoding(), IonEncoding::Text_1_0);
+        assert_eq!(ivm.new_encoding()?, IonEncoding::Text_1_1);
+        assert!(ivm.is_text());
+        assert!(!ivm.is_binary());
+
+        // After encountering the IVM, the reader will have changed its detected encoding to Text v1.1.
+        assert_eq!(reader.detected_encoding(), IonEncoding::Text_1_1);
+
+        // The next stream item is an encoding directive that defines some symbols and some macros.
+        let _directive = reader.next_item()?.expect_encoding_directive()?;
+
+        // === Make sure it has the expected symbol definitions ===
+        let pending_changes = reader
+            .pending_context_changes()
+            .new_active_module()
+            .expect("this directive defines a new active module");
+        let new_symbol_table = pending_changes.symbol_table();
+        assert_eq!(
+            new_symbol_table.symbols_tail(3),
+            &[
+                Symbol::from("foo"),
+                Symbol::from("bar"),
+                Symbol::from("baz")
+            ]
+        );
+
+        // === Make sure it has the expected macro definitions ====
+        let new_macro_table = pending_changes.macro_table();
+        // There are currently 3 supported system macros: void, values, and make_string.
+        // This directive defines two more.
+        assert_eq!(new_macro_table.len(), 2 + MacroTable::NUM_SYSTEM_MACROS);
+        assert_eq!(
+            new_macro_table.macro_with_id(3),
+            new_macro_table.macro_with_name("seventeen")
+        );
+        assert_eq!(
+            new_macro_table.macro_with_id(4),
+            new_macro_table.macro_with_name("twelve")
+        );
+
+        // Expand the e-expressions to make sure the macro definitions work as expected.
+        assert_eq!(reader.expect_next_value()?.read()?.expect_i64()?, 17);
+        assert_eq!(reader.expect_next_value()?.read()?.expect_i64()?, 12);
         Ok(())
     }
 }

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -1055,8 +1055,8 @@ mod tests {
         // the expected values.
         let ivm = reader.next_item()?.expect_ivm()?;
         assert_eq!(ivm.major_minor(), (1, 1));
-        assert_eq!(ivm.old_encoding(), IonEncoding::Text_1_0);
-        assert_eq!(ivm.new_encoding()?, IonEncoding::Text_1_1);
+        assert_eq!(ivm.stream_encoding_before_marker(), IonEncoding::Text_1_0);
+        assert_eq!(ivm.stream_encoding_after_marker()?, IonEncoding::Text_1_1);
         assert!(ivm.is_text());
         assert!(!ivm.is_binary());
 

--- a/src/lazy/system_stream_item.rs
+++ b/src/lazy/system_stream_item.rs
@@ -1,12 +1,11 @@
 use std::fmt::{Debug, Formatter};
 
 use crate::lazy::decoder::{Decoder, RawVersionMarker};
-use crate::lazy::expanded::ExpandedValueSource;
 use crate::lazy::r#struct::LazyStruct;
 use crate::lazy::raw_stream_item::{EndPosition, LazyRawStreamItem, RawStreamItem};
 use crate::lazy::value::LazyValue;
 use crate::result::IonFailure;
-use crate::{IonError, IonResult};
+use crate::{IonError, IonResult, LazySExp};
 
 /// System stream elements that a SystemReader may encounter.
 #[non_exhaustive]
@@ -14,8 +13,10 @@ pub enum SystemStreamItem<'top, D: Decoder> {
     /// An Ion Version Marker (IVM) indicating the Ion major and minor version that were used to
     /// encode the values that follow.
     VersionMarker(D::VersionMarker<'top>),
-    /// An Ion symbol table encoded as a struct annotated with `$ion_symbol_table`.
+    /// An Ion 1.0-style symbol table encoded as a struct annotated with `$ion_symbol_table`.
     SymbolTable(LazyStruct<'top, D>),
+    /// An Ion 1.1 encoding directive; an s-expression annotated with `$ion_encoding`.
+    EncodingDirective(LazySExp<'top, D>),
     /// An application-level Ion value
     Value(LazyValue<'top, D>),
     /// The end of the stream
@@ -29,6 +30,7 @@ impl<'top, D: Decoder> Debug for SystemStreamItem<'top, D> {
                 write!(f, "version marker v{}.{}", marker.major(), marker.minor())
             }
             SystemStreamItem::SymbolTable(_) => write!(f, "a symbol table"),
+            SystemStreamItem::EncodingDirective(_) => write!(f, "an encoding directive"),
             SystemStreamItem::Value(value) => write!(f, "{}", value.ion_type()),
             SystemStreamItem::EndOfStream(_) => write!(f, "<nothing>"),
         }
@@ -38,7 +40,7 @@ impl<'top, D: Decoder> Debug for SystemStreamItem<'top, D> {
 impl<'top, D: Decoder> SystemStreamItem<'top, D> {
     /// If this item is an Ion version marker (IVM), returns `Some(version_marker)` indicating the
     /// version. Otherwise, returns `None`.
-    pub fn version_marker(&self) -> Option<D::VersionMarker<'top>> {
+    pub fn as_version_marker(&self) -> Option<D::VersionMarker<'top>> {
         if let Self::VersionMarker(marker) = self {
             Some(*marker)
         } else {
@@ -46,16 +48,16 @@ impl<'top, D: Decoder> SystemStreamItem<'top, D> {
         }
     }
 
-    /// Like [`Self::version_marker`], but returns a [`crate::IonError::Decoding`] if this item
+    /// Like [`Self::as_version_marker`], but returns a [`crate::IonError::Decoding`] if this item
     /// is not an IVM.
     pub fn expect_ivm(self) -> IonResult<D::VersionMarker<'top>> {
-        self.version_marker()
+        self.as_version_marker()
             .ok_or_else(|| IonError::decoding_error(format!("expected IVM, found {:?}", self)))
     }
 
     /// If this item is a application-level value, returns `Some(&LazyValue)`. Otherwise,
     /// returns `None`.
-    pub fn value(&self) -> Option<LazyValue<'top, D>> {
+    pub fn as_value(&self) -> Option<LazyValue<'top, D>> {
         if let Self::Value(value) = self {
             Some(*value)
         } else {
@@ -63,7 +65,7 @@ impl<'top, D: Decoder> SystemStreamItem<'top, D> {
         }
     }
 
-    /// Like [`Self::value`], but returns a [`IonError::Decoding`] if this item is not
+    /// Like [`Self::as_value`], but returns a [`IonError::Decoding`] if this item is not
     /// an application-level value.
     pub fn expect_value(self) -> IonResult<LazyValue<'top, D>> {
         if let Self::Value(value) = self {
@@ -92,25 +94,35 @@ impl<'top, D: Decoder> SystemStreamItem<'top, D> {
         }
     }
 
+    /// If this item is a symbol table, returns `Some(lazy_struct)`. Otherwise, returns `None`.
+    pub fn as_encoding_directive(self) -> Option<LazySExp<'top, D>> {
+        if let Self::EncodingDirective(sexp) = self {
+            Some(sexp)
+        } else {
+            None
+        }
+    }
+
+    /// Like [`Self::as_symbol_table`], but returns a [`IonError::Decoding`] if this item is not
+    /// a symbol table.
+    pub fn expect_encoding_directive(self) -> IonResult<LazySExp<'top, D>> {
+        if let Self::EncodingDirective(sexp) = self {
+            Ok(sexp)
+        } else {
+            IonResult::decoding_error(format!("expected encoding directive, found {:?}", self))
+        }
+    }
+
     pub fn raw_stream_item(&self) -> Option<LazyRawStreamItem<'top, D>> {
-        let item = match self {
-            SystemStreamItem::VersionMarker(marker) => RawStreamItem::VersionMarker(*marker),
-            SystemStreamItem::SymbolTable(symtab) => {
-                use ExpandedValueSource::*;
-                match symtab.as_value().expanded().source {
-                    ValueLiteral(literal) => RawStreamItem::Value(literal),
-                    Template(..) | Constructed(..) => return None,
-                }
+        let value = match self {
+            SystemStreamItem::VersionMarker(marker) => {
+                return Some(RawStreamItem::VersionMarker(*marker))
             }
-            SystemStreamItem::Value(value) => {
-                use ExpandedValueSource::*;
-                match value.expanded().source {
-                    ValueLiteral(literal) => RawStreamItem::Value(literal),
-                    Template(..) | Constructed(..) => return None,
-                }
-            }
-            SystemStreamItem::EndOfStream(end) => RawStreamItem::EndOfStream(*end),
+            SystemStreamItem::SymbolTable(symtab) => symtab.as_value(),
+            SystemStreamItem::EncodingDirective(directive) => directive.as_value(),
+            SystemStreamItem::Value(value) => *value,
+            SystemStreamItem::EndOfStream(end) => return Some(RawStreamItem::EndOfStream(*end)),
         };
-        Some(item)
+        value.raw().map(RawStreamItem::Value)
     }
 }

--- a/src/lazy/system_stream_item.rs
+++ b/src/lazy/system_stream_item.rs
@@ -37,6 +37,9 @@ impl<'top, D: Decoder> Debug for SystemStreamItem<'top, D> {
     }
 }
 
+// Clippy complains that `as_` methods should return a reference. In this case, all of the types
+// are `Copy`, so returning a copy isn't a problem.
+#[allow(clippy::wrong_self_convention)]
 impl<'top, D: Decoder> SystemStreamItem<'top, D> {
     /// If this item is an Ion version marker (IVM), returns `Some(version_marker)` indicating the
     /// version. Otherwise, returns `None`.

--- a/src/lazy/text/buffer.rs
+++ b/src/lazy/text/buffer.rs
@@ -1073,7 +1073,6 @@ impl<'top> TextBufferView<'top> {
                 }
             };
         // For the matched span, we use `self` again to include the opening `(:` and whitespace.
-        // We also trim the
         let matched = self.slice(0, span.len());
         let remaining = self.slice_to_end(span.len());
         let arg_group = TextEExpArgGroup::new(parameter, matched, child_expr_cache);

--- a/src/lazy/text/raw/struct.rs
+++ b/src/lazy/text/raw/struct.rs
@@ -106,7 +106,7 @@ impl<'top> HasRange for LazyRawTextFieldName_1_0<'top> {
     }
 }
 
-impl<'top> LazyRawFieldName<'top> for LazyRawTextFieldName_1_0<'top> {
+impl<'top> LazyRawFieldName<'top, TextEncoding_1_0> for LazyRawTextFieldName_1_0<'top> {
     fn read(&self) -> IonResult<RawSymbolRef<'top>> {
         self.matched.read()
     }

--- a/src/lazy/text/raw/v1_1/arg_group.rs
+++ b/src/lazy/text/raw/v1_1/arg_group.rs
@@ -1,0 +1,184 @@
+use std::ops::Range;
+
+use crate::lazy::decoder::{LazyRawValueExpr, RawValueExpr};
+use crate::lazy::encoding::TextEncoding_1_1;
+use crate::lazy::expanded::e_expression::ArgGroup;
+use crate::lazy::expanded::macro_evaluator::{
+    EExpArgGroupIterator, EExpressionArgGroup, MacroExpr, RawEExpression, ValueExpr,
+};
+use crate::lazy::expanded::template::{Parameter, ParameterEncoding};
+use crate::lazy::expanded::EncodingContextRef;
+use crate::lazy::text::buffer::TextBufferView;
+use crate::result::IonFailure;
+use crate::{Decoder, HasRange, HasSpan, IonResult, LazyExpandedValue, Span};
+
+#[derive(Copy, Clone, Debug)]
+pub struct EExpArg<'top, D: Decoder> {
+    parameter: &'top Parameter,
+    expr: EExpArgExpr<'top, D>,
+}
+
+impl<'top, D: Decoder> EExpArg<'top, D> {
+    pub fn new(parameter: &'top Parameter, expr: EExpArgExpr<'top, D>) -> Self {
+        Self { parameter, expr }
+    }
+
+    pub fn encoding(&self) -> &'top Parameter {
+        self.parameter
+    }
+
+    pub fn expr(&self) -> &EExpArgExpr<'top, D> {
+        &self.expr
+    }
+
+    pub fn resolve(&self, context: EncodingContextRef<'top>) -> IonResult<ValueExpr<'top, D>> {
+        let value_expr = match self.expr {
+            EExpArgExpr::ValueLiteral(value) => {
+                ValueExpr::ValueLiteral(LazyExpandedValue::from_literal(context, value))
+            }
+            EExpArgExpr::EExp(eexp) => {
+                ValueExpr::MacroInvocation(MacroExpr::from_eexp(eexp.resolve(context)?))
+            }
+            EExpArgExpr::ArgGroup(group) => {
+                ValueExpr::MacroInvocation(MacroExpr::from_eexp_arg_group(group.resolve(context)))
+            }
+        };
+        Ok(value_expr)
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum EExpArgExpr<'top, D: Decoder> {
+    ValueLiteral(<D as Decoder>::Value<'top>),
+    EExp(<D as Decoder>::EExp<'top>),
+    ArgGroup(<<D as Decoder>::EExp<'top> as RawEExpression<'top, D>>::ArgGroup),
+}
+
+impl<'top, D: Decoder> EExpArgExpr<'top, D> {
+    pub fn expect_value(&self) -> IonResult<<D as Decoder>::Value<'top>> {
+        let EExpArgExpr::ValueLiteral(value) = self else {
+            return IonResult::decoding_error(format!("expected a value literal, found {self:?}"));
+        };
+        Ok(*value)
+    }
+
+    pub fn expect_eexp(&self) -> IonResult<<D as Decoder>::EExp<'top>> {
+        let EExpArgExpr::EExp(eexp) = self else {
+            return IonResult::decoding_error(format!("expected an e-expression, found {self:?}"));
+        };
+        Ok(*eexp)
+    }
+
+    pub fn expect_arg_group(
+        &self,
+    ) -> IonResult<<<D as Decoder>::EExp<'top> as RawEExpression<'top, D>>::ArgGroup> {
+        let EExpArgExpr::ArgGroup(group) = self else {
+            return IonResult::decoding_error(format!("expected an arg group, found {self:?}"));
+        };
+        Ok(*group)
+    }
+}
+
+impl<'top, D: Decoder> From<LazyRawValueExpr<'top, D>> for EExpArgExpr<'top, D> {
+    fn from(value: LazyRawValueExpr<'top, D>) -> Self {
+        match value {
+            RawValueExpr::ValueLiteral(v) => EExpArgExpr::ValueLiteral(v),
+            RawValueExpr::EExp(e) => EExpArgExpr::EExp(e),
+        }
+    }
+}
+
+impl<'top, D: Decoder> HasRange for EExpArgExpr<'top, D> {
+    fn range(&self) -> Range<usize> {
+        match self {
+            EExpArgExpr::ValueLiteral(v) => v.range(),
+            EExpArgExpr::EExp(e) => e.range(),
+            EExpArgExpr::ArgGroup(a) => a.range(),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct TextEExpArgGroup<'top> {
+    input: TextBufferView<'top>,
+    parameter: &'top Parameter,
+    // Notice that the expressions inside an arg group cannot themselves be arg groups,
+    // only value literals or e-expressions.
+    expr_cache: &'top [LazyRawValueExpr<'top, TextEncoding_1_1>],
+}
+
+impl<'top> TextEExpArgGroup<'top> {
+    pub fn new(
+        parameter: &'top Parameter,
+        input: TextBufferView<'top>,
+        child_expr_cache: &'top [LazyRawValueExpr<'top, TextEncoding_1_1>],
+    ) -> Self {
+        Self {
+            input,
+            parameter,
+            expr_cache: child_expr_cache,
+        }
+    }
+}
+
+impl<'top> HasRange for TextEExpArgGroup<'top> {
+    fn range(&self) -> Range<usize> {
+        self.input.range()
+    }
+}
+
+impl<'top> HasSpan<'top> for TextEExpArgGroup<'top> {
+    fn span(&self) -> Span<'top> {
+        Span::with_offset(self.input.offset(), self.input.bytes())
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct TextEExpArgGroupIterator<'top> {
+    child_expr_cache: &'top [LazyRawValueExpr<'top, TextEncoding_1_1>],
+    index: usize,
+}
+
+impl<'top> EExpArgGroupIterator<'top, TextEncoding_1_1> for TextEExpArgGroupIterator<'top> {
+    fn is_exhausted(&self) -> bool {
+        self.index == self.child_expr_cache.len()
+    }
+}
+
+impl<'top> Iterator for TextEExpArgGroupIterator<'top> {
+    type Item = IonResult<LazyRawValueExpr<'top, TextEncoding_1_1>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let child_expr = self.child_expr_cache.get(self.index)?;
+        self.index += 1;
+        Some(Ok(*child_expr))
+    }
+}
+
+impl<'top> IntoIterator for TextEExpArgGroup<'top> {
+    type Item = IonResult<LazyRawValueExpr<'top, TextEncoding_1_1>>;
+    type IntoIter = TextEExpArgGroupIterator<'top>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        TextEExpArgGroupIterator {
+            child_expr_cache: self.expr_cache,
+            index: 0,
+        }
+    }
+}
+
+impl<'top> EExpressionArgGroup<'top, TextEncoding_1_1> for TextEExpArgGroup<'top> {
+    type Iterator = TextEExpArgGroupIterator<'top>;
+
+    fn encoding(&self) -> ParameterEncoding {
+        self.parameter.encoding()
+    }
+
+    fn resolve(self, context: EncodingContextRef<'top>) -> ArgGroup<'top, TextEncoding_1_1> {
+        ArgGroup::new(self, context)
+    }
+
+    fn iter(self) -> Self::Iterator {
+        self.into_iter()
+    }
+}

--- a/src/lazy/text/raw/v1_1/mod.rs
+++ b/src/lazy/text/raw/v1_1/mod.rs
@@ -1,1 +1,2 @@
+pub mod arg_group;
 pub mod reader;

--- a/src/lazy/text/value.rs
+++ b/src/lazy/text/value.rs
@@ -127,7 +127,7 @@ impl<'top, E: TextEncoding<'top>> RawVersionMarker<'top> for LazyRawTextVersionM
         (self.major, self.minor)
     }
 
-    fn old_encoding(&self) -> IonEncoding {
+    fn stream_encoding_before_marker(&self) -> IonEncoding {
         IonEncoding::Text_1_0
     }
 }

--- a/src/lazy/text/value.rs
+++ b/src/lazy/text/value.rs
@@ -12,7 +12,7 @@ use crate::lazy::raw_value_ref::RawValueRef;
 use crate::lazy::span::Span;
 use crate::lazy::text::buffer::TextBufferView;
 use crate::lazy::text::encoded_value::EncodedTextValue;
-use crate::{IonResult, IonType, RawSymbolRef};
+use crate::{IonEncoding, IonResult, IonType, RawSymbolRef};
 
 /// A value that has been identified in the text input stream but whose data has not yet been read.
 ///
@@ -123,8 +123,12 @@ impl<'top, E: TextEncoding<'top>> HasRange for LazyRawTextVersionMarker<'top, E>
 }
 
 impl<'top, E: TextEncoding<'top>> RawVersionMarker<'top> for LazyRawTextVersionMarker<'top, E> {
-    fn version(&self) -> (u8, u8) {
+    fn major_minor(&self) -> (u8, u8) {
         (self.major, self.minor)
+    }
+
+    fn old_encoding(&self) -> IonEncoding {
+        IonEncoding::Text_1_0
     }
 }
 

--- a/src/types/symbol.rs
+++ b/src/types/symbol.rs
@@ -13,7 +13,9 @@ pub(crate) enum SymbolText {
     // This Symbol refers to a string in the symbol table
     Shared(Arc<str>),
     // This Symbol owns its own text
-    // TODO: Turn this into a Box<str>
+    // TODO: Turn this into a Box<str>.
+    //       Symbols are read-only, so there's no chance we'll add data to the `String`. Using
+    //       a `Box<str>` shrinks this value from 24 bytes to 8 bytes.
     Owned(String),
     // This Symbol is equivalent to SID zero (`$0`)
     Unknown,

--- a/src/types/symbol.rs
+++ b/src/types/symbol.rs
@@ -13,6 +13,7 @@ pub(crate) enum SymbolText {
     // This Symbol refers to a string in the symbol table
     Shared(Arc<str>),
     // This Symbol owns its own text
+    // TODO: Turn this into a Box<str>
     Owned(String),
     // This Symbol is equivalent to SID zero (`$0`)
     Unknown,

--- a/tests/element_display.rs
+++ b/tests/element_display.rs
@@ -1,5 +1,4 @@
-#![cfg(feature = "experimental-reader")]
-#![cfg(feature = "experimental-writer")]
+#![cfg(feature = "experimental-reader-writer")]
 use crate::ion_tests::contains_path;
 use ion_rs::IonData;
 use ion_rs::{Element, IonResult, Sequence};

--- a/tests/ion_data_consistency.rs
+++ b/tests/ion_data_consistency.rs
@@ -5,7 +5,7 @@ use std::cmp::Ordering;
 use std::fmt::Debug;
 
 use std::fs::read;
-use std::path::MAIN_SEPARATOR as PATH_SEPARATOR;
+use std::path::MAIN_SEPARATOR_STR as PATH_SEPARATOR;
 use test_generator::test_resources;
 
 /// Determines if the given file name is in the paths list.  This deals with platform
@@ -15,7 +15,7 @@ fn contains_path(paths: &[&str], file_name: &str) -> bool {
     paths
         .iter()
         // TODO construct the paths in a not so hacky way
-        .map(|p| p.replace('/', &PATH_SEPARATOR.to_string()))
+        .map(|p| p.replace('/', PATH_SEPARATOR))
         .any(|p| p == file_name)
 }
 

--- a/tests/ion_tests/lazy_element_ion_tests.rs
+++ b/tests/ion_tests/lazy_element_ion_tests.rs
@@ -1,24 +1,19 @@
-#![cfg(feature = "experimental-lazy-reader")]
-#![cfg(feature = "experimental-writer")]
-mod ion_tests;
+#![cfg(feature = "experimental-reader-writer")]
 
+use crate::good_round_trip;
 use crate::ion_tests::{
     bad, equivs, non_equivs, ElementApi, SkipList, ELEMENT_EQUIVS_SKIP_LIST,
     ELEMENT_GLOBAL_SKIP_LIST, ELEMENT_ROUND_TRIP_SKIP_LIST,
 };
-use ion_rs::lazy::reader::Reader;
-use ion_rs::IonResult;
+use ion_rs::Reader;
+use ion_rs::{AnyEncoding, IonResult};
 use ion_rs::{Format, TextFormat};
 use test_generator::test_resources;
 
 struct LazyReaderElementApi;
 
 impl ElementApi for LazyReaderElementApi {
-    type ElementReader<'a> = Reader<&'a [u8]>;
-
-    fn make_reader(data: &[u8]) -> IonResult<Self::ElementReader<'_>> {
-        Ok(Reader::new(data))
-    }
+    type ElementReader<'a> = Reader<AnyEncoding, &'a [u8]>;
 
     fn global_skip_list() -> SkipList {
         ELEMENT_GLOBAL_SKIP_LIST
@@ -39,22 +34,26 @@ impl ElementApi for LazyReaderElementApi {
     fn non_equivs_skip_list() -> SkipList {
         &[]
     }
+
+    fn make_reader(data: &[u8]) -> IonResult<Self::ElementReader<'_>> {
+        Reader::new(AnyEncoding, data)
+    }
 }
 
 good_round_trip! {
     use LazyReaderElementApi;
-    fn binary_compact(Format::Binary, Format::Text(TextKind::Compact));
-    fn binary_lines(Format::Binary, Format::Text(TextKind::Lines));
-    fn binary_pretty(Format::Binary, Format::Text(TextKind::Pretty));
-    fn compact_binary(Format::Text(TextKind::Compact), Format::Binary);
-    fn compact_lines(Format::Text(TextKind::Compact), Format::Text(TextKind::Lines));
-    fn compact_pretty(Format::Text(TextKind::Compact), Format::Text(TextKind::Pretty));
-    fn lines_binary(Format::Text(TextKind::Lines), Format::Binary);
-    fn lines_compact(Format::Text(TextKind::Lines), Format::Text(TextKind::Compact));
-    fn lines_pretty(Format::Text(TextKind::Lines), Format::Text(TextKind::Pretty));
-    fn pretty_binary(Format::Text(TextKind::Pretty), Format::Binary);
-    fn pretty_compact(Format::Text(TextKind::Pretty), Format::Text(TextKind::Compact));
-    fn pretty_lines(Format::Text(TextKind::Pretty), Format::Text(TextKind::Lines));
+    fn binary_compact(Format::Binary, Format::Text(TextFormat::Compact));
+    fn binary_lines(Format::Binary, Format::Text(TextFormat::Lines));
+    fn binary_pretty(Format::Binary, Format::Text(TextFormat::Pretty));
+    fn compact_binary(Format::Text(TextFormat::Compact), Format::Binary);
+    fn compact_lines(Format::Text(TextFormat::Compact), Format::Text(TextFormat::Lines));
+    fn compact_pretty(Format::Text(TextFormat::Compact), Format::Text(TextFormat::Pretty));
+    fn lines_binary(Format::Text(TextFormat::Lines), Format::Binary);
+    fn lines_compact(Format::Text(TextFormat::Lines), Format::Text(TextFormat::Compact));
+    fn lines_pretty(Format::Text(TextFormat::Lines), Format::Text(TextFormat::Pretty));
+    fn pretty_binary(Format::Text(TextFormat::Pretty), Format::Binary);
+    fn pretty_compact(Format::Text(TextFormat::Pretty), Format::Text(TextFormat::Compact));
+    fn pretty_lines(Format::Text(TextFormat::Pretty), Format::Text(TextFormat::Lines));
 }
 
 #[test_resources("ion-tests/iontestdata_1_0/bad/**/*.ion")]

--- a/tests/ion_tests_1_1.rs
+++ b/tests/ion_tests_1_1.rs
@@ -1,20 +1,20 @@
-#![cfg(feature = "experimental-lazy-reader")]
+#![cfg(feature = "experimental-reader-writer")]
 
 /// TODO: When the Ion 1.1 binary reader is complete, update this module to include binary tests
 mod ion_tests;
 
 use crate::ion_tests::{bad, equivs, non_equivs, ElementApi, SkipList};
-use ion_rs::lazy::reader::TextReader_1_1;
 use ion_rs::IonResult;
+use ion_rs::{v1_1, Reader};
 use test_generator::test_resources;
 
 struct LazyReaderElementApi;
 
 impl ElementApi for LazyReaderElementApi {
-    type ElementReader<'a> = TextReader_1_1<&'a [u8]>;
+    type ElementReader<'a> = Reader<v1_1::Text, &'a [u8]>;
 
     fn make_reader(data: &[u8]) -> IonResult<Self::ElementReader<'_>> {
-        Ok(TextReader_1_1::new(data).unwrap())
+        Ok(Reader::new(v1_1::Text, data).unwrap())
     }
 
     fn global_skip_list() -> SkipList {


### PR DESCRIPTION
* Adds support for switching encodings midstream
* Adds support for parameter cardinality modifiers
* Adds support for reading argument groups
* Adds support for length-prefixed e-expressions
* Optimizes and simplifies macro evaluation
* Simplifies struct expansion logic
* Adds static analysis optimizations to template evaluation
* Adds support for lazily evaluating top-level e-expressions
* Adds more Ion 1.1 encodings to the `read_many_structs` benchmark
* Shrinks many data types