### PR TITLE
Renames `append_macros` to `add_macros`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,11 @@ codegen-units = 1
 inherits = "release"
 debug = true
 
+# All dependencies (but not ion-rs itself) are optimized by default, even in debug builds.
+# This makes test runs faster without affecting incremental build times.
+[profile.dev.package."*"]
+opt-level = 2
+
 [[test]]
 name = "conformance"
 harness = false

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -1406,7 +1406,7 @@ mod tests {
     fn explicit_expr_group_arg() -> IonResult<()> {
         stream_eq(
             r#"
-            (:append_macros
+            (:add_macros
                 (macro greet (x) (.make_string (.. "Hello, " (%x))))
             )
             (:greet "Gary")
@@ -1418,11 +1418,11 @@ mod tests {
     }
 
     #[test]
-    fn built_in_append_macros() -> IonResult<()> {
+    fn built_in_add_macros() -> IonResult<()> {
         stream_eq(
             r#"
             // Define two macros that call system macros
-            (:append_macros
+            (:add_macros
                 (macro greet (x) (.make_string "Hello, " (%x) ))
                 (macro twice (x) (.values (%x) (%x)))
             )
@@ -1431,7 +1431,7 @@ mod tests {
             (:twice "foo")
 
             // Define a new macro
-            (:append_macros
+            (:add_macros
                 (macro greet_twice (x)
                     (.twice (.greet (%x)))
                 )
@@ -1455,7 +1455,7 @@ mod tests {
     }
 
     #[test]
-    fn append_macros_preserves_symbols() -> IonResult<()> {
+    fn add_macros_preserves_symbols() -> IonResult<()> {
         // TODO: update symbol IDs when reading and writing system symbols are implemented
         stream_eq(
             r#"
@@ -1467,7 +1467,7 @@ mod tests {
             $3
 
             // Define a new macro
-            (:append_macros
+            (:add_macros
                 (macro greet (x)
                     (.make_string "Hello, " (%x))
                 )
@@ -1580,7 +1580,7 @@ mod tests {
             fn does_not_accept_empty_tdl_arg_group() {
                 stream_eq(
                     r#"
-                        (:append_macros
+                        (:add_macros
                             (macro foo (x) (.make_string x x))
                             (macro bar () (.foo (..)))
                         )
@@ -1613,7 +1613,7 @@ mod tests {
             fn does_not_accept_populated_tdl_arg_group() {
                 stream_eq(
                     r#"
-                        (:append_macros
+                        (:add_macros
                             (macro foo (x) (.make_string x x))
                             (macro bar () (.foo (:: "Hi")))
                         )
@@ -1658,7 +1658,7 @@ mod tests {
             fn accepts_tdl_empty_or_expr() -> IonResult<()> {
                 stream_eq(
                     r#"
-                        (:append_macros
+                        (:add_macros
                             (macro foo (x?) (.make_string (%x) (%x)))
                             (macro  bar () (.foo (..)))    // Explicit empty group
                             (macro  baz () (.foo)    )     // Implicit empty group
@@ -1696,7 +1696,7 @@ mod tests {
             fn does_not_accept_populated_tdl_arg_groups() {
                 stream_eq(
                     r#"
-                    (:append_macros
+                    (:add_macros
                         (macro foo (x?) (make_string (%x) (%x)))
                         (macro bar () (foo (.. "a"))))
                 (:bar)
@@ -1823,7 +1823,7 @@ mod tests {
             fn does_not_accept_empty_tdl_arg_group() {
                 stream_eq(
                     r#"
-                        (:append_macros
+                        (:add_macros
                             (macro foo (x+) (make_string (%x) (%x)))
                             (macro bar () (foo (..)))
                         )
@@ -1841,7 +1841,7 @@ mod tests {
             fn does_not_accept_empty_tdl_rest() {
                 stream_eq(
                     r#"
-                        (:append_macros
+                        (:add_macros
                             (macro foo (x+) (make_string (%x) (%x)))
                             (macro bar () (foo))
                         )

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -319,7 +319,7 @@ impl MacroTable {
                 },
             )),
             // This macro is equivalent to:
-            //    (macro append_macros ($macro_definitions*)
+            //    (macro add_macros ($macro_definitions*)
             //        (annotate
             //          (literal $ion_encoding)
             //          (make_sexp [
@@ -337,7 +337,7 @@ impl MacroTable {
             // In particular, we don't need `(make_sexp ...)`, `(annotate ...)` or `(literal ...)`.
             // We can "say what we mean" via instantiation instead.
             Rc::new(Macro::from_template_macro(TemplateMacro {
-                name: Some("append_macros".into()),
+                name: Some("add_macros".into()),
                 signature: MacroSignature::new(vec![Parameter::new(
                     "$macro_definitions",
                     ParameterEncoding::Tagged,


### PR DESCRIPTION
* Updates the `append_macros` macro name to `add_macros`.
* Enables optimizations for dependencies (but not `ion-rust` itself) in debug builds, speeding up test runs without affecting incremental build times.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
