### PR TITLE
Adds `make_sexp` macro, enabling output of system values

### DIFF
--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -10,8 +10,8 @@ use crate::lazy::encoding::TextEncoding_1_1;
 use crate::lazy::expanded::compiler::{ExpansionAnalysis, ExpansionSingleton};
 use crate::lazy::expanded::macro_evaluator::{
     AnnotateExpansion, EExpArgGroupIterator, EExpressionArgGroup, MacroExpansion,
-    MacroExpansionKind, MacroExpr, MacroExprArgsIterator, MakeStringExpansion, RawEExpression,
-    TemplateExpansion, ValueExpr, ValuesExpansion,
+    MacroExpansionKind, MacroExpr, MacroExprArgsIterator, MakeSExpExpansion, MakeStringExpansion,
+    RawEExpression, TemplateExpansion, ValueExpr, ValuesExpansion,
 };
 use crate::lazy::expanded::macro_table::{MacroKind, MacroRef};
 use crate::lazy::expanded::template::TemplateMacroRef;
@@ -125,6 +125,7 @@ impl<'top, D: Decoder> EExpression<'top, D> {
             MacroKind::MakeString => {
                 MacroExpansionKind::MakeString(MakeStringExpansion::new(arguments))
             }
+            MacroKind::MakeSExp => MacroExpansionKind::MakeSExp(MakeSExpExpansion::new(arguments)),
             MacroKind::Annotate => MacroExpansionKind::Annotate(AnnotateExpansion::new(arguments)),
             MacroKind::Template(template_body) => {
                 let template_ref = TemplateMacroRef::new(invoked_macro, template_body);

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -1050,7 +1050,7 @@ impl<'top, D: Decoder> MakeSExpExpansion<'top, D> {
     ) -> IonResult<MacroExpansionStep<'top, D>> {
         // The `make_sexp` macro always produces a single s-expression. When `next()` is called
         // to begin its evaluation, immediately return a lazy value representing the (not yet
-        // computed) struct. If/when the application tries to iterate over its child expressions,
+        // computed) sexp. If/when the application tries to iterate over its child expressions,
         // the iterator will evaluate the child expressions incrementally.
         let lazy_expanded_sexp = LazyExpandedSExp {
             source: ExpandedSExpSource::Constructed(environment, self.arguments),
@@ -1058,7 +1058,7 @@ impl<'top, D: Decoder> MakeSExpExpansion<'top, D> {
         };
         let lazy_sexp = LazySExp::new(lazy_expanded_sexp);
         // Store the `SExp` in the bump so it's guaranteed to be around as long as the reader is
-        // positioned on this top-level value.git
+        // positioned on this top-level value.
         let value_ref = context.allocator().alloc_with(|| ValueRef::SExp(lazy_sexp));
         let lazy_expanded_value = LazyExpandedValue::from_constructed(context, &[], value_ref);
         Ok(MacroExpansionStep::FinalStep(Some(

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -33,7 +33,10 @@ use crate::lazy::str_ref::StrRef;
 use crate::lazy::text::raw::v1_1::arg_group::EExpArg;
 use crate::lazy::text::raw::v1_1::reader::MacroIdRef;
 use crate::result::IonFailure;
-use crate::{ExpandedValueSource, IonError, IonResult, LazyValue, Span, SymbolRef, ValueRef};
+use crate::{
+    ExpandedSExpSource, ExpandedValueSource, IonError, IonResult, LazyExpandedSExp, LazySExp,
+    LazyValue, Span, SymbolRef, ValueRef,
+};
 
 pub trait EExpArgGroupIterator<'top, D: Decoder>:
     Copy + Clone + Debug + Iterator<Item = IonResult<LazyRawValueExpr<'top, D>>>
@@ -387,6 +390,7 @@ pub enum MacroExpansionKind<'top, D: Decoder> {
     Void,
     Values(ValuesExpansion<'top, D>),
     MakeString(MakeStringExpansion<'top, D>),
+    MakeSExp(MakeSExpExpansion<'top, D>),
     Annotate(AnnotateExpansion<'top, D>),
     Template(TemplateExpansion<'top>),
 }
@@ -459,6 +463,7 @@ impl<'top, D: Decoder> MacroExpansion<'top, D> {
             Template(template_expansion) => template_expansion.next(context, environment),
             Values(values_expansion) => values_expansion.next(context, environment),
             MakeString(make_string_expansion) => make_string_expansion.next(context, environment),
+            MakeSExp(make_sexp_expansion) => make_sexp_expansion.next(context, environment),
             Annotate(annotate_expansion) => annotate_expansion.next(context, environment),
             // `void` is trivial and requires no delegation
             Void => Ok(MacroExpansionStep::FinalStep(None)),
@@ -478,6 +483,7 @@ impl<'top, D: Decoder> Debug for MacroExpansion<'top, D> {
             MacroExpansionKind::Void => "void",
             MacroExpansionKind::Values(_) => "values",
             MacroExpansionKind::MakeString(_) => "make_string",
+            MacroExpansionKind::MakeSExp(_) => "make_sexp",
             MacroExpansionKind::Annotate(_) => "annotate",
             MacroExpansionKind::Template(t) => {
                 return if let Some(name) = t.template.name() {
@@ -1024,6 +1030,38 @@ impl<'top, D: Decoder> MakeStringExpansion<'top, D> {
     }
 }
 
+// ====== Implementation of the `make_sexp` macro
+
+#[derive(Copy, Clone, Debug)]
+pub struct MakeSExpExpansion<'top, D: Decoder> {
+    arguments: MacroExprArgsIterator<'top, D>,
+}
+
+impl<'top, D: Decoder> MakeSExpExpansion<'top, D> {
+    pub fn new(arguments: MacroExprArgsIterator<'top, D>) -> Self {
+        Self { arguments }
+    }
+
+    /// Yields the next [`ValueExpr`] in this `make_sexp` macro's evaluation.
+    pub fn next(
+        &mut self,
+        context: EncodingContextRef<'top>,
+        environment: Environment<'top, D>,
+    ) -> IonResult<MacroExpansionStep<'top, D>> {
+        let lazy_expanded_sexp = LazyExpandedSExp {
+            source: ExpandedSExpSource::Constructed(environment, self.arguments),
+            context,
+        };
+        let lazy_sexp = LazySExp::new(lazy_expanded_sexp);
+        let value_ref = context.allocator().alloc_with(|| ValueRef::SExp(lazy_sexp));
+        let lazy_expanded_value = LazyExpandedValue::from_constructed(context, &[], value_ref);
+        Ok(MacroExpansionStep::FinalStep(Some(
+            ValueExpr::ValueLiteral(lazy_expanded_value),
+        )))
+    }
+}
+
+// ===== Implementation of the `annotate` macro =====
 #[derive(Copy, Clone, Debug)]
 pub struct AnnotateExpansion<'top, D: Decoder> {
     arguments: MacroExprArgsIterator<'top, D>,
@@ -1173,7 +1211,7 @@ impl<'top> TemplateExpansion<'top> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{v1_1, ElementReader, Int, IonResult, Reader};
+    use crate::{v1_1, ElementReader, Int, IonResult, MacroTable, Reader};
 
     /// Reads `input` and `expected` using an expanding reader and asserts that their output
     /// is the same.
@@ -1224,6 +1262,62 @@ mod tests {
             "#,
             r#"
                 1 2 3 4 5
+            "#,
+        )
+    }
+
+    #[test]
+    fn make_sexp() -> IonResult<()> {
+        eval_template_invocation(
+            r#"(macro foo ($x) (make_sexp [1, $x, 3] [(literal a), $x, (literal c)]))"#,
+            r#"
+                (:foo 5)
+                (:foo quuz)
+                (:foo {a: 1, b: 2})
+                (:foo [])
+            "#,
+            r#"
+                (1 5 3 a 5 c)
+                (1 quuz 3 a quuz c)
+                (1 {a: 1, b: 2} 3 a {a: 1, b: 2} c)
+                (1 [] 3 a [] c)
+            "#,
+        )
+    }
+
+    #[test]
+    fn produce_system_value() -> IonResult<()> {
+        // This macro produces the following system value:
+        //    $ion_encoding::(
+        //        (macro_table
+        //            ... // $macros expand here
+        //        )
+        //    )
+        eval_template_invocation(
+            r#"
+                (macro def_macros ($macros*)
+                    (annotate
+                        (literal $ion_encoding)
+                        (make_sexp [
+                            (make_sexp [
+                                (literal macro_table),
+                                $macros
+                            ])
+                        ])
+                    )
+                )"#,
+            r#"
+                (:def_macros
+                    (macro foo () 1)
+                    (macro bar () 2)
+                    (macro baz () 3)
+                )
+                (:foo)
+                (:bar)
+                (:baz)
+            "#,
+            r#"
+                1 2 3
             "#,
         )
     }
@@ -1466,11 +1560,12 @@ mod tests {
     #[test]
     fn flex_uint_parameters() -> IonResult<()> {
         let template_definition = "(macro int_pair (flex_uint::$x flex_uint::$y) (values $x $y)))";
+        let macro_id = MacroTable::FIRST_USER_MACRO_ID as u8;
         let tests: &[(&[u8], (u64, u64))] = &[
             // invocation+args, expected arg values
-            (&[0x04, 0x01, 0x01], (0, 0)),
-            (&[0x04, 0x09, 0x03], (4, 1)),
-            (&[0x04, 0x0B, 0x0D], (5, 6)), // TODO: non-required cardinalities
+            (&[macro_id, 0x01, 0x01], (0, 0)),
+            (&[macro_id, 0x09, 0x03], (4, 1)),
+            (&[macro_id, 0x0B, 0x0D], (5, 6)), // TODO: non-required cardinalities
         ];
 
         for test in tests {
@@ -1772,6 +1867,21 @@ mod tests {
             e_expression,
             r#" "foobarbaz" "foobarbaz" "first name" "Hello, world!" "#,
         )
+    }
+
+    #[test]
+    fn make_sexp_e_expression() -> IonResult<()> {
+        let e_expression = r#"
+        (:make_sexp
+            [1, 2, 3]
+            []
+            []
+            (4 5 6)
+            ()
+            ()
+            (7))
+        "#;
+        eval_enc_expr(e_expression, r#" (1 2 3 4 5 6 7) "#)
     }
 
     #[test]

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -103,6 +103,7 @@ pub enum MacroKind {
     Void,
     Values,
     MakeString,
+    MakeSExp,
     Annotate,
     Template(TemplateBody),
 }
@@ -174,6 +175,7 @@ impl MacroTable {
         MacroKind::Void,
         MacroKind::Values,
         MacroKind::MakeString,
+        MacroKind::MakeSExp,
         MacroKind::Annotate,
     ];
     pub const NUM_SYSTEM_MACROS: usize = Self::SYSTEM_MACRO_KINDS.len();
@@ -231,6 +233,30 @@ impl MacroTable {
                     expansion_singleton: Some(ExpansionSingleton {
                         is_null: false,
                         ion_type: IonType::String,
+                        num_annotations: 0,
+                    }),
+                },
+            ),
+            Macro::named(
+                "make_sexp",
+                MacroSignature::new(vec![Parameter::new(
+                    "sequences",
+                    ParameterEncoding::Tagged,
+                    ParameterCardinality::ZeroOrMore,
+                    RestSyntaxPolicy::Allowed,
+                )])
+                .unwrap(),
+                MacroKind::MakeSExp,
+                ExpansionAnalysis {
+                    // `make_sexp` produces an unannotated s-expression, so it can't make a system
+                    // value when it's the body of a macro. (It would need to be nested in a call
+                    // to `annotate`.
+                    could_produce_system_value: false,
+                    must_produce_exactly_one_value: true,
+                    can_be_lazily_evaluated_at_top_level: true,
+                    expansion_singleton: Some(ExpansionSingleton {
+                        is_null: false,
+                        ion_type: IonType::SExp,
                         num_annotations: 0,
                     }),
                 },

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -10,7 +10,8 @@ use crate::lazy::decoder::Decoder;
 use crate::lazy::expanded::compiler::ExpansionAnalysis;
 use crate::lazy::expanded::macro_evaluator::{
     AnnotateExpansion, MacroEvaluator, MacroExpansion, MacroExpansionKind, MacroExpr,
-    MacroExprArgsIterator, MakeStringExpansion, TemplateExpansion, ValueExpr, ValuesExpansion,
+    MacroExprArgsIterator, MakeSExpExpansion, MakeStringExpansion, TemplateExpansion, ValueExpr,
+    ValuesExpansion,
 };
 use crate::lazy::expanded::macro_table::{Macro, MacroKind, MacroRef};
 use crate::lazy::expanded::r#struct::UnexpandedField;
@@ -1065,6 +1066,7 @@ impl<'top> TemplateMacroInvocation<'top> {
             MacroKind::MakeString => {
                 MacroExpansionKind::MakeString(MakeStringExpansion::new(arguments))
             }
+            MacroKind::MakeSExp => MacroExpansionKind::MakeSExp(MakeSExpExpansion::new(arguments)),
             MacroKind::Annotate => MacroExpansionKind::Annotate(AnnotateExpansion::new(arguments)),
             MacroKind::Template(template_body) => {
                 let template_ref = TemplateMacroRef::new(macro_ref, template_body);

--- a/src/lazy/text/buffer.rs
+++ b/src/lazy/text/buffer.rs
@@ -3255,25 +3255,25 @@ mod tests {
             "(:foo (1 2 3))",
             "(:foo \"foo\")",
             "(:foo foo)",
-            "(:4)",
-            "(:4 1)",
-            "(:4 1 2 3)",
-            "(:4 (1 2 3))",
-            "(:4 \"foo\")",
-            "(:4 foo)",
-            "(:004 foo)", // Leading zeros are ok/ignored
+            "(:5)",
+            "(:5 1)",
+            "(:5 1 2 3)",
+            "(:5 (1 2 3))",
+            "(:5 \"foo\")",
+            "(:5 foo)",
+            "(:005 foo)", // Leading zeros are ok/ignored
         ],
         expect_mismatch: [
             "foo",   // No parens
             "(foo)", // No `:` after opening paren
-            "(4",    // No parens
-            "(4)",   // No `:` after opening paren
-            "(:0x4)",   // Hexadecimal not allowed
-            "(:4_000)", // Underscores not allowed
+            "(5",    // No parens
+            "(5)",   // No `:` after opening paren
+            "(:0x5)",   // Hexadecimal not allowed
+            "(:5_000)", // Underscores not allowed
         ],
         expect_incomplete: [
             "(:foo",
-            "(:4"
+            "(:5"
         ]
     }
 


### PR DESCRIPTION
This PR implements the `make_sexp` macro, allowing a macro body to include dynamically populated (i.e. not `(literal ...)`) s-expressions.

Combined with `annotate`, this enables macros to produce system values like encoding directives. For example:

```ion
$ion_encoding::(
  (macro def_macros ($macros*)
    (annotate
      (literal $ion_encoding)
      (make_sexp [
        (make_sexp [
          (literal macro_table),
          $macros
        ])
      ])
    )
  )
)

(:def_macros
  (macro foo () 1)
  (macro bar () 2)
  (macro baz () 3))

(:foo)
(:bar)
(:baz)
```
produces
```ion
1 2 3
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
