### PR TITLE
Configures Miri to use tree borrows, fixes remaining errors

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,6 +1,6 @@
 name: Miri test
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
   build:
@@ -11,9 +11,9 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-rust'
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
         # build and test for experimental features with miri
-        features: ['experimental']
+        features: [ 'experimental' ]
     permissions:
       checks: write
 
@@ -37,9 +37,17 @@ jobs:
       - name: Test with Miri (ubuntu and macos)
         # miri test for Linux and macOS os, since Windows os requires a different syntax to enable miri flags
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
-        # We need to pass the miri flag to disable host isolation in order to access host for clock information on timestamps
-        # more information can be found: https://github.com/rust-lang/miri#miri--z-flags-and-environment-variables
-        run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test serde --features "${{ matrix.features }}"
+        # Miri flags
+        #
+        # -Zmiri-disable-isolation
+        #     We need to pass the miri flag to disable host isolation in order to access host for clock information on timestamps
+        #     more information can be found: https://github.com/rust-lang/miri#miri--z-flags-and-environment-variables
+        #
+        # -Zmiri-tree-borrows
+        #     Miri's default aliasing model (stacked borrows) is known to be unnecessarily restrictive. Their alternative
+        #     aliasing model (tree borrows) accepts valid programs that stacked borrows would reject.
+        #     For more information, see: https://www.ralfj.de/blog/2023/06/02/tree-borrows.html
+        run: MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-tree-borrows" cargo miri test serde --features "${{ matrix.features }}"
       - name: Test with Miri (windows)
         if: matrix.os == 'windows-latest'
-        run: $env:MIRIFLAGS="-Zmiri-disable-isolation" ; cargo miri test serde --features "${{ matrix.features }}"
+        run: $env:MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-tree-borrows" ; cargo miri test serde --features "${{ matrix.features }}"

--- a/src/lazy/encoder/binary/v1_0/writer.rs
+++ b/src/lazy/encoder/binary/v1_0/writer.rs
@@ -11,7 +11,7 @@ use crate::lazy::encoder::value_writer::SequenceWriter;
 use crate::lazy::encoder::write_as_ion::WriteAsIon;
 use crate::lazy::encoder::LazyRawWriter;
 use crate::lazy::encoding::Encoding;
-use crate::unsafe_helpers::{mut_ref_to_ptr, ptr_to_mut_ref};
+use crate::unsafe_helpers::{mut_ref_to_ptr, ptr_to_mut_ref, ptr_to_ref};
 use crate::write_config::{WriteConfig, WriteConfigKind};
 use crate::{IonEncoding, IonResult};
 
@@ -70,17 +70,13 @@ impl<W: Write> LazyRawBinaryWriter_1_0<W> {
             allocator,
             encoding_buffer_ptr,
         } = self;
-
-        let encoding_buffer = match encoding_buffer_ptr {
-            // If `encoding_buffer_ptr` is set, get the slice of bytes to which it refers.
-            Some(ptr) => unsafe { ptr_to_mut_ref::<'_, BumpVec<'_, u8>>(*ptr).as_slice() },
-            // Otherwise, there's nothing in the buffer. Use an empty slice.
-            None => &[],
-        };
-        // Write our top level encoding buffer's contents to the output sink.
-        output.write_all(encoding_buffer)?;
-        // Flush the output sink, which may have its own buffers.
-        output.flush()?;
+        if let Some(ptr) = encoding_buffer_ptr {
+            let encoding_buffer = unsafe { ptr_to_ref::<'_, BumpVec<'_, u8>>(*ptr).as_slice() };
+            // Write our top level encoding buffer's contents to the output sink.
+            output.write_all(encoding_buffer)?;
+            // Flush the output sink, which may have its own buffers.
+            output.flush()?;
+        }
         // Now that we've written the encoding buffer's contents to output, clear it.
         self.encoding_buffer_ptr = None;
         // Clear the allocator. A new encoding buffer will be allocated on the next write.
@@ -88,22 +84,39 @@ impl<W: Write> LazyRawBinaryWriter_1_0<W> {
         Ok(())
     }
 
-    pub(crate) fn value_writer(&mut self) -> BinaryValueWriter_1_0<'_, '_> {
-        let top_level = match self.encoding_buffer_ptr {
+    fn get_or_allocate_encoding_buffer<'value, 'top>(
+        encoding_buffer_ptr: &'value mut Option<*mut ()>,
+        allocator: &'top BumpAllocator,
+    ) -> &'value mut BumpVec<'top, u8> {
+        match encoding_buffer_ptr {
             // If the `encoding_buffer_ptr` is set, we already allocated an encoding buffer on
             // a previous call to `value_writer()`. Dereference the pointer and continue encoding
             // to that buffer.
-            Some(ptr) => unsafe { ptr_to_mut_ref::<'_, BumpVec<'_, u8>>(ptr) },
-            // Otherwise, allocate a new encoding buffer and set the pointer to refer to it.
-            None => {
-                let buffer = self
-                    .allocator
-                    .alloc_with(|| BumpVec::new_in(&self.allocator));
-                self.encoding_buffer_ptr = Some(mut_ref_to_ptr(buffer));
-                buffer
+            Some(ptr) => {
+                let new_ptr = *ptr;
+                unsafe { ptr_to_mut_ref::<'_, BumpVec<'_, u8>>(new_ptr) }
             }
-        };
-        let annotated_value_writer = BinaryValueWriter_1_0::new(&self.allocator, top_level);
+            None => {
+                let encoding_buffer = allocator.alloc_with(|| BumpVec::<u8>::new_in(allocator));
+                let ptr = mut_ref_to_ptr(encoding_buffer);
+                // SAFETY: We cannot both store `ptr` in `encoding_buffer_ptr` AND turn it into
+                //         a mutable BumVec reference to return because this (briefly) constructs
+                //         two mutable references. Instead, we store it in `encoding_buffer_ptr`
+                //         and then read it from its new location.
+                *encoding_buffer_ptr = Some(ptr);
+                unsafe { ptr_to_mut_ref::<'_, BumpVec<'_, u8>>(encoding_buffer_ptr.unwrap()) }
+            }
+        }
+    }
+
+    pub(crate) fn value_writer(&mut self) -> BinaryValueWriter_1_0<'_, '_> {
+        let Self {
+            ref allocator,
+            ref mut encoding_buffer_ptr,
+            ..
+        } = *self;
+        let top_level = Self::get_or_allocate_encoding_buffer(encoding_buffer_ptr, allocator);
+        let annotated_value_writer = BinaryValueWriter_1_0::new(allocator, top_level);
         annotated_value_writer
     }
 }

--- a/src/unsafe_helpers.rs
+++ b/src/unsafe_helpers.rs
@@ -19,6 +19,15 @@ pub(crate) unsafe fn ptr_to_mut_ref<'a, T>(ptr: *mut ()) -> &'a mut T {
     &mut *typed_ptr
 }
 
+/// Helper function that turns a raw pointer into an immutable reference of the specified type.
+///
+/// The caller is responsible for confirming that `ptr` is a valid reference to some value
+/// of type `T`.
+pub(crate) unsafe fn ptr_to_ref<'a, T>(ptr: *mut ()) -> &'a T {
+    let typed_ptr: *const T = ptr.cast();
+    &*typed_ptr
+}
+
 /// Helper function that turns a mutable reference into a raw pointer.
 ///
 /// Because this method does not read the data to which the reference points,


### PR DESCRIPTION
Related to #794.

Miri's [tree borrows](https://perso.crans.org/vanille/treebor/index.html) aliasing model is more permissive than stacked borrows (the default), which is known to reject some programs that are actually safe.

This PR configures our CI `miri` check to use tree borrows and addresses several of Miri's complaints. This is enough to satisfy the tests currently in CI (the tests for the experimental `serde` feature).

There are still some issues to investigate. When running Miri on the entire test suite, it complains about at least one more problem, though it's unclear whether it's actually a potential problem or another limitation in its aliasing model. This patch is an improvement, however, and I'd rather not block these changes as we look into the others.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
