### PR TITLE
Adds the `(annotate ...)` form and bin read support for `flex_uint` parameters

### DIFF
--- a/src/ion_data/ion_eq.rs
+++ b/src/ion_data/ion_eq.rs
@@ -24,7 +24,7 @@ use std::ops::Deref;
 /// * Decimal `0.0` and `-0.0` are mathematically equivalent but not Ion equivalent.
 /// * Decimal `0.0` and `0.00` are mathematically equivalent but not Ion equivalent.
 /// * Timestamps representing the same point in time at different precisions or at different
-/// timezone offsets are not Ion equivalent.
+///   timezone offsets are not Ion equivalent.
 pub trait IonEq {
     fn ion_eq(&self, other: &Self) -> bool;
 }

--- a/src/ion_hash/type_qualifier.rs
+++ b/src/ion_hash/type_qualifier.rs
@@ -18,7 +18,7 @@ pub(crate) struct TypeQualifier(u8);
 /// From the spec:
 ///
 /// > TQ: is a type qualifier octet consisting of a four-bit type code T
-/// followed by a four-bit qualifier Q
+/// > followed by a four-bit qualifier Q
 ///
 /// To compute a TQ from a `T` and a `Q`, all we need to is a bitwise shift!
 const fn combine(ion_type_code: IonTypeCode, q: u8) -> TypeQualifier {

--- a/src/lazy/binary/immutable_buffer.rs
+++ b/src/lazy/binary/immutable_buffer.rs
@@ -16,6 +16,7 @@ use crate::lazy::decoder::LazyRawFieldExpr;
 use crate::lazy::encoder::binary::v1_1::flex_int::FlexInt;
 use crate::lazy::encoder::binary::v1_1::flex_uint::FlexUInt;
 use crate::lazy::encoding::BinaryEncoding_1_0;
+use crate::lazy::expanded::template::ParameterEncoding;
 use crate::result::IonFailure;
 use crate::{Int, IonError, IonResult, IonType};
 
@@ -703,12 +704,14 @@ impl<'a> ImmutableBuffer<'a> {
         }
 
         let encoded_value = EncodedValue {
+            encoding: ParameterEncoding::Tagged,
             header,
             // If applicable, these are populated by the caller: `read_annotated_value()`
             annotations_header_length: 0,
             annotations_sequence_length: 0,
             annotations_encoding: AnnotationsEncoding::SymbolAddress,
             header_offset,
+            opcode_length: 1,
             length_length,
             value_body_length: value_length,
             total_length,

--- a/src/lazy/encoder/binary/v1_1/container_writers.rs
+++ b/src/lazy/encoder/binary/v1_1/container_writers.rs
@@ -7,7 +7,7 @@ use crate::lazy::encoder::value_writer::internal::{FieldEncoder, MakeValueWriter
 use crate::lazy::encoder::value_writer::{EExpWriter, SequenceWriter, StructWriter};
 use crate::lazy::encoder::write_as_ion::WriteAsIon;
 use crate::raw_symbol_ref::AsRawSymbolRef;
-use crate::IonResult;
+use crate::{IonResult, UInt};
 
 /// A helper type that holds fields and logic that is common to [`BinaryListWriter_1_1`],
 /// [`BinarySExpWriter_1_1`], and [`BinaryStructWriter_1_1`].
@@ -393,4 +393,9 @@ impl<'value, 'top> SequenceWriter for BinaryEExpWriter_1_1<'value, 'top> {
     }
 }
 
-impl<'value, 'top> EExpWriter for BinaryEExpWriter_1_1<'value, 'top> {}
+impl<'value, 'top> EExpWriter for BinaryEExpWriter_1_1<'value, 'top> {
+    fn write_flex_uint(&mut self, value: impl Into<UInt>) -> IonResult<()> {
+        FlexUInt::write(self.buffer, value)?;
+        Ok(())
+    }
+}

--- a/src/lazy/encoder/binary/v1_1/flex_uint.rs
+++ b/src/lazy/encoder/binary/v1_1/flex_uint.rs
@@ -65,7 +65,6 @@ impl FlexUInt {
                 false,
             );
         }
-
         let flex_uint = Self::read_small_flex_uint(input);
         Ok(flex_uint)
     }
@@ -115,7 +114,7 @@ impl FlexUInt {
     /// (`support_sign_extension=true`), then the six bits beyond the supported 64 must all be the
     /// same as the 64th (highest supported) bit. This will allow encodings of up to 70 bits
     /// to be correctly interpreted as positive, negative, or beyond the bounds of the 64 bit
-    /// limitation.  
+    /// limitation.
     pub(crate) fn read_flex_primitive_as_uint(
         input: &[u8],
         offset: usize,

--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -627,7 +627,7 @@ impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
             MacroIdRef::LocalAddress(_address) => {
                 todo!("macros with addresses higher than 64");
             }
-        }
+        };
         Ok(BinaryEExpWriter_1_1::new(
             self.allocator,
             self.encoding_buffer,
@@ -832,6 +832,9 @@ impl<'value, 'top> BinaryAnnotatedValueWriter_1_1<'value, 'top> {
 
 #[cfg(test)]
 mod tests {
+    use num_traits::FloatConst;
+    use rstest::rstest;
+
     use crate::ion_data::IonEq;
     use crate::lazy::encoder::annotate::{Annotatable, Annotated};
     use crate::lazy::encoder::annotation_seq::AnnotationSeq;
@@ -845,8 +848,6 @@ mod tests {
         v1_1, Decimal, Element, Int, IonResult, IonType, Null, RawSymbolRef, SymbolId, Timestamp,
         Writer,
     };
-    use num_traits::FloatConst;
-    use rstest::rstest;
 
     fn encoding_test(
         test: impl FnOnce(&mut LazyRawBinaryWriter_1_1<&mut Vec<u8>>) -> IonResult<()>,

--- a/src/lazy/encoder/value_writer.rs
+++ b/src/lazy/encoder/value_writer.rs
@@ -3,7 +3,7 @@ use crate::lazy::encoder::value_writer::internal::{FieldEncoder, MakeValueWriter
 use crate::lazy::encoder::write_as_ion::WriteAsIon;
 use crate::lazy::text::raw::v1_1::reader::MacroIdRef;
 use crate::raw_symbol_ref::AsRawSymbolRef;
-use crate::{Decimal, Int, IonResult, IonType, RawSymbolRef, Timestamp};
+use crate::{Decimal, Int, IonResult, IonType, RawSymbolRef, Timestamp, UInt};
 
 pub mod internal {
     use crate::lazy::encoder::value_writer::ValueWriter;
@@ -32,7 +32,10 @@ pub mod internal {
 }
 
 pub trait EExpWriter: SequenceWriter {
-    // TODO: methods for writing tagless encodings
+    // TODO: more methods for writing tagless encodings
+    fn write_flex_uint(&mut self, _value: impl Into<UInt>) -> IonResult<()> {
+        todo!("current only implemented for binary 1.1 to enable unit testing for the reader")
+    }
 }
 
 pub trait AnnotatableWriter {

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -20,7 +20,7 @@ use crate::result::IonFailure;
 use crate::write_config::WriteConfig;
 use crate::{
     Decimal, Element, ElementWriter, Int, IonResult, IonType, RawSymbolRef, Symbol, SymbolId,
-    SymbolTable, Timestamp, Value,
+    SymbolTable, Timestamp, UInt, Value,
 };
 
 pub(crate) struct WriteContext {
@@ -505,6 +505,9 @@ impl<'value, V: ValueWriter> MakeValueWriter for ApplicationEExpWriter<'value, V
 
 impl<'value, V: ValueWriter> EExpWriter for ApplicationEExpWriter<'value, V> {
     // Default methods
+    fn write_flex_uint(&mut self, value: impl Into<UInt>) -> IonResult<()> {
+        self.raw_eexp_writer.write_flex_uint(value)
+    }
 }
 
 impl<S: SequenceWriter> ElementWriter for S {

--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -8,9 +8,9 @@ use crate::lazy::decoder::{Decoder, RawValueExpr};
 use crate::lazy::encoding::TextEncoding_1_1;
 use crate::lazy::expanded::compiler::{ExpansionAnalysis, ExpansionSingleton};
 use crate::lazy::expanded::macro_evaluator::{
-    EExpArgGroupIterator, EExpressionArgGroup, MacroExpansion, MacroExpansionKind, MacroExpr,
-    MacroExprArgsIterator, MakeStringExpansion, RawEExpression, TemplateExpansion, ValueExpr,
-    ValuesExpansion,
+    AnnotateExpansion, EExpArgGroupIterator, EExpressionArgGroup, MacroExpansion,
+    MacroExpansionKind, MacroExpr, MacroExprArgsIterator, MakeStringExpansion, RawEExpression,
+    TemplateExpansion, ValueExpr, ValuesExpansion,
 };
 use crate::lazy::expanded::macro_table::{MacroKind, MacroRef};
 use crate::lazy::expanded::template::TemplateMacroRef;
@@ -124,6 +124,7 @@ impl<'top, D: Decoder> EExpression<'top, D> {
             MacroKind::MakeString => {
                 MacroExpansionKind::MakeString(MakeStringExpansion::new(arguments))
             }
+            MacroKind::Annotate => MacroExpansionKind::Annotate(AnnotateExpansion::new(arguments)),
             MacroKind::Template(template_body) => {
                 let template_ref = TemplateMacroRef::new(invoked_macro, template_body);
                 environment = self.new_evaluation_environment()?;

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -1438,11 +1438,13 @@ mod tests {
     }
 
     #[test]
-    fn flex_uint_parameter() -> IonResult<()> {
+    fn flex_uint_parameters() -> IonResult<()> {
         let template_definition = "(macro int_pair (flex_uint::$x flex_uint::$y) (values $x $y)))";
         let tests: &[(&[u8], (u64, u64))] = &[
-            (&[0x04, 0x09, 0x01], (4, 0)),
-            (&[0x04, 0x0B, 0x0D], (5, 6)), // TODO: More test cases
+            // invocation+args, expected arg values
+            (&[0x04, 0x01, 0x01], (0, 0)),
+            (&[0x04, 0x09, 0x03], (4, 1)),
+            (&[0x04, 0x0B, 0x0D], (5, 6)), // TODO: non-required cardinalities
         ];
 
         for test in tests {

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -12,7 +12,7 @@ use crate::lazy::expanded::{
     EncodingContextRef, ExpandedValueSource, LazyExpandedValue, TemplateVariableReference,
 };
 use crate::lazy::expanded::compiler::ExpansionAnalysis;
-use crate::lazy::expanded::macro_evaluator::{MacroEvaluator, MacroExpansion, MacroExpansionKind, MacroExpr, MacroExprArgsIterator, MakeStringExpansion, TemplateExpansion, ValueExpr, ValuesExpansion};
+use crate::lazy::expanded::macro_evaluator::{AnnotateExpansion, MacroEvaluator, MacroExpansion, MacroExpansionKind, MacroExpr, MacroExprArgsIterator, MakeStringExpansion, TemplateExpansion, ValueExpr, ValuesExpansion};
 use crate::lazy::expanded::macro_table::{Macro, MacroKind, MacroRef};
 use crate::lazy::expanded::r#struct::UnexpandedField;
 use crate::lazy::expanded::sequence::Environment;
@@ -56,6 +56,7 @@ impl Parameter {
 pub enum ParameterEncoding {
     /// A 'tagged' type is one whose binary encoding begins with an opcode (sometimes called a 'tag'.)
     Tagged,
+    FlexUInt,
     // TODO: tagless types, including fixed-width types and macros
 }
 
@@ -899,6 +900,7 @@ impl<'top> TemplateMacroInvocation<'top> {
             MacroKind::MakeString => {
                 MacroExpansionKind::MakeString(MakeStringExpansion::new(arguments))
             }
+            MacroKind::Annotate => MacroExpansionKind::Annotate(AnnotateExpansion::new(arguments)),
             MacroKind::Template(template_body) => {
                 let template_ref = TemplateMacroRef::new(macro_ref, template_body);
                 environment = self.new_evaluation_environment(environment)?;

--- a/src/lazy/streaming_raw_reader.rs
+++ b/src/lazy/streaming_raw_reader.rs
@@ -342,7 +342,6 @@ impl<R: Read> IonDataSource for IonStream<R> {
 ///
 /// In general, this trait is implemented by mapping `Self` to either:
 ///   * [`IonSlice`], if `Self` is an implementation of `AsRef<[u8]>`
-/// OR
 ///   * [`IonStream`], if `Self` is an implementation of `io::Read`
 pub trait IonInput {
     type DataSource: IonDataSource;

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -1087,11 +1087,11 @@ mod tests {
         // This directive defines two more.
         assert_eq!(new_macro_table.len(), 2 + MacroTable::NUM_SYSTEM_MACROS);
         assert_eq!(
-            new_macro_table.macro_with_id(3),
+            new_macro_table.macro_with_id(4),
             new_macro_table.macro_with_name("seventeen")
         );
         assert_eq!(
-            new_macro_table.macro_with_id(4),
+            new_macro_table.macro_with_id(5),
             new_macro_table.macro_with_name("twelve")
         );
 

--- a/src/lazy/value_ref.rs
+++ b/src/lazy/value_ref.rs
@@ -135,7 +135,7 @@ impl<'top, D: Decoder> ValueRef<'top, D> {
         if let ValueRef::Int(i) = self {
             Ok(i)
         } else {
-            IonResult::decoding_error("expected an int")
+            IonResult::decoding_error(format!("expected an int but found a(n) {self:?}"))
         }
     }
 
@@ -143,7 +143,7 @@ impl<'top, D: Decoder> ValueRef<'top, D> {
         if let ValueRef::Int(i) = self {
             i.expect_i64()
         } else {
-            IonResult::decoding_error("expected an int (i64)")
+            IonResult::decoding_error(format!("expected an int (i64) but found a(n) {self:?}"))
         }
     }
 
@@ -242,7 +242,7 @@ impl<'top, D: Decoder> ValueRef<'top, D> {
         if let ValueRef::Struct(s) = self {
             Ok(s)
         } else {
-            IonResult::decoding_error("expected a struct")
+            IonResult::decoding_error(format!("expected a struct but found a(n) {self:?}"))
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ pub use crate::lazy::decoder::{HasRange, HasSpan};
 pub use crate::lazy::span::Span;
 macro_rules! v1_x_reader_writer {
     ($visibility:vis) => {
-        #[allow(unused_imports)]
+       #[allow(unused_imports)]
         $visibility use crate::{
             lazy::streaming_raw_reader::{IonInput, IonSlice, IonStream},
             lazy::decoder::Decoder,
@@ -286,6 +286,7 @@ macro_rules! v1_x_tooling_apis {
                 LazyExpandedField,
                 LazyExpandedFieldName
             },
+            lazy::expanded::e_expression::{EExpression, EExpressionArgsIterator},
             lazy::expanded::sequence::{Environment, ExpandedListSource, ExpandedSExpSource, LazyExpandedList, LazyExpandedSExp},
             lazy::expanded::{LazyExpandedValue, ExpandingReader, ExpandedValueSource, ExpandedAnnotationsSource, ExpandedValueRef},
             lazy::system_stream_item::SystemStreamItem,

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -1,5 +1,6 @@
-use std::collections::HashMap;
 use std::sync::Arc;
+
+use rustc_hash::FxHashMap;
 
 use crate::constants::v1_0;
 use crate::lazy::any_encoding::IonVersion;
@@ -12,7 +13,7 @@ use crate::{Symbol, SymbolId};
 pub struct SymbolTable {
     ion_version: IonVersion,
     symbols_by_id: Vec<Symbol>,
-    ids_by_text: HashMap<Symbol, SymbolId>,
+    ids_by_text: FxHashMap<Symbol, SymbolId>,
 }
 
 impl Default for SymbolTable {
@@ -29,7 +30,7 @@ impl SymbolTable {
         let mut symbol_table = SymbolTable {
             ion_version,
             symbols_by_id: Vec::with_capacity(INITIAL_SYMBOLS_CAPACITY),
-            ids_by_text: HashMap::new(),
+            ids_by_text: FxHashMap::default(),
         };
         symbol_table.initialize();
         symbol_table

--- a/src/text/text_formatter.rs
+++ b/src/text/text_formatter.rs
@@ -246,6 +246,7 @@ impl<'a, W: std::fmt::Write> FmtValueFormatter<'a, W> {
     /// * `first_name`
     /// * `name_1`
     /// * `$name`
+    ///
     /// Unlike other symbols, identifiers don't have to be wrapped in quotes.
     fn token_is_identifier(token: &str) -> bool {
         if token.is_empty() {

--- a/src/types/decimal/mod.rs
+++ b/src/types/decimal/mod.rs
@@ -292,6 +292,7 @@ impl TryFrom<f64> for Decimal {
     ///   * Infinity
     ///   * Negative infinity
     ///   * NaN (not-a-number)
+    ///
     /// Otherwise, returns Ok.
     ///
     /// Because Decimal can represent negative zero, f64::neg_zero() IS supported.


### PR DESCRIPTION
Adds:
* An implementation of the `(annotate)` TDL form
* Binary read support for `flex_uint::`-encoded template parameters
* Very limited binary write support for `flex_uint::`-encoded template parameters to enable unit testing for the reader.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
