### PR TITLE
Support 1.1 LST append, binary e-exps in field value position

### DIFF
--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -1601,7 +1601,7 @@ impl<'data> From<LazyRawFieldExpr<'data, BinaryEncoding_1_1>>
         use LazyRawFieldExpr::*;
         match binary_field {
             NameValue(name, value) => NameValue(name.into(), value.into()),
-            NameEExp(_, _) => todo!("(name, e-exp) field in binary Ion 1.1"),
+            NameEExp(name, eexp) => NameEExp(name.into(), eexp.into()),
             EExp(_) => todo!("e-exp field in binary Ion 1.1"),
         }
     }

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -23,6 +23,10 @@ impl Default for SymbolTable {
 }
 
 impl SymbolTable {
+    const NUM_SYSTEM_SYMBOLS_1_0: usize = 10;
+    // TODO: Update this when the implementation is complete
+    const NUM_SYSTEM_SYMBOLS_1_1: usize = 10;
+
     /// Constructs a new symbol table pre-populated with the system symbols defined in the spec.
     pub(crate) fn new(ion_version: IonVersion) -> SymbolTable {
         // Enough to hold the 1.0 system table and several user symbols.
@@ -141,6 +145,26 @@ impl SymbolTable {
     /// [Symbol] for more information.
     pub fn symbols(&self) -> &[Symbol] {
         &self.symbols_by_id
+    }
+
+    pub fn number_of_system_symbols(&self) -> usize {
+        match self.ion_version {
+            IonVersion::v1_0 => Self::NUM_SYSTEM_SYMBOLS_1_0,
+            IonVersion::v1_1 => Self::NUM_SYSTEM_SYMBOLS_1_1,
+        }
+    }
+
+    /// Returns a slice of the symbols that were defined by the application--those that follow the
+    /// system symbols in the table.
+    pub fn application_symbols(&self) -> &[Symbol] {
+        let num_sys_symbols = self.number_of_system_symbols();
+        &self.symbols()[num_sys_symbols..]
+    }
+
+    /// Returns the slice of symbols that were defined by the specification.
+    pub fn system_symbols(&self) -> &[Symbol] {
+        let num_sys_symbols = self.number_of_system_symbols();
+        &self.symbols()[0..num_sys_symbols]
     }
 
     /// Returns a slice of the last `n` symbols in the symbol table. The caller must confirm that


### PR DESCRIPTION
Changes:
* When writing Ion 1.1, `Writer` now emits an encoding directive instead of a 1.0-style symbol table.
* The reader now recognizes `(symbol_table $ion_encoding ["sym1", "sym2", "sym3"])` syntax as re-exporting the symbols in the current context's table at the head of the new context's table.
* The raw binary 1.1 reader surfaces e-expressions found in struct field value position.
* The `SymbolTable` type now exposes methods for getting its system symbols and its application symbols separately.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
