### PR TITLE
Flesh out set/add macros/symbols

### DIFF
--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -1406,14 +1406,14 @@ mod tests {
     fn explicit_expr_group_arg() -> IonResult<()> {
         stream_eq(
             r#"
-            (:add_macros
-                (macro greet (x) (.make_string (.. "Hello, " (%x))))
-            )
-            (:greet "Gary")
-        "#,
+                (:add_macros
+                    (macro greet (x) (.make_string (.. "Hello, " (%x))))
+                )
+                (:greet "Gary")
+            "#,
             r#"
-            "Hello, Gary"
-        "#,
+                "Hello, Gary"
+            "#,
         )
     }
 
@@ -1421,17 +1421,17 @@ mod tests {
     fn built_in_set_symbols() -> IonResult<()> {
         stream_eq(
             r#"
-            // Define some symbols
-            (:set_symbols foo bar) // $1, $2
+                // Define some symbols
+                (:set_symbols foo bar) // $1, $2
 
-            // Use them
-            $1
-            $2
-        "#,
+                // Use them
+                $1
+                $2
+            "#,
             r#"
-            foo
-            bar
-        "#,
+                foo
+                bar
+            "#,
         )
     }
 
@@ -1439,26 +1439,26 @@ mod tests {
     fn set_symbols_drops_prior_definitions() -> IonResult<()> {
         stream_eq(
             r#"
-            // Define some symbols
-            (:set_symbols foo bar) // $1, $2
+                // Define some symbols
+                (:set_symbols foo bar) // $1, $2
 
-            // Use them
-            $1
-            $2
+                // Use them
+                $1
+                $2
 
-            // Define new symbols
-            (:set_symbols baz qux) // $1, $2
+                // Define new symbols
+                (:set_symbols baz qux) // $1, $2
 
-            // Use them
-            $1
-            $2
-        "#,
+                // Use them
+                $1
+                $2
+            "#,
             r#"
-            foo
-            bar
-            baz
-            qux
-        "#,
+                foo
+                bar
+                baz
+                qux
+            "#,
         )
     }
 
@@ -1466,25 +1466,25 @@ mod tests {
     fn built_in_add_symbols() -> IonResult<()> {
         stream_eq(
             r#"
-            // Define some symbols
-            $ion_encoding::(
-                (symbol_table ["foo", "bar"]) // $1, $2
-            )
-            // Use them
-            $1
-            $2
+                // Define some symbols
+                $ion_encoding::(
+                    (symbol_table ["foo", "bar"]) // $1, $2
+                )
+                // Use them
+                $1
+                $2
 
-            // Define new symbols
-            (:add_symbols baz quux) // $3, $4
-            $3
-            $4
-        "#,
+                // Define new symbols
+                (:add_symbols baz quux) // $3, $4
+                $3
+                $4
+            "#,
             r#"
-            foo
-            bar
-            baz
-            quux
-        "#,
+                foo
+                bar
+                baz
+                quux
+            "#,
         )
     }
 
@@ -1492,16 +1492,16 @@ mod tests {
     fn built_in_set_macros() -> IonResult<()> {
         stream_eq(
             r#"
-            // Define a macro which calls a system macros
-            (:set_macros
-                (macro greet (x) (.make_string "Hello, " (%x) ))
-            )
-            // Invoke it
-            (:greet "Waldo")
-        "#,
-            r#"
-            "Hello, Waldo"
-        "#,
+                // Define a macro which calls a system macro
+                (:set_macros
+                    (macro greet (x) (.make_string "Hello, " (%x) ))
+                )
+                // Invoke it
+                (:greet "Waldo")
+            "#,
+                r#"
+                "Hello, Waldo"
+            "#,
         )
     }
 
@@ -1510,19 +1510,22 @@ mod tests {
     fn set_macros_drops_previous_macros() -> () {
         stream_eq(
             r#"
-            // Define a macro which calls a system macros
-            (:set_macros
-                (macro greet (x) (.make_string "Hello, " (%x) ))
-            )
-            // Invoke it
-            (:greet "Waldo")
+                // Define a macro which calls a system macro
+                (:set_macros
+                    (macro greet (x) (.make_string "Hello, " (%x) ))
+                )
+                // Invoke it
+                (:greet "Waldo")
 
-            (:make_string "Hello, " "Waldo")
-        "#,
+                // Drop our user-defined macros
+                (:set_macros)
+                // This invocation should error
+                (:greet "Waldo")
+            "#,
             r#"
-            "Hello, Waldo"
-            // should raise an error
-        "#,
+                "Hello, Waldo"
+                // should raise an error
+            "#,
         ).unwrap()
     }
 
@@ -1531,39 +1534,39 @@ mod tests {
         // TODO: update symbol IDs when reading and writing system symbols are implemented
         stream_eq(
             r#"
-            $ion_encoding::(
-                (symbol_table ["foo", "bar", "baz"]) // $1, $2, $3
-            )
-            $1
-            $2
-            $3
-
-            // Define a new macro
-            (:set_macros
-                (macro greet (x)
-                    (.make_string "Hello, " (%x))
+                $ion_encoding::(
+                    (symbol_table ["foo", "bar", "baz"]) // $1, $2, $3
                 )
-                (macro greet_foo()
-                    (.greet $1)
-                )
-            )
+                $1
+                $2
+                $3
 
-            (:greet "Gary")
-            (:greet_foo)
-            $1
-            $2
-            $3
-        "#,
+                // Define a new macro
+                (:set_macros
+                    (macro greet (x)
+                        (.make_string "Hello, " (%x))
+                    )
+                    (macro greet_foo()
+                        (.greet $1)
+                    )
+                )
+
+                (:greet "Gary")
+                (:greet_foo)
+                $1
+                $2
+                $3
+            "#,
             r#"
-            foo
-            bar
-            baz
-            "Hello, Gary"
-            "Hello, foo"
-            foo
-            bar
-            baz
-        "#,
+                foo
+                bar
+                baz
+                "Hello, Gary"
+                "Hello, foo"
+                foo
+                bar
+                baz
+            "#,
         )
     }
 
@@ -1571,36 +1574,36 @@ mod tests {
     fn built_in_add_macros() -> IonResult<()> {
         stream_eq(
             r#"
-            // Define two macros that call system macros
-            (:add_macros
-                (macro greet (x) (.make_string "Hello, " (%x) ))
-                (macro twice (x) (.values (%x) (%x)))
-            )
-            // Invoke them
-            (:greet "Waldo")
-            (:twice "foo")
-
-            // Define a new macro
-            (:add_macros
-                (macro greet_twice (x)
-                    (.twice (.greet (%x)))
+                // Define two macros that call system macros
+                (:add_macros
+                    (macro greet (x) (.make_string "Hello, " (%x) ))
+                    (macro twice (x) (.values (%x) (%x)))
                 )
-            )
+                // Invoke them
+                (:greet "Waldo")
+                (:twice "foo")
 
-            // // The original macros are still available
-            (:greet "Sally")
-            (:twice "bar")
-            //
-            // // And so is the new one
-            (:greet_twice "Gary")
-        "#,
+                // Define a new macro
+                (:add_macros
+                    (macro greet_twice (x)
+                        (.twice (.greet (%x)))
+                    )
+                )
+
+                // // The original macros are still available
+                (:greet "Sally")
+                (:twice "bar")
+                //
+                // // And so is the new one
+                (:greet_twice "Gary")
+            "#,
             r#"
-            "Hello, Waldo"
-            "foo" "foo"
-            "Hello, Sally"
-            "bar" "bar"
-            "Hello, Gary" "Hello, Gary"
-        "#,
+                "Hello, Waldo"
+                "foo" "foo"
+                "Hello, Sally"
+                "bar" "bar"
+                "Hello, Gary" "Hello, Gary"
+            "#,
         )
     }
 
@@ -1609,39 +1612,39 @@ mod tests {
         // TODO: update symbol IDs when reading and writing system symbols are implemented
         stream_eq(
             r#"
-            $ion_encoding::(
-                (symbol_table ["foo", "bar", "baz"]) // $1, $2, $3
-            )
-            $1
-            $2
-            $3
-
-            // Define a new macro
-            (:add_macros
-                (macro greet (x)
-                    (.make_string "Hello, " (%x))
+                $ion_encoding::(
+                    (symbol_table ["foo", "bar", "baz"]) // $1, $2, $3
                 )
-                (macro greet_foo()
-                    (.greet $1)
-                )
-            )
+                $1
+                $2
+                $3
 
-            (:greet "Gary")
-            (:greet_foo)
-            $1
-            $2
-            $3
-        "#,
+                // Define a new macro
+                (:add_macros
+                    (macro greet (x)
+                        (.make_string "Hello, " (%x))
+                    )
+                    (macro greet_foo()
+                        (.greet $1)
+                    )
+                )
+
+                (:greet "Gary")
+                (:greet_foo)
+                $1
+                $2
+                $3
+            "#,
             r#"
-            foo
-            bar
-            baz
-            "Hello, Gary"
-            "Hello, foo"
-            foo
-            bar
-            baz
-        "#,
+                foo
+                bar
+                baz
+                "Hello, Gary"
+                "Hello, foo"
+                foo
+                bar
+                baz
+            "#,
         )
     }
 

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -1507,7 +1507,7 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn set_macros_drops_previous_macros() -> () {
+    fn set_macros_drops_previous_macros() {
         stream_eq(
             r#"
                 // Define a macro which calls a system macro

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -212,7 +212,6 @@ impl MacroTable {
         // We cannot compile template macros from source (text Ion) because that would require a Reader,
         // and a Reader would require system macros. To avoid this circular dependency, we manually
         // compile any TemplateMacros ourselves.
-
         vec![
             Rc::new(Macro::named(
                 "none",
@@ -320,20 +319,13 @@ impl MacroTable {
             )),
             // This macro is equivalent to:
             //    (macro set_symbols (symbols*)
-            //        (annotate
-            //          $ion_encoding
-            //          (make_sexp [
-            //              // Set a new symbol table
-            //              (make_sexp [ symbol_table, [(%symbols)] ])
-            //              // Include the active encoding module macros
-            //              (make_sexp [ macro_table, $ion_encoding ])
-            //          ])
-            //        )
+            //      $ion_encoding::(
+            //        // Set a new symbol table
+            //        (symbol_table [(%symbols)])
+            //        // Include the active encoding module macros
+            //        (macro_table $ion_encoding)
+            //      )
             //    )
-            //
-            // However, because we're manually compiling it we can reduce some of the expressions.
-            // In particular, we don't need `(make_sexp ...)` or `(annotate ...)`.
-            // We can "say what we mean" via instantiation instead.
             Rc::new(Macro::from_template_macro(TemplateMacro {
                 name: Some("set_symbols".into()),
                 signature: MacroSignature::new(vec![Parameter::new(
@@ -412,20 +404,13 @@ impl MacroTable {
             })),
             // This macro is equivalent to:
             //    (macro add_symbols (symbols*)
-            //        (annotate
-            //          $ion_encoding
-            //          (make_sexp [
-            //              // Include the active encoding module symbols, and add more
-            //              (make_sexp [ symbol_table, $ion_encoding, [(%symbols)] ])
-            //              // Include the active encoding module macros
-            //              (make_sexp [ macro_table, $ion_encoding ])
-            //          ])
-            //        )
+            //      $ion_encoding::(
+            //        // Include the active encoding module symbols, and add more
+            //        (symbol_table $ion_encoding [(%symbols)])
+            //        // Include the active encoding module macros
+            //        (macro_table $ion_encoding)
+            //      )
             //    )
-            //
-            // However, because we're manually compiling it we can reduce some of the expressions.
-            // In particular, we don't need `(make_sexp ...)` or `(annotate ...)`.
-            // We can "say what we mean" via instantiation instead.
             Rc::new(Macro::from_template_macro(TemplateMacro {
                 name: Some("add_symbols".into()),
                 signature: MacroSignature::new(vec![Parameter::new(
@@ -510,20 +495,13 @@ impl MacroTable {
             })),
             // This macro is equivalent to:
             //    (macro set_macros (macro_definitions*)
-            //        (annotate
-            //          $ion_encoding
-            //          (make_sexp [
-            //              // Include the active encoding module symbols
-            //              (make_sexp [ symbol_table, $ion_encoding, ])
-            //              // Set a new macro table
-            //              (make_sexp [ macro_table, (%macro_definitions) ])
-            //          ])
-            //        )
+            //      $ion_encoding::(
+            //        // Include the active encoding module symbols
+            //        (symbol_table $ion_encoding)
+            //        // Set a new macro table
+            //        (macro_table (%macro_definitions))
+            //      )
             //    )
-            //
-            // However, because we're manually compiling it we can reduce some of the expressions.
-            // In particular, we don't need `(make_sexp ...)` or `(annotate ...)`.
-            // We can "say what we mean" via instantiation instead.
             Rc::new(Macro::from_template_macro(TemplateMacro {
                 name: Some("set_macros".into()),
                 signature: MacroSignature::new(vec![Parameter::new(
@@ -598,20 +576,13 @@ impl MacroTable {
             })),
             // This macro is equivalent to:
             //    (macro add_macros (macro_definitions*)
-            //        (annotate
-            //          $ion_encoding
-            //          (make_sexp [
-            //              // Include the active encoding module symbols
-            //              (make_sexp [ symbol_table, $ion_encoding, ])
-            //              // Include the active encoding module macros, and add more
-            //              (make_sexp [ macro_table, $ion_encoding, (%macro_definitions) ])
-            //          ])
-            //        )
+            //      $ion_encoding::(
+            //        // Include the active encoding module symbols
+            //        (symbol_table $ion_encoding)
+            //        // Include the active encoding module macros and add more
+            //        (macro_table $ion_encoding (%macro_definitions))
+            //      )
             //    )
-            //
-            // However, because we're manually compiling it we can reduce some of the expressions.
-            // In particular, we don't need `(make_sexp ...)` or `(annotate ...)`.
-            // We can "say what we mean" via instantiation instead.
             Rc::new(Macro::from_template_macro(TemplateMacro {
                 name: Some("add_macros".into()),
                 signature: MacroSignature::new(vec![Parameter::new(


### PR DESCRIPTION
*Issue #, if available:* Contributes to #661

*Description of changes:* Defines `set_macros`, `set_symbols`, and `add_symbols`, as described in [the Ion 1.1 spec](https://amazon-ion.github.io/ion-docs/books/ion-1-1/macros/system_macros.html). 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
