### PR TITLE
Enables dependent macros

### DIFF
--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -299,7 +299,7 @@ impl MacroTable {
         self.macros_by_name.get(name).copied()
     }
 
-    pub fn macro_with_name<'a>(&'a self, name: &str) -> Option<MacroRef<'a>> {
+    pub fn macro_with_name(&self, name: &str) -> Option<MacroRef> {
         let address = *self.macros_by_name.get(name)?;
         let reference = self.macros_by_address.get(address)?;
         Some(MacroRef { address, reference })

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -388,7 +388,8 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
                     arg.ion_type()
                 ))
             })?;
-            let new_macro = TemplateCompiler::compile_from_sexp(context, macro_def_sexp)?;
+            let new_macro =
+                TemplateCompiler::compile_from_sexp(context, &macro_table, macro_def_sexp)?;
             macro_table.add_macro(new_macro)?;
         }
         Ok(macro_table)


### PR DESCRIPTION
This builds on PR #821. It also borrows from and supersedes the changes in @jobarr-amzn's PR #818.

Modifies the `TemplateCompiler` to resolve macro IDs in the table of 'pending' macros (defined in the current encoding directive) rather than the active macro table. This allows macros to depend on previously defined macros.

> [!NOTE] 
> `cargo fmt` did some reflows that accounts for ~half of the diff. Fortunately, all of the formatting changes occur in a contiguous block at the end of the PR. I've added a PR tour comment showing where that begins.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
