### PR TITLE
Allow `?` and `*` parameters to be omitted in tail position

### DIFF
--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -49,6 +49,13 @@ impl Parameter {
     pub fn is_variadic(&self) -> bool {
         !matches!(self.cardinality, ParameterCardinality::ExactlyOne)
     }
+    /// Returns true if a text e-expression can omit this argument.
+    ///
+    /// Arguments for parameters with a cardinality of zero-or-one (`?`) or zero-or-more (`*`) can
+    /// be omitted if there are no other arguments being passed.
+    pub fn can_be_omitted(&self) -> bool {
+        matches!(self.cardinality, ParameterCardinality::ZeroOrOne | ParameterCardinality::ZeroOrMore)
+    }
 }
 
 /// The encoding used to serialize and deserialize the associated parameter.

--- a/src/lazy/text/buffer.rs
+++ b/src/lazy/text/buffer.rs
@@ -3066,6 +3066,9 @@ mod tests {
             "(:foo 1 2 3)",
             "(:foo 1 2 3 4)",
             "(:foo 1 2 3 4 5 6)", // implicit rest
+            "(:foo 1 2 3 (:))",   // explicit empty stream
+            "(:foo 1 2 (:) 4)",
+            "(:foo 1 2 (:) (:))",
         ],
         expect_mismatch: [
             "(:foo 1)",


### PR DESCRIPTION
Previously the text reader only allowed arguments that could use rest syntax to also be omitted altogether.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
