### PR TITLE
Put Ion 1.1 support behind a feature flag

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,6 +54,7 @@ jobs:
     # H/T: https://github.com/Dart-Code/Dart-Code/commit/612732d5879730608baa9622bf7f5e5b7b51ae65
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-rust'
     strategy:
+      fail-fast: false
       matrix:
         # use the available runner types that were determined by the setup step
         os: ${{ fromJSON(needs.setup.outputs.available-runners) }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,11 @@ experimental = [
     "experimental-reader-writer",
     "experimental-tooling-apis",
     "experimental-serde",
+    "experimental-ion-1-1",
 ]
+
+# Feature for indicating explicit opt-in to Ion 1.1
+experimental-ion-1-1 = [ "experimental-reader-writer" ]
 
 # Access to the streaming Reader and Writer types.
 # These APIs are functional and well-tested, but are not yet stable.

--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -1860,6 +1860,11 @@ mod tests {
 
         expect_int(context_ref, &mut reader, IonEncoding::Text_1_0, 2)?;
 
+        if cfg!(not(feature = "experimental-ion-1-1")) {
+            reader.next(context_ref).expect_err("Ion 1.1 IVM should return an error.");
+            return Ok(())
+        }
+
         // This IVM changes the encoding from 1.0 text to 1.1 text
         expect_version_change(
             context_ref,
@@ -1921,6 +1926,11 @@ mod tests {
         )?;
 
         expect_int(context_ref, &mut reader, IonEncoding::Binary_1_0, 2)?;
+
+        if cfg!(not(feature = "experimental-ion-1-1")) {
+            reader.next(context_ref).expect_err("Ion 1.1 IVM should return an error.");
+            return Ok(())
+        }
 
         // This IVM changes the encoding from 1.0 binary to 1.1 binary
         expect_version_change(

--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -1118,6 +1118,7 @@ pub struct EncodedAnnotations {
     pub sequence_length: u16,
 }
 
+#[cfg(feature = "experimental-ion-1-1")]
 #[cfg(test)]
 mod tests {
     use rstest::rstest;

--- a/src/lazy/binary/raw/v1_1/struct.rs
+++ b/src/lazy/binary/raw/v1_1/struct.rs
@@ -322,6 +322,7 @@ impl<'top> Iterator for RawBinaryStructIterator_1_1<'top> {
     }
 }
 
+#[cfg(feature = "experimental-ion-1-1")]
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -125,6 +125,7 @@ pub trait RawVersionMarker<'top>: Debug + Copy + Clone + HasSpan<'top> {
     fn stream_version_after_marker(&self) -> IonResult<IonVersion> {
         match self.major_minor() {
             (1, 0) => Ok(IonVersion::v1_0),
+            #[cfg(feature = "experimental-ion-1-1")]
             (1, 1) => Ok(IonVersion::v1_1),
             (major, minor) => {
                 IonResult::decoding_error(format!("Ion version {major}.{minor} is not supported"))

--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -933,6 +933,7 @@ impl<'value, 'top> BinaryAnnotatedValueWriter_1_1<'value, 'top> {
 }
 
 #[cfg(test)]
+#[cfg(feature = "experimental-ion-1-1")]
 mod tests {
     use num_traits::FloatConst;
     use rstest::rstest;

--- a/src/lazy/encoder/text/v1_1/writer.rs
+++ b/src/lazy/encoder/text/v1_1/writer.rs
@@ -105,6 +105,7 @@ impl<W: Write> LazyRawWriter<W> for LazyRawTextWriter_1_1<W> {
     }
 }
 
+#[cfg(feature = "experimental-ion-1-1")]
 #[cfg(test)]
 mod tests {
     use crate::lazy::any_encoding::IonVersion;

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -742,6 +742,7 @@ impl<S: SequenceWriter> ElementWriter for S {
     }
 }
 
+#[cfg(feature = "experimental-ion-1-1")]
 #[cfg(test)]
 mod tests {
     use crate::lazy::encoder::value_writer::AnnotatableWriter;

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -1569,6 +1569,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(feature = "experimental-ion-1-1")]
     #[test]
     fn dependent_macros() -> IonResult<()> {
         let ion = r#"

--- a/src/lazy/reader.rs
+++ b/src/lazy/reader.rs
@@ -311,6 +311,7 @@ mod tests {
         test_fn(reader)
     }
 
+    #[cfg(feature = "experimental-ion-1-1")]
     #[test]
     fn expand_binary_template_macro() -> IonResult<()> {
         let macro_source = "(macro seventeen () 17)";
@@ -321,6 +322,7 @@ mod tests {
         })
     }
 
+    #[cfg(feature = "experimental-ion-1-1")]
     #[test]
     fn expand_binary_template_macro_with_one_arg() -> IonResult<()> {
         let macro_source = r#"
@@ -349,6 +351,7 @@ mod tests {
         })
     }
 
+    #[cfg(feature = "experimental-ion-1-1")]
     #[test]
     fn expand_binary_template_macro_with_multiple_outputs() -> IonResult<()> {
         let macro_source = r#"

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -1003,6 +1003,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(feature = "experimental-ion-1-1")]
     #[test]
     fn detect_encoding_directive_text() -> IonResult<()> {
         let text = r#"
@@ -1016,6 +1017,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(feature = "experimental-ion-1-1")]
     #[test]
     fn detect_encoding_directive_binary() -> IonResult<()> {
         let mut writer = LazyRawBinaryWriter_1_1::new(Vec::new())?;
@@ -1073,6 +1075,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(feature = "experimental-ion-1-1")]
     #[test]
     fn read_encoding_directive_new_active_module() -> IonResult<()> {
         let ion = r#"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,7 +379,23 @@ pub mod v1_0 {
     pub use crate::lazy::encoding::{BinaryEncoding_1_0 as Binary, TextEncoding_1_0 as Text};
 }
 
+#[cfg(feature = "experimental-ion-1-1")]
 pub mod v1_1 {
+    #[cfg(feature = "experimental-tooling-apis")]
+    v1_1_tooling_apis!(pub);
+
+    #[cfg(not(feature = "experimental-tooling-apis"))]
+    v1_1_tooling_apis!(pub(crate));
+
+    #[cfg(feature = "experimental-reader-writer")]
+    v1_1_reader_writer!(pub);
+
+    #[cfg(not(feature = "experimental-reader-writer"))]
+    v1_1_reader_writer!(pub(crate));
+}
+
+#[cfg(not(feature = "experimental-ion-1-1"))]
+pub(crate) mod v1_1 {
     #[cfg(feature = "experimental-tooling-apis")]
     v1_1_tooling_apis!(pub);
 

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "experimental-ion-1-1")]
 
 #[cfg(feature = "experimental-reader-writer")]
 mod conformance_dsl;

--- a/tests/conformance_dsl/mod.rs
+++ b/tests/conformance_dsl/mod.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "experimental-ion-1-1")]
 #![allow(dead_code)]
 
 mod context;

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "experimental-ion-1-1")]
 #![cfg(feature = "experimental-reader-writer")]
 mod conformance_dsl;
 use conformance_dsl::prelude::*;

--- a/tests/detect_incomplete_text.rs
+++ b/tests/detect_incomplete_text.rs
@@ -42,6 +42,7 @@ fn detect_incomplete_input_1_0(file_name: &str) {
     incomplete_text_detection_test(&SKIP_LIST_1_0, file_name).unwrap()
 }
 
+#[cfg(feature = "experimental-ion-1-1")]
 #[test_resources("ion-tests/iontestdata_1_1/good/**/*.ion")]
 fn detect_incomplete_input_1_1(file_name: &str) {
     incomplete_text_detection_test(&SKIP_LIST_1_1, file_name).unwrap()

--- a/tests/ion_tests_1_1.rs
+++ b/tests/ion_tests_1_1.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "experimental-ion-1-1")]
 #![cfg(feature = "experimental-reader-writer")]
 /// TODO: When the Ion 1.1 binary reader is complete, update this module to include binary tests
 mod ion_tests;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

I tried to make this as minimally invasive as possible:
* The `experimental-ion-1-1` feature enables`experimental-reader-writer`
* The `experimental` feature flag enables `experimental-ion-1-1`
* When `experimental-ion-1-1` is not enabled
  * the `v1_1` module is only `pub(crate)`
  * the decoder doesn't have a match arm for the `(1, 1)` version.
  * the tests for switching versions have a branch that checks that an `Err` is returned for an Ion 1.1 IVM
  * the conformance dsl tests and a number of Ion 1.1 specific tests are disabled (omitted from compilation, really)
* When `experimental-ion-1-1` is enabled, all APIs and behaviors are as they were prior to this PR

I also updated the build workflow to _not_ cancel all outstanding jobs if one job in the build matrix fails. It's a lot quicker to identify issues if you can see that e.g. the tests pass for certain feature sets but not for others.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
