### PR TITLE
Adds AsRef<[Element]> for Sequence, List, and SExp

### DIFF
--- a/src/element/sequence.rs
+++ b/src/element/sequence.rs
@@ -131,6 +131,12 @@ impl AsRef<Sequence> for Sequence {
     }
 }
 
+impl AsRef<[Element]> for Sequence {
+    fn as_ref(&self) -> &[Element] {
+        self.elements.as_slice()
+    }
+}
+
 // This is more efficient than Sequence::new(), which will iterate over and convert each value to
 // an Element for better ergonomics.
 impl From<Vec<Element>> for Sequence {

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -52,6 +52,12 @@ impl AsRef<Sequence> for List {
     }
 }
 
+impl AsRef<[Element]> for List {
+    fn as_ref(&self) -> &[Element] {
+        &self.0.as_ref()
+    }
+}
+
 // Allows `for element in &list {...}` syntax
 impl<'a> IntoIterator for &'a List {
     type Item = &'a Element;

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -54,7 +54,7 @@ impl AsRef<Sequence> for List {
 
 impl AsRef<[Element]> for List {
     fn as_ref(&self) -> &[Element] {
-        &self.0.as_ref()
+        self.0.as_ref()
     }
 }
 

--- a/src/types/sexp.rs
+++ b/src/types/sexp.rs
@@ -52,6 +52,12 @@ impl AsRef<Sequence> for SExp {
     }
 }
 
+impl AsRef<[Element]> for SExp {
+    fn as_ref(&self) -> &[Element] {
+        &self.0.as_ref()
+    }
+}
+
 // Allows `for element in &sexp {...}` syntax
 impl<'a> IntoIterator for &'a SExp {
     type Item = &'a Element;

--- a/src/types/sexp.rs
+++ b/src/types/sexp.rs
@@ -54,7 +54,7 @@ impl AsRef<Sequence> for SExp {
 
 impl AsRef<[Element]> for SExp {
     fn as_ref(&self) -> &[Element] {
-        &self.0.as_ref()
+        self.0.as_ref()
     }
 }
 


### PR DESCRIPTION
**Issue #, if available:**

None.

**Description of changes:**

I was working on something else, and having a hard time coming up with a clean way to deal with an input that could be a `Vec<Element>` or `Sequence`. It makes it so much easier to write APIs that can accept a borrowed, ordered collections of `Element` if we can use `AsRef<[Element]>`.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
