### PR TITLE
Make newly-compiled macros available for use

### DIFF
--- a/benches/read_many_structs.rs
+++ b/benches/read_many_structs.rs
@@ -400,9 +400,7 @@ mod benchmark {
         let binary_1_1_data = test_data_1_1.binary_data.as_slice();
         let name = test_data_1_1.name.as_str();
 
-        let empty_context = EncodingContext::for_ion_version(IonVersion::v1_1);
         let compiled_macro = TemplateCompiler::compile_from_text(
-            empty_context.get_ref(),
             &test_data_1_1.template_definition_text,
         )
         .unwrap();

--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -1106,7 +1106,7 @@ mod tests {
         test_fn: impl FnOnce(BinaryEExpArgsIterator_1_1) -> IonResult<()>,
     ) -> IonResult<()> {
         let mut context = EncodingContext::empty();
-        let template_macro = TemplateCompiler::compile_from_text(context.get_ref(), macro_source)?;
+        let template_macro = TemplateCompiler::compile_from_text(macro_source)?;
         let macro_address = context.macro_table.add_macro(template_macro)?;
         let opcode_byte = u8::try_from(macro_address).unwrap();
         let binary_ion = encode_macro_fn(opcode_byte as usize);

--- a/src/lazy/encoder/text/v1_1/writer.rs
+++ b/src/lazy/encoder/text/v1_1/writer.rs
@@ -281,7 +281,7 @@ mod tests {
         let mut reader = LazyRawTextReader_1_1::new(encoded_text.as_bytes());
         let mut context = EncodingContext::for_ion_version(IonVersion::v1_1);
         let macro_foo =
-            TemplateCompiler::compile_from_text(context.get_ref(), "(macro foo (x*) null)")?;
+            TemplateCompiler::compile_from_text("(macro foo (x*) null)")?;
         context.macro_table.add_macro(macro_foo)?;
         let context = context.get_ref();
         let _marker = reader.next(context)?.expect_ivm()?;

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -153,7 +153,7 @@ impl EncodingContext {
     // TODO: These methods are temporary; they will be removed once shared modules are supported.
     pub fn register_template_src(&mut self, template_definition: &str) -> IonResult<MacroAddress> {
         let template_macro: TemplateMacro =
-            TemplateCompiler::compile_from_text(self.get_ref(), template_definition)?;
+            TemplateCompiler::compile_from_text(template_definition)?;
         self.register_template(template_macro)
     }
 
@@ -278,7 +278,7 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
     }
 
     fn compile_template(&self, template_definition: &str) -> IonResult<TemplateMacro> {
-        TemplateCompiler::compile_from_text(self.context(), template_definition)
+        TemplateCompiler::compile_from_text(template_definition)
     }
 
     fn add_macro(&mut self, template_macro: TemplateMacro) -> IonResult<MacroAddress> {

--- a/src/lazy/text/buffer.rs
+++ b/src/lazy/text/buffer.rs
@@ -2538,7 +2538,7 @@ mod tests {
 
         fn register_macro(&mut self, text: &str) -> &mut Self {
             let new_macro =
-                TemplateCompiler::compile_from_text(self.context.get_ref(), text).unwrap();
+                TemplateCompiler::compile_from_text(text).unwrap();
             self.context.macro_table.add_macro(new_macro).unwrap();
             self
         }

--- a/src/lazy/text/raw/v1_1/reader.rs
+++ b/src/lazy/text/raw/v1_1/reader.rs
@@ -807,7 +807,7 @@ mod tests {
 
         let mut context = EncodingContext::for_ion_version(IonVersion::v1_1);
         let macro_quux =
-            TemplateCompiler::compile_from_text(context.get_ref(), "(macro quux (x) null)")?;
+            TemplateCompiler::compile_from_text("(macro quux (x) null)")?;
         context.macro_table.add_macro(macro_quux)?;
         let reader = &mut LazyRawTextReader_1_1::new(data.as_bytes());
         let context = context.get_ref();


### PR DESCRIPTION
Formerly, a macro defined in a macro table definition could not be referenced in a subsequent macro in that same definition. Now it can!

Fixes #817.

*Issue #, if available:* #817

*Description of changes:* 
Removed the `EncodingContext` from `compiler.rs`, replaced with a reference to the macro table under assembly as values are compiled. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
