### PR TITLE
TDL syntax updates

### DIFF
--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -1451,7 +1451,7 @@ mod tests {
     #[test]
     fn read_eexp_with_star_parameter_arg_group_nested_eexp() -> IonResult<()> {
         let macro_source = r#"
-            (macro wrap_in_list (values*) ["first", values, "last"])
+            (macro wrap_in_list (values*) ["first", (%values), "last"])
         "#;
 
         let expected_text = r#"
@@ -1494,7 +1494,7 @@ mod tests {
     #[test]
     fn read_length_prefixed_eexp_with_star_parameter_arg_group_nested_eexp() -> IonResult<()> {
         let macro_source = r#"
-            (macro wrap_in_list (values*) ["first", values, "last"])
+            (macro wrap_in_list (values*) ["first", (%values), "last"])
         "#;
 
         let expected_text = r#"
@@ -1579,7 +1579,7 @@ mod tests {
     #[test]
     fn read_length_prefixed_eexp_with_star_parameter_empty() -> IonResult<()> {
         let macro_source = r#"
-            (macro wrap_in_list (values*) ["first", values, "last"])
+            (macro wrap_in_list (values*) ["first", (%values), "last"])
         "#;
 
         let expected_text = r#"

--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -1280,7 +1280,7 @@ mod tests {
     fn read_eexp_with_one_arg() -> IonResult<()> {
         let macro_source = r#"
             (macro greet (name)
-                (make_string "Hello, " name "!")
+                (.make_string "Hello, " name "!")
             )
         "#;
 
@@ -1313,7 +1313,7 @@ mod tests {
     fn read_eexp_with_two_args() -> IonResult<()> {
         let macro_source = r#"
             (macro greet (name day)
-                (make_string "Hello, " name "! Have a pleasant " day ".")
+                (.make_string "Hello, " name "! Have a pleasant " day ".")
             )
         "#;
 

--- a/src/lazy/binary/raw/v1_1/struct.rs
+++ b/src/lazy/binary/raw/v1_1/struct.rs
@@ -339,7 +339,7 @@ mod tests {
                     (symbol_table $ion_encoding)
                     (macro_table
                         $ion_encoding
-                        (macro greet (name) (.make_string "hello, " name))
+                        (macro greet (name) (.make_string "hello, " (%name)))
                     )
                 )
             "#,

--- a/src/lazy/binary/raw/v1_1/struct.rs
+++ b/src/lazy/binary/raw/v1_1/struct.rs
@@ -339,7 +339,7 @@ mod tests {
                     (symbol_table $ion_encoding)
                     (macro_table
                         $ion_encoding
-                        (macro greet (name) (make_string "hello, " name))
+                        (macro greet (name) (.make_string "hello, " name))
                     )
                 )
             "#,

--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -113,7 +113,7 @@ impl<'top, D: Decoder> EExpression<'top, D> {
         // Initialize a `MacroExpansionKind` with the state necessary to evaluate the requested
         // macro.
         let expansion_kind = match invoked_macro.kind() {
-            MacroKind::Void => MacroExpansionKind::Void,
+            MacroKind::None => MacroExpansionKind::None,
             MacroKind::ExprGroup => {
                 MacroExpansionKind::ExprGroup(ExprGroupExpansion::new(arguments))
             }

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -111,7 +111,7 @@ impl Macro {
 /// but its variants do not hold any associated state.
 #[derive(Debug, Clone, PartialEq)]
 pub enum MacroKind {
-    Void,
+    None, // `(.none)` returns the empty stream
     ExprGroup,
     MakeString,
     MakeSExp,
@@ -197,7 +197,7 @@ impl Default for MacroTable {
 
 impl MacroTable {
     pub const SYSTEM_MACRO_KINDS: &'static [MacroKind] = &[
-        MacroKind::Void,
+        MacroKind::None,
         MacroKind::ExprGroup,
         MacroKind::MakeString,
         MacroKind::MakeSExp,
@@ -215,9 +215,9 @@ impl MacroTable {
 
         vec![
             Rc::new(Macro::named(
-                "void",
+                "none",
                 MacroSignature::new(vec![]).unwrap(),
-                MacroKind::Void,
+                MacroKind::None,
                 ExpansionAnalysis {
                     could_produce_system_value: false,
                     must_produce_exactly_one_value: false,

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -193,8 +193,8 @@ impl<'top> EncodingContextRef<'top> {
 
     pub(crate) fn none_macro(&self) -> Rc<Macro> {
         self.system_macro_table()
-            .clone_macro_with_name("void")
-            .expect("`values` macro in system macro table")
+            .clone_macro_with_name("none")
+            .expect("`none` macro in system macro table")
     }
 
     pub(crate) fn values_macro(&self) -> Rc<Macro> {
@@ -553,7 +553,7 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
         self.between_top_level_expressions();
 
         // See if the raw reader can get another expression from the input stream. It's possible
-        // to find an expression that yields no values (for example: `(:void)`), so we perform this
+        // to find an expression that yields no values (for example: `(:none)`), so we perform this
         // step in a loop until we get a value or end-of-stream.
         let context_ref = self.context();
 
@@ -635,7 +635,7 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
         self.between_top_level_expressions();
 
         // See if the raw reader can get another expression from the input stream. It's possible
-        // to find an expression that yields no values (for example: `(:void)`), so we perform this
+        // to find an expression that yields no values (for example: `(:none)`), so we perform this
         // step in a loop until we get a value or end-of-stream.
         let context_ref = self.context();
 
@@ -693,7 +693,7 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
                         // If we get a value, return it.
                         return self.interpret_value(value);
                     } else {
-                        // If the expression was equivalent to `(:void)`, return to the top of
+                        // If the expression was equivalent to `(:none)`, return to the top of
                         // the loop and get the next expression.
                         continue;
                     }

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -1167,7 +1167,7 @@ impl<'top, D: Decoder> TemplateMacroInvocation<'top, D> {
         let macro_ref = self.invoked_macro();
         let arguments = MacroExprArgsIterator::from_template_macro(self.arguments());
         let expansion_kind = match macro_ref.kind() {
-            MacroKind::Void => MacroExpansionKind::Void,
+            MacroKind::None => MacroExpansionKind::None,
             MacroKind::ExprGroup => {
                 unreachable!("cannot invoke ExprGroup from a TemplateMacroInvocation")
             },

--- a/src/lazy/reader.rs
+++ b/src/lazy/reader.rs
@@ -327,7 +327,7 @@ mod tests {
     fn expand_binary_template_macro_with_one_arg() -> IonResult<()> {
         let macro_source = r#"
             (macro greet (name)
-                (.make_string "Hello, " name "!")
+                (.make_string "Hello, " (%name) "!")
             )
         "#;
         #[rustfmt::skip]
@@ -357,9 +357,9 @@ mod tests {
         let macro_source = r#"
             (macro questions (food)
                 (.values
-                    (.make_string "What color is a " food "?")
-                    (.make_string "How much potassium is in a " food "?")
-                    (.make_string "What wine should I pair with a " food "?")))
+                    (.make_string "What color is a " (%food) "?")
+                    (.make_string "How much potassium is in a " (%food) "?")
+                    (.make_string "What wine should I pair with a " (%food) "?")))
         "#;
         #[rustfmt::skip]
             let encode_macro_fn = |address| vec![

--- a/src/lazy/reader.rs
+++ b/src/lazy/reader.rs
@@ -327,7 +327,7 @@ mod tests {
     fn expand_binary_template_macro_with_one_arg() -> IonResult<()> {
         let macro_source = r#"
             (macro greet (name)
-                (make_string "Hello, " name "!")
+                (.make_string "Hello, " name "!")
             )
         "#;
         #[rustfmt::skip]
@@ -356,10 +356,10 @@ mod tests {
     fn expand_binary_template_macro_with_multiple_outputs() -> IonResult<()> {
         let macro_source = r#"
             (macro questions (food)
-                (values
-                    (make_string "What color is a " food "?")
-                    (make_string "How much potassium is in a " food "?")
-                    (make_string "What wine should I pair with a " food "?")))
+                (.values
+                    (.make_string "What color is a " food "?")
+                    (.make_string "How much potassium is in a " food "?")
+                    (.make_string "What wine should I pair with a " food "?")))
         "#;
         #[rustfmt::skip]
             let encode_macro_fn = |address| vec![

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -1126,8 +1126,7 @@ mod tests {
 
         // === Make sure it has the expected macro definitions ====
         let new_macro_table = pending_changes.macro_table();
-        // There are currently 3 supported system macros: void, values, and make_string.
-        // This directive defines two more.
+        // This directive defines two new macros in addition to the existing system macros.
         assert_eq!(new_macro_table.len(), 2 + MacroTable::NUM_SYSTEM_MACROS);
         assert_eq!(
             new_macro_table.macro_with_id(MacroTable::FIRST_USER_MACRO_ID),

--- a/tests/conformance_dsl/clause.rs
+++ b/tests/conformance_dsl/clause.rs
@@ -26,7 +26,7 @@ pub(crate) enum ClauseType {
     Text,
     /// Provide a sequence of bytes that is interpreted as binary ion, that will be inserted into
     /// the document.
-    Binary,
+    Bytes,
     /// Provide a major and minor version that will be emitted into the document as an IVM.
     Ivm,
     /// Specify a ion data to be inserted into the document, using inline ion syntax.
@@ -72,7 +72,7 @@ impl FromStr for ClauseType {
             "produces" => Ok(Produces),
             "denotes" => Ok(Denotes),
             "text" => Ok(Text),
-            "binary" => Ok(Binary),
+            "bytes" => Ok(Bytes),
             "and" => Ok(And),
             "not" => Ok(Not),
             "then" => Ok(Then),
@@ -88,11 +88,10 @@ impl FromStr for ClauseType {
 }
 
 impl ClauseType {
-
     /// Utility function to test if the Clause is a fragment node.
     pub fn is_fragment(&self) -> bool {
         use ClauseType::*;
-        matches!(self, Text | Binary | Ivm | TopLevel | Encoding | MacTab)
+        matches!(self, Text | Bytes | Ivm | TopLevel | Encoding | MacTab)
     }
 
     /// Utility function to test if the Clause is an expectation node.
@@ -120,13 +119,14 @@ impl TryFrom<&Sequence> for Clause {
             .as_symbol()
             .ok_or(ConformanceErrorKind::ExpectedDocumentClause)?;
 
-        let tpe = ClauseType::from_str(clause_type.text().ok_or(ConformanceErrorKind::ExpectedDocumentClause)?)?;
+        let tpe = ClauseType::from_str(
+            clause_type
+                .text()
+                .ok_or(ConformanceErrorKind::ExpectedDocumentClause)?,
+        )?;
         let body: Vec<Element> = other.iter().skip(1).cloned().collect();
 
-        Ok(Clause {
-            tpe,
-            body,
-        })
+        Ok(Clause { tpe, body })
     }
 }
 
@@ -149,12 +149,13 @@ impl TryFrom<&[Element]> for Clause {
             .as_symbol()
             .ok_or(ConformanceErrorKind::ExpectedDocumentClause)?;
 
-        let tpe = ClauseType::from_str(clause_type.text().ok_or(ConformanceErrorKind::ExpectedDocumentClause)?)?;
+        let tpe = ClauseType::from_str(
+            clause_type
+                .text()
+                .ok_or(ConformanceErrorKind::ExpectedDocumentClause)?,
+        )?;
         let body: Vec<Element> = other.iter().skip(1).cloned().collect();
 
-        Ok(Clause {
-            tpe,
-            body,
-        })
+        Ok(Clause { tpe, body })
     }
 }

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -8,25 +8,23 @@ use test_generator::test_resources;
 
 use std::str::FromStr;
 
-
-
 mod implementation {
     use super::*;
 
     #[test]
     fn test_absent_symbol() {
         let tests: &[&str] = &[
-        r#"(ion_1_1
+            r#"(ion_1_1
               (toplevel '#$2' {'#$9': '#$8'})
               (text "")
               (denotes (Symbol 2) (Struct (9 (Symbol 8))))
            )"#,
-        r#"(ion_1_0
+            r#"(ion_1_0
               (text '''$ion_symbol_table::{imports:[{name:"abcs", version: 2}]}''')
               (text "$10 $11")
               (produces '#$abcs#1' '#$abcs#2')
            )"#,
-        r#"(ion_1_0
+            r#"(ion_1_0
               (text '''$ion_symbol_table::{imports:[{name:"abcs", version: 2}]}''')
               (text "$10 $11")
               (denotes (Symbol (absent "abcs" 1)) (Symbol (absent "abcs" 2)))
@@ -57,7 +55,7 @@ mod implementation {
                 .unwrap_or_else(|e| panic!("Failed to load document: <<{}>>\n{:?}", test, e))
                 .run()
                 .unwrap_or_else(|e| panic!("Test failed for simple doc: <<{}>>\n{:?}", test, e));
-         }
+        }
     }
 
     #[test]
@@ -84,13 +82,13 @@ mod implementation {
             "(ion_1_1 (produces ))",
             "(document (and (produces ) (produces )))",
             "(document (text \"a\") (not (and (produces b) (produces c))))",
-            "(ion_1_1 (binary 0x60 0x61 0x01 0xEB 0x01) (produces 0 1 null.int))",
+            "(ion_1_1 (bytes 0x60 0x61 0x01 0xEB 0x01) (produces 0 1 null.int))",
             r#"(ion_1_0 (then (text "a") (produces a)))"#,
             r#"(ion_1_1 (text "a") (text "b") (text "c") (produces a b c))"#,
             r#"(ion_1_1 (text "\"Hello\" null.int false") (denotes (String "Hello") (Null int) (Bool false)))"#,
             r#"(ion_1_1 (each 
                              (text "0")
-                             (binary 0x60)
+                             (bytes 0x60)
                              (denotes (Int 0)))
                         )"#,
             r#"(document (ivm 1 2) (signals "Invalid Version"))"#,
@@ -101,8 +99,8 @@ mod implementation {
             Document::from_str(test)
                 .unwrap_or_else(|e| panic!("Failed to load document: <<{}>>\n{:?}", test, e))
                 .run()
-                .unwrap_or_else(|e| panic!("Test failed for simple doc: <<{}>>\n{:?}", test, e)); 
-            }
+                .unwrap_or_else(|e| panic!("Test failed for simple doc: <<{}>>\n{:?}", test, e));
+        }
     }
 }
 

--- a/tests/ion_tests_1_1.rs
+++ b/tests/ion_tests_1_1.rs
@@ -35,10 +35,10 @@ impl ElementApi for LazyReaderElementApi {
             // TODO: https://github.com/amazon-ion/ion-rust/issues/653
             "ion-tests/iontestdata_1_1/good/equivs/macros/make_string.ion",
             "ion-tests/iontestdata_1_1/good/equivs/macros/values.ion",
-            "ion-tests/iontestdata_1_1/good/equivs/macros/void.ion",
-            "ion-tests/iontestdata_1_1/good/macros/void_invoked_deeply_nested.ion",
-            "ion-tests/iontestdata_1_1/good/macros/void_invoked_in_struct.ion",
-            "ion-tests/iontestdata_1_1/good/macros/void_invoked_in_struct_field.ion",
+            "ion-tests/iontestdata_1_1/good/equivs/macros/none.ion",
+            "ion-tests/iontestdata_1_1/good/macros/none_invoked_deeply_nested.ion",
+            "ion-tests/iontestdata_1_1/good/macros/none_invoked_in_struct.ion",
+            "ion-tests/iontestdata_1_1/good/macros/none_invoked_in_struct_field.ion",
             // Ints outside the i128 range
             "ion-tests/iontestdata_1_1/good/intBigSize16.10n",
             "ion-tests/iontestdata_1_1/good/intBigSize256.ion",

--- a/tests/ion_tests_1_1.rs
+++ b/tests/ion_tests_1_1.rs
@@ -32,13 +32,6 @@ impl ElementApi for LazyReaderElementApi {
             // TODO: Remove from skiplist when shared symbol tables are supported
             "ion-tests/iontestdata_1_1/good/localSymbolTableImportZeroMaxId.ion",
             "ion-tests/iontestdata_1_1/good/testfile35.ion",
-            // TODO: https://github.com/amazon-ion/ion-rust/issues/653
-            "ion-tests/iontestdata_1_1/good/equivs/macros/make_string.ion",
-            "ion-tests/iontestdata_1_1/good/equivs/macros/values.ion",
-            "ion-tests/iontestdata_1_1/good/equivs/macros/none.ion",
-            "ion-tests/iontestdata_1_1/good/macros/none_invoked_deeply_nested.ion",
-            "ion-tests/iontestdata_1_1/good/macros/none_invoked_in_struct.ion",
-            "ion-tests/iontestdata_1_1/good/macros/none_invoked_in_struct_field.ion",
             // Ints outside the i128 range
             "ion-tests/iontestdata_1_1/good/intBigSize16.10n",
             "ion-tests/iontestdata_1_1/good/intBigSize256.ion",


### PR DESCRIPTION
* Macro invocation syntax is now `(.macro_name)`
* Variable expansion syntax is now `(%variable_name)`
* The `void` macro has been renamed to `none`
* Pulls in the latest version of `ion-tests`, which includes amazon-ion/ion-tests#125

I suggest looking at the commits individually.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
