### PR TITLE
API improvements for usage of owned `Element`s

### DIFF
--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -886,13 +886,13 @@ impl Element {
 
 impl IonTypeExpectation for Element {
     fn ion_type(&self) -> IonType {
-        self.ion_type()
+        Element::ion_type(self)
     }
 }
 
 impl IonTypeExpectation for &Element {
     fn ion_type(&self) -> IonType {
-        self.ion_type()
+        Element::ion_type(self)
     }
 }
 

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -1,5 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates.
 
+// Disabled for this file because `Element`'s `try_into_<x>` methods return
+// `ConversionOperationError<Element, <X>>` which embeds an `Element`. `Element` itself is 128 bytes.
+// This trips `clippy::result_large_err`. However, most usages of this type are expected to be
+// converted or destructured immediately.
+//
+// Cf. https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err
+#![allow(clippy::result_large_err)]
+
 //! Provides a dynamically typed, materialized representation of an Ion value.
 //!
 //! An [Element] represents an `(annotations, value)` pair, where a `value` is

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -389,12 +389,11 @@ impl Element {
         }
     }
 
-    fn expected(&self, expectation: impl ToString) -> IonError {
-        IonError::decoding_error(format!(
-            "expected a(n) {}, found a(n) {}",
-            expectation.to_string(),
-            self.ion_type()
-        ))
+    fn expected<ToType>(&self, maybe: Option<ToType>) -> IonResult<ToType>
+    where
+        ToType: TypeExpectation,
+    {
+        Ok(maybe.expect_convert(self)?)
     }
 
     /// Returns a reference to this [Element]'s [Value].
@@ -489,7 +488,7 @@ impl Element {
     }
 
     pub fn expect_int(&self) -> IonResult<&Int> {
-        self.as_int().ok_or_else(|| self.expected(IonType::Int))
+        self.expected(self.as_int())
     }
 
     pub fn try_into_int(self) -> Conversion<Element, Int> {
@@ -507,10 +506,7 @@ impl Element {
     }
 
     pub fn expect_i64(&self) -> IonResult<i64> {
-        match &self.value {
-            Value::Int(i) => i.expect_i64(),
-            _ => Err(self.expected(IonType::Int)),
-        }
+        self.expected(self.as_i64())
     }
 
     pub fn try_into_i64(self) -> Conversion<Element, i64> {
@@ -528,7 +524,7 @@ impl Element {
     }
 
     pub fn expect_float(&self) -> IonResult<f64> {
-        self.as_float().ok_or_else(|| self.expected(IonType::Float))
+        self.expected(self.as_float())
     }
 
     pub fn try_into_float(self) -> Conversion<Element, f64> {
@@ -546,8 +542,7 @@ impl Element {
     }
 
     pub fn expect_decimal(&self) -> IonResult<Decimal> {
-        self.as_decimal()
-            .ok_or_else(|| self.expected(IonType::Decimal))
+        self.expected(self.as_decimal())
     }
 
     pub fn try_into_decimal(self) -> Conversion<Element, Decimal> {
@@ -565,8 +560,7 @@ impl Element {
     }
 
     pub fn expect_timestamp(&self) -> IonResult<Timestamp> {
-        self.as_timestamp()
-            .ok_or_else(|| self.expected(IonType::Timestamp))
+        self.expected(self.as_timestamp())
     }
 
     pub fn try_into_timestamp(self) -> Conversion<Element, Timestamp> {
@@ -585,7 +579,7 @@ impl Element {
     }
 
     pub fn expect_text(&self) -> IonResult<&str> {
-        self.as_text().ok_or_else(|| self.expected("text value"))
+        self.expected(self.as_text())
     }
 
     pub fn try_into_text(self) -> Conversion<Element, String> {
@@ -613,8 +607,7 @@ impl Element {
     }
 
     pub fn expect_string(&self) -> IonResult<&str> {
-        self.as_string()
-            .ok_or_else(|| self.expected(IonType::String))
+        self.expected(self.as_string())
     }
 
     pub fn try_into_string(self) -> Conversion<Element, Str> {
@@ -632,8 +625,7 @@ impl Element {
     }
 
     pub fn expect_symbol(&self) -> IonResult<&Symbol> {
-        self.as_symbol()
-            .ok_or_else(|| self.expected(IonType::Symbol))
+        self.expected(self.as_symbol())
     }
 
     pub fn try_into_symbol(self) -> Conversion<Element, Symbol> {
@@ -651,7 +643,7 @@ impl Element {
     }
 
     pub fn expect_bool(&self) -> IonResult<bool> {
-        self.as_bool().ok_or_else(|| self.expected(IonType::Bool))
+        self.expected(self.as_bool())
     }
 
     pub fn try_into_bool(self) -> Conversion<Element, bool> {
@@ -669,7 +661,7 @@ impl Element {
     }
 
     pub fn expect_lob(&self) -> IonResult<&[u8]> {
-        self.as_lob().ok_or_else(|| self.expected("lob value"))
+        self.expected(self.as_lob())
     }
 
     pub fn try_into_lob(self) -> Conversion<Element, Bytes> {
@@ -687,7 +679,7 @@ impl Element {
     }
 
     pub fn expect_blob(&self) -> IonResult<&[u8]> {
-        self.as_blob().ok_or_else(|| self.expected(IonType::Blob))
+        self.expected(self.as_blob())
     }
 
     pub fn try_into_blob(self) -> Conversion<Element, Bytes> {
@@ -705,7 +697,7 @@ impl Element {
     }
 
     pub fn expect_clob(&self) -> IonResult<&[u8]> {
-        self.as_clob().ok_or_else(|| self.expected(IonType::Clob))
+        self.expected(self.as_clob())
     }
 
     pub fn try_into_clob(self) -> Conversion<Element, Bytes> {
@@ -723,8 +715,7 @@ impl Element {
     }
 
     pub fn expect_sequence(&self) -> IonResult<&Sequence> {
-        self.as_sequence()
-            .ok_or_else(|| self.expected("sequence value"))
+        self.expected(self.as_sequence())
     }
 
     pub fn try_into_sequence(self) -> Conversion<Element, Sequence> {
@@ -742,7 +733,7 @@ impl Element {
     }
 
     pub fn expect_list(&self) -> IonResult<&Sequence> {
-        self.as_list().ok_or_else(|| self.expected(IonType::List))
+        self.expected(self.as_list())
     }
 
     pub fn try_into_list(self) -> Conversion<Element, Sequence> {
@@ -760,7 +751,7 @@ impl Element {
     }
 
     pub fn expect_sexp(&self) -> IonResult<&Sequence> {
-        self.as_sexp().ok_or_else(|| self.expected(IonType::SExp))
+        self.expected(self.as_sexp())
     }
 
     pub fn try_into_sexp(self) -> Conversion<Element, Sequence> {
@@ -778,8 +769,7 @@ impl Element {
     }
 
     pub fn expect_struct(&self) -> IonResult<&Struct> {
-        self.as_struct()
-            .ok_or_else(|| self.expected(IonType::Struct))
+        self.expected(self.as_struct())
     }
 
     pub fn try_into_struct(self) -> Conversion<Element, Struct> {

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -1252,7 +1252,7 @@ mod tests {
             ion_type: IonType::Bool,
             ops: vec![AsBool, TryIntoBool],
             op_assert: Box::new(|e: &Element| {
-                let expected = e.expect_bool().expect("expected bool");
+                let _ = e.expect_bool().expect("expected bool");
                 let expected = Element::from(true);
                 assert_eq!(Some(true), e.as_bool());
                 assert_eq!(&expected, e);
@@ -1269,8 +1269,8 @@ mod tests {
             ion_type: IonType::Int,
             ops: vec![AsAnyInt, TryIntoInt, TryIntoI64],
             op_assert: Box::new(|e: &Element| {
-                let expected = e.expect_i64().expect("expected i64");
-                let expected = e.expect_int().expect("expected int");
+                let _ = e.expect_i64().expect("expected i64");
+                let _ = e.expect_int().expect("expected int");
                 let expected: Element = 100i64.into();
                 assert_eq!(Some(&Int::from(100i64)), e.as_int());
                 assert_eq!(Some(100), e.as_i64());
@@ -1289,7 +1289,7 @@ mod tests {
             ion_type: IonType::Int,
             ops: vec![AsAnyInt, TryIntoInt],
             op_assert: Box::new(|e: &Element| {
-                let expected = e.expect_int().expect("expected int");
+                let _ = e.expect_int().expect("expected int");
                 let expected: Element = 9223372036854775808i128.into();
                 assert_eq!(Some(&Int::from(9223372036854775808i128)), e.as_int());
                 assert_eq!(&expected, e);
@@ -1304,7 +1304,7 @@ mod tests {
             ion_type: IonType::Float,
             ops: vec![AsF64, TryIntoF64],
             op_assert: Box::new(|e: &Element| {
-                let expected = e.expect_float().expect("expected float");
+                let _ = e.expect_float().expect("expected float");
                 let expected = Element::from(16.0f64);
                 assert_eq!(Some(16.0), e.as_float());
                 assert_eq!(&expected, e);
@@ -1319,7 +1319,7 @@ mod tests {
             ion_type: IonType::Timestamp,
             ops: vec![AsTimestamp, TryIntoTimestamp],
             op_assert: Box::new(|e: &Element| {
-                let expected = e.expect_timestamp().expect("expected timestamp");
+                let _ = e.expect_timestamp().expect("expected timestamp");
                 let expected: Element = make_timestamp("2014-10-16T12:01:00+00:00").into();
                 assert_eq!(
                     Some(make_timestamp("2014-10-16T12:01:00+00:00")),
@@ -1337,7 +1337,7 @@ mod tests {
             ion_type: IonType::Decimal,
             ops: vec![AsDecimal, TryIntoDecimal],
             op_assert: Box::new(|e: &Element| {
-                let expected = e.expect_decimal().expect("expected decimal");
+                let _ = e.expect_decimal().expect("expected decimal");
                 let expected: Element = Decimal::new(8, 3).into();
                 assert_eq!(Some(Decimal::new(80, 2)), e.as_decimal());
                 assert_eq!(&expected, e);
@@ -1352,8 +1352,8 @@ mod tests {
             ion_type: IonType::String,
             ops: vec![AsStr, TryIntoText, TryIntoString],
             op_assert: Box::new(|e: &Element| {
-                let expected = e.expect_text().expect("expected text");
-                let expected = e.expect_string().expect("expected string");
+                let _ = e.expect_text().expect("expected text");
+                let _ = e.expect_string().expect("expected string");
                 assert_eq!(Some("hello"), e.as_text())
             }),
             owned_asserts: vec![
@@ -1369,8 +1369,8 @@ mod tests {
             ion_type: IonType::Symbol,
             ops: vec![AsSym, AsStr, TryIntoText, TryIntoSymbol],
             op_assert: Box::new(|e: &Element| {
-                let expected = e.expect_text().expect("expected text");
-                let expected = e.expect_symbol().expect("expected symbol");
+                let _ = e.expect_text().expect("expected text");
+                let _ = e.expect_symbol().expect("expected symbol");
                 assert_eq!(Some("foo"), e.as_symbol().unwrap().text());
                 assert_eq!(Some("foo"), e.as_text());
             }),
@@ -1384,8 +1384,8 @@ mod tests {
             ion_type: IonType::Blob,
             ops: vec![AsBytes, TryIntoLob, TryIntoBlob],
             op_assert: Box::new(|e: &Element| {
-                let expected = e.expect_lob().expect("expected lob");
-                let expected = e.expect_blob().expect("expected blob");
+                let _ = e.expect_lob().expect("expected lob");
+                let _ = e.expect_blob().expect("expected blob");
                 assert_eq!(Some("hello".as_bytes()), e.as_lob())
             }),
             owned_asserts: vec![
@@ -1401,8 +1401,8 @@ mod tests {
             ion_type: IonType::Clob,
             ops: vec![AsBytes, TryIntoLob, TryIntoClob],
             op_assert: Box::new(|e: &Element| {
-                let expected = e.expect_lob().expect("expected lob");
-                let expected = e.expect_clob().expect("expected clob");
+                let _ = e.expect_lob().expect("expected lob");
+                let _ = e.expect_clob().expect("expected clob");
                 assert_eq!(Some("goodbye".as_bytes()), e.as_lob())
             }),
             owned_asserts: vec![
@@ -1418,8 +1418,8 @@ mod tests {
             ion_type: IonType::List,
             ops: vec![AsSequence, TryIntoList, TryIntoSequence],
             op_assert: Box::new(|e: &Element| {
-                let expected = e.expect_list().expect("expected list");
-                let expected = e.expect_sequence().expect("expected sequence");
+                let _ = e.expect_list().expect("expected list");
+                let _ = e.expect_sequence().expect("expected sequence");
                 let actual = e.as_sequence().unwrap();
                 let expected: Vec<Element> = ion_vec([true, false]);
                 // assert the length of list
@@ -1443,8 +1443,8 @@ mod tests {
             ion_type: IonType::SExp,
             ops: vec![AsSequence, TryIntoSexp, TryIntoSequence],
             op_assert: Box::new(|e: &Element| {
-                let expected = e.expect_sexp().expect("expected sexp");
-                let expected = e.expect_sequence().expect("expected sequence");
+                let _ = e.expect_sexp().expect("expected sexp");
+                let _ = e.expect_sequence().expect("expected sequence");
                 let actual = e.as_sequence().unwrap();
                 let expected: Vec<Element> = ion_vec([true, false]);
                 // assert the length of s-expression
@@ -1467,7 +1467,7 @@ mod tests {
             ion_type: IonType::Struct,
             ops: vec![AsStruct, TryIntoStruct],
             op_assert: Box::new(|e: &Element| {
-                let expected = e.expect_struct().expect("expected struct");
+                let _ = e.expect_struct().expect("expected struct");
                 let actual: &Struct = e.as_struct().unwrap();
 
                 // verify that the field order is maintained when creating Struct

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -29,7 +29,8 @@ use crate::lazy::encoding::Encoding;
 use crate::lazy::reader::Reader;
 use crate::lazy::streaming_raw_reader::{IonInput, IonSlice};
 use crate::result::{
-    Conversion, ConversionError, ConversionExpectation, IonTypeExpectation, TypeExpectation,
+    Conversion, ConversionError, ConversionExpectation, ConversionResult, IonTypeExpectation,
+    TypeExpectation,
 };
 use crate::text::text_formatter::FmtValueFormatter;
 use crate::types::symbol::SymbolText;
@@ -361,7 +362,7 @@ macro_rules! impl_try_from_element {
         impl TryFrom<Element> for $to_type {
             type Error = ConversionError;
 
-            fn try_from(element: Element) -> Result<$to_type, Self::Error> {
+            fn try_from(element: Element) -> ConversionResult<$to_type> {
                 element.$to_fn().into()
             }
         }

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -17,9 +17,8 @@ pub use sequence::{OwnedSequenceIterator, Sequence};
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 use std::io;
-use std::ops::ControlFlow;
 
-use crate::{ion_data, Decimal, Int, IonError, IonResult, IonType, Str, Symbol, Timestamp};
+use crate::{ion_data, Decimal, Int, IonResult, IonType, Str, Symbol, Timestamp};
 use crate::{Blob, Bytes, Clob, List, SExp, Struct};
 // Re-export the Value variant types and traits so they can be accessed directly from this module.
 use crate::element::builders::{SequenceBuilder, StructBuilder};
@@ -30,8 +29,7 @@ use crate::lazy::encoding::Encoding;
 use crate::lazy::reader::Reader;
 use crate::lazy::streaming_raw_reader::{IonInput, IonSlice};
 use crate::result::{
-    Conversion, ConversionError, ConversionExpectation, ConversionResult, IonFailure,
-    IonTypeExpectation, TypeExpectation, ValueTypeExpectation,
+    Conversion, ConversionError, ConversionExpectation, IonTypeExpectation, TypeExpectation,
 };
 use crate::text::text_formatter::FmtValueFormatter;
 use crate::types::symbol::SymbolText;

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -1252,6 +1252,7 @@ mod tests {
             ion_type: IonType::Bool,
             ops: vec![AsBool, TryIntoBool],
             op_assert: Box::new(|e: &Element| {
+                let expected = e.expect_bool().expect("expected bool");
                 let expected = Element::from(true);
                 assert_eq!(Some(true), e.as_bool());
                 assert_eq!(&expected, e);
@@ -1268,6 +1269,8 @@ mod tests {
             ion_type: IonType::Int,
             ops: vec![AsAnyInt, TryIntoInt, TryIntoI64],
             op_assert: Box::new(|e: &Element| {
+                let expected = e.expect_i64().expect("expected i64");
+                let expected = e.expect_int().expect("expected int");
                 let expected: Element = 100i64.into();
                 assert_eq!(Some(&Int::from(100i64)), e.as_int());
                 assert_eq!(Some(100), e.as_i64());
@@ -1286,6 +1289,7 @@ mod tests {
             ion_type: IonType::Int,
             ops: vec![AsAnyInt, TryIntoInt],
             op_assert: Box::new(|e: &Element| {
+                let expected = e.expect_int().expect("expected int");
                 let expected: Element = 9223372036854775808i128.into();
                 assert_eq!(Some(&Int::from(9223372036854775808i128)), e.as_int());
                 assert_eq!(&expected, e);
@@ -1300,6 +1304,7 @@ mod tests {
             ion_type: IonType::Float,
             ops: vec![AsF64, TryIntoF64],
             op_assert: Box::new(|e: &Element| {
+                let expected = e.expect_float().expect("expected float");
                 let expected = Element::from(16.0f64);
                 assert_eq!(Some(16.0), e.as_float());
                 assert_eq!(&expected, e);
@@ -1314,6 +1319,7 @@ mod tests {
             ion_type: IonType::Timestamp,
             ops: vec![AsTimestamp, TryIntoTimestamp],
             op_assert: Box::new(|e: &Element| {
+                let expected = e.expect_timestamp().expect("expected timestamp");
                 let expected: Element = make_timestamp("2014-10-16T12:01:00+00:00").into();
                 assert_eq!(
                     Some(make_timestamp("2014-10-16T12:01:00+00:00")),
@@ -1331,6 +1337,7 @@ mod tests {
             ion_type: IonType::Decimal,
             ops: vec![AsDecimal, TryIntoDecimal],
             op_assert: Box::new(|e: &Element| {
+                let expected = e.expect_decimal().expect("expected decimal");
                 let expected: Element = Decimal::new(8, 3).into();
                 assert_eq!(Some(Decimal::new(80, 2)), e.as_decimal());
                 assert_eq!(&expected, e);
@@ -1344,7 +1351,11 @@ mod tests {
             elem: "hello".into(),
             ion_type: IonType::String,
             ops: vec![AsStr, TryIntoText, TryIntoString],
-            op_assert: Box::new(|e: &Element| assert_eq!(Some("hello"), e.as_text())),
+            op_assert: Box::new(|e: &Element| {
+                let expected = e.expect_text().expect("expected text");
+                let expected = e.expect_string().expect("expected string");
+                assert_eq!(Some("hello"), e.as_text())
+            }),
             owned_asserts: vec![
                 assert_pass_try_into!(try_into_text),
                 assert_pass_try_into!(try_into_string),
@@ -1358,6 +1369,8 @@ mod tests {
             ion_type: IonType::Symbol,
             ops: vec![AsSym, AsStr, TryIntoText, TryIntoSymbol],
             op_assert: Box::new(|e: &Element| {
+                let expected = e.expect_text().expect("expected text");
+                let expected = e.expect_symbol().expect("expected symbol");
                 assert_eq!(Some("foo"), e.as_symbol().unwrap().text());
                 assert_eq!(Some("foo"), e.as_text());
             }),
@@ -1370,7 +1383,11 @@ mod tests {
             elem: Element::blob(b"hello"),
             ion_type: IonType::Blob,
             ops: vec![AsBytes, TryIntoLob, TryIntoBlob],
-            op_assert: Box::new(|e: &Element| assert_eq!(Some("hello".as_bytes()), e.as_lob())),
+            op_assert: Box::new(|e: &Element| {
+                let expected = e.expect_lob().expect("expected lob");
+                let expected = e.expect_blob().expect("expected blob");
+                assert_eq!(Some("hello".as_bytes()), e.as_lob())
+            }),
             owned_asserts: vec![
                 assert_pass_try_into!(try_into_lob),
                 assert_pass_try_into!(try_into_blob),
@@ -1383,7 +1400,11 @@ mod tests {
             elem: Element::clob(b"goodbye"),
             ion_type: IonType::Clob,
             ops: vec![AsBytes, TryIntoLob, TryIntoClob],
-            op_assert: Box::new(|e: &Element| assert_eq!(Some("goodbye".as_bytes()), e.as_lob())),
+            op_assert: Box::new(|e: &Element| {
+                let expected = e.expect_lob().expect("expected lob");
+                let expected = e.expect_clob().expect("expected clob");
+                assert_eq!(Some("goodbye".as_bytes()), e.as_lob())
+            }),
             owned_asserts: vec![
                 assert_pass_try_into!(try_into_lob),
                 assert_pass_try_into!(try_into_clob),
@@ -1397,6 +1418,8 @@ mod tests {
             ion_type: IonType::List,
             ops: vec![AsSequence, TryIntoList, TryIntoSequence],
             op_assert: Box::new(|e: &Element| {
+                let expected = e.expect_list().expect("expected list");
+                let expected = e.expect_sequence().expect("expected sequence");
                 let actual = e.as_sequence().unwrap();
                 let expected: Vec<Element> = ion_vec([true, false]);
                 // assert the length of list
@@ -1420,6 +1443,8 @@ mod tests {
             ion_type: IonType::SExp,
             ops: vec![AsSequence, TryIntoSexp, TryIntoSequence],
             op_assert: Box::new(|e: &Element| {
+                let expected = e.expect_sexp().expect("expected sexp");
+                let expected = e.expect_sequence().expect("expected sequence");
                 let actual = e.as_sequence().unwrap();
                 let expected: Vec<Element> = ion_vec([true, false]);
                 // assert the length of s-expression
@@ -1442,6 +1467,7 @@ mod tests {
             ion_type: IonType::Struct,
             ops: vec![AsStruct, TryIntoStruct],
             op_assert: Box::new(|e: &Element| {
+                let expected = e.expect_struct().expect("expected struct");
                 let actual: &Struct = e.as_struct().unwrap();
 
                 // verify that the field order is maintained when creating Struct

--- a/src/element/sequence.rs
+++ b/src/element/sequence.rs
@@ -214,3 +214,29 @@ impl std::fmt::Debug for OwnedSequenceIterator {
             .finish()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{ion_list, Element, Value};
+
+    #[test]
+    fn owned_sequence() {
+        let list: Element = ion_list![true, false, "hello"].into();
+        let seq = list.try_into_sequence().unwrap();
+        let mut it = seq.into_iter();
+
+        assert_eq!(
+            format!("{:?}", it),
+            "OwnedSequenceIterator([true, false, \"hello\"])"
+        );
+
+        assert_eq!(it.size_hint(), (3, Some(3)));
+        assert_eq!(it.next(), Some(true.into()));
+        assert_eq!(it.size_hint(), (2, Some(2)));
+        assert_eq!(it.next(), Some(false.into()));
+        assert_eq!(it.size_hint(), (1, Some(1)));
+        assert_eq!(it.next(), Some("hello".into()));
+        assert_eq!(it.size_hint(), (0, Some(0)));
+        assert_eq!(it.next(), None);
+    }
+}

--- a/src/element/sequence.rs
+++ b/src/element/sequence.rs
@@ -207,7 +207,6 @@ impl Iterator for OwnedSequenceIterator {
     }
 }
 
-
 impl std::fmt::Debug for OwnedSequenceIterator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("OwnedSequenceIterator")

--- a/src/element/sequence.rs
+++ b/src/element/sequence.rs
@@ -217,7 +217,7 @@ impl std::fmt::Debug for OwnedSequenceIterator {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ion_list, Element, Value};
+    use crate::{ion_list, Element};
 
     #[test]
     fn owned_sequence() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ pub use catalog::{Catalog, EmptyCatalog, MapCatalog};
 pub use element::builders::{SequenceBuilder, StructBuilder};
 pub use element::{
     element_writer::ElementWriter, reader::ElementReader, Annotations, Element,
-    IntoAnnotatedElement, IntoAnnotations, Sequence, Value, OwnedSequenceIterator
+    IntoAnnotatedElement, IntoAnnotations, OwnedSequenceIterator, Sequence, Value,
 };
 pub use ion_data::IonData;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ pub use catalog::{Catalog, EmptyCatalog, MapCatalog};
 pub use element::builders::{SequenceBuilder, StructBuilder};
 pub use element::{
     element_writer::ElementWriter, reader::ElementReader, Annotations, Element,
-    IntoAnnotatedElement, IntoAnnotations, Sequence, Value,
+    IntoAnnotatedElement, IntoAnnotations, Sequence, Value, OwnedSequenceIterator
 };
 pub use ion_data::IonData;
 

--- a/src/result/conversion.rs
+++ b/src/result/conversion.rs
@@ -1,0 +1,125 @@
+use crate::{Bytes, Decimal, Int, IonType, Sequence, Str, Struct, Symbol, Timestamp};
+use thiserror::Error;
+
+pub type ConversionResult<T> = Result<T, ConversionError>;
+
+/// A mismatch between the expected type and the actual value's type.
+#[derive(Clone, Debug, Error, PartialEq)]
+#[error("Type conversion error; expected a(n) {output_type}, found a(n) {input_type}")]
+pub struct ConversionError {
+    input_type: String,
+    output_type: String,
+}
+
+/// Represents the output of a conversion operation, returning either the successfully
+/// converted value or the original value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Conversion<FromType, ToType> {
+    /// Conversion success.
+    Success(ToType),
+    /// Conversion failure; returning original.
+    Fail(FromType),
+}
+
+impl<FromType, ToType> Conversion<FromType, ToType> {
+    pub fn is_success(&self) -> bool {
+        matches!(self, Conversion::Success(_))
+    }
+
+    pub fn is_failure(&self) -> bool {
+        matches!(self, Conversion::Fail(_))
+    }
+}
+
+pub(crate) trait IonTypeExpectation {
+    fn ion_type(&self) -> IonType;
+}
+
+pub(crate) trait ValueTypeExpectation {
+    fn expected_type_name(&self) -> String;
+}
+
+pub(crate) trait TypeExpectation {
+    fn expected_type_name() -> String;
+}
+macro_rules! impl_type_expectation {
+    ($ty:ty, $e:expr) => {
+        impl TypeExpectation for $ty {
+            fn expected_type_name() -> String {
+                $e.to_string()
+            }
+        }
+    };
+}
+
+impl_type_expectation!(Int, IonType::Int);
+impl_type_expectation!(i64, "i64 value");
+impl_type_expectation!(f64, IonType::Float);
+impl_type_expectation!(Decimal, IonType::Decimal);
+impl_type_expectation!(Timestamp, IonType::Timestamp);
+impl_type_expectation!(String, "text value");
+impl_type_expectation!(&str, "text value");
+impl_type_expectation!(Str, IonType::String);
+impl_type_expectation!(Symbol, IonType::Symbol);
+impl_type_expectation!(bool, IonType::Bool);
+impl_type_expectation!(Bytes, "lob value");
+impl_type_expectation!(&[u8], "lob value");
+impl_type_expectation!(Sequence, "sequence value");
+impl_type_expectation!(Struct, IonType::Struct);
+
+impl<T> ValueTypeExpectation for T
+where
+    T: IonTypeExpectation,
+{
+    fn expected_type_name(&self) -> String {
+        self.ion_type().to_string()
+    }
+}
+
+impl<FromType, ToType> From<Conversion<FromType, ToType>> for Option<ToType>
+where
+    ToType: TypeExpectation,
+    FromType: ValueTypeExpectation,
+{
+    fn from(conversion: Conversion<FromType, ToType>) -> Self {
+        match conversion {
+            Conversion::Success(to) => Some(to),
+            Conversion::Fail(from) => None,
+        }
+    }
+}
+
+impl<FromType, ToType> From<Conversion<FromType, ToType>> for ConversionResult<ToType>
+where
+    ToType: TypeExpectation,
+    FromType: ValueTypeExpectation,
+{
+    fn from(conversion: Conversion<FromType, ToType>) -> Self {
+        match conversion {
+            Conversion::Success(to) => Ok(to),
+            Conversion::Fail(from) => Err(ConversionError {
+                input_type: ToType::expected_type_name(),
+                output_type: from.expected_type_name(),
+            }),
+        }
+    }
+}
+
+pub(crate) trait ConversionExpectation<ToType> {
+    fn expect_convert(self, input_type: &impl ValueTypeExpectation) -> ConversionResult<ToType>;
+}
+
+impl<ToType> ConversionExpectation<ToType> for Option<ToType>
+where
+    ToType: TypeExpectation,
+{
+    fn expect_convert(self, input_type: &impl ValueTypeExpectation) -> ConversionResult<ToType> {
+        match self {
+            Some(value) => Ok(value),
+            None => Err(ConversionError {
+                input_type: input_type.expected_type_name(),
+                output_type: ToType::expected_type_name(),
+            }),
+        }
+    }
+}

--- a/src/result/conversion.rs
+++ b/src/result/conversion.rs
@@ -29,6 +29,15 @@ impl<FromType, ToType> Conversion<FromType, ToType> {
     pub fn is_failure(&self) -> bool {
         matches!(self, Conversion::Fail(_))
     }
+
+    pub fn unwrap(self) -> ToType
+    where
+        ToType: TypeExpectation,
+        FromType: ValueTypeExpectation,
+    {
+        let result: ConversionResult<ToType> = self.into();
+        result.unwrap()
+    }
 }
 
 pub(crate) trait IonTypeExpectation {
@@ -92,7 +101,7 @@ where
     fn from(conversion: Conversion<FromType, ToType>) -> Self {
         match conversion {
             Conversion::Success(to) => Some(to),
-            Conversion::Fail(from) => None,
+            Conversion::Fail(_) => None,
         }
     }
 }

--- a/src/result/conversion.rs
+++ b/src/result/conversion.rs
@@ -42,6 +42,7 @@ pub(crate) trait ValueTypeExpectation {
 pub(crate) trait TypeExpectation {
     fn expected_type_name() -> String;
 }
+
 macro_rules! impl_type_expectation {
     ($ty:ty, $e:expr) => {
         impl TypeExpectation for $ty {
@@ -52,20 +53,27 @@ macro_rules! impl_type_expectation {
     };
 }
 
-impl_type_expectation!(Int, IonType::Int);
+macro_rules! impl_type_and_ref_expectation {
+    ($ty:ty, $e:expr) => {
+        impl_type_expectation!($ty, $e);
+        impl_type_expectation!(&$ty, $e);
+    };
+}
+
+impl_type_and_ref_expectation!(Int, IonType::Int);
 impl_type_expectation!(i64, "i64 value");
 impl_type_expectation!(f64, IonType::Float);
-impl_type_expectation!(Decimal, IonType::Decimal);
-impl_type_expectation!(Timestamp, IonType::Timestamp);
-impl_type_expectation!(String, "text value");
+impl_type_and_ref_expectation!(Decimal, IonType::Decimal);
+impl_type_and_ref_expectation!(Timestamp, IonType::Timestamp);
+impl_type_and_ref_expectation!(String, "text value");
 impl_type_expectation!(&str, "text value");
-impl_type_expectation!(Str, IonType::String);
-impl_type_expectation!(Symbol, IonType::Symbol);
+impl_type_and_ref_expectation!(Str, IonType::String);
+impl_type_and_ref_expectation!(Symbol, IonType::Symbol);
 impl_type_expectation!(bool, IonType::Bool);
-impl_type_expectation!(Bytes, "lob value");
+impl_type_and_ref_expectation!(Bytes, "lob value");
 impl_type_expectation!(&[u8], "lob value");
-impl_type_expectation!(Sequence, "sequence value");
-impl_type_expectation!(Struct, IonType::Struct);
+impl_type_and_ref_expectation!(Sequence, "sequence value");
+impl_type_and_ref_expectation!(Struct, IonType::Struct);
 
 impl<T> ValueTypeExpectation for T
 where

--- a/src/result/conversion.rs
+++ b/src/result/conversion.rs
@@ -29,26 +29,28 @@ impl<FromType, ToType> Conversion<FromType, ToType> {
     pub fn is_failure(&self) -> bool {
         matches!(self, Conversion::Fail(_))
     }
+}
 
-    pub fn unwrap(self) -> ToType
-    where
-        ToType: TypeExpectation,
-        FromType: ValueTypeExpectation,
-    {
+impl<FromType, ToType> Conversion<FromType, ToType>
+where
+    ToType: TypeExpectation,
+    FromType: ValueTypeExpectation,
+{
+    pub fn unwrap(self) -> ToType {
         let result: ConversionResult<ToType> = self.into();
         result.unwrap()
     }
 }
 
-pub(crate) trait IonTypeExpectation {
+pub trait IonTypeExpectation {
     fn ion_type(&self) -> IonType;
 }
 
-pub(crate) trait ValueTypeExpectation {
+pub trait ValueTypeExpectation {
     fn expected_type_name(&self) -> String;
 }
 
-pub(crate) trait TypeExpectation {
+pub trait TypeExpectation {
     fn expected_type_name() -> String;
 }
 
@@ -122,7 +124,7 @@ where
     }
 }
 
-pub(crate) trait ConversionExpectation<ToType> {
+pub trait ConversionExpectation<ToType> {
     fn expect_convert(self, input_type: &impl ValueTypeExpectation) -> ConversionResult<ToType>;
 }
 

--- a/src/result/conversion.rs
+++ b/src/result/conversion.rs
@@ -1,9 +1,13 @@
 use crate::{Bytes, Decimal, Int, IonType, Sequence, Str, Struct, Symbol, Timestamp};
+
+use std::marker::PhantomData;
 use thiserror::Error;
 
-pub type ConversionResult<T> = Result<T, ConversionError>;
+pub type ConversionOperationResult<FromType, ToType> =
+    Result<ToType, ConversionOperationError<FromType, ToType>>;
+pub type ConversionResult<ToType> = Result<ToType, ConversionError>;
 
-/// A mismatch between the expected type and the actual value's type.
+/// Represents a mismatch during conversion between the expected type and the actual value's type.
 #[derive(Clone, Debug, Error, PartialEq)]
 #[error("Type conversion error; expected a(n) {output_type}, found a(n) {input_type}")]
 pub struct ConversionError {
@@ -11,34 +15,53 @@ pub struct ConversionError {
     output_type: String,
 }
 
-/// Represents the output of a conversion operation, returning either the successfully
-/// converted value or the original value.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Conversion<FromType, ToType> {
-    /// Conversion success.
-    Success(ToType),
-    /// Conversion failure; returning original.
-    Fail(FromType),
-}
-
-impl<FromType, ToType> Conversion<FromType, ToType> {
-    pub fn is_success(&self) -> bool {
-        matches!(self, Conversion::Success(_))
-    }
-
-    pub fn is_failure(&self) -> bool {
-        matches!(self, Conversion::Fail(_))
-    }
-}
-
-impl<FromType, ToType> Conversion<FromType, ToType>
+impl<FromType, ToType> From<ConversionOperationError<FromType, ToType>> for ConversionError
 where
-    ToType: TypeExpectation,
     FromType: ValueTypeExpectation,
+    ToType: TypeExpectation,
 {
-    pub fn unwrap(self) -> ToType {
-        let result: ConversionResult<ToType> = self.into();
-        result.unwrap()
+    fn from(err: ConversionOperationError<FromType, ToType>) -> Self {
+        ConversionError {
+            input_type: err.input_value.expected_type_name(),
+            output_type: ToType::expected_type_name(),
+        }
+    }
+}
+
+/// Represents a mismatch during conversion between the expected type and the actual value's type;
+/// Holds the original value that was not able to be converted.
+#[derive(Clone, Debug, Error, PartialEq)]
+#[error("Type conversion error; expected a(n) {}, found a(n) {}",
+            ToType::expected_type_name(), .input_value.expected_type_name())]
+pub struct ConversionOperationError<FromType, ToType>
+where
+    FromType: ValueTypeExpectation,
+    ToType: TypeExpectation,
+{
+    input_value: FromType,
+    output_type: PhantomData<ToType>,
+}
+
+impl<FromType, ToType> ConversionOperationError<FromType, ToType>
+where
+    FromType: ValueTypeExpectation,
+    ToType: TypeExpectation,
+{
+    pub fn new(input_value: FromType) -> Self {
+        Self {
+            input_value,
+            output_type: PhantomData::default(),
+        }
+    }
+}
+
+impl<FromType, ToType> From<FromType> for ConversionOperationError<FromType, ToType>
+where
+    FromType: ValueTypeExpectation,
+    ToType: TypeExpectation,
+{
+    fn from(input_value: FromType) -> Self {
+        Self::new(input_value)
     }
 }
 
@@ -92,53 +115,5 @@ where
 {
     fn expected_type_name(&self) -> String {
         self.ion_type().to_string()
-    }
-}
-
-impl<FromType, ToType> From<Conversion<FromType, ToType>> for Option<ToType>
-where
-    ToType: TypeExpectation,
-    FromType: ValueTypeExpectation,
-{
-    fn from(conversion: Conversion<FromType, ToType>) -> Self {
-        match conversion {
-            Conversion::Success(to) => Some(to),
-            Conversion::Fail(_) => None,
-        }
-    }
-}
-
-impl<FromType, ToType> From<Conversion<FromType, ToType>> for ConversionResult<ToType>
-where
-    ToType: TypeExpectation,
-    FromType: ValueTypeExpectation,
-{
-    fn from(conversion: Conversion<FromType, ToType>) -> Self {
-        match conversion {
-            Conversion::Success(to) => Ok(to),
-            Conversion::Fail(from) => Err(ConversionError {
-                input_type: ToType::expected_type_name(),
-                output_type: from.expected_type_name(),
-            }),
-        }
-    }
-}
-
-pub trait ConversionExpectation<ToType> {
-    fn expect_convert(self, input_type: &impl ValueTypeExpectation) -> ConversionResult<ToType>;
-}
-
-impl<ToType> ConversionExpectation<ToType> for Option<ToType>
-where
-    ToType: TypeExpectation,
-{
-    fn expect_convert(self, input_type: &impl ValueTypeExpectation) -> ConversionResult<ToType> {
-        match self {
-            Some(value) => Ok(value),
-            None => Err(ConversionError {
-                input_type: input_type.expected_type_name(),
-                output_type: ToType::expected_type_name(),
-            }),
-        }
     }
 }

--- a/src/result/conversion.rs
+++ b/src/result/conversion.rs
@@ -38,7 +38,7 @@ where
     FromType: ValueTypeExpectation,
     ToType: TypeExpectation,
 {
-    input_value: FromType,
+    input_value: Box<FromType>,
     output_type: PhantomData<ToType>,
 }
 
@@ -49,8 +49,8 @@ where
 {
     pub fn new(input_value: FromType) -> Self {
         Self {
-            input_value,
-            output_type: PhantomData::default(),
+            input_value: Box::new(input_value),
+            output_type: PhantomData,
         }
     }
 }

--- a/src/result/conversion.rs
+++ b/src/result/conversion.rs
@@ -38,7 +38,7 @@ where
     FromType: ValueTypeExpectation,
     ToType: TypeExpectation,
 {
-    input_value: Box<FromType>,
+    input_value: FromType,
     output_type: PhantomData<ToType>,
 }
 
@@ -49,7 +49,7 @@ where
 {
     pub fn new(input_value: FromType) -> Self {
         Self {
-            input_value: Box::new(input_value),
+            input_value,
             output_type: PhantomData,
         }
     }

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -23,7 +23,6 @@ pub use conversion::ConversionExpectation;
 pub use conversion::ConversionResult;
 pub use conversion::IonTypeExpectation;
 pub use conversion::TypeExpectation;
-pub use conversion::ValueTypeExpectation;
 pub use decoding_error::DecodingError;
 pub use encoding_error::EncodingError;
 pub use illegal_operation::IllegalOperation;

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -10,12 +10,20 @@ use thiserror::Error;
 #[cfg(feature = "experimental-serde")]
 use serde::{de, ser};
 
+mod conversion;
 mod decoding_error;
 mod encoding_error;
 mod illegal_operation;
 mod incomplete;
 mod io_error;
 
+pub use conversion::Conversion;
+pub use conversion::ConversionError;
+pub(crate) use conversion::ConversionExpectation;
+pub use conversion::ConversionResult;
+pub(crate) use conversion::IonTypeExpectation;
+pub(crate) use conversion::TypeExpectation;
+pub(crate) use conversion::ValueTypeExpectation;
 pub use decoding_error::DecodingError;
 pub use encoding_error::EncodingError;
 pub use illegal_operation::IllegalOperation;
@@ -53,6 +61,11 @@ pub enum IonError {
     /// on the cursor at the top level.)
     #[error("{0}")]
     IllegalOperation(#[from] IllegalOperation),
+
+    /// Returned when the user has attempted to convert a value to a type for which that value is
+    /// not trivially convertable.
+    #[error("{0}")]
+    Conversion(#[from] ConversionError),
 }
 
 impl From<io::Error> for IonError {

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -19,11 +19,11 @@ mod io_error;
 
 pub use conversion::Conversion;
 pub use conversion::ConversionError;
-pub(crate) use conversion::ConversionExpectation;
+pub use conversion::ConversionExpectation;
 pub use conversion::ConversionResult;
-pub(crate) use conversion::IonTypeExpectation;
-pub(crate) use conversion::TypeExpectation;
-pub(crate) use conversion::ValueTypeExpectation;
+pub use conversion::IonTypeExpectation;
+pub use conversion::TypeExpectation;
+pub use conversion::ValueTypeExpectation;
 pub use decoding_error::DecodingError;
 pub use encoding_error::EncodingError;
 pub use illegal_operation::IllegalOperation;

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -17,10 +17,8 @@ mod illegal_operation;
 mod incomplete;
 mod io_error;
 
-pub use conversion::Conversion;
-pub use conversion::ConversionError;
-pub use conversion::ConversionExpectation;
-pub use conversion::ConversionResult;
+pub use conversion::ConversionOperationError;
+pub use conversion::ConversionOperationResult;
 pub use conversion::IonTypeExpectation;
 pub use conversion::TypeExpectation;
 pub use decoding_error::DecodingError;
@@ -30,6 +28,7 @@ pub use incomplete::IncompleteError;
 pub use io_error::IoError;
 
 use crate::position::Position;
+use crate::result::conversion::{ConversionError, ValueTypeExpectation};
 
 /// A unified Result type representing the outcome of method calls that may fail.
 pub type IonResult<T> = Result<T, IonError>;
@@ -93,6 +92,16 @@ impl From<IonError> for fmt::Error {
         // This no-op transformation allows `?` to be used in `Debug` implementations wherever
         // an IonError could surface.
         fmt::Error
+    }
+}
+
+impl<FromType, ToType> From<ConversionOperationError<FromType, ToType>> for IonError
+where
+    FromType: ValueTypeExpectation,
+    ToType: TypeExpectation,
+{
+    fn from(err: ConversionOperationError<FromType, ToType>) -> Self {
+        ConversionError::from(err).into()
     }
 }
 


### PR DESCRIPTION
This PR includes a couple changes intended to make working with owned `Element`s easier are not require cloning for 'projecting' an element to be replaced by something it contains.

- Exposes `OwnedSequenceIterator` and modifies its implementation to clone less
- Adds `try_into_<x>` methods similar to `as_<x>` methods on `Element`
    -  These allow 'partial' conversions of owned `Element`s with the 'failure' case returning the original `Element`


Example simplified usage:
```rust
#[derive(Debug)]
enum ElementIterator {
    Single(Element),
    Sequence(OwnedSequenceIterator),
}

...

match elt.try_into_sequence() {
    Err(elt) => ElementIterator::Single(elt),
    Ok(seq) => ElementIterator::Sequence(seq.into_iter()),
}
```

---


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
