### PR TITLE
Update conformance testing DSL to support unknown symbols

### DIFF
--- a/tests/conformance_dsl/context.rs
+++ b/tests/conformance_dsl/context.rs
@@ -120,6 +120,7 @@ impl<'a> Context<'a> {
         let (data, data_encoding) = self.input(encoding)?;
         let data_slice = IonSlice::new(data);
 
+
         if self.fragments.is_empty() {
             let empty: Vec<Element> = vec!();
             return Ok(empty.into());

--- a/tests/conformance_dsl/continuation.rs
+++ b/tests/conformance_dsl/continuation.rs
@@ -13,10 +13,10 @@ pub(crate) enum Continuation {
     // expectations
 
     // Verify that reading the current document produces the expected data provided.
-    Produces(Vec<Element>),
+    Produces(Produces),
     // Verify that reading the current document produces the expected data, provided through data
     // model elements.
-    Denotes(Vec<ModelValue>),
+    Denotes(Denotes),
     // Verify that reading the current document produces an error.
     Signals(String),
     // extensions
@@ -39,18 +39,7 @@ impl Continuation {
     pub fn evaluate(&self, ctx: &Context) -> InnerResult<()> {
         match self {
             // Produces is terminal, so we can evaluate.
-            Continuation::Produces(expected_elems) => {
-                let elems = ctx.read_all(ctx.encoding())?;
-                if expected_elems.len() != elems.len() {
-                    Err(ConformanceErrorKind::MismatchedProduce)
-                } else {
-                    let zip = expected_elems.iter().zip(elems.iter());
-                    match zip.fold(true, |acc, (x, y)| acc && (*x == *y)) {
-                        true => Ok(()),
-                        false => Err(ConformanceErrorKind::MismatchedProduce),
-                    }
-                }
-            }
+            Continuation::Produces(produces) => produces.evaluate(ctx),
             Continuation::Not(inner) => match inner.evaluate(ctx) {
                 Err(_) => Ok(()),
                 Ok(_) => Err(ConformanceErrorKind::UnknownError),
@@ -62,18 +51,7 @@ impl Continuation {
                 Ok(())
             }
             Continuation::Then(then) => then.evaluate(ctx),
-            Continuation::Denotes(expected_vals) => {
-                let elems = ctx.read_all(ctx.encoding())?;
-                if expected_vals.len() != elems.len() {
-                    Err(ConformanceErrorKind::MismatchedDenotes)
-                } else {
-                    let zip = expected_vals.iter().zip(elems.iter());
-                    match zip.fold(true, |acc, (x, y)| acc && (*x == *y)) {
-                        true => Ok(()),
-                        false => Err(ConformanceErrorKind::MismatchedDenotes),
-                    }
-                }
-            }
+            Continuation::Denotes(denotes) => denotes.evaluate(ctx),
             Continuation::Extensions(exts) => {
                 for ext in exts {
                     ext.evaluate(ctx)?;
@@ -97,11 +75,12 @@ impl Continuation {
             }
         }
     }
+
 }
 
 impl Default for Continuation {
     fn default() -> Self {
-        Continuation::Produces(vec!())
+        Continuation::Produces(Produces { elems: vec!() })
     }
 }
 
@@ -109,7 +88,7 @@ impl Default for Continuation {
 pub fn parse_continuation(clause: Clause) -> InnerResult<Continuation> {
     let continuation = match clause.tpe {
         ClauseType::Produces => {
-            Continuation::Produces(clause.body.clone())
+            Continuation::Produces(Produces { elems: clause.body.clone() })
         }
         ClauseType::And => {
             if !clause.body.is_empty() {
@@ -159,7 +138,7 @@ pub fn parse_continuation(clause: Clause) -> InnerResult<Continuation> {
                     return Err(ConformanceErrorKind::ExpectedModelValue);
                 }
             }
-            Continuation::Denotes(values)
+            Continuation::Denotes(Denotes { model: values })
         }
         ClauseType::Each => {
             let mut parsing_branches = true;
@@ -228,6 +207,66 @@ pub fn parse_continuation(clause: Clause) -> InnerResult<Continuation> {
 pub(crate) struct EachBranch {
     name: Option<String>,
     fragment: Fragment,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct Produces {
+    pub elems: Vec<Element>,
+}
+
+impl Produces {
+    pub fn evaluate(&self, ctx: &Context) -> InnerResult<()> {
+        let (input, _encoding) = ctx.input(ctx.encoding())?;
+        let mut reader = ion_rs::Reader::new(ion_rs::AnyEncoding, input)?;
+
+        let mut is_equal = true;
+        let mut elem_iter = self.elems.iter();
+
+        while is_equal {
+            let (actual_value, expected_elem) = (reader.next()?, elem_iter.next());
+            match (actual_value, expected_elem) {
+                (None, None) => break,
+                (Some(actual_value), Some(expected_elem)) => 
+                    is_equal &= super::fragment::ProxyElement(expected_elem) == actual_value,
+                _ => is_equal = false,
+            }
+        }
+
+        if is_equal {
+            Ok(())
+        } else {
+            Err(ConformanceErrorKind::MismatchedProduce)
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct Denotes {
+    pub model: Vec<ModelValue>,
+}
+
+impl Denotes {
+    pub fn evaluate(&self, ctx: &Context) -> InnerResult<()> {
+        let (input, _encoding) = ctx.input(ctx.encoding())?;
+        let mut reader = ion_rs::Reader::new(ion_rs::AnyEncoding, input)?;
+        let mut elem_iter = self.model.iter();
+
+        let mut is_equal = true;
+        while is_equal {
+            let (read_value, expected_element) = (reader.next()?, elem_iter.next());
+            match (read_value, expected_element) {
+                (Some(actual), Some(expected)) => is_equal = is_equal && (expected == actual),
+                (None, None) => break,
+                _ => is_equal = false,
+            }
+        }
+
+        if is_equal {
+            Ok(())
+        } else {
+            Err(ConformanceErrorKind::MismatchedDenotes)
+        }
+    }
 }
 
 /// Represents a Then clause, it's optional name, the list of fragments, and continuation. A 'Then'

--- a/tests/conformance_dsl/document.rs
+++ b/tests/conformance_dsl/document.rs
@@ -39,7 +39,7 @@ pub(crate) struct Document {
 impl Document {
     /// Execute the test by evaluating the document's continuation.
     pub fn run(&self) -> Result<()> {
-        let ctx = Context::new(IonVersion::Unspecified, self.encoding(), &self.fragments);
+        let ctx = Context::new(IonVersion::Unspecified, self.encoding(), &self.fragments)?;
         self.continuation.evaluate(&ctx)?;
         Ok(())
     }

--- a/tests/conformance_dsl/mod.rs
+++ b/tests/conformance_dsl/mod.rs
@@ -306,3 +306,26 @@ pub(crate) fn parse_text_exp<'a, I: IntoIterator<Item=&'a Element>>(elems: I) ->
     let val_string = bytes.iter().map(|v| unsafe { String::from_utf8_unchecked(v.to_vec()) }).collect();
     Ok(val_string)
 }
+
+/// Parses absent symbol notation from a symbol within a Toplevel fragment, or produces
+/// Continuation. The notation is '#$<id>' for an absent symbol id, or '#$<name>#<id>' for a symbol
+/// ID from a specific symbol table named 'name'.
+pub(crate) fn parse_absent_symbol<T: AsRef<str>>(txt: T) -> (Option<String>, Option<usize>) {
+    let txt = txt.as_ref();
+    if let Some(id_txt) = txt.strip_prefix("#$") {
+        let split_txt: Vec<&str> = id_txt.split('#').collect(); // format: '#$<name>#<id>' or '#$<id>'
+        match split_txt.len() {
+            1 => (
+                None,
+                split_txt[0].parse::<usize>().map(Some).unwrap_or(None)
+            ),
+            2 => (
+                Some(split_txt[0].to_string()),
+                split_txt[1].parse::<usize>().map(Some).unwrap_or(None)
+            ),
+            _ => panic!("invalid absent symbol notation"),
+        }
+    } else {
+        (None, None)
+    }
+}

--- a/tests/conformance_dsl/model.rs
+++ b/tests/conformance_dsl/model.rs
@@ -1,7 +1,7 @@
 use ion_rs::{Decimal, Element, IonType, Sequence, Timestamp, ValueRef};
 use ion_rs::{LazyRawValue, LazyRawFieldName, v1_0::RawValueRef};
 use ion_rs::decimal::coefficient::Coefficient;
-use super::{Clause, ClauseType, ConformanceErrorKind, InnerResult, parse_text_exp, parse_bytes_exp};
+use super::{Clause, ClauseType, Context, ConformanceErrorKind, InnerResult, parse_text_exp, parse_bytes_exp};
 
 
 /// Represents a symbol in the Data Model representation of ion data.
@@ -132,8 +132,8 @@ impl TryFrom<&Sequence> for ModelValue {
                                 Ok(ModelValue::Symbol(SymbolToken::Text(text)))
                             },
                             ClauseType::Absent => {
-                                let symtab= clause.body.get(1).and_then(|v| v.as_string()).ok_or(ConformanceErrorKind::ExpectedSymbolType)?;
-                                let offset = clause.body.get(2).and_then(|v| v.as_i64()).ok_or(ConformanceErrorKind::ExpectedSymbolType)?;
+                                let symtab= clause.body.first().and_then(|v| v.as_string()).ok_or(ConformanceErrorKind::ExpectedSymbolType)?;
+                                let offset = clause.body.get(1).and_then(|v| v.as_i64()).ok_or(ConformanceErrorKind::ExpectedSymbolType)?;
                                 Ok(ModelValue::Symbol(SymbolToken::Absent(symtab.to_string(), offset)))
                             }
                             _ => unreachable!(),
@@ -205,52 +205,12 @@ impl PartialEq<Element> for ModelValue {
             ModelValue::Float(val) => other.as_float() == Some(*val),
             ModelValue::Decimal(dec) => other.as_decimal() == Some(*dec),
             ModelValue::String(val) => other.as_string() == Some(val),
-            ModelValue::List(vals) => {
-                if other.ion_type() != IonType::List {
-                    return false;
-                }
-                let other_seq = other.as_sequence().unwrap(); // SAFETY: Confirmed it's a list.
-                if other_seq.len() != vals.len() {
-                    return false;
-                }
-
-                for (ours, others) in vals.iter().zip(other_seq) {
-                    if ours != others {
-                        return false;
-                    }
-                }
-                true
-            }
-            ModelValue::Sexp(vals) => {
-                if other.ion_type() != IonType::SExp {
-                    return false;
-                }
-                let other_seq = other.as_sequence().unwrap(); // SAFETY: Confirmed it's a list.
-                if other_seq.len() != vals.len() {
-                    return false;
-                }
-
-                for (ours, others) in vals.iter().zip(other_seq) {
-                    if ours != others {
-                        return false;
-                    }
-                }
-                true
-            }
-            ModelValue::Struct(_) => panic!("should not be using element eq for struct"),
             ModelValue::Blob(data) => other.as_blob() == Some(data.as_slice()),
             ModelValue::Clob(data) => other.as_clob() == Some(data.as_slice()),
-            ModelValue::Symbol(sym) => {
-                if let Some(other_sym) = other.as_symbol() {
-                    match sym {
-                        SymbolToken::Text(text) => Some(text.as_ref()) == other_sym.text(),
-                        _ => unreachable!(),
-                    }
-                } else {
-                    false
-                }
-            }
             ModelValue::Timestamp(ts) => other.as_timestamp() == Some(*ts),
+            _ => unreachable!(), // SAFETY: EQ of Symbols, Lists, Structs, and SExps are handled
+                                 // via comparison to LazyValues after moving to using a Reader instead of Element
+                                 // API. These should join them but haven't yet.
         }
     }
 }
@@ -261,94 +221,120 @@ impl PartialEq<Element> for &ModelValue {
     }
 }
 
-impl<T: ion_rs::Decoder> PartialEq<ion_rs::LazyValue<'_, T>> for &ModelValue {
-    fn eq(&self, other: &ion_rs::LazyValue<'_, T>) -> bool {
-        match self {
-            ModelValue::Symbol(symbol_token) if other.ion_type() == IonType::Symbol => {
-                let Some(raw_symbol) = other.raw().map(|r| r.read()) else {
-                    unreachable!()
-                };
-                let raw_symbol = raw_symbol.expect("error reading symbol");
+/// Compares a ModelValue to a LazyValue for evaluating Denotes clauses. This is used in place of
+/// PartialEq in order to communicate errors.
+pub(crate) fn compare_values<T: ion_rs::Decoder>(ctx: &Context, model: &ModelValue, other: &ion_rs::LazyValue<'_, T>) -> InnerResult<bool> {
+    match model {
+        ModelValue::Symbol(symbol_token) if other.ion_type() == IonType::Symbol => {
+            // SAFETY: Tested other in the guard above, should not hit the else clause.
+            let Some(raw_symbol) = other.raw().map(|r| r.read()) else {
+                return Ok(false)
+            };
 
-                let RawValueRef::Symbol(raw_symbol) = raw_symbol else {
-                    return false
-                };
+            let raw_symbol = raw_symbol?;
 
-                let ValueRef::Symbol(symbol_text) = other.read().expect("error resolving symbol") else {
-                    return false;
-                };
+            let RawValueRef::Symbol(raw_symbol) = raw_symbol else {
+                return Ok(false)
+            };
 
-                let (expected_txt, expected_id) = match symbol_token {
-                    SymbolToken::Text(txt) => return symbol_text == txt,
-                    SymbolToken::Offset(id) => (&String::from(""), *id as usize),
-                    SymbolToken::Absent(txt, id) => (txt, *id as usize),
-                };
+            let ValueRef::Symbol(symbol_text) = other.read().expect("error resolving symbol") else {
+                return Ok(false);
+            };
 
-                raw_symbol.matches_sid_or_text(expected_id, expected_txt)
-            }
-            ModelValue::Struct(expected_fields) if other.ion_type() == IonType::Struct => {
-                let ValueRef::Struct(strukt) = other.read().expect("error reading struct") else {
-                    return false;
-                };
-
-                let mut is_equal = true;
-                let mut strukt_iter = strukt.iter();
-                let mut expected_iter = expected_fields.iter();
-
-                while is_equal {
-                    let actual = strukt_iter.next();
-                    let expected = expected_iter.next();
-
-                    match (actual, expected) {
-                        (Some(actual), Some((expected_field, expected_val))) => {
-                            let actual = actual.expect("unable to read struct field");
-                            let actual_field = actual.raw_name().map(|n| n.read()).expect("unable to get symbolref for field name");
-                            let actual_field = actual_field.expect("unable to read symbolref for field name");
-
-                            let (expected_txt, expected_id) = match expected_field {
-                                SymbolToken::Text(txt) => (txt, usize::MAX),
-                                SymbolToken::Offset(id) => (&String::from(""), *id as usize),
-                                SymbolToken::Absent(txt, id) => (txt, *id as usize),
-                            };
-                            is_equal = is_equal && actual_field.matches_sid_or_text(expected_id, expected_txt);
-
-                            let actual_value = actual.value();
-
-                            is_equal = is_equal && (expected_val == actual_value);
-                        }
-                        (None, None) => break,
-                        _ => is_equal = false,
+            let (expected_txt, expected_id) = match symbol_token {
+                SymbolToken::Text(txt) => return Ok(symbol_text == txt),
+                SymbolToken::Offset(id) => (String::from(""), *id as usize),
+                SymbolToken::Absent(symtab, id) => match ctx.get_symbol_from_table(symtab, *id as usize) {
+                    None => (String::from(""), 0_usize),
+                    Some(shared_symbol) => {
+                        let shared_text = shared_symbol.text().unwrap_or("");
+                        (shared_text.to_string(), other.symbol_table().sid_for(&shared_text).unwrap_or(0))
                     }
                 }
-                is_equal
-            }
-            ModelValue::List(expected) if other.ion_type() == IonType::List => {
-                let ValueRef::List(list) = other.read().expect("error reading list") else {
-                    unreachable!();
-                };
+            };
 
-                let actual: ion_rs::IonResult<Vec<ion_rs::LazyValue<_>>> = list.iter().collect();
-                let actual = actual.expect("Error parsing list");
+            Ok(raw_symbol.matches_sid_or_text(expected_id, &expected_txt))
+        }
+        ModelValue::Struct(expected_fields) if other.ion_type() == IonType::Struct => {
+            // SAFETY: Tested other in the guard above, should not hit the else clause.
+            let ValueRef::Struct(strukt) = other.read().expect("error reading struct") else {
+                return Ok(false);
+            };
 
-                actual.iter().zip(expected.iter())
-                    .fold(true, |acc, (actual_val, expected_val)| acc && (&expected_val == actual_val))
-            }
-            ModelValue::Sexp(expected) if other.ion_type() == IonType::SExp => {
-                let ValueRef::SExp(sexp) = other.read().expect("error reading sexp") else {
-                    unreachable!();
-                };
+            let mut is_equal = true;
+            let mut strukt_iter = strukt.iter();
+            let mut expected_iter = expected_fields.iter();
 
-                let actual: ion_rs::IonResult<Vec<ion_rs::LazyValue<_>>> = sexp.iter().collect();
-                let actual = actual.expect("Error parsing sexp");
-                actual.iter().zip(expected.iter())
-                    .fold(true, |acc, (actual_val, expected_val)| acc && (&expected_val == actual_val))
+            while is_equal {
+                let actual = strukt_iter.next();
+                let expected = expected_iter.next();
+
+                match (actual, expected) {
+                    (Some(actual), Some((expected_field, expected_val))) => {
+                        let actual = actual.expect("unable to read struct field");
+                        let actual_field = actual.raw_name().map(|n| n.read()).expect("unable to get symbolref for field name");
+                        let actual_field = actual_field.expect("unable to read symbolref for field name");
+
+                        let (expected_txt, expected_id) = match expected_field {
+                            SymbolToken::Text(txt) => (txt.clone(), usize::MAX),
+                            SymbolToken::Offset(id) => (String::from(""), *id as usize),
+                            SymbolToken::Absent(symtab, id) => match ctx.get_symbol_from_table(symtab, *id as usize) {
+                                None => (String::from(""), 0_usize),
+                                Some(shared_symbol) => {
+                                    let shared_text = shared_symbol.text().unwrap_or("");
+                                    (shared_text.to_string(), other.symbol_table().sid_for(&shared_text).unwrap_or(0))
+                                }
+                            }
+                        };
+                        is_equal = is_equal && actual_field.matches_sid_or_text(expected_id, &expected_txt);
+
+                        let actual_value = actual.value();
+
+                        is_equal = is_equal && compare_values(ctx, expected_val, &actual_value)?;
+                    }
+                    (None, None) => break,
+                    _ => is_equal = false,
+                }
             }
-            _ => {
-                // Anything that reaches down here isn't a symbol, or can't contain a symbol. So
-                // we just have to worry about equality.
-                let other_elem: Element = Element::try_from(*other).expect("Unable to convert value into element");
-                *self == other_elem
+            Ok(is_equal)
+        }
+        ModelValue::List(expected) if other.ion_type() == IonType::List => {
+            // SAFETY: Tested other in the guard above, should not hit the else clause.
+            let ValueRef::List(list) = other.read().expect("error reading list") else {
+                return Ok(false);
+            };
+
+            let actual: ion_rs::IonResult<Vec<ion_rs::LazyValue<_>>> = list.iter().collect();
+            let actual = actual.expect("Error parsing list");
+
+
+            for (actual_val, expected_val) in actual.iter().zip(expected.iter()) {
+                if !compare_values(ctx, expected_val, actual_val)? {
+                    return Ok(false)
+                }
             }
+            Ok(true)
+        }
+        ModelValue::Sexp(expected) if other.ion_type() == IonType::SExp => {
+            // SAFETY: Tested other in the guard above, should not hit the else clause.
+            let ValueRef::SExp(sexp) = other.read().expect("error reading sexp") else {
+                return Ok(false);
+            };
+
+            let actual: ion_rs::IonResult<Vec<ion_rs::LazyValue<_>>> = sexp.iter().collect();
+            let actual = actual?;
+            for (actual_val, expected_val) in actual.iter().zip(expected.iter()) {
+                if !compare_values(ctx, expected_val, actual_val)? {
+                    return Ok(false)
+                }
+            }
+            Ok(true)
+        }
+        _ => {
+            // Anything that reaches down here isn't a symbol, or can't contain a symbol. So
+            // we just have to worry about equality.
+            let other_elem: Element = Element::try_from(*other)?;
+            Ok(model == other_elem)
         }
     }
 }

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "experimental-reader-writer")]
+#![cfg(feature = "experimental-tooling-apis")]
 mod conformance_dsl;
 use conformance_dsl::prelude::*;
 
@@ -10,6 +11,21 @@ use std::str::FromStr;
 
 mod implementation {
     use super::*;
+
+    #[test]
+    fn test_absent_symbol() {
+        let test = r#"
+           (ion_1_1
+              (toplevel '#$2' {'#$9': '#$8'})
+              (text "")
+              (denotes (Symbol 2) (Struct (9 (Symbol 8))))
+           )
+        "#;
+        Document::from_str(test)
+            .unwrap_or_else(|e| panic!("Failed to load document:\n{:?}", e))
+            .run()
+            .unwrap_or_else(|e| panic!("Test failed: {:?}", e));
+    }
 
     #[test]
     fn test_timestamps() {

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -14,17 +14,30 @@ mod implementation {
 
     #[test]
     fn test_absent_symbol() {
-        let test = r#"
-           (ion_1_1
+        let tests: &[&str] = &[
+        r#"(ion_1_1
               (toplevel '#$2' {'#$9': '#$8'})
               (text "")
               (denotes (Symbol 2) (Struct (9 (Symbol 8))))
-           )
-        "#;
-        Document::from_str(test)
-            .unwrap_or_else(|e| panic!("Failed to load document:\n{:?}", e))
-            .run()
-            .unwrap_or_else(|e| panic!("Test failed: {:?}", e));
+           )"#,
+        r#"(ion_1_0
+              (text '''$ion_symbol_table::{imports:[{name:"abcs", version: 2}]}''')
+              (text "$10 $11")
+              (produces '#$abcs#1' '#$abcs#2')
+           )"#,
+        r#"(ion_1_0
+              (text '''$ion_symbol_table::{imports:[{name:"abcs", version: 2}]}''')
+              (text "$10 $11")
+              (denotes (Symbol (absent "abcs" 1)) (Symbol (absent "abcs" 2)))
+           )"#,
+        ];
+
+        for test in tests {
+            Document::from_str(test)
+                .unwrap_or_else(|e| panic!("Failed to load document:\n{:?}", e))
+                .run()
+                .unwrap_or_else(|e| panic!("Test failed: {:?}", e));
+        }
     }
 
     #[test]
@@ -37,12 +50,13 @@ mod implementation {
             r#"(ion_1_1 "Timestamp Second" (text "2023-03-23T10:12:21Z") (denotes (Timestamp second 2023 3 23 (offset 0) 10 12 21))) "#,
             r#"(ion_1_1 "Timestamp Fractional" (text "2023-03-23T10:12:21.23Z") (denotes (Timestamp fraction 2023 3 23 (offset 0) 10 12 21 23 -2))) "#,
         ];
+
         for test in tests {
             Document::from_str(test)
                 .unwrap_or_else(|e| panic!("Failed to load document: <<{}>>\n{:?}", test, e))
                 .run()
                 .unwrap_or_else(|e| panic!("Test failed for simple doc: <<{}>>\n{:?}", test, e));
-            }
+         }
     }
 
     #[test]
@@ -103,7 +117,6 @@ mod ion_tests {
         println!("Testing: {}", file_name);
         let collection = TestCollection::load(file_name).expect("unable to load test file");
 
-        println!("Collection: {:?}", collection);
         collection.run().expect("failed to run collection");
     }
 }


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
This PR adds missing symbol notation for Toplevel and Produces clauses.

This turned out to be a lot simpler than I had originally thought. My first (few) pass(es) through the spec left my understanding to be that the notation could define symbol mappings, which would have to be created during the evaluation of the fragments, and supported when evaluating expectations. Unfortunately I didn't realize my misunderstanding until after having implemented creating the symbol mappings.

The functionality now allows symbol IDs to be specified as quoted symbols, with the `#$` notation for identifying such symbol IDs.

### Details
When the Toplevel fragment is triggered to encode it's contents into a new document fragment, it uses `ProxyElement` to wrap each of the ion elements that were defined within its body. ProxyElement implements `WriteAsIon` in order to hijack any symbols being written and detect any `#$` prefixed symbols so that it can parse out the symbol table name, and offset. Once parsed, it will write the symbol ID to the document fragment.

When a Produces clause is evaluated, it will walk through its body of ion elements, while reading the concatenated ion document. As each element is evaluated for equality, any symbols found in the Produces' body will also be tested for `#$` prefix, and offsets/symtabs extracted.

In addition to Toplevel and Produces support, the Denotes clause was updated to use a reader rather than the Element API, so that it can access the symbol IDs to complete its data model tests.

### Additionally
I also used this PR to follow up on #828, and rolled the typed null handling into a `read_null` function and reset the `ion_type` back to its original for consistency. I'll follow up with a PR to return the underlying type from `ion_type` for all value implementations.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
