### PR TITLE
Adds support for qualified refs to `$ion`, `$ion_encoding`

### DIFF
--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -277,6 +277,15 @@ pub enum AnyEExpArgGroupKind<'top> {
     Binary_1_1(BinaryEExpArgGroup<'top>),
 }
 
+impl<'top> AnyEExpArgGroupKind<'top> {
+    fn encoding(&self) -> &ParameterEncoding {
+        match self {
+            AnyEExpArgGroupKind::Text_1_1(g) => g.encoding(),
+            AnyEExpArgGroupKind::Binary_1_1(g) => g.encoding(),
+        }
+    }
+}
+
 impl<'top> HasRange for AnyEExpArgGroup<'top> {
     fn range(&self) -> Range<usize> {
         match self.kind {
@@ -353,11 +362,8 @@ impl<'top> Iterator for AnyEExpArgGroupIterator<'top> {
 impl<'top> EExpressionArgGroup<'top, AnyEncoding> for AnyEExpArgGroup<'top> {
     type Iterator = AnyEExpArgGroupIterator<'top>;
 
-    fn encoding(&self) -> ParameterEncoding {
-        match self.kind {
-            AnyEExpArgGroupKind::Text_1_1(g) => g.encoding(),
-            AnyEExpArgGroupKind::Binary_1_1(g) => g.encoding(),
-        }
+    fn encoding(&self) -> &ParameterEncoding {
+        self.kind.encoding()
     }
 
     fn resolve(self, context: EncodingContextRef<'top>) -> ArgGroup<'top, AnyEncoding> {

--- a/src/lazy/binary/encoded_value.rs
+++ b/src/lazy/binary/encoded_value.rs
@@ -90,8 +90,6 @@ pub(crate) struct EncodedValue<HeaderType: EncodedHeader> {
     pub annotations_encoding: AnnotationsEncoding,
     // The offset of the type descriptor byte within the overall input stream.
     pub header_offset: usize,
-    // If this value was written with a tagless encoding, this will be 0. Otherwise, it's 1.
-    pub opcode_length: u8,
     // The number of bytes used to encode the optional length VarUInt following the header byte.
     pub length_length: u8,
     // The number of bytes used to encode the value itself, not including the header byte
@@ -128,6 +126,15 @@ impl<HeaderType: EncodedHeader> EncodedValue<HeaderType> {
         let start = self.header_offset;
         let end = start + self.header_length();
         start..end
+    }
+
+    /// Returns the number of bytes used to encode this value's opcode. If this value was serialized
+    /// using a tagless encoding, returns `0`.
+    pub fn opcode_length(&self) -> usize {
+        match self.encoding {
+            ParameterEncoding::Tagged => 1,
+            _ => 0,
+        }
     }
 
     /// Returns the number of bytes used to encode this value's data.
@@ -279,7 +286,6 @@ mod tests {
             annotations_sequence_length: 1,
             annotations_encoding: AnnotationsEncoding::SymbolAddress,
             header_offset: 200,
-            opcode_length: 1,
             length_length: 0,
             value_body_length: 3,
             total_length: 7,

--- a/src/lazy/binary/encoded_value.rs
+++ b/src/lazy/binary/encoded_value.rs
@@ -1,6 +1,6 @@
 use crate::lazy::binary::raw::type_descriptor::Header;
 use crate::lazy::binary::raw::v1_1::immutable_buffer::AnnotationsEncoding;
-use crate::lazy::expanded::template::ParameterEncoding;
+use crate::lazy::binary::raw::v1_1::value::BinaryValueEncoding;
 use crate::IonType;
 use std::ops::Range;
 
@@ -41,7 +41,7 @@ impl EncodedHeader for Header {
 /// without re-parsing its header information each time.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct EncodedValue<HeaderType: EncodedHeader> {
-    pub(crate) encoding: ParameterEncoding,
+    pub(crate) encoding: BinaryValueEncoding,
     // If the compiler decides that a value is too large to be moved/copied with inline code,
     // it will relocate the value using memcpy instead. This can be quite slow by comparison.
     //
@@ -132,7 +132,7 @@ impl<HeaderType: EncodedHeader> EncodedValue<HeaderType> {
     /// using a tagless encoding, returns `0`.
     pub fn opcode_length(&self) -> usize {
         match self.encoding {
-            ParameterEncoding::Tagged => 1,
+            BinaryValueEncoding::Tagged => 1,
             _ => 0,
         }
     }
@@ -269,14 +269,14 @@ mod tests {
     use crate::lazy::binary::encoded_value::EncodedValue;
     use crate::lazy::binary::raw::type_descriptor::Header;
     use crate::lazy::binary::raw::v1_1::immutable_buffer::AnnotationsEncoding;
-    use crate::lazy::expanded::template::ParameterEncoding;
+    use crate::lazy::binary::raw::v1_1::value::BinaryValueEncoding;
     use crate::{IonResult, IonType};
 
     #[test]
     fn accessors() -> IonResult<()> {
         // 3-byte String with 1-byte annotation
         let value = EncodedValue {
-            encoding: ParameterEncoding::Tagged,
+            encoding: BinaryValueEncoding::Tagged,
             header: Header {
                 ion_type: IonType::String,
                 ion_type_code: IonTypeCode::String,

--- a/src/lazy/binary/immutable_buffer.rs
+++ b/src/lazy/binary/immutable_buffer.rs
@@ -11,12 +11,12 @@ use crate::lazy::binary::encoded_value::EncodedValue;
 use crate::lazy::binary::raw::r#struct::LazyRawBinaryFieldName_1_0;
 use crate::lazy::binary::raw::type_descriptor::{Header, TypeDescriptor, ION_1_0_TYPE_DESCRIPTORS};
 use crate::lazy::binary::raw::v1_1::immutable_buffer::AnnotationsEncoding;
+use crate::lazy::binary::raw::v1_1::value::BinaryValueEncoding;
 use crate::lazy::binary::raw::value::{LazyRawBinaryValue_1_0, LazyRawBinaryVersionMarker_1_0};
 use crate::lazy::decoder::LazyRawFieldExpr;
 use crate::lazy::encoder::binary::v1_1::flex_int::FlexInt;
 use crate::lazy::encoder::binary::v1_1::flex_uint::FlexUInt;
 use crate::lazy::encoding::BinaryEncoding_1_0;
-use crate::lazy::expanded::template::ParameterEncoding;
 use crate::result::IonFailure;
 use crate::{Int, IonError, IonResult, IonType};
 
@@ -704,7 +704,7 @@ impl<'a> ImmutableBuffer<'a> {
         }
 
         let encoded_value = EncodedValue {
-            encoding: ParameterEncoding::Tagged,
+            encoding: BinaryValueEncoding::Tagged,
             header,
             // If applicable, these are populated by the caller: `read_annotated_value()`
             annotations_header_length: 0,

--- a/src/lazy/binary/immutable_buffer.rs
+++ b/src/lazy/binary/immutable_buffer.rs
@@ -711,7 +711,6 @@ impl<'a> ImmutableBuffer<'a> {
             annotations_sequence_length: 0,
             annotations_encoding: AnnotationsEncoding::SymbolAddress,
             header_offset,
-            opcode_length: 1,
             length_length,
             value_body_length: value_length,
             total_length,

--- a/src/lazy/binary/raw/v1_1/e_expression.rs
+++ b/src/lazy/binary/raw/v1_1/e_expression.rs
@@ -306,6 +306,9 @@ impl<'top> Iterator for BinaryEExpArgsInputIter<'top> {
                         EExpArg::new(parameter, EExpArgExpr::ValueLiteral(value_ref)),
                         remaining,
                     )
+                }
+                ParameterEncoding::MacroShaped(_macro_ref) => {
+                    todo!("macro-shaped parameter encoding")
                 } // TODO: The other tagless encodings
             },
             // If it's an argument group...
@@ -448,7 +451,7 @@ impl<'top> IntoIterator for BinaryEExpArgGroup<'top> {
 impl<'top> EExpressionArgGroup<'top, BinaryEncoding_1_1> for BinaryEExpArgGroup<'top> {
     type Iterator = BinaryEExpArgGroupIterator<'top>;
 
-    fn encoding(&self) -> ParameterEncoding {
+    fn encoding(&self) -> &ParameterEncoding {
         self.parameter.encoding()
     }
 

--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -11,7 +11,7 @@ use crate::lazy::binary::raw::v1_1::e_expression::{
 };
 use crate::lazy::binary::raw::v1_1::r#struct::LazyRawBinaryFieldName_1_1;
 use crate::lazy::binary::raw::v1_1::value::{
-    DelimitedContents, LazyRawBinaryValue_1_1, LazyRawBinaryVersionMarker_1_1,
+    BinaryValueEncoding, DelimitedContents, LazyRawBinaryValue_1_1, LazyRawBinaryVersionMarker_1_1,
 };
 use crate::lazy::binary::raw::v1_1::{Header, LengthType, Opcode, OpcodeType, ION_1_1_OPCODES};
 use crate::lazy::decoder::{LazyRawFieldExpr, LazyRawValueExpr, RawValueExpr};
@@ -21,7 +21,6 @@ use crate::lazy::encoder::binary::v1_1::flex_int::FlexInt;
 use crate::lazy::encoder::binary::v1_1::flex_sym::{FlexSym, FlexSymValue};
 use crate::lazy::encoder::binary::v1_1::flex_uint::FlexUInt;
 use crate::lazy::expanded::macro_table::MacroRef;
-use crate::lazy::expanded::template::ParameterEncoding;
 use crate::lazy::expanded::EncodingContextRef;
 use crate::lazy::text::raw::v1_1::arg_group::EExpArgExpr;
 use crate::lazy::text::raw::v1_1::reader::MacroAddress;
@@ -663,7 +662,7 @@ impl<'a> ImmutableBuffer<'a> {
         }
 
         let encoded_value = EncodedValue {
-            encoding: ParameterEncoding::Tagged,
+            encoding: BinaryValueEncoding::Tagged,
             header,
             // If applicable, these are populated by the caller: `read_annotated_value()`
             annotations_header_length: 0,
@@ -1542,7 +1541,8 @@ mod tests {
 
         // Construct an encoding directive that defines this number of macros. Each macro will expand
         // to its own address.
-        let mut macro_definitions = String::from("$ion_encoding::(\n  (macro_table\n");
+        let mut macro_definitions =
+            String::from("$ion_encoding::(\n  (macro_table $ion_encoding\n");
         for address in MacroTable::FIRST_USER_MACRO_ID..MAX_TEST_MACRO_ADDRESS {
             writeln!(macro_definitions, "    (macro m{address} () {address})")?;
         }

--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -670,8 +670,6 @@ impl<'a> ImmutableBuffer<'a> {
             annotations_sequence_length: 0,
             annotations_encoding: AnnotationsEncoding::SymbolAddress,
             header_offset,
-            // This is a tagged value, so its opcode length is always 1
-            opcode_length: 1,
             length_length,
             value_body_length,
             total_length,

--- a/src/lazy/binary/raw/v1_1/struct.rs
+++ b/src/lazy/binary/raw/v1_1/struct.rs
@@ -337,6 +337,7 @@ mod tests {
                 $ion_encoding::(
                     (symbol_table $ion_encoding)
                     (macro_table
+                        $ion_encoding
                         (macro greet (name) (make_string "hello, " name))
                     )
                 )

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -304,7 +304,6 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
             annotations_encoding: AnnotationsEncoding::SymbolAddress,
 
             header_offset: input.offset(),
-            opcode_length: 0,
             length_length: 0,
             value_body_length: input.len(),
             total_length: input.len(),
@@ -847,7 +846,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
 
 impl<'top> EncodedBinaryValue<'top, BinaryEncoding_1_1> for &'top LazyRawBinaryValue_1_1<'top> {
     fn opcode_length(&self) -> usize {
-        self.encoded_value.opcode_length as usize
+        self.encoded_value.opcode_length()
     }
 
     fn length_length(&self) -> usize {

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -225,7 +225,7 @@ pub trait EncodedBinaryValue<'top, D: Decoder>: LazyRawValue<'top, D> {
 
 impl<'top> EncodedBinaryValue<'top, BinaryEncoding_1_0> for LazyRawBinaryValue_1_0<'top> {
     fn opcode_length(&self) -> usize {
-        self.encoded_value.opcode_length as usize
+        self.encoded_value.opcode_length()
     }
 
     fn length_length(&self) -> usize {

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -69,7 +69,7 @@ impl<E: Encoding, Output: Write> Writer<E, Output> {
         // TODO: LazyEncoder should define a method to construct a new symtab and/or macro table
         let ion_version = E::ion_version();
         let symbol_table = SymbolTable::new(ion_version);
-        let macro_table = MacroTable::new();
+        let macro_table = MacroTable::with_system_macros();
         let context = WriterContext::new(symbol_table, macro_table);
         let mut writer = Writer {
             context,

--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -128,7 +128,7 @@ impl<'top, D: Decoder> EExpression<'top, D> {
             MacroKind::MakeSExp => MacroExpansionKind::MakeSExp(MakeSExpExpansion::new(arguments)),
             MacroKind::Annotate => MacroExpansionKind::Annotate(AnnotateExpansion::new(arguments)),
             MacroKind::Template(template_body) => {
-                let template_ref = TemplateMacroRef::new(invoked_macro, template_body);
+                let template_ref = TemplateMacroRef::new(invoked_macro.reference(), template_body);
                 environment = self.new_evaluation_environment()?;
                 MacroExpansionKind::Template(TemplateExpansion::new(template_ref))
             }

--- a/src/lazy/expanded/encoding_module.rs
+++ b/src/lazy/expanded/encoding_module.rs
@@ -1,5 +1,5 @@
 use crate::lazy::expanded::macro_table::MacroTable;
-use crate::SymbolTable;
+use crate::{IonVersion, SymbolTable};
 
 #[derive(Debug, Clone)]
 pub struct EncodingModule {
@@ -15,6 +15,13 @@ impl EncodingModule {
             macro_table,
             symbol_table,
         }
+    }
+    pub fn ion_1_1_system_module() -> Self {
+        Self::new(
+            String::from("$ion"),
+            MacroTable::with_system_macros(),
+            SymbolTable::new(IonVersion::v1_1),
+        )
     }
     pub fn name(&self) -> &str {
         &self.name

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -47,6 +47,7 @@ use crate::lazy::decoder::{Decoder, LazyRawValue};
 use crate::lazy::encoding::RawValueLiteral;
 use crate::lazy::expanded::compiler::TemplateCompiler;
 use crate::lazy::expanded::e_expression::EExpression;
+use crate::lazy::expanded::encoding_module::EncodingModule;
 use crate::lazy::expanded::macro_evaluator::{
     MacroEvaluator, MacroExpansion, MacroExpr, RawEExpression,
 };
@@ -92,6 +93,7 @@ pub mod template;
 //  would need to be proved out first.
 #[derive(Debug)]
 pub struct EncodingContext {
+    pub(crate) system_module: EncodingModule,
     pub(crate) macro_table: MacroTable,
     pub(crate) symbol_table: SymbolTable,
     pub(crate) allocator: BumpAllocator,
@@ -104,6 +106,7 @@ impl EncodingContext {
         allocator: BumpAllocator,
     ) -> Self {
         Self {
+            system_module: EncodingModule::ion_1_1_system_module(),
             macro_table,
             symbol_table,
             allocator,
@@ -112,7 +115,7 @@ impl EncodingContext {
 
     pub fn for_ion_version(version: IonVersion) -> Self {
         Self::new(
-            MacroTable::new(),
+            MacroTable::with_system_macros(),
             SymbolTable::new(version),
             BumpAllocator::new(),
         )
@@ -120,7 +123,7 @@ impl EncodingContext {
 
     pub fn empty() -> Self {
         Self::new(
-            MacroTable::new(),
+            MacroTable::with_system_macros(),
             SymbolTable::new(IonVersion::default()),
             BumpAllocator::new(),
         )

--- a/src/lazy/expanded/struct.rs
+++ b/src/lazy/expanded/struct.rs
@@ -263,7 +263,7 @@ impl<'top, D: Decoder> LazyExpandedStruct<'top, D> {
                             self.context,
                             *environment,
                             TemplateElement::new(
-                                element.template().macro_ref(),
+                                element.template(),
                                 body_element,
                                 first_result_expr.expr_range(),
                             ),
@@ -291,7 +291,7 @@ impl<'top, D: Decoder> LazyExpandedStruct<'top, D> {
                     TemplateBodyExprKind::MacroInvocation(body_invocation) => {
                         let invocation = body_invocation.resolve(
                             self.context,
-                            element.template().address(),
+                            element.template(),
                             first_result_expr.expr_range(),
                         );
                         let mut evaluator = MacroEvaluator::new_with_environment(*environment);

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -1,9 +1,9 @@
+use bumpalo::collections::Vec as BumpVec;
+use rustc_hash::FxHashMap;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::ops::{Deref, Range};
-
-use bumpalo::collections::Vec as BumpVec;
-use rustc_hash::FxHashMap;
+use std::rc::Rc;
 
 use crate::lazy::binary::raw::v1_1::immutable_buffer::ArgGroupingBitmap;
 use crate::lazy::decoder::Decoder;
@@ -13,13 +13,12 @@ use crate::lazy::expanded::macro_evaluator::{
     MacroExprArgsIterator, MakeSExpExpansion, MakeStringExpansion, TemplateExpansion, ValueExpr,
     ValuesExpansion,
 };
-use crate::lazy::expanded::macro_table::{Macro, MacroKind, MacroRef};
+use crate::lazy::expanded::macro_table::{Macro, MacroKind};
 use crate::lazy::expanded::r#struct::UnexpandedField;
 use crate::lazy::expanded::sequence::Environment;
 use crate::lazy::expanded::{
     EncodingContextRef, ExpandedValueSource, LazyExpandedValue, TemplateVariableReference,
 };
-use crate::lazy::text::raw::v1_1::reader::{MacroAddress, MacroIdRef};
 use crate::result::IonFailure;
 use crate::{
     try_or_some_err, Bytes, Decimal, Int, IonResult, IonType, LazyExpandedFieldName, Str, Symbol,
@@ -53,8 +52,8 @@ impl Parameter {
     pub fn name(&self) -> &str {
         self.name.as_str()
     }
-    pub fn encoding(&self) -> ParameterEncoding {
-        self.encoding
+    pub fn encoding(&self) -> &ParameterEncoding {
+        &self.encoding
     }
     pub fn cardinality(&self) -> ParameterCardinality {
         self.cardinality
@@ -79,13 +78,14 @@ impl Parameter {
 }
 
 /// The encoding used to serialize and deserialize the associated parameter.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ParameterEncoding {
     /// A 'tagged' type is one whose binary encoding begins with an opcode (sometimes called a 'tag'.)
     Tagged,
     FlexUInt,
     // MacroShaped(MacroAddress),
     // TODO: tagless types, including fixed-width types and macros
+    MacroShaped(Rc<Macro>),
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -345,15 +345,15 @@ impl TemplateMacro {
     }
 }
 
-/// A reference to a template macro definition paired with the macro table address at which it was found.
+/// A reference to a template macro definition paired with the more general macro reference.
 #[derive(Copy, Clone, Debug)]
 pub struct TemplateMacroRef<'top> {
-    macro_ref: MacroRef<'top>,
+    macro_ref: &'top Macro,
     template_body: &'top TemplateBody,
 }
 
 impl<'top> TemplateMacroRef<'top> {
-    pub fn new(macro_ref: MacroRef<'top>, template_body: &'top TemplateBody) -> Self {
+    pub fn new(macro_ref: &'top Macro, template_body: &'top TemplateBody) -> Self {
         Self {
             macro_ref,
             template_body,
@@ -363,13 +363,13 @@ impl<'top> TemplateMacroRef<'top> {
         self.template_body
     }
 
-    pub fn macro_ref(&self) -> MacroRef<'top> {
+    pub fn macro_ref(&self) -> &'top Macro {
         self.macro_ref
     }
 }
 
 impl<'top> Deref for TemplateMacroRef<'top> {
-    type Target = MacroRef<'top>;
+    type Target = &'top Macro;
 
     fn deref(&self) -> &Self::Target {
         &self.macro_ref
@@ -423,7 +423,7 @@ impl<'top, D: Decoder> Iterator for TemplateSequenceIterator<'top, D> {
                         source: ExpandedValueSource::Template(
                             environment,
                             TemplateElement::new(
-                                self.template.macro_ref,
+                                self.template,
                                 element,
                                 current_expr.expr_range(),
                             ),
@@ -435,14 +435,10 @@ impl<'top, D: Decoder> Iterator for TemplateSequenceIterator<'top, D> {
                 TemplateBodyExprKind::MacroInvocation(body_invocation) => {
                     // ...it's a TDL macro invocation. Resolve the invocation to get a reference to the
                     // macro being invoked.
-                    let invoked_macro = self
-                        .context
-                        .macro_table()
-                        .macro_at_address(body_invocation.invoked_macro_address)
-                        .unwrap();
+                    let invoked_macro = body_invocation.invoked_macro.as_ref();
                     let invocation = TemplateMacroInvocation::new(
                         self.context,
-                        self.template.address(),
+                        self.template,
                         invoked_macro,
                         ExprRange::new(current_expr.expr_range().tail()),
                     );
@@ -555,21 +551,17 @@ impl<'top, D: Decoder> Iterator for TemplateStructUnexpandedFieldsIterator<'top,
                     self.context,
                     self.environment,
                     TemplateElement::new(
-                        self.template.macro_ref(),
+                        self.template,
                         element,
                         value_expr.expr_range(),
                     ),
                 ),
             ),
             TemplateBodyExprKind::MacroInvocation(body_invocation) => {
-                let invoked_macro = self
-                    .context
-                    .macro_table()
-                    .macro_at_address(body_invocation.invoked_macro_address)
-                    .unwrap();
+                let invoked_macro = body_invocation.invoked_macro.as_ref();
                 let invocation = TemplateMacroInvocation::new(
                     self.context,
-                    self.template.address(),
+                    self.template,
                     invoked_macro,
                     ExprRange::new(value_expr.expr_range().tail()),
                 );
@@ -580,7 +572,7 @@ impl<'top, D: Decoder> Iterator for TemplateStructUnexpandedFieldsIterator<'top,
             }
             TemplateBodyExprKind::Variable(variable) => {
                 let arg_expr = self.environment.require_expr(variable.signature_index());
-                let variable_ref = variable.resolve(self.template.macro_ref.reference());
+                let variable_ref = variable.resolve(self.template.macro_ref);
                 let field_name = LazyExpandedFieldName::TemplateName(self.template, name);
                 let field = match arg_expr {
                     ValueExpr::ValueLiteral(value) => {
@@ -633,9 +625,9 @@ impl TemplateBody {
         ))
     }
 
-    pub fn push_macro_invocation(&mut self, invoked_macro_address: usize, expr_range: ExprRange) {
+    pub fn push_macro_invocation(&mut self, macro_ref: Rc<Macro>, expr_range: ExprRange) {
         self.expressions.push(TemplateBodyExpr::macro_invocation(
-            invoked_macro_address,
+            macro_ref,
             expr_range,
         ))
     }
@@ -668,10 +660,10 @@ impl TemplateBodyExpr {
         }
     }
 
-    pub fn macro_invocation(invoked_macro_address: MacroAddress, expr_range: ExprRange) -> Self {
+    pub fn macro_invocation(invoked_macro: Rc<Macro>, expr_range: ExprRange) -> Self {
         Self {
             kind: TemplateBodyExprKind::MacroInvocation(TemplateBodyMacroInvocation::new(
-                invoked_macro_address,
+                invoked_macro,
             )),
             expr_range,
         }
@@ -859,8 +851,8 @@ impl TemplateBodyExprKind {
     ) -> Result<usize, fmt::Error> {
         writeln!(
             f,
-            "{indentation}<invoke macro @ address {}>",
-            invocation.invoked_macro_address
+            "{indentation}<invoke macro {}>",
+            invocation.invoked_macro.name().unwrap_or("<anonymous>")
         )?;
         let args = host_template
             .body
@@ -900,46 +892,34 @@ impl TemplateBodyExprKind {
 }
 
 /// A macro invocation found in the body of a template.
-///
-/// Because the template definition lives in the macro table (which may need to grow in the process
-/// of evaluating a stream), this type holds the address of the invoked macro rather than a
-/// reference to it.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TemplateBodyMacroInvocation {
-    invoked_macro_address: MacroAddress,
+    pub(crate) invoked_macro: Rc<Macro>,
 }
 
 impl TemplateBodyMacroInvocation {
-    pub fn new(invoked_macro_address: MacroAddress) -> Self {
+    pub fn new(invoked_macro: Rc<Macro>) -> Self {
         Self {
-            invoked_macro_address,
+            invoked_macro,
         }
-    }
-    pub fn macro_address(&self) -> MacroAddress {
-        self.invoked_macro_address
     }
 
     /// Finds the definition of the macro being invoked in the provided `context`'s macro table.
     ///
     /// It is a logic error for this method to be called with an [`EncodingContextRef`] that does not
     /// contain the necessary information; doing so will cause this method to panic.
-    pub(crate) fn resolve(
-        self,
-        context: EncodingContextRef,
-        host_template_address: MacroAddress,
+    pub(crate) fn resolve<'a>(
+        &'a self,
+        context: EncodingContextRef<'a>,
+        host_template: TemplateMacroRef<'a>,
         expr_range: ExprRange,
-    ) -> TemplateMacroInvocation {
-        let invoked_macro = context
-            .macro_table()
-            .macro_at_address(self.invoked_macro_address)
-            .unwrap();
-
+    ) -> TemplateMacroInvocation<'a> {
         let arg_expr_range = ExprRange::new(expr_range.tail());
 
         TemplateMacroInvocation::new(
             context,
-            host_template_address,
-            invoked_macro,
+            host_template,
+            self.invoked_macro.as_ref(),
             arg_expr_range,
         )
     }
@@ -950,10 +930,9 @@ impl TemplateBodyMacroInvocation {
 #[derive(Copy, Clone)]
 pub struct TemplateMacroInvocation<'top> {
     context: EncodingContextRef<'top>,
-    // We store the address of the host template (8 bytes) rather than a full TemplateMacroRef (24)
-    host_template_address: MacroAddress,
+    host_template: TemplateMacroRef<'top>,
     // The macro being invoked
-    invoked_macro: MacroRef<'top>,
+    invoked_macro: &'top Macro,
     // The range of value expressions in the host template's body that are arguments to the
     // macro being invoked
     arg_expressions_range: ExprRange,
@@ -963,8 +942,8 @@ impl<'top> Debug for TemplateMacroInvocation<'top> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "TemplateMacroInvocation <target macro address={}>",
-            self.invoked_macro.address()
+            "TemplateMacroInvocation <target macro={}>",
+            self.invoked_macro.name().unwrap_or("<anonymous>")
         )
     }
 }
@@ -972,21 +951,18 @@ impl<'top> Debug for TemplateMacroInvocation<'top> {
 impl<'top> TemplateMacroInvocation<'top> {
     pub fn new(
         context: EncodingContextRef<'top>,
-        host_template_address: MacroAddress,
-        invoked_macro: MacroRef<'top>,
+        host_template: TemplateMacroRef<'top>,
+        invoked_macro: &'top Macro,
         arg_expressions_range: ExprRange,
     ) -> Self {
         Self {
             context,
-            host_template_address,
+            host_template,
             invoked_macro,
             arg_expressions_range,
         }
     }
 
-    pub fn id(&self) -> MacroIdRef<'top> {
-        MacroIdRef::LocalAddress(self.invoked_macro.address())
-    }
     pub fn arguments<D: Decoder>(
         &self,
         environment: Environment<'top, D>,
@@ -995,32 +971,20 @@ impl<'top> TemplateMacroInvocation<'top> {
             self.context,
             environment,
             self.arg_expressions(),
-            self.host_macro_ref(),
+            self.host_template(),
         )
-    }
-    pub fn host_template_address(&self) -> MacroAddress {
-        self.host_template_address
     }
 
     /// Helper method to access the definition of the host template. Useful for debugging,
     /// but not required for macro expansion.
-    pub fn host_macro_ref(&self) -> MacroRef<'top> {
-        self.context()
-            .macro_table()
-            .macro_at_address(self.host_template_address)
-            .unwrap()
+    pub fn host_macro_ref(&self) -> &'top Macro {
+        self.host_template.macro_ref
     }
 
     /// Helper method to access the definition of the host template. Useful for debugging,
     /// but not required for macro expansion.
     pub fn host_template(&self) -> TemplateMacroRef<'top> {
-        // We only store the macro address (8 bytes) instead of the full `TemplateMacroRef` (24 bytes)
-        // for size savings. Because the address was copied from a resolved `TemplateMacroRef` in the
-        // constructor and the encoding context is frozen for the duration of `'top`, we can safely
-        // assume that the address maps to a template macro in the current encoding context. This
-        // allows us to call `unwrap()` freely.
-        let macro_ref = self.host_macro_ref();
-        macro_ref.require_template()
+        self.host_template
     }
 
     pub fn arg_expressions(&self) -> &'top [TemplateBodyExpr] {
@@ -1030,9 +994,11 @@ impl<'top> TemplateMacroInvocation<'top> {
             .get(self.arg_expressions_range.ops_range())
             .unwrap()
     }
-    pub fn invoked_macro(&self) -> MacroRef<'top> {
+
+    pub fn invoked_macro(&self) -> &'top Macro {
         self.invoked_macro
     }
+
     pub fn context(&self) -> EncodingContextRef<'top> {
         self.context
     }
@@ -1059,7 +1025,7 @@ impl<'top> TemplateMacroInvocation<'top> {
     ) -> IonResult<MacroExpansion<'top, D>> {
         // Initialize a `MacroExpansionKind` with the state necessary to evaluate the requested
         // macro.
-        let macro_ref: MacroRef<'top> = self.invoked_macro();
+        let macro_ref = self.invoked_macro();
         let arguments = MacroExprArgsIterator::from_template_macro(self.arguments(environment));
         let expansion_kind = match macro_ref.kind() {
             MacroKind::Void => MacroExpansionKind::Void,
@@ -1094,7 +1060,7 @@ impl<'top, D: Decoder> From<TemplateMacroInvocation<'top>> for MacroExpr<'top, D
 pub struct TemplateMacroInvocationArgsIterator<'top, D: Decoder> {
     context: EncodingContextRef<'top>,
     environment: Environment<'top, D>,
-    host_template: MacroRef<'top>,
+    host_template: TemplateMacroRef<'top>,
     // The range of value expressions in the host template's body that are arguments to the
     // macro being invoked
     arg_expressions: &'top [TemplateBodyExpr],
@@ -1106,7 +1072,7 @@ impl<'top, D: Decoder> TemplateMacroInvocationArgsIterator<'top, D> {
         context: EncodingContextRef<'top>,
         environment: Environment<'top, D>,
         arg_expressions: &'top [TemplateBodyExpr],
-        host_template: MacroRef<'top>,
+        host_template: TemplateMacroRef<'top>,
     ) -> Self {
         Self {
             environment,
@@ -1146,14 +1112,14 @@ impl<'top, D: Decoder> Iterator for TemplateMacroInvocationArgsIterator<'top, D>
                 // come from this variable in the template body.
                 if let ValueExpr::ValueLiteral(ref mut value) = expr {
                     *value =
-                        value.via_variable(variable_ref.resolve(self.host_template.reference()))
+                        value.via_variable(variable_ref.resolve(self.host_template.macro_ref()))
                 }
                 expr
             }
             TemplateBodyExprKind::MacroInvocation(body_invocation) => {
                 let invocation = body_invocation.resolve(
                     self.context,
-                    self.host_template.address(),
+                    self.host_template,
                     arg.expr_range(),
                 );
                 ValueExpr::MacroInvocation(invocation.into())
@@ -1205,14 +1171,14 @@ impl TemplateBodyVariableReference {
 pub struct TemplateElement<'top> {
     // This type holds a reference to the host template macro, which contains some shared resources
     // like a `Vec` of annotation definitions.
-    template: MacroRef<'top>,
+    template: TemplateMacroRef<'top>,
     element: &'top TemplateBodyElement,
     expr_range: ExprRange,
 }
 
 impl<'top> TemplateElement<'top> {
     pub fn new(
-        template: MacroRef<'top>,
+        template: TemplateMacroRef<'top>,
         element: &'top TemplateBodyElement,
         expr_range: ExprRange,
     ) -> Self {
@@ -1224,7 +1190,6 @@ impl<'top> TemplateElement<'top> {
     }
     pub fn annotations(&self) -> &'top [Symbol] {
         self.template
-            .require_template()
             .body()
             .annotations_storage()
             .get(self.element.annotations_range().ops_range())
@@ -1237,7 +1202,7 @@ impl<'top> TemplateElement<'top> {
         &self.element.value
     }
     pub fn template(&self) -> TemplateMacroRef<'top> {
-        self.template.require_template()
+        self.template
     }
     pub fn expr_range(&self) -> ExprRange {
         self.expr_range

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -84,6 +84,7 @@ pub enum ParameterEncoding {
     /// A 'tagged' type is one whose binary encoding begins with an opcode (sometimes called a 'tag'.)
     Tagged,
     FlexUInt,
+    // MacroShaped(MacroAddress),
     // TODO: tagless types, including fixed-width types and macros
 }
 

--- a/src/lazy/never.rs
+++ b/src/lazy/never.rs
@@ -176,7 +176,7 @@ impl<'top, D: Decoder> HasSpan<'top> for NeverArgGroup<'top, D> {
 impl<'top, D: Decoder> EExpressionArgGroup<'top, D> for NeverArgGroup<'top, D> {
     type Iterator = NeverArgGroupIterator<'top, D>;
 
-    fn encoding(&self) -> ParameterEncoding {
+    fn encoding(&self) -> &ParameterEncoding {
         unreachable!("<NeverArgGroup as EExpressionArgGroup>::encoding")
     }
 

--- a/src/lazy/reader.rs
+++ b/src/lazy/reader.rs
@@ -10,7 +10,7 @@ use crate::read_config::ReadConfig;
 use crate::result::IonFailure;
 use crate::{IonError, IonResult};
 
-/// A binary reader that only reads each value that it visits upon request (that is: lazily).
+/// An Ion reader that only reads each value that it visits upon request (that is: lazily).
 ///
 /// Each time [`Reader::next`] is called, the reader will advance to the next top-level value
 /// in the input stream. Once positioned on a top-level value, users may visit nested values by

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -259,7 +259,7 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
                 let new_encoding_module = match pending_changes.take_new_active_module() {
                     None => EncodingModule::new(
                         "$ion_encoding".to_owned(),
-                        MacroTable::new(),
+                        MacroTable::with_system_macros(),
                         symbol_table,
                     ),
                     Some(mut module) => {
@@ -378,19 +378,35 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
                 "expected a macro table definition operation, but found: {operation:?}"
             ));
         }
-        let mut macro_table = MacroTable::new();
+        let mut macro_table = MacroTable::empty();
         for arg in args {
             let arg = arg?;
             let context = operation.expanded_sexp.context;
-            let macro_def_sexp = arg.read()?.expect_sexp().map_err(|_| {
-                IonError::decoding_error(format!(
-                    "macro_table had a non-sexp parameter: {}",
-                    arg.ion_type()
-                ))
-            })?;
-            let new_macro =
-                TemplateCompiler::compile_from_sexp(context, &macro_table, macro_def_sexp)?;
-            macro_table.add_macro(new_macro)?;
+            match arg.read()? {
+                ValueRef::SExp(macro_def_sexp) => {
+                    let new_macro =
+                        TemplateCompiler::compile_from_sexp(context, &macro_table, macro_def_sexp)?;
+                    macro_table.add_macro(new_macro)?;
+                }
+                ValueRef::Symbol(module_name) if module_name == "$ion_encoding" => {
+                    let active_mactab = operation.expanded().context.macro_table();
+                    macro_table.append_all_macros_from(&active_mactab)?;
+                }
+                ValueRef::Symbol(module_name) if module_name == "$ion" => {
+                    let expanded_value = operation.expanded();
+                    let system_mactab = expanded_value.context.system_module.macro_table();
+                    macro_table.append_all_macros_from(&system_mactab)?;
+                }
+                ValueRef::Symbol(_module_name) => {
+                    todo!("re-exporting macros from a module other than $ion_encoding")
+                }
+                _other => {
+                    return IonResult::decoding_error(format!(
+                        "macro_table was passed an unsupported argument type ({})",
+                        arg.ion_type()
+                    ));
+                }
+            }
         }
         Ok(macro_table)
     }
@@ -1068,6 +1084,7 @@ mod tests {
             $ion_encoding::(
                 (symbol_table ["foo", "bar", "baz"])
                 (macro_table
+                    $ion_encoding
                     (macro seventeen () 17)
                     (macro twelve () 12)))
             (:seventeen)

--- a/src/lazy/text/raw/v1_1/arg_group.rs
+++ b/src/lazy/text/raw/v1_1/arg_group.rs
@@ -170,7 +170,7 @@ impl<'top> IntoIterator for TextEExpArgGroup<'top> {
 impl<'top> EExpressionArgGroup<'top, TextEncoding_1_1> for TextEExpArgGroup<'top> {
     type Iterator = TextEExpArgGroupIterator<'top>;
 
-    fn encoding(&self) -> ParameterEncoding {
+    fn encoding(&self) -> &ParameterEncoding {
         self.parameter.encoding()
     }
 

--- a/src/symbol_ref.rs
+++ b/src/symbol_ref.rs
@@ -41,7 +41,7 @@ impl<'a> SymbolRef<'a> {
         }
     }
 
-    pub fn expect_text(&self) -> IonResult<&str> {
+    pub fn expect_text(&self) -> IonResult<&'a str> {
         match self.text() {
             Some(text) => Ok(text),
             None => IonResult::decoding_error("symbol has unknown text"),


### PR DESCRIPTION
* Modifies compiled macros to use `Rc` to store references to dependent macros. This allows the macro to continue referring to its dependent even if the latter is no longer directly addressable.
* Adds support for `module_name::encoding_name::parameter_name` syntax and `(module_name::macro_name ...)` syntax. The only modules currently supported are `$ion` (the system module) and `$ion_encoding` (the active encoding module).



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
