### PR TITLE
Adds additional tooling APIs to enable Ion 1.1 support in the CLI's `inspect` command

### DIFF
--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -1149,10 +1149,12 @@ impl<'top> LazyContainerPrivate<'top, AnyEncoding> for LazyRawAnyList<'top> {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
 pub struct RawAnyListIterator<'data> {
     encoding: RawAnyListIteratorKind<'data>,
 }
 
+#[derive(Debug, Copy, Clone)]
 pub enum RawAnyListIteratorKind<'data> {
     Text_1_0(RawTextListIterator_1_0<'data>),
     Binary_1_0(RawBinarySequenceIterator_1_0<'data>),
@@ -1310,10 +1312,12 @@ impl<'data> LazyContainerPrivate<'data, AnyEncoding> for LazyRawAnySExp<'data> {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
 pub struct RawAnySExpIterator<'data> {
     encoding: RawAnySExpIteratorKind<'data>,
 }
 
+#[derive(Debug, Copy, Clone)]
 pub enum RawAnySExpIteratorKind<'data> {
     Text_1_0(RawTextSExpIterator_1_0<'data>),
     Binary_1_0(RawBinarySequenceIterator_1_0<'data>),
@@ -1513,10 +1517,12 @@ impl<'top> From<LazyRawBinaryFieldName_1_1<'top>> for LazyRawAnyFieldName<'top> 
     }
 }
 
+#[derive(Debug, Copy, Clone)]
 pub struct RawAnyStructIterator<'data> {
     encoding: RawAnyStructIteratorKind<'data>,
 }
 
+#[derive(Debug, Copy, Clone)]
 pub enum RawAnyStructIteratorKind<'data> {
     Text_1_0(RawTextStructIterator_1_0<'data>),
     Binary_1_0(RawBinaryStructIterator_1_0<'data>),

--- a/src/lazy/binary/raw/reader.rs
+++ b/src/lazy/binary/raw/reader.rs
@@ -148,6 +148,7 @@ impl<'data> LazyRawReader<'data, BinaryEncoding_1_0> for LazyRawBinaryReader_1_0
 
 /// Wraps an [`ImmutableBuffer`], allowing the reader to advance each time an item is successfully
 /// parsed from it.
+#[derive(Debug, Copy, Clone)]
 pub(crate) struct DataSource<'data> {
     // The buffer we're reading from
     buffer: ImmutableBuffer<'data>,

--- a/src/lazy/binary/raw/reader.rs
+++ b/src/lazy/binary/raw/reader.rs
@@ -10,6 +10,7 @@ use crate::{Encoding, IonResult};
 
 use crate::lazy::any_encoding::IonEncoding;
 use crate::lazy::expanded::EncodingContextRef;
+use crate::lazy::streaming_raw_reader::RawReaderState;
 
 /// A binary Ion 1.0 reader that yields [`LazyRawBinaryValue_1_0`]s representing the top level values found
 /// in the provided input stream.
@@ -118,9 +119,9 @@ impl<'data> LazyRawReader<'data, BinaryEncoding_1_0> for LazyRawBinaryReader_1_0
         }
     }
 
-    fn stream_data(&self) -> (&'data [u8], usize, IonEncoding) {
+    fn save_state(&self) -> RawReaderState<'data> {
         let stream_offset = self.position();
-        (
+        RawReaderState::new(
             &self.data.buffer.bytes()[self.data.bytes_to_skip..],
             stream_offset,
             IonEncoding::Binary_1_0,

--- a/src/lazy/binary/raw/sequence.rs
+++ b/src/lazy/binary/raw/sequence.rs
@@ -139,6 +139,7 @@ impl<'a> Debug for LazyRawBinarySequence_1_0<'a> {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
 pub struct RawBinarySequenceIterator_1_0<'top> {
     source: DataSource<'top>,
 }

--- a/src/lazy/binary/raw/struct.rs
+++ b/src/lazy/binary/raw/struct.rs
@@ -86,6 +86,7 @@ impl<'top> LazyRawStruct<'top, BinaryEncoding_1_0> for LazyRawBinaryStruct_1_0<'
     }
 }
 
+#[derive(Debug, Copy, Clone)]
 pub struct RawBinaryStructIterator_1_0<'top> {
     source: DataSource<'top>,
 }

--- a/src/lazy/binary/raw/v1_1/e_expression.rs
+++ b/src/lazy/binary/raw/v1_1/e_expression.rs
@@ -281,8 +281,9 @@ impl<'top> Iterator for BinaryEExpArgsInputIter<'top> {
                 let expr = EExpArgExpr::ArgGroup(BinaryEExpArgGroup::new(parameter, input, 0));
                 (EExpArg::new(parameter, expr), self.remaining_args_buffer)
             }
-            // If it's a tagged value expression, parse it as usual.
+            // It's a single expression; we'll need to look at the parameter's declared encoding.
             ArgGrouping::ValueExprLiteral => match parameter.encoding() {
+                // The encoding starts with an opcode.
                 ParameterEncoding::Tagged => {
                     let (expr, remaining) = try_or_some_err! {
                         self
@@ -291,6 +292,7 @@ impl<'top> Iterator for BinaryEExpArgsInputIter<'top> {
                     };
                     (EExpArg::new(parameter, expr), remaining)
                 }
+                // It's a FlexUInt.
                 ParameterEncoding::FlexUInt => {
                     let (flex_uint_lazy_value, remaining) = try_or_some_err! {
                         self.remaining_args_buffer.read_flex_uint_as_lazy_value()
@@ -304,7 +306,7 @@ impl<'top> Iterator for BinaryEExpArgsInputIter<'top> {
                         EExpArg::new(parameter, EExpArgExpr::ValueLiteral(value_ref)),
                         remaining,
                     )
-                }
+                } // TODO: The other tagless encodings
             },
             // If it's an argument group...
             ArgGrouping::ArgGroup => {

--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -247,7 +247,7 @@ impl<'a> ImmutableBuffer<'a> {
         }
         // XXX: This *doesn't* slice `self` because FlexUInt::read() is faster if the input
         //      is at least the size of a u64.
-        let matched_input = self;
+        let matched_input = self.slice(0, size_in_bytes);
         let remaining_input = self.slice_to_end(size_in_bytes);
         let value = LazyRawBinaryValue_1_1::for_flex_uint(matched_input);
         Ok((value, remaining_input))

--- a/src/lazy/binary/raw/v1_1/reader.rs
+++ b/src/lazy/binary/raw/v1_1/reader.rs
@@ -8,6 +8,7 @@ use crate::lazy::encoder::private::Sealed;
 use crate::lazy::encoding::BinaryEncoding_1_1;
 use crate::lazy::expanded::EncodingContextRef;
 use crate::lazy::raw_stream_item::{EndPosition, LazyRawStreamItem, RawStreamItem};
+use crate::lazy::streaming_raw_reader::RawReaderState;
 use crate::{Encoding, IonResult};
 
 pub struct LazyRawBinaryReader_1_1<'data> {
@@ -107,8 +108,8 @@ impl<'data> LazyRawReader<'data, BinaryEncoding_1_1> for LazyRawBinaryReader_1_1
         Self::new_with_offset(data, offset)
     }
 
-    fn stream_data(&self) -> (&'data [u8], usize, IonEncoding) {
-        (
+    fn save_state(&self) -> RawReaderState<'data> {
+        RawReaderState::new(
             &self.input[self.local_offset..],
             self.position(),
             self.encoding(),

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -345,8 +345,8 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
 
     /// Reads this value's data, returning it as a [`RawValueRef`]. If this value is a container,
     /// calling this method will not read additional data; the `RawValueRef` will provide a
-    /// [`LazyRawBinarySequence_1_1`](crate::lazy::binary::raw::v1_1::sequence::LazyRawBinarySequence_1_1)
-    /// or [`LazyStruct`] that can be traversed to access the container's contents.
+    /// lazy sequence or lazy struct that can be traversed to access the container's
+    /// contents.
     pub fn read(&'top self) -> ValueParseResult<'top, BinaryEncoding_1_1> {
         <&'top Self as LazyRawValue<'top, BinaryEncoding_1_1>>::read(&self)
     }

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -290,7 +290,10 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
             header: Header {
                 // It is an int, that's true.
                 ion_type: IonType::Int,
-                // Nonsense values for now
+                // Eventually we'll refactor `EncodedValue` to accommodate values that don't have
+                // a header (i.e., parameters with tagless encodings). See:
+                // https://github.com/amazon-ion/ion-rust/issues/805
+                // For now, we'll populate these fields with nonsense values and ignore them.
                 ion_type_code: OpcodeType::Nop,
                 low_nibble: 0,
             },

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -96,19 +96,6 @@ impl<'top> RawVersionMarker<'top> for LazyRawBinaryVersionMarker_1_1<'top> {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub enum DelimitedContents<'top> {
-    None,
-    Values(&'top [LazyRawValueExpr<'top, BinaryEncoding_1_1>]),
-    Fields(&'top [LazyRawFieldExpr<'top, BinaryEncoding_1_1>]),
-}
-
-impl<'top> DelimitedContents<'top> {
-    pub fn is_none(&self) -> bool {
-        matches!(self, Self::None)
-    }
-}
-
-#[derive(Debug, Copy, Clone)]
 pub struct LazyRawBinaryValue_1_1<'top> {
     pub(crate) encoded_value: EncodedValue<Header>,
     pub(crate) input: ImmutableBuffer<'top>,
@@ -278,6 +265,19 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_1> for &'top LazyRawBinaryValue_1
         let range = self.encoded_value.unannotated_value_range();
         let local_range = (range.start - self.input.offset())..(range.end - self.input.offset());
         Span::with_offset(range.start, &self.input.bytes()[local_range])
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum DelimitedContents<'top> {
+    None,
+    Values(&'top [LazyRawValueExpr<'top, BinaryEncoding_1_1>]),
+    Fields(&'top [LazyRawFieldExpr<'top, BinaryEncoding_1_1>]),
+}
+
+impl<'top> DelimitedContents<'top> {
+    pub fn is_none(&self) -> bool {
+        matches!(self, Self::None)
     }
 }
 

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -840,15 +840,6 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
         use crate::lazy::decoder::private::LazyContainerPrivate;
         Ok(LazyRawBinaryStruct_1_1::from_value(self))
     }
-
-    // #[cfg(feature = "experimental-tooling-apis")]
-    // pub fn encoded_annotations(&self) -> Option<EncodedBinaryAnnotations<'_, 'top>> {
-    //     if self.has_annotations() {
-    //         Some(EncodedBinaryAnnotations { value: self })
-    //     } else {
-    //         None
-    //     }
-    // }
 }
 
 impl<'top> EncodedBinaryValue<'top, BinaryEncoding_1_1> for &'top LazyRawBinaryValue_1_1<'top> {

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -189,7 +189,10 @@ pub trait EncodedBinaryValue<'top, D: Decoder>: LazyRawValue<'top, D> {
     /// The span containing the value's opcode.
     fn value_opcode_span(&self) -> Span<'top> {
         let value_span = self.value_span();
-        Span::with_offset(value_span.range().start, &value_span.bytes()[0..1])
+        Span::with_offset(
+            value_span.range().start,
+            &value_span.bytes()[0..self.opcode_length()],
+        )
     }
 
     /// The span containing the value's encoded length (if it is not encoded within the opcode.)

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -582,13 +582,51 @@ pub trait LazyRawValue<'top, D: Decoder>:
     fn value_span(&self) -> Span<'top>;
 }
 
+pub trait RawSequenceIterator<'top, D: Decoder>:
+    Debug + Copy + Clone + Iterator<Item = IonResult<LazyRawValueExpr<'top, D>>>
+{
+    /// Returns the next raw value expression (or `None` if exhausted) without advancing the iterator.
+    fn peek_next(&self) -> Option<IonResult<LazyRawValueExpr<'top, D>>> {
+        // Because RawSequenceIterator impls are `Copy`, we can make a cheap copy of `self` and advance
+        // *it* without affecting `self`.
+        let mut iter_clone = *self;
+        iter_clone.next()
+    }
+}
+
+impl<'top, D: Decoder, T> RawSequenceIterator<'top, D> for T
+where
+    T: Debug + Copy + Clone + Iterator<Item = IonResult<LazyRawValueExpr<'top, D>>>,
+{
+    // Nothing to do
+}
+
 pub trait LazyRawSequence<'top, D: Decoder>:
     LazyRawContainer<'top, D> + private::LazyContainerPrivate<'top, D> + Debug + Copy + Clone
 {
-    type Iterator: Iterator<Item = IonResult<LazyRawValueExpr<'top, D>>>;
+    type Iterator: RawSequenceIterator<'top, D>;
     fn annotations(&self) -> D::AnnotationsIterator<'top>;
     fn ion_type(&self) -> IonType;
     fn iter(&self) -> Self::Iterator;
+}
+
+pub trait RawStructIterator<'top, D: Decoder>:
+    Debug + Copy + Clone + Iterator<Item = IonResult<LazyRawFieldExpr<'top, D>>>
+{
+    /// Returns the next raw value expression (or `None` if exhausted) without advancing the iterator.
+    fn peek_next(&self) -> Option<IonResult<LazyRawFieldExpr<'top, D>>> {
+        // Because RawStructIterator impls are `Copy`, we can make a cheap copy of `self` and advance
+        // *it* without affecting `self`.
+        let mut iter_clone = *self;
+        iter_clone.next()
+    }
+}
+
+impl<'top, D: Decoder, T> RawStructIterator<'top, D> for T
+where
+    T: Debug + Copy + Clone + Iterator<Item = IonResult<LazyRawFieldExpr<'top, D>>>,
+{
+    // Nothing to do
 }
 
 pub trait LazyRawStruct<'top, D: Decoder>:
@@ -599,7 +637,7 @@ pub trait LazyRawStruct<'top, D: Decoder>:
     + Copy
     + Clone
 {
-    type Iterator: Iterator<Item = IonResult<LazyRawFieldExpr<'top, D>>>;
+    type Iterator: RawStructIterator<'top, D>;
 
     fn annotations(&self) -> D::AnnotationsIterator<'top>;
 

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -38,6 +38,12 @@ pub trait HasRange {
     }
 }
 
+impl HasRange for Range<usize> {
+    fn range(&self) -> Range<usize> {
+        self.start..self.end
+    }
+}
+
 /// A family of types that collectively comprise the lazy reader API for an Ion serialization
 /// format. These types operate at the 'raw' level; they do not attempt to resolve symbols
 /// using the active symbol table.

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -14,6 +14,7 @@ use crate::lazy::expanded::{EncodingContext, EncodingContextRef};
 use crate::lazy::raw_stream_item::LazyRawStreamItem;
 use crate::lazy::raw_value_ref::RawValueRef;
 use crate::lazy::span::Span;
+use crate::lazy::streaming_raw_reader::RawReaderState;
 use crate::read_config::ReadConfig;
 use crate::result::IonFailure;
 use crate::{
@@ -446,7 +447,7 @@ pub trait LazyRawReader<'data, D: Decoder>: Sized {
     fn resume_at_offset(data: &'data [u8], offset: usize, encoding_hint: IonEncoding) -> Self;
 
     /// Deconstructs this reader, returning a tuple of `(remaining_data, stream_offset, encoding)`.
-    fn stream_data(&self) -> (&'data [u8], usize, IonEncoding);
+    fn save_state(&self) -> RawReaderState<'data>;
 
     fn next<'top>(
         &'top mut self,

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -4,6 +4,7 @@ use std::ops::Range;
 
 use rustc_hash::FxHashMap;
 
+use crate::element::iterators::SymbolsIterator;
 use crate::lazy::decoder::Decoder;
 use crate::lazy::expanded::template::{
     ExprRange, MacroSignature, Parameter, ParameterCardinality, ParameterEncoding,
@@ -17,7 +18,7 @@ use crate::lazy::value::LazyValue;
 use crate::lazy::value_ref::ValueRef;
 use crate::result::IonFailure;
 use crate::symbol_ref::AsSymbolRef;
-use crate::{v1_1, IonError, IonResult, IonType, Reader, SymbolRef};
+use crate::{v1_1, IonError, IonResult, IonType, Reader, Symbol, SymbolRef};
 
 /// Information inferred about a template's expansion at compile time.
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -73,6 +74,12 @@ impl ExpansionSingleton {
 
     pub fn num_annotations(&self) -> usize {
         self.num_annotations as usize
+    }
+
+    pub fn annotations<'a>(&self, annotations_storage: &'a [Symbol]) -> SymbolsIterator<'a> {
+        let annotations_range = 0..self.num_annotations();
+        let annotations = &annotations_storage[annotations_range];
+        SymbolsIterator::new(annotations)
     }
 }
 

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -48,10 +48,20 @@ impl ExpansionAnalysis {
     }
 }
 
-/// When static analysis can detect that a template body will always expand to a single value,
-/// information inferred about that value is stored in this type. When this template backs a
-/// lazy value, having these fields available allows the lazy value to answer basic queries without
-/// needing to fully evaluate the template.
+/// When the [`TemplateCompiler`] is able to determine that a macro's template will always produce
+/// exactly one value, that macro is considered a "singleton macro." Singleton macros offer
+/// a few benefits:
+///
+/// * Because evaluation will produce be exactly one value, the reader can hand out a LazyValue
+///   holding the e-expression as its backing data. Other macros cannot do this because if you're
+///   holding a LazyValue and the macro later evaluates to 0 values or 100 values, there's not a way
+///   for the application to handle those outcomes.
+/// * Expanding a singleton macro doesn't require an evaluator with a stack because as soon as
+///   you've gotten a value, you're done--no need to `pop()` and preserve state.
+///
+/// Information inferred about a singleton macro's output value is stored in an `ExpansionSingleton`.
+/// When a singleton macro backs a lazy value, having these fields available allows the lazy value to
+/// answer basic queries without needing to fully evaluate the template.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct ExpansionSingleton {
     pub(crate) is_null: bool,

--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -151,6 +151,9 @@ impl<'top, D: Decoder> EExpression<'top, D> {
         self.invoked_macro.expansion_analysis()
     }
 
+    /// Returns `true` if this `EExpression` was statically determined to always return exactly
+    /// one value. If this method returns `false`, no assertion about the expansion's cardinality
+    /// is made--the evaluation may still produce one value.
     pub fn is_singleton(&self) -> bool {
         self.expansion_singleton().is_some()
     }
@@ -158,12 +161,21 @@ impl<'top, D: Decoder> EExpression<'top, D> {
     pub fn expansion_singleton(&self) -> Option<ExpansionSingleton> {
         self.expansion_analysis().expansion_singleton()
     }
+
+    /// Returns the `ExpansionSingleton` describing the template expansion information that was
+    /// inferred from the macro compilation process.
+    ///
     /// Caller must guarantee that this e-expression invokes a template and that the template
     /// has a `ExpansionSingleton`. If these prerequisites are not met, this method will panic.
     pub fn require_expansion_singleton(&self) -> ExpansionSingleton {
         self.expansion_singleton().unwrap()
     }
 
+    /// Returns the annotations that this template expansion will produce, as inferred from the
+    /// macro compilation process.
+    ///
+    /// Caller must guarantee that this e-expression invokes a template and that the template
+    /// has a `ExpansionSingleton`. If these prerequisites are not met, this method will panic.
     pub fn require_singleton_annotations(&self) -> SymbolsIterator<'top> {
         let storage = self
             .invoked_macro

--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -151,6 +151,10 @@ impl<'top, D: Decoder> EExpression<'top, D> {
         self.invoked_macro.expansion_analysis()
     }
 
+    pub fn is_singleton(&self) -> bool {
+        self.expansion_singleton().is_some()
+    }
+
     pub fn expansion_singleton(&self) -> Option<ExpansionSingleton> {
         self.expansion_analysis().expansion_singleton()
     }

--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -4,6 +4,7 @@
 use std::fmt::{Debug, Formatter};
 use std::ops::Range;
 
+use crate::element::iterators::SymbolsIterator;
 use crate::lazy::decoder::{Decoder, RawValueExpr};
 use crate::lazy::encoding::TextEncoding_1_1;
 use crate::lazy::expanded::compiler::{ExpansionAnalysis, ExpansionSingleton};
@@ -157,6 +158,15 @@ impl<'top, D: Decoder> EExpression<'top, D> {
     /// has a `ExpansionSingleton`. If these prerequisites are not met, this method will panic.
     pub fn require_expansion_singleton(&self) -> ExpansionSingleton {
         self.expansion_singleton().unwrap()
+    }
+
+    pub fn require_singleton_annotations(&self) -> SymbolsIterator<'top> {
+        let storage = self
+            .invoked_macro
+            .require_template()
+            .body()
+            .annotations_storage();
+        self.expansion_singleton().unwrap().annotations(storage)
     }
 }
 

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -342,7 +342,7 @@ impl<'top, D: Decoder> ValueExpr<'top, D> {
             ValueExpr::ValueLiteral(value) => {
                 use ExpandedValueSource::*;
                 match value.source {
-                    EExp(_) => todo!(),
+                    SingletonEExp(_) => todo!(),
                     ValueLiteral(literal) => Some(literal.range()),
                     Template(_, _) => None,
                     Constructed(_, _) => None,

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -444,6 +444,12 @@ impl<'top, D: Decoder> MacroExpansion<'top, D> {
             Void => Ok(MacroExpansionStep::FinalStep(None)),
         }
     }
+
+    // Calculate the next step in this macro expansion without advancing the expansion.
+    pub fn peek_next_step(&self) -> IonResult<MacroExpansionStep<'top, D>> {
+        let mut expansion_copy = *self;
+        expansion_copy.next_step()
+    }
 }
 
 impl<'top, D: Decoder> Debug for MacroExpansion<'top, D> {

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -335,6 +335,7 @@ impl<'top, D: Decoder> ValueExpr<'top, D> {
         }
     }
 
+    /// Returns `true` if this expression was produced by evaluating a macro. Otherwise, returns `false`.
     pub fn is_ephemeral(&self) -> bool {
         match self {
             ValueExpr::ValueLiteral(value) => value.is_ephemeral(),
@@ -356,7 +357,7 @@ impl<'top, D: Decoder> ValueExpr<'top, D> {
     }
 
     /// If this `ValueExpr` represents an entity encoded in the data stream, returns `Some(range)`.
-    /// If it represents a template value or a constructed value, returns `None`.
+    /// If it represents an ephemeral value produced by a macro evaluation, returns `None`.
     pub fn span(&self) -> Option<Span<'top>> {
         match self {
             ValueExpr::ValueLiteral(value) => {

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -16,7 +16,6 @@ use std::fmt::{Debug, Formatter};
 use std::ops::Range;
 
 use bumpalo::collections::{String as BumpString, Vec as BumpVec};
-use ice_code::ice;
 
 use crate::lazy::decoder::{Decoder, HasSpan, LazyRawValueExpr};
 use crate::lazy::expanded::e_expression::{
@@ -408,16 +407,16 @@ impl<'top, D: Decoder> MacroExpansion<'top, D> {
     }
 
     /// Expands the current macro with the expectation that it will produce exactly one value.
+    /// For more information about singleton macros, see
+    /// [`ExpansionSingleton`](crate::lazy::expanded::compiler::ExpansionSingleton).
     #[inline(always)]
     pub(crate) fn expand_singleton(mut self) -> IonResult<LazyExpandedValue<'top, D>> {
         // We don't need to construct an evaluator because this is guaranteed to produce exactly
         // one value.
         match self.next_step()? {
-            // If the expansion produces anything other than a final value, there's a bug.
             MacroExpansionStep::FinalStep(Some(ValueExpr::ValueLiteral(value))) => Ok(value),
-            _ => ice!(IonResult::decoding_error(format!(
-                "expansion of {self:?} was required to produce exactly one value",
-            ))),
+            // If the expansion produces anything other than a final value, there's a bug.
+            _ => unreachable!("expansion of {self:?} was required to produce exactly one value"),
         }
     }
 

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -179,7 +179,7 @@ impl MacroTable {
     pub const NUM_SYSTEM_MACROS: usize = Self::SYSTEM_MACRO_KINDS.len();
     // When a user defines new macros, this is the first ID that will be assigned. This value
     // is expected to change as development continues. It is currently used in several unit tests.
-    pub const FIRST_USER_MACRO_ID: usize = 4;
+    pub const FIRST_USER_MACRO_ID: usize = Self::NUM_SYSTEM_MACROS;
 
     pub fn new() -> Self {
         let macros_by_id = vec![

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -131,7 +131,7 @@ impl<'top> MacroRef<'top> {
     pub fn id_text(&'top self) -> Cow<'top, str> {
         self.name()
             .map(Cow::from)
-            .unwrap_or_else(move || Cow::from(format!("<address={}>", self.address())))
+            .unwrap_or_else(move || Cow::from(format!("{}", self.address())))
     }
 
     pub fn address(&self) -> MacroAddress {

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -821,17 +821,9 @@ impl<'top, Encoding: Decoder> LazyExpandedValue<'top, Encoding> {
                     annotations.iter(),
                 ))
             }
-            SingletonEExp(eexp) => {
-                let annotations_range = 0..eexp.require_expansion_singleton().num_annotations();
-                let annotations = &eexp
-                    .invoked_macro
-                    .require_template()
-                    .body()
-                    .annotations_storage()[annotations_range];
-                ExpandedAnnotationsIterator::new(ExpandedAnnotationsSource::Template(
-                    SymbolsIterator::new(annotations),
-                ))
-            }
+            SingletonEExp(eexp) => ExpandedAnnotationsIterator::new(
+                ExpandedAnnotationsSource::Template(eexp.require_singleton_annotations()),
+            ),
         }
     }
 

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -995,7 +995,7 @@ impl<'top, Encoding: Decoder> LazyExpandedValue<'top, Encoding> {
 
     /// Returns `true` if this value was produced by evaluating a macro. Otherwise, returns `false`.
     pub fn is_ephemeral(&self) -> bool {
-        !matches!(&self.source, ExpandedValueSource::ValueLiteral(_))
+        !matches!(&self.source, ExpandedValueSource::ValueLiteral(_)) || self.is_parameter()
     }
 
     /// Returns `true` if this value was an argument passed into a macro.

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -962,9 +962,15 @@ impl<'top, D: Decoder> Iterator for TemplateMacroInvocationArgsIterator<'top, D>
                 ))
             }
             TemplateBodyExprKind::Variable(variable_ref) => {
-                self
+                let mut expr = self
                     .environment
-                    .require_expr(variable_ref.signature_index())
+                    .require_expr(variable_ref.signature_index());
+                // If this is a value (and therefore needs no further evaluation), tag it as having
+                // come from this variable in the template body.
+                if let ValueExpr::ValueLiteral(ref mut value) = expr {
+                    *value = value.via_variable(variable_ref.resolve(self.host_template.reference()))
+                }
+                expr
             },
             TemplateBodyExprKind::MacroInvocation(body_invocation) => {
                 let invocation = body_invocation

--- a/src/lazy/raw_stream_item.rs
+++ b/src/lazy/raw_stream_item.rs
@@ -5,9 +5,9 @@ use crate::{AnyEncoding, IonEncoding, IonError, IonResult};
 use std::fmt::Debug;
 use std::ops::Range;
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 /// Raw stream components that a RawReader may encounter.
-pub enum RawStreamItem<M: Debug, V: Debug, E: Debug> {
+pub enum RawStreamItem<M: Debug + Copy + Clone, V: Debug + Copy + Clone, E: Debug + Copy + Clone> {
     /// An Ion Version Marker (IVM) indicating the Ion major and minor version that were used to
     /// encode the values that follow.
     VersionMarker(M),
@@ -38,8 +38,11 @@ impl<'top> LazyRawStreamItem<'top, AnyEncoding> {
     }
 }
 
-impl<M: Debug + HasRange, V: Debug + HasRange, E: Debug + HasRange> HasRange
-    for RawStreamItem<M, V, E>
+impl<
+        M: Debug + Copy + Clone + HasRange,
+        V: Debug + Copy + Clone + HasRange,
+        E: Debug + Copy + Clone + HasRange,
+    > HasRange for RawStreamItem<M, V, E>
 {
     fn range(&self) -> Range<usize> {
         use RawStreamItem::*;
@@ -52,8 +55,12 @@ impl<M: Debug + HasRange, V: Debug + HasRange, E: Debug + HasRange> HasRange
     }
 }
 
-impl<'top, M: Debug + HasSpan<'top>, V: Debug + HasSpan<'top>, E: Debug + HasSpan<'top>>
-    HasSpan<'top> for RawStreamItem<M, V, E>
+impl<
+        'top,
+        M: Debug + Copy + Clone + HasSpan<'top>,
+        V: Debug + Copy + Clone + HasSpan<'top>,
+        E: Debug + Copy + Clone + HasSpan<'top>,
+    > HasSpan<'top> for RawStreamItem<M, V, E>
 {
     fn span(&self) -> Span<'top> {
         use RawStreamItem::*;

--- a/src/lazy/span.rs
+++ b/src/lazy/span.rs
@@ -20,9 +20,9 @@ impl<'a> AsRef<[u8]> for Span<'a> {
     }
 }
 
-impl<'a> Into<&'a [u8]> for Span<'a> {
-    fn into(self) -> &'a [u8] {
-        self.bytes
+impl<'a> From<Span<'a>> for &'a [u8] {
+    fn from(value: Span<'a>) -> Self {
+        value.bytes
     }
 }
 

--- a/src/lazy/span.rs
+++ b/src/lazy/span.rs
@@ -14,6 +14,18 @@ pub struct Span<'a> {
     offset: usize,
 }
 
+impl<'a> AsRef<[u8]> for Span<'a> {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes()
+    }
+}
+
+impl<'a> Into<&'a [u8]> for Span<'a> {
+    fn into(self) -> &'a [u8] {
+        self.bytes
+    }
+}
+
 impl<'a, A: AsRef<[u8]>> PartialEq<A> for Span<'a> {
     fn eq(&self, other: &A) -> bool {
         self.bytes() == other.as_ref()
@@ -40,5 +52,13 @@ impl<'a> Span<'a> {
     pub fn expect_text(&self) -> IonResult<&'a str> {
         std::str::from_utf8(self.bytes)
             .map_err(|_| IonError::decoding_error("span text was not valid UTF-8"))
+    }
+
+    pub fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
     }
 }

--- a/src/lazy/streaming_raw_reader.rs
+++ b/src/lazy/streaming_raw_reader.rs
@@ -45,6 +45,34 @@ pub struct StreamingRawReader<Encoding: Decoder, Input: IonInput> {
 
 const DEFAULT_IO_BUFFER_SIZE: usize = 4 * 1024;
 
+pub struct RawReaderState<'a> {
+    data: &'a [u8],
+    offset: usize,
+    encoding: IonEncoding,
+}
+
+impl<'a> RawReaderState<'a> {
+    pub fn new(data: &'a [u8], offset: usize, encoding: IonEncoding) -> Self {
+        Self {
+            data,
+            offset,
+            encoding,
+        }
+    }
+
+    pub fn data(&self) -> &'a [u8] {
+        self.data
+    }
+
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    pub fn encoding(&self) -> IonEncoding {
+        self.encoding
+    }
+}
+
 impl<Encoding: Decoder, Input: IonInput> StreamingRawReader<Encoding, Input> {
     pub fn new(_encoding: Encoding, input: Input) -> StreamingRawReader<Encoding, Input> {
         StreamingRawReader {
@@ -75,6 +103,12 @@ impl<Encoding: Decoder, Input: IonInput> StreamingRawReader<Encoding, Input> {
         let input = unsafe { &*self.input.get() };
         input.buffer().is_empty()
     }
+
+    // pub fn next<'top>(
+    //     &'top mut self,
+    //     context: EncodingContextRef<'top>,
+    // ) -> IonResult<LazyRawStreamItem<'top, Encoding>> {
+    // }
 
     pub fn next<'top>(
         &'top mut self,

--- a/src/lazy/streaming_raw_reader.rs
+++ b/src/lazy/streaming_raw_reader.rs
@@ -108,20 +108,14 @@ impl<Encoding: Decoder, Input: IonInput> StreamingRawReader<Encoding, Input> {
         &'top mut self,
         context: EncodingContextRef<'top>,
     ) -> IonResult<LazyRawStreamItem<'top, Encoding>> {
-        self.read_next(
-            context, // is_peek =
-            false,
-        )
+        self.read_next(context, /*is_peek=*/ false)
     }
 
     pub fn peek_next<'top>(
         &'top mut self,
         context: EncodingContextRef<'top>,
     ) -> IonResult<LazyRawStreamItem<'top, Encoding>> {
-        self.read_next(
-            context, // is_peek =
-            true,
-        )
+        self.read_next(context, /*is_peek=*/ true)
     }
 
     fn read_next<'top>(

--- a/src/lazy/struct.rs
+++ b/src/lazy/struct.rs
@@ -13,7 +13,10 @@ use crate::lazy::expanded::LazyExpandedValue;
 use crate::lazy::value::{AnnotationsIterator, LazyValue};
 use crate::lazy::value_ref::ValueRef;
 use crate::result::IonFailure;
-use crate::{Annotations, Element, IntoAnnotatedElement, IonError, IonResult, Struct, SymbolRef};
+use crate::{
+    Annotations, Element, ExpandedValueSource, IntoAnnotatedElement, IonError, IonResult,
+    LazyExpandedFieldName, Struct, SymbolRef,
+};
 
 /// An as-of-yet unread binary Ion struct. `LazyStruct` is immutable; its fields and annotations
 /// can be read any number of times.
@@ -297,6 +300,24 @@ impl<'top, D: Decoder> LazyField<'top, D> {
     pub fn value(&self) -> LazyValue<'top, D> {
         LazyValue {
             expanded_value: self.expanded_field.value(),
+        }
+    }
+
+    #[cfg(feature = "experimental-tooling-apis")]
+    pub fn raw_name(&self) -> Option<D::FieldName<'top>> {
+        if let LazyExpandedFieldName::RawName(_context, raw_name) = self.expanded_field.name() {
+            Some(raw_name)
+        } else {
+            None
+        }
+    }
+
+    #[cfg(feature = "experimental-tooling-apis")]
+    pub fn raw_value(&self) -> Option<D::Value<'top>> {
+        if let ExpandedValueSource::ValueLiteral(literal) = self.expanded_field.value().source() {
+            Some(literal)
+        } else {
+            None
         }
     }
 }

--- a/src/lazy/struct.rs
+++ b/src/lazy/struct.rs
@@ -1,8 +1,5 @@
 #![allow(non_camel_case_types)]
 
-use std::fmt;
-use std::fmt::{Debug, Formatter};
-
 use crate::element::builders::StructBuilder;
 use crate::lazy::decoder::{Decoder, LazyRawContainer};
 use crate::lazy::encoding::BinaryEncoding_1_0;
@@ -14,6 +11,8 @@ use crate::lazy::value::{AnnotationsIterator, LazyValue};
 use crate::lazy::value_ref::ValueRef;
 use crate::result::IonFailure;
 use crate::{Annotations, Element, IntoAnnotatedElement, IonError, IonResult, Struct, SymbolRef};
+use std::fmt;
+use std::fmt::{Debug, Formatter};
 
 /// An as-of-yet unread binary Ion struct. `LazyStruct` is immutable; its fields and annotations
 /// can be read any number of times.
@@ -319,6 +318,17 @@ impl<'top, D: Decoder> LazyField<'top, D> {
             Some(literal)
         } else {
             None
+        }
+    }
+
+    #[cfg(feature = "experimental-tooling-apis")]
+    pub fn range(&self) -> Option<std::ops::Range<usize>> {
+        use crate::HasRange;
+        match (self.raw_name(), self.raw_value()) {
+            (Some(raw_name), Some(raw_value)) => {
+                Some(raw_name.range().start..raw_value.range().end)
+            }
+            _ => None,
         }
     }
 }

--- a/src/lazy/struct.rs
+++ b/src/lazy/struct.rs
@@ -13,10 +13,7 @@ use crate::lazy::expanded::LazyExpandedValue;
 use crate::lazy::value::{AnnotationsIterator, LazyValue};
 use crate::lazy::value_ref::ValueRef;
 use crate::result::IonFailure;
-use crate::{
-    Annotations, Element, ExpandedValueSource, IntoAnnotatedElement, IonError, IonResult,
-    LazyExpandedFieldName, Struct, SymbolRef,
-};
+use crate::{Annotations, Element, IntoAnnotatedElement, IonError, IonResult, Struct, SymbolRef};
 
 /// An as-of-yet unread binary Ion struct. `LazyStruct` is immutable; its fields and annotations
 /// can be read any number of times.
@@ -305,7 +302,9 @@ impl<'top, D: Decoder> LazyField<'top, D> {
 
     #[cfg(feature = "experimental-tooling-apis")]
     pub fn raw_name(&self) -> Option<D::FieldName<'top>> {
-        if let LazyExpandedFieldName::RawName(_context, raw_name) = self.expanded_field.name() {
+        if let crate::LazyExpandedFieldName::RawName(_context, raw_name) =
+            self.expanded_field.name()
+        {
             Some(raw_name)
         } else {
             None
@@ -314,7 +313,9 @@ impl<'top, D: Decoder> LazyField<'top, D> {
 
     #[cfg(feature = "experimental-tooling-apis")]
     pub fn raw_value(&self) -> Option<D::Value<'top>> {
-        if let ExpandedValueSource::ValueLiteral(literal) = self.expanded_field.value().source() {
+        if let crate::ExpandedValueSource::ValueLiteral(literal) =
+            self.expanded_field.value().source()
+        {
             Some(literal)
         } else {
             None

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -195,14 +195,17 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
         self.expanding_reader.pending_context_changes()
     }
 
-    /// Returns the next top-level stream item (IVM, Symbol Table, Value, or Nothing) as a
-    /// [`SystemStreamItem`].
-    pub fn next_expr(&mut self) -> IonResult<ExpandedStreamItem<'_, Encoding>> {
+    /// Returns the next top-level stream item (IVM, symbol table, encoding directive, Value, or nothing)
+    /// as an [`ExpandedStreamItem`].
+    ///
+    /// This method exists largely for tooling; most applications will want to
+    /// use [`next_item`](Self::next_item).
+    pub fn next_expanded_item(&mut self) -> IonResult<ExpandedStreamItem<'_, Encoding>> {
         self.expanding_reader.next_item()
     }
 
-    /// Returns the next top-level stream item (IVM, Symbol Table, Value, or Nothing) as a
-    /// [`SystemStreamItem`].
+    /// Returns the next top-level stream item (IVM, symbol table, encoding directive, Value, or nothing)
+    /// as a [`SystemStreamItem`].
     pub fn next_item(&mut self) -> IonResult<SystemStreamItem<'_, Encoding>> {
         self.expanding_reader.next_system_item()
     }

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -6,7 +6,7 @@ use crate::lazy::expanded::compiler::TemplateCompiler;
 use crate::lazy::expanded::encoding_module::EncodingModule;
 use crate::lazy::expanded::macro_table::MacroTable;
 use crate::lazy::expanded::template::TemplateMacro;
-use crate::lazy::expanded::{ExpandingReader, LazyExpandedValue};
+use crate::lazy::expanded::{ExpandedStreamItem, ExpandingReader, LazyExpandedValue};
 use crate::lazy::sequence::SExpIterator;
 use crate::lazy::streaming_raw_reader::{IonInput, StreamingRawReader};
 use crate::lazy::system_stream_item::SystemStreamItem;
@@ -197,8 +197,14 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
 
     /// Returns the next top-level stream item (IVM, Symbol Table, Value, or Nothing) as a
     /// [`SystemStreamItem`].
-    pub fn next_item(&mut self) -> IonResult<SystemStreamItem<'_, Encoding>> {
+    pub fn next_expr(&mut self) -> IonResult<ExpandedStreamItem<'_, Encoding>> {
         self.expanding_reader.next_item()
+    }
+
+    /// Returns the next top-level stream item (IVM, Symbol Table, Value, or Nothing) as a
+    /// [`SystemStreamItem`].
+    pub fn next_item(&mut self) -> IonResult<SystemStreamItem<'_, Encoding>> {
+        self.expanding_reader.next_system_item()
     }
 
     /// Returns the next value that is part of the application data model, bypassing all encoding

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -1086,7 +1086,7 @@ mod tests {
             &[
                 Symbol::from("foo"),
                 Symbol::from("bar"),
-                Symbol::from("baz")
+                Symbol::from("baz"),
             ]
         );
 
@@ -1096,11 +1096,11 @@ mod tests {
         // This directive defines two more.
         assert_eq!(new_macro_table.len(), 2 + MacroTable::NUM_SYSTEM_MACROS);
         assert_eq!(
-            new_macro_table.macro_with_id(4),
+            new_macro_table.macro_with_id(MacroTable::FIRST_USER_MACRO_ID),
             new_macro_table.macro_with_name("seventeen")
         );
         assert_eq!(
-            new_macro_table.macro_with_id(5),
+            new_macro_table.macro_with_id(MacroTable::FIRST_USER_MACRO_ID + 1),
             new_macro_table.macro_with_name("twelve")
         );
 

--- a/src/lazy/system_stream_item.rs
+++ b/src/lazy/system_stream_item.rs
@@ -24,6 +24,7 @@ pub enum SystemStreamItem<'top, D: Decoder> {
 }
 
 impl<'top, D: Decoder> SystemStreamItem<'top, D> {
+    /// Returns an [`ExpandedStreamItem`] view of this item.
     pub fn as_expanded_stream_item(&self) -> ExpandedStreamItem<'top, D> {
         use SystemStreamItem::*;
         match self {

--- a/src/lazy/system_stream_item.rs
+++ b/src/lazy/system_stream_item.rs
@@ -5,7 +5,7 @@ use crate::lazy::r#struct::LazyStruct;
 use crate::lazy::raw_stream_item::{EndPosition, LazyRawStreamItem, RawStreamItem};
 use crate::lazy::value::LazyValue;
 use crate::result::IonFailure;
-use crate::{IonError, IonResult, LazySExp};
+use crate::{ExpandedStreamItem, IonError, IonResult, LazySExp};
 
 /// System stream elements that a SystemReader may encounter.
 #[non_exhaustive]
@@ -21,6 +21,19 @@ pub enum SystemStreamItem<'top, D: Decoder> {
     Value(LazyValue<'top, D>),
     /// The end of the stream
     EndOfStream(EndPosition),
+}
+
+impl<'top, D: Decoder> SystemStreamItem<'top, D> {
+    pub fn as_expanded_stream_item(&self) -> ExpandedStreamItem<'top, D> {
+        use SystemStreamItem::*;
+        match self {
+            VersionMarker(m) => ExpandedStreamItem::VersionMarker(*m),
+            SymbolTable(s) => ExpandedStreamItem::SymbolTable(*s),
+            EncodingDirective(d) => ExpandedStreamItem::EncodingDirective(*d),
+            Value(v) => ExpandedStreamItem::Value(*v),
+            EndOfStream(e) => ExpandedStreamItem::EndOfStream(*e),
+        }
+    }
 }
 
 impl<'top, D: Decoder> Debug for SystemStreamItem<'top, D> {

--- a/src/lazy/text/buffer.rs
+++ b/src/lazy/text/buffer.rs
@@ -1573,10 +1573,11 @@ impl<'top> TextBufferView<'top> {
             // will be handled by this parser branch.
             pair(satisfy(|c| c.is_ascii_digit()), complete_digit0),
             // Note: ^-- We use this `pair(satisfy(...), complete_digit0)` to guarantee a subtle
-            //       behavior. At the end of a buffer, `1.` must be considered 'incomplete' instead
-            //       of 'invalid'. In contrast, `1.1` must be considered complete even though
-            //       the buffer could get more data later. If the buffer gets more data, it's
-            //       the StreamingRawReader's responsibility to discard the `1.1` and try again.
+            //       behavior. At the end of the buffer, an empty input to this parser must be
+            //       considered 'incomplete' instead of 'invalid'. In contrast, an input of a single
+            //       digit would be considered complete even though the buffer could get more data later.
+            //       (If the buffer gets more data, it's the StreamingRawReader's responsibility to
+            //       discard the `1.1` and try again.)
         ))(self)
     }
 

--- a/src/lazy/text/buffer.rs
+++ b/src/lazy/text/buffer.rs
@@ -1569,7 +1569,7 @@ impl<'top> TextBufferView<'top> {
             // Zero or more digits-followed-by-underscores
             many0_count(pair(complete_digit1, complete_char('_'))),
             // One or more digits
-            complete_digit1,
+            digit1,
         ))(self)
     }
 

--- a/src/lazy/text/buffer.rs
+++ b/src/lazy/text/buffer.rs
@@ -1088,6 +1088,11 @@ impl<'top> TextBufferView<'top> {
         // TODO: Support macro ID kinds besides unqualified names
         let (exp_body_after_id, (macro_id_bytes, matched_symbol)) =
             consumed(Self::match_identifier)(eexp_body)?;
+        if exp_body_after_id.is_empty() {
+            // Unlike a symbol value with identifier syntax, an e-expression identifier cannot be
+            // the last thing in the stream.
+            return Err(nom::Err::Incomplete(Needed::Unknown));
+        }
 
         let id = match matched_symbol
             .read(self.context.allocator(), macro_id_bytes)

--- a/src/lazy/text/parse_result.rs
+++ b/src/lazy/text/parse_result.rs
@@ -129,10 +129,16 @@ impl<'data> From<InvalidInputError<'data>> for IonError {
                 .unwrap_or("invalid Ion syntax encountered"),
         );
         if let Some(label) = invalid_input_error.label {
-            message.push_str(" while ");
+            message.push_str("\n    while ");
             message.push_str(label.as_ref());
         }
-        message.push_str("; buffer: ");
+        use std::fmt::Write;
+        write!(
+            message,
+            "\n        <offset={}, buffer=",
+            invalid_input_error.input.offset()
+        )
+        .unwrap();
         let input = invalid_input_error.input;
         let buffer_text = if let Ok(text) = invalid_input_error.input.as_text() {
             text.chars().take(32).collect::<String>()
@@ -143,7 +149,7 @@ impl<'data> From<InvalidInputError<'data>> for IonError {
             )
         };
         message.push_str(buffer_text.as_str());
-        message.push_str("...");
+        message.push_str("...>");
         let position = Position::with_offset(invalid_input_error.input.offset())
             .with_length(invalid_input_error.input.len());
         let decoding_error = DecodingError::new(message).with_position(position);

--- a/src/lazy/text/raw/reader.rs
+++ b/src/lazy/text/raw/reader.rs
@@ -5,6 +5,7 @@ use crate::lazy::decoder::LazyRawReader;
 use crate::lazy::encoding::TextEncoding_1_0;
 use crate::lazy::expanded::EncodingContextRef;
 use crate::lazy::raw_stream_item::{EndPosition, LazyRawStreamItem, RawStreamItem};
+use crate::lazy::streaming_raw_reader::RawReaderState;
 use crate::lazy::text::buffer::TextBufferView;
 use crate::lazy::text::parse_result::AddContext;
 use crate::{Encoding, IonResult};
@@ -92,8 +93,8 @@ impl<'data> LazyRawReader<'data, TextEncoding_1_0> for LazyRawTextReader_1_0<'da
         LazyRawTextReader_1_0::new_with_offset(data, offset)
     }
 
-    fn stream_data(&self) -> (&'data [u8], usize, IonEncoding) {
-        (
+    fn save_state(&self) -> RawReaderState<'data> {
+        RawReaderState::new(
             &self.input[self.local_offset..],
             self.position(),
             self.encoding(),

--- a/src/lazy/text/raw/v1_1/reader.rs
+++ b/src/lazy/text/raw/v1_1/reader.rs
@@ -18,6 +18,7 @@ use crate::lazy::expanded::macro_evaluator::RawEExpression;
 use crate::lazy::expanded::EncodingContextRef;
 use crate::lazy::raw_stream_item::{EndPosition, LazyRawStreamItem, RawStreamItem};
 use crate::lazy::span::Span;
+use crate::lazy::streaming_raw_reader::RawReaderState;
 use crate::lazy::text::buffer::TextBufferView;
 use crate::lazy::text::matched::{MatchedFieldName, MatchedValue};
 use crate::lazy::text::parse_result::{AddContext, ToIteratorOutput};
@@ -50,8 +51,8 @@ impl<'data> LazyRawReader<'data, TextEncoding_1_1> for LazyRawTextReader_1_1<'da
         }
     }
 
-    fn stream_data(&self) -> (&'data [u8], usize, IonEncoding) {
-        (
+    fn save_state(&self) -> RawReaderState<'data> {
+        RawReaderState::new(
             &self.input[self.local_offset..],
             self.position(),
             self.encoding(),

--- a/src/lazy/value.rs
+++ b/src/lazy/value.rs
@@ -52,7 +52,7 @@ use crate::{
 ///# #[cfg(not(feature = "experimental-reader-writer"))]
 ///# fn main() -> IonResult<()> { Ok(()) }
 /// ```
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct LazyValue<'top, D: Decoder> {
     pub(crate) expanded_value: LazyExpandedValue<'top, D>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,7 @@ macro_rules! v1_x_tooling_apis {
             },
             lazy::expanded::e_expression::{EExpression, EExpressionArgsIterator},
             lazy::expanded::sequence::{Environment, ExpandedListSource, ExpandedSExpSource, LazyExpandedList, LazyExpandedSExp},
-            lazy::expanded::{LazyExpandedValue, ExpandingReader, ExpandedValueSource, ExpandedAnnotationsSource, ExpandedValueRef},
+            lazy::expanded::{ExpandedStreamItem, LazyExpandedValue, ExpandingReader, ExpandedValueSource, ExpandedAnnotationsSource, ExpandedValueRef},
             lazy::system_stream_item::SystemStreamItem,
             lazy::system_reader::{SystemReader},
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,8 +339,6 @@ macro_rules! v1_1_tooling_apis {
             lazy::binary::raw::v1_1::value::{
                 LazyRawBinaryValue_1_1 as LazyRawBinaryValue,
                 LazyRawBinaryVersionMarker_1_1 as LazyRawBinaryVersionMarker,
-                // EncodedBinaryValueData_1_1 as EncodedBinaryValueData,
-                // EncodedBinaryAnnotations_1_1 as EncodedBinaryAnnotations
             },
         };
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,6 +313,7 @@ macro_rules! v1_0_tooling_apis {
             },
             lazy::binary::raw::r#struct::{LazyRawBinaryStruct_1_0 as LazyRawBinaryStruct, LazyRawBinaryFieldName_1_0 as LazyRawBinaryFieldName},
             lazy::binary::raw::value::{
+                EncodedBinaryValue,
                 LazyRawBinaryValue_1_0 as LazyRawBinaryValue,
                 LazyRawBinaryVersionMarker_1_0 as LazyRawBinaryVersionMarker,
                 EncodedBinaryValueData_1_0 as EncodedBinaryValueData,
@@ -330,6 +331,17 @@ macro_rules! v1_1_tooling_apis {
             lazy::encoder::binary::v1_1::flex_uint::FlexUInt,
             lazy::encoder::binary::v1_1::writer::LazyRawBinaryWriter_1_1 as RawBinaryWriter,
             lazy::encoder::text::v1_1::writer::LazyRawTextWriter_1_1 as RawTextWriter,
+            lazy::binary::raw::v1_1::sequence::{
+                LazyRawBinaryList_1_1 as LazyRawBinaryList,
+                LazyRawBinarySExp_1_1 as LazyRawBinarySExp
+            },
+            lazy::binary::raw::v1_1::r#struct::{LazyRawBinaryStruct_1_1 as LazyRawBinaryStruct, LazyRawBinaryFieldName_1_1 as LazyRawBinaryFieldName},
+            lazy::binary::raw::v1_1::value::{
+                LazyRawBinaryValue_1_1 as LazyRawBinaryValue,
+                LazyRawBinaryVersionMarker_1_1 as LazyRawBinaryVersionMarker,
+                // EncodedBinaryValueData_1_1 as EncodedBinaryValueData,
+                // EncodedBinaryAnnotations_1_1 as EncodedBinaryAnnotations
+            },
         };
     };
 }


### PR DESCRIPTION
This PR:
* Adds a new trait, `EncodedBinaryValue`, with methods for exposing `Span`s representing the various components of a value's encoding. This trait is implemented by the 1.0 and 1.1 binary value types. These methods allow `ion inspect` to handle both versions' values uniformly.
* Adds `peek` methods to raw container iterators and `MacroExpansion`, allowing tools to see the next value without advancing state.
* Adds an `ExpandedStreamItem` enum that surfaces input `EExp`s in addition to their expansion. This allows tools (like `inspect` to investigate the `EExp` and then investigate its output values.
* Renames `ExpandedValueSource::EExp` to `SingletonEExp`. If a `LazyValue` is backed by an `EExp`, it's because it was found to always expand to a single value at compile time--that makes it possible to hand out a `LazyValue` knowing that when it is eventually read there will be exactly one value. Other values can _come from_ an `EExp`, but are not backed by it. The renaming hopes to make that less fuzzy.
* Adds convenience methods for inspecting where a value/expr came from, like `is_ephemeral`, `is_parameter`, etc.

It also fixes three bugs for detecting incomplete input:
* Text `EExp` IDs were being parsed using the `identifier` symbol parser. Unlike a symbol, an `EExp`'s ID cannot be the last thing in a stream.
* The `float` parser correctly rejected input like `123e` (no digits after `e`), but it did it by declaring it `invalid` rather than `incomplete`. If the buffer received more data, it's possible retrying would succeed.
* Binary 1.1 values were not confirming that the entire value was in the buffer after reading its length.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
