### PR TITLE
Adds binary eexp subfield span accessors

### DIFF
--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -202,6 +202,10 @@ pub enum LazyRawAnyEExpressionKind<'top> {
 }
 
 impl<'top> LazyRawAnyEExpression<'top> {
+    pub fn kind(&self) -> LazyRawAnyEExpressionKind<'top> {
+        self.encoding
+    }
+
     pub fn encoding(&self) -> IonEncoding {
         use LazyRawAnyEExpressionKind::*;
         match self.encoding {

--- a/src/lazy/binary/raw/v1_1/e_expression.rs
+++ b/src/lazy/binary/raw/v1_1/e_expression.rs
@@ -90,7 +90,7 @@ impl<'top> BinaryEExpression_1_1<'top> {
     /// Returns `true` if this binary e-expression includes a length prefix.
     pub fn has_length_prefix(&self) -> bool {
         // If these offsets are equal, there are no bytes representing the length.
-        self.length_offset == self.bitmap_offset
+        self.length_offset != self.bitmap_offset
     }
 
     /// Returns a span of bytes representing the length prefix. If there is no length prefix,
@@ -104,8 +104,8 @@ impl<'top> BinaryEExpression_1_1<'top> {
 
     /// Returns `true` if this binary e-expression includes an argument encoding bitmap.
     pub fn has_bitmap(&self) -> bool {
-        // If these offsets are equal, there are no bytes representing the length.
-        self.bitmap_offset == self.args_offset
+        // If these offsets are equal, there are no bytes representing the bitmap.
+        self.bitmap_offset != self.args_offset
     }
 
     /// Returns a span of bytes representing the e-expression's argument encoding bitmap.

--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -963,6 +963,9 @@ impl<'a> BinaryBuffer<'a> {
                     MacroRef::new(macro_address, macro_ref),
                     bitmap_bits,
                     matched_eexp_bytes,
+                    // There is no length prefix, so we re-use the bitmap_offset as the first position
+                    // beyond the opcode and address subfields.
+                    bitmap_offset as u8,
                     bitmap_offset as u8,
                     args_offset as u8,
                 )
@@ -996,6 +999,7 @@ impl<'a> BinaryBuffer<'a> {
             })?
             .reference();
         // Offset from `self`, not offset from the beginning of the stream.
+        let length_offset = (input_after_address.offset() - self.offset()) as u8;
         let bitmap_offset = (input_after_length.offset() - self.offset()) as u8;
         let (bitmap_bits, _input_after_bitmap) =
             input_after_length.read_eexp_bitmap(macro_ref.signature().bitmap_size_in_bytes())?;
@@ -1006,6 +1010,7 @@ impl<'a> BinaryBuffer<'a> {
                 MacroRef::new(macro_address, macro_ref),
                 bitmap_bits,
                 matched_bytes,
+                length_offset,
                 bitmap_offset,
                 args_offset,
             ),

--- a/src/lazy/span.rs
+++ b/src/lazy/span.rs
@@ -1,3 +1,5 @@
+use crate::lazy::binary::raw::v1_1::immutable_buffer::BinaryBuffer;
+use crate::lazy::text::buffer::TextBuffer;
 use crate::result::IonFailure;
 use crate::{IonError, IonResult};
 use std::ops::Range;
@@ -60,5 +62,23 @@ impl<'a> Span<'a> {
 
     pub fn is_empty(&self) -> bool {
         self.bytes.is_empty()
+    }
+}
+
+impl<'a> From<BinaryBuffer<'a>> for Span<'a> {
+    fn from(value: BinaryBuffer<'a>) -> Self {
+        Span {
+            bytes: value.bytes(),
+            offset: value.offset(),
+        }
+    }
+}
+
+impl<'a> From<TextBuffer<'a>> for Span<'a> {
+    fn from(value: TextBuffer<'a>) -> Self {
+        Span {
+            bytes: value.bytes(),
+            offset: value.offset(),
+        }
     }
 }


### PR DESCRIPTION
For use in tooling, particularly `ion inspect`. These methods allow an application to access the encoded subfields of a binary 1.1 e-expression.

Related to amazon-ion/ion-cli#181.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
