### PR TITLE
Adds reusable `RawValueExpr::resolve` method

### DIFF
--- a/src/lazy/sequence.rs
+++ b/src/lazy/sequence.rs
@@ -140,7 +140,7 @@ impl<'top, D: Decoder> TryFrom<LazyList<'top, D>> for Sequence {
     fn try_from(lazy_sequence: LazyList<'top, D>) -> Result<Self, Self::Error> {
         let sequence: Sequence = lazy_sequence
             .iter()
-            .map(|v| Element::try_from(v?))
+            .map(|result| result.and_then(Element::try_from))
             .collect::<IonResult<Vec<_>>>()?
             .into();
         Ok(sequence)


### PR DESCRIPTION
This PR contains no new features, just a refactor.

There are some complex generics around the `RawValueExpr` type (described in dev comments therein) that made writing a centralized, reusable `resolve` method difficult to express. I guess I'm older and wiser now, though, 'cause I managed to figure it out this time around.

Along with adding the `resolve` method, I removed two places where the same logic had been implemented.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
