### PR TITLE
Fix certain symbols being incorrectly identified as incomplete boolean values

### DIFF
--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -1481,4 +1481,26 @@ mod value_tests {
         let element: Element = int.into();
         assert_eq!(element.expect_i64(), int.expect_i64())
     }
+
+    #[rstest]
+    fn read_a_symbol_terminated_by_end_of_input(
+        #[values(
+        "a","b","c","d","e","f","g","h","i","j",
+        "k","l","m","n","o","p","q","r","s","t",
+        // These are all things that look like they _could_
+        // be an incomplete value (or IVM).
+        "fa", "fal", "fals",
+        "na", "nu", "nul",
+        "tr", "tru",
+        "$ion_",
+        "$ion_1",
+        "$ion_1_",
+        )]
+        input: &str,
+    ) -> IonResult<()> {
+        let value = Element::read_one(input)?;
+        let actual_text = value.as_symbol().unwrap().text().unwrap();
+        assert_eq!(actual_text, input);
+        Ok(())
+    }
 }


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

Fixes a small bug in `match_bool` that was incorrectly reporting things like "fal" as incomplete booleans rather than as non-matches.

Also adds test cases, and updates existing test cases with a more concise macro and the ability to specify whether a value is a mismatch vs an incomplete match.

You may want to view this PR in the "split" diff view.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
