### PR TITLE
Adds #![deny(rust_2018_idioms)], applies lifetime elision suggestions

### DIFF
--- a/benches/read_many_structs.rs
+++ b/benches/read_many_structs.rs
@@ -49,8 +49,7 @@ fn maximally_compact_1_1_data(num_values: usize) -> TestData_1_1 {
 
     let mut binary_1_1_data = vec![0xE0u8, 0x01, 0x01, 0xEA]; // IVM
     #[rustfmt::skip]
-    let mut binary_1_1_data_body: Vec<u8> = vec![
-        MacroTable::FIRST_USER_MACRO_ID as u8, // Macro ID
+    let mut binary_1_1_data_body: Vec<u8> = [MacroTable::FIRST_USER_MACRO_ID as u8, // Macro ID
         0b10, // [NOTE: `0b`] `parameters*` arg is an arg group
         0x66, // 6-byte integer (`timestamp` param)
         0x75, 0x5D, 0x63, 0xEE, 0x84, 0x01,
@@ -73,8 +72,7 @@ fn maximally_compact_1_1_data(num_values: usize) -> TestData_1_1 {
         0x32, 0x30, 0x3A, 0x35,
         0x39, 0x3A, 0x35, 0x39,
         0x2E, 0x37, 0x34, 0x34,
-        0x30, 0x30, 0x30, 0x5A,
-    ].repeat(num_values);
+        0x30, 0x30, 0x30, 0x5A].repeat(num_values);
     binary_1_1_data.append(&mut binary_1_1_data_body);
     TestData_1_1 {
         name: "maximally compact".to_owned(),
@@ -111,8 +109,7 @@ fn moderately_compact_1_1_data(num_values: usize) -> TestData_1_1 {
     let text_1_1_data = r#"(:event 1670446800245 418 "scheduler-thread-6" "example-client-1" "aws-us-east-5f-abc123" (: "region 4" "2022-12-07T20:59:59.744000Z"))"#.repeat(num_values);
     let mut binary_1_1_data = vec![0xE0u8, 0x01, 0x01, 0xEA]; // IVM
     #[rustfmt::skip]
-    let mut binary_1_1_data_body: Vec<u8> = vec![
-        MacroTable::FIRST_USER_MACRO_ID as u8, // Macro ID
+    let mut binary_1_1_data_body: Vec<u8> = [MacroTable::FIRST_USER_MACRO_ID as u8, // Macro ID
         0b10, // [NOTE: `0b` prefix] `parameters*` arg is an arg group
         0x66, // 6-byte integer (`timestamp` param)
         0x75, 0x5D, 0x63, 0xEE, 0x84, 0x01,
@@ -143,8 +140,7 @@ fn moderately_compact_1_1_data(num_values: usize) -> TestData_1_1 {
         0x32, 0x30, 0x3A, 0x35,
         0x39, 0x3A, 0x35, 0x39,
         0x2E, 0x37, 0x34, 0x34,
-        0x30, 0x30, 0x30, 0x5A,
-    ].repeat(num_values);
+        0x30, 0x30, 0x30, 0x5A].repeat(num_values);
 
     binary_1_1_data.append(&mut binary_1_1_data_body);
     TestData_1_1 {
@@ -182,8 +178,7 @@ fn length_prefixed_moderately_compact_1_1_data(num_values: usize) -> TestData_1_
     let text_1_1_data = r#"(:event 1670446800245 418 "scheduler-thread-6" "example-client-1" "aws-us-east-5f-abc123" (: "region 4" "2022-12-07T20:59:59.744000Z"))"#.repeat(num_values);
     let mut binary_1_1_data = vec![0xE0u8, 0x01, 0x01, 0xEA]; // IVM
     #[rustfmt::skip]
-    let mut binary_1_1_data_body: Vec<u8> = vec![
-        0xF5, // LP invocation
+    let mut binary_1_1_data_body: Vec<u8> = [0xF5, // LP invocation
         ((MacroTable::FIRST_USER_MACRO_ID * 2) + 1) as u8, // Macro ID
         0xDF, // Length prefix: FlexUInt 111
         0b10, // [NOTE: `0b` prefix] `parameters*` arg is an arg group
@@ -216,8 +211,7 @@ fn length_prefixed_moderately_compact_1_1_data(num_values: usize) -> TestData_1_
         0x32, 0x30, 0x3A, 0x35,
         0x39, 0x3A, 0x35, 0x39,
         0x2E, 0x37, 0x34, 0x34,
-        0x30, 0x30, 0x30, 0x5A,
-    ].repeat(num_values);
+        0x30, 0x30, 0x30, 0x5A].repeat(num_values);
 
     binary_1_1_data.append(&mut binary_1_1_data_body);
     TestData_1_1 {

--- a/benches/write_many_structs.rs
+++ b/benches/write_many_structs.rs
@@ -39,7 +39,7 @@ mod benchmark {
             // $16 = parameters
             .write(
                 16,
-                &[
+                [
                     black_box("SUCCESS"),
                     black_box("example-client-1"),
                     black_box("aws-us-east-5f-abc-123"),
@@ -68,7 +68,7 @@ mod benchmark {
             // $16 = parameters
             .write(
                 16,
-                &[
+                [
                     // $21 = SUCCESS
                     symbol_id(black_box(21)),
                     // $22 = example-client-1

--- a/examples/read_all_values.rs
+++ b/examples/read_all_values.rs
@@ -21,7 +21,7 @@ mod lazy_reader_example {
     pub fn read_all_values() -> IonResult<()> {
         let args: Vec<String> = std::env::args().collect();
         let path = args.get(1).unwrap_or_else(|| {
-            eprintln!("USAGE:\n\n    {} [Binary Ion file]\n", args.get(0).unwrap());
+            eprintln!("USAGE:\n\n    {} [Binary Ion file]\n", args.first().unwrap());
             eprintln!("No mode was specified.");
             exit(1);
         });

--- a/examples/write_log_events.rs
+++ b/examples/write_log_events.rs
@@ -29,10 +29,10 @@ mod example {
         // By default, this program deletes the encoded output before it ends. To keep the files
         // for further review, you can pass a `--keep-files`/`-k` flag.
         let args: Vec<String> = args().collect();
-        let keep_files_flag = match args.get(1).map(|a| a.as_str()) {
-            Some("--keep-files") | Some("-k") => true,
-            _ => false,
-        };
+        let keep_files_flag = matches!(
+            args.get(1).map(|a| a.as_str()),
+            Some("--keep-files") | Some("-k")
+        );
 
         // Create a set of Log4J-style statements that might appear in a typical program. These statements
         // have a fixed combination of (logger name, log level, format string) fields.

--- a/src/element/annotations.rs
+++ b/src/element/annotations.rs
@@ -38,7 +38,7 @@ impl Annotations {
 
     /// Returns an [`Iterator`] that yields each of the [`Symbol`]s in this annotations
     /// sequence in order.
-    pub fn iter(&self) -> SymbolsIterator {
+    pub fn iter(&self) -> SymbolsIterator<'_> {
         SymbolsIterator::new(self.symbols.as_slice())
     }
 

--- a/src/element/reader.rs
+++ b/src/element/reader.rs
@@ -75,7 +75,7 @@ pub struct ElementIterator<'a, R: ElementReader + ?Sized> {
     reader: &'a mut R,
 }
 
-impl<'a, R: ElementReader + ?Sized> Iterator for ElementIterator<'a, R> {
+impl<R: ElementReader + ?Sized> Iterator for ElementIterator<'_, R> {
     type Item = IonResult<Element>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -103,7 +103,7 @@ pub enum LazyRawAnyVersionMarkerKind<'top> {
     Binary_1_1(LazyRawBinaryVersionMarker_1_1<'top>),
 }
 
-impl<'top> LazyRawAnyVersionMarker<'top> {
+impl LazyRawAnyVersionMarker<'_> {
     pub fn encoding(&self) -> IonEncoding {
         use crate::lazy::any_encoding::LazyRawAnyVersionMarkerKind::*;
         match self.encoding {
@@ -127,7 +127,7 @@ impl<'top> HasSpan<'top> for LazyRawAnyVersionMarker<'top> {
     }
 }
 
-impl<'top> HasRange for LazyRawAnyVersionMarker<'top> {
+impl HasRange for LazyRawAnyVersionMarker<'_> {
     fn range(&self) -> Range<usize> {
         use LazyRawAnyVersionMarkerKind::*;
         match self.encoding {
@@ -240,7 +240,7 @@ impl<'top> HasSpan<'top> for LazyRawAnyEExpression<'top> {
     }
 }
 
-impl<'top> HasRange for LazyRawAnyEExpression<'top> {
+impl HasRange for LazyRawAnyEExpression<'_> {
     fn range(&self) -> Range<usize> {
         use LazyRawAnyEExpressionKind::*;
         match self.encoding {
@@ -286,7 +286,7 @@ pub enum AnyEExpArgGroupKind<'top> {
     Binary_1_1(BinaryEExpArgGroup<'top>),
 }
 
-impl<'top> AnyEExpArgGroupKind<'top> {
+impl AnyEExpArgGroupKind<'_> {
     fn encoding(&self) -> &ParameterEncoding {
         match self {
             AnyEExpArgGroupKind::Text_1_1(g) => g.encoding(),
@@ -295,7 +295,7 @@ impl<'top> AnyEExpArgGroupKind<'top> {
     }
 }
 
-impl<'top> HasRange for AnyEExpArgGroup<'top> {
+impl HasRange for AnyEExpArgGroup<'_> {
     fn range(&self) -> Range<usize> {
         match self.kind {
             AnyEExpArgGroupKind::Text_1_1(group) => group.range(),
@@ -445,7 +445,7 @@ pub struct LazyRawAnyReader<'data> {
     encoding_reader: RawReaderKind<'data>,
 }
 
-impl<'data> LazyRawAnyReader<'data> {
+impl LazyRawAnyReader<'_> {
     fn detect_encoding(data: &[u8]) -> IonEncoding {
         const BINARY_1_0_IVM: &[u8] = &[0xEA, 0x01, 0x00, 0xE0];
 
@@ -1008,7 +1008,7 @@ impl<'top> HasSpan<'top> for LazyRawAnyValue<'top> {
     }
 }
 
-impl<'top> HasRange for LazyRawAnyValue<'top> {
+impl HasRange for LazyRawAnyValue<'_> {
     fn range(&self) -> Range<usize> {
         use LazyRawValueKind::*;
         match &self.encoding {
@@ -1490,7 +1490,7 @@ impl<'top> HasSpan<'top> for LazyRawAnyFieldName<'top> {
     }
 }
 
-impl<'top> HasRange for LazyRawAnyFieldName<'top> {
+impl HasRange for LazyRawAnyFieldName<'_> {
     fn range(&self) -> Range<usize> {
         use LazyRawFieldNameKind::*;
         match self.encoding {

--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -478,7 +478,7 @@ impl<'data> RawReaderKind<'data> {
         data: &'data [u8],
         stream_offset: usize,
         encoding_hint: IonEncoding,
-    ) -> RawReaderKind {
+    ) -> RawReaderKind<'data> {
         use IonEncoding::*;
         match encoding_hint {
             Text_1_0 => RawReaderKind::Text_1_0(LazyRawTextReader_1_0::resume_at_offset(
@@ -659,7 +659,7 @@ impl<'data> LazyRawReader<'data, AnyEncoding> for LazyRawAnyReader<'data> {
         }
 
         use RawReaderKind::*;
-        let item: LazyRawStreamItem<AnyEncoding> = match &mut self.encoding_reader {
+        let item: LazyRawStreamItem<'_, AnyEncoding> = match &mut self.encoding_reader {
             Text_1_0(r) => r.next(context)?.into(),
             Binary_1_0(r) => r.next()?.into(),
             Text_1_1(r) => r.next(context)?.into(),
@@ -1817,8 +1817,8 @@ mod tests {
     }
 
     fn expect_version_change(
-        context_ref: EncodingContextRef,
-        reader: &mut LazyRawAnyReader,
+        context_ref: EncodingContextRef<'_>,
+        reader: &mut LazyRawAnyReader<'_>,
         encoding_before: IonEncoding,
         encoding_after: IonEncoding,
     ) -> IonResult<()> {
@@ -1835,8 +1835,8 @@ mod tests {
     }
 
     fn expect_int(
-        context_ref: EncodingContextRef,
-        reader: &mut LazyRawAnyReader,
+        context_ref: EncodingContextRef<'_>,
+        reader: &mut LazyRawAnyReader<'_>,
         expected_encoding: IonEncoding,
         expected_int: i64,
     ) -> IonResult<()> {

--- a/src/lazy/binary/immutable_buffer.rs
+++ b/src/lazy/binary/immutable_buffer.rs
@@ -57,11 +57,11 @@ pub(crate) type ParseResult<'a, T> = IonResult<(T, BinaryBuffer<'a>)>;
 impl<'a> BinaryBuffer<'a> {
     /// Constructs a new `BinaryBuffer` that wraps `data`.
     #[inline]
-    pub fn new(data: &[u8]) -> BinaryBuffer {
+    pub fn new(data: &[u8]) -> BinaryBuffer<'_> {
         Self::new_with_offset(data, 0)
     }
 
-    pub fn new_with_offset(data: &[u8], offset: usize) -> BinaryBuffer {
+    pub fn new_with_offset(data: &[u8], offset: usize) -> BinaryBuffer<'_> {
         BinaryBuffer { data, offset }
     }
 

--- a/src/lazy/binary/immutable_buffer.rs
+++ b/src/lazy/binary/immutable_buffer.rs
@@ -42,7 +42,7 @@ pub struct BinaryBuffer<'a> {
     offset: usize,
 }
 
-impl<'a> Debug for BinaryBuffer<'a> {
+impl Debug for BinaryBuffer<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "BinaryBuffer {{")?;
         for byte in self.bytes().iter().take(16) {

--- a/src/lazy/binary/raw/sequence.rs
+++ b/src/lazy/binary/raw/sequence.rs
@@ -106,7 +106,7 @@ impl<'top> LazyRawBinarySequence_1_0<'top> {
     }
 }
 
-impl<'a, 'top> IntoIterator for &'a LazyRawBinarySequence_1_0<'top> {
+impl<'top> IntoIterator for &LazyRawBinarySequence_1_0<'top> {
     type Item = IonResult<LazyRawValueExpr<'top, BinaryEncoding_1_0>>;
     type IntoIter = RawBinarySequenceIterator_1_0<'top>;
 
@@ -115,7 +115,7 @@ impl<'a, 'top> IntoIterator for &'a LazyRawBinarySequence_1_0<'top> {
     }
 }
 
-impl<'a> Debug for LazyRawBinarySequence_1_0<'a> {
+impl Debug for LazyRawBinarySequence_1_0<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self.value.encoded_value.ion_type() {
             IonType::SExp => {

--- a/src/lazy/binary/raw/struct.rs
+++ b/src/lazy/binary/raw/struct.rs
@@ -157,7 +157,7 @@ mod tests {
         // occupy the specified input ranges.
         type FieldNameAndRange<'a> = (RawSymbolRef<'a>, Range<usize>);
         type FieldTest<'a> = (&'a [u8], &'a [FieldNameAndRange<'a>]);
-        let tests: &[FieldTest] = &[
+        let tests: &[FieldTest<'_>] = &[
             // (Ion input, expected ranges of the struct's field names)
             (
                 &[0xD2, 0x84, 0x80], // {name: ""}

--- a/src/lazy/binary/raw/struct.rs
+++ b/src/lazy/binary/raw/struct.rs
@@ -27,7 +27,7 @@ impl<'top> LazyRawBinaryStruct_1_0<'top> {
     }
 }
 
-impl<'a, 'top> IntoIterator for &'a LazyRawBinaryStruct_1_0<'top> {
+impl<'top> IntoIterator for &LazyRawBinaryStruct_1_0<'top> {
     type Item = IonResult<LazyRawFieldExpr<'top, BinaryEncoding_1_0>>;
     type IntoIter = RawBinaryStructIterator_1_0<'top>;
 
@@ -36,7 +36,7 @@ impl<'a, 'top> IntoIterator for &'a LazyRawBinaryStruct_1_0<'top> {
     }
 }
 
-impl<'top> Debug for LazyRawBinaryStruct_1_0<'top> {
+impl Debug for LazyRawBinaryStruct_1_0<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{{")?;
         for field in self {
@@ -129,7 +129,7 @@ impl<'top> HasSpan<'top> for LazyRawBinaryFieldName_1_0<'top> {
     }
 }
 
-impl<'top> HasRange for LazyRawBinaryFieldName_1_0<'top> {
+impl HasRange for LazyRawBinaryFieldName_1_0<'_> {
     fn range(&self) -> Range<usize> {
         self.matched.range()
     }

--- a/src/lazy/binary/raw/v1_1/e_expression.rs
+++ b/src/lazy/binary/raw/v1_1/e_expression.rs
@@ -413,7 +413,7 @@ impl<'top> BinaryEExpArgGroup<'top> {
     }
 }
 
-impl<'top> HasRange for BinaryEExpArgGroup<'top> {
+impl HasRange for BinaryEExpArgGroup<'_> {
     fn range(&self) -> Range<usize> {
         self.input.range()
     }

--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -938,7 +938,7 @@ impl<'a> BinaryBuffer<'a> {
         // the batch size because it is a power of two and ~400 bytes seemed like a reasonable
         // chunk of stack space. This can be changed as needed.
         const ARG_BATCH_SIZE: usize = 4;
-        let mut args_array: ArrayVec<ValueExpr<v1_1::Binary>, 4> = ArrayVec::new();
+        let mut args_array: ArrayVec<ValueExpr<'_, v1_1::Binary>, 4> = ArrayVec::new();
         for arg in &mut args_iter {
             let arg = arg?;
             let value_expr = arg.resolve(self.context)?;
@@ -1259,7 +1259,7 @@ mod tests {
         #[case] input: &[u8],
         #[case] expected_header_length: usize,
         #[case] expected_sequence_length: usize,
-        #[case] expected_annotations: &[RawSymbolRef],
+        #[case] expected_annotations: &[RawSymbolRef<'_>],
     ) -> IonResult<()> {
         let context = EncodingContext::empty();
         let buffer = BinaryBuffer::new(context.get_ref(), input);
@@ -1289,7 +1289,7 @@ mod tests {
     fn eexp_test(
         macro_source: &str,
         encode_macro_fn: impl FnOnce(MacroAddress) -> Vec<u8>,
-        test_fn: impl FnOnce(BinaryEExpArgsIterator_1_1) -> IonResult<()>,
+        test_fn: impl FnOnce(BinaryEExpArgsIterator_1_1<'_>) -> IonResult<()>,
     ) -> IonResult<()> {
         let mut context = EncodingContext::empty();
         let template_macro = TemplateCompiler::compile_from_text(context.get_ref(), macro_source)?;
@@ -1314,7 +1314,7 @@ mod tests {
         eexp_test(
             macro_source,
             encode_eexp_fn,
-            |mut args: BinaryEExpArgsIterator_1_1| {
+            |mut args: BinaryEExpArgsIterator_1_1<'_>| {
                 assert!(args.next().is_none());
                 Ok(())
             },
@@ -1338,7 +1338,7 @@ mod tests {
             0x4D, 0x69, 0x63, 0x68, 0x65, 0x6C, 0x6C, 0x65,
         ];
 
-        let args_test = |mut args: BinaryEExpArgsIterator_1_1| {
+        let args_test = |mut args: BinaryEExpArgsIterator_1_1<'_>| {
             assert_eq!(
                 args.next()
                     .unwrap()?
@@ -1375,7 +1375,7 @@ mod tests {
             0x54, 0x75, 0x65, 0x73, 0x64, 0x61, 0x79,
         ];
 
-        let args_test = |mut args: BinaryEExpArgsIterator_1_1| {
+        let args_test = |mut args: BinaryEExpArgsIterator_1_1<'_>| {
             assert_eq!(
                 args.next()
                     .unwrap()?
@@ -1414,7 +1414,7 @@ mod tests {
             0b00,
         ];
 
-        let args_test = |mut args: BinaryEExpArgsIterator_1_1| {
+        let args_test = |mut args: BinaryEExpArgsIterator_1_1<'_>| {
             let arg_group = args.next().unwrap()?.expr().expect_arg_group()?;
             let mut group_args = arg_group.iter();
             assert!(group_args.next().is_none());
@@ -1440,7 +1440,7 @@ mod tests {
             0x61, 0x01
         ];
 
-        let args_test = |mut args: BinaryEExpArgsIterator_1_1| {
+        let args_test = |mut args: BinaryEExpArgsIterator_1_1<'_>| {
             let arg1 = args.next().unwrap()?.expr().expect_value()?;
             assert_eq!(arg1.read()?, RawValueRef::Int(1.into()));
             Ok(())
@@ -1468,7 +1468,7 @@ mod tests {
             0x61, 0x03, // Int 3
         ];
 
-        let args_test = |mut args: BinaryEExpArgsIterator_1_1| {
+        let args_test = |mut args: BinaryEExpArgsIterator_1_1<'_>| {
             let arg_group = args.next().unwrap()?.expr().expect_arg_group()?;
             let mut group_exprs = arg_group.iter();
             let group_arg1 = group_exprs.next().unwrap()?;

--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -49,7 +49,7 @@ pub struct BinaryBuffer<'a> {
     context: EncodingContextRef<'a>,
 }
 
-impl<'a> Debug for BinaryBuffer<'a> {
+impl Debug for BinaryBuffer<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "BinaryBuffer {{")?;
         for byte in self.bytes().iter().take(16) {
@@ -59,7 +59,7 @@ impl<'a> Debug for BinaryBuffer<'a> {
     }
 }
 
-impl<'a> PartialEq for BinaryBuffer<'a> {
+impl PartialEq for BinaryBuffer<'_> {
     fn eq(&self, other: &Self) -> bool {
         // A definition of equality that ignores the `context` field.
         self.offset == other.offset && self.data == other.data

--- a/src/lazy/binary/raw/v1_1/reader.rs
+++ b/src/lazy/binary/raw/v1_1/reader.rs
@@ -92,7 +92,7 @@ impl<'data> LazyRawBinaryReader_1_1<'data> {
     }
 }
 
-impl<'data> Sealed for LazyRawBinaryReader_1_1<'data> {}
+impl Sealed for LazyRawBinaryReader_1_1<'_> {}
 
 impl<'data> LazyRawReader<'data, BinaryEncoding_1_1> for LazyRawBinaryReader_1_1<'data> {
     fn new(data: &'data [u8]) -> Self {

--- a/src/lazy/binary/raw/v1_1/reader.rs
+++ b/src/lazy/binary/raw/v1_1/reader.rs
@@ -357,7 +357,7 @@ mod tests {
         let mut reader = LazyRawBinaryReader_1_1::new(&data);
         let _ivm = reader.next(context)?.expect_ivm()?;
 
-        let expected_symbols: &[RawSymbolRef] = &[
+        let expected_symbols: &[RawSymbolRef<'_>] = &[
             RawSymbolRef::Text(""),
             RawSymbolRef::Text("fourteen bytes"),
             RawSymbolRef::Text("variable length encoding"),
@@ -985,7 +985,7 @@ mod tests {
 
         #[rustfmt::skip]
         #[allow(clippy::type_complexity)]
-        let tests: &[(&[u8], &[(RawSymbolRef, IonType)])] = &[
+        let tests: &[(&[u8], &[(RawSymbolRef<'_>, IonType)])] = &[
             // Symbol Address
             (
                 // {}

--- a/src/lazy/binary/raw/v1_1/sequence.rs
+++ b/src/lazy/binary/raw/v1_1/sequence.rs
@@ -129,7 +129,7 @@ impl<'top> LazyRawBinarySequence_1_1<'top> {
     }
 }
 
-impl<'a, 'top> IntoIterator for &'a LazyRawBinarySequence_1_1<'top> {
+impl<'top> IntoIterator for &LazyRawBinarySequence_1_1<'top> {
     type Item = IonResult<LazyRawValueExpr<'top, BinaryEncoding_1_1>>;
     type IntoIter = RawBinarySequenceIterator_1_1<'top>;
 
@@ -138,7 +138,7 @@ impl<'a, 'top> IntoIterator for &'a LazyRawBinarySequence_1_1<'top> {
     }
 }
 
-impl<'a> Debug for LazyRawBinarySequence_1_1<'a> {
+impl Debug for LazyRawBinarySequence_1_1<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self.value.encoded_value.ion_type() {
             IonType::SExp => {

--- a/src/lazy/binary/raw/v1_1/struct.rs
+++ b/src/lazy/binary/raw/v1_1/struct.rs
@@ -43,7 +43,7 @@ impl<'top> HasSpan<'top> for LazyRawBinaryFieldName_1_1<'top> {
     }
 }
 
-impl<'top> HasRange for LazyRawBinaryFieldName_1_1<'top> {
+impl HasRange for LazyRawBinaryFieldName_1_1<'_> {
     fn range(&self) -> Range<usize> {
         self.matched.range()
     }
@@ -62,7 +62,7 @@ pub struct LazyRawBinaryStruct_1_1<'top> {
         Option<&'top [LazyRawFieldExpr<'top, BinaryEncoding_1_1>]>,
 }
 
-impl<'a, 'top> IntoIterator for &'a LazyRawBinaryStruct_1_1<'top> {
+impl<'top> IntoIterator for &LazyRawBinaryStruct_1_1<'top> {
     type Item = IonResult<LazyRawFieldExpr<'top, BinaryEncoding_1_1>>;
     type IntoIter = RawBinaryStructIterator_1_1<'top>;
 
@@ -71,7 +71,7 @@ impl<'a, 'top> IntoIterator for &'a LazyRawBinaryStruct_1_1<'top> {
     }
 }
 
-impl<'top> Debug for LazyRawBinaryStruct_1_1<'top> {
+impl Debug for LazyRawBinaryStruct_1_1<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{{")?;
         for field in self {

--- a/src/lazy/binary/raw/v1_1/struct.rs
+++ b/src/lazy/binary/raw/v1_1/struct.rs
@@ -251,7 +251,7 @@ impl<'top> RawBinaryStructIterator_1_1<'top> {
     fn peek_field(
         input: BinaryBuffer<'top>,
         mut mode: StructMode,
-    ) -> ParseResult<Option<(LazyRawFieldExpr<'top, BinaryEncoding_1_1>, StructMode)>> {
+    ) -> ParseResult<'top, Option<(LazyRawFieldExpr<'top, BinaryEncoding_1_1>, StructMode)>> {
         let mut buffer = input;
         loop {
             // Peek at our field name.

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -242,8 +242,8 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_1> for &'top LazyRawBinaryValue_1
                     IonType::Timestamp => ValueRef::Timestamp(value.read_timestamp()?),
                     IonType::String => ValueRef::String(value.read_string()?),
                     IonType::Symbol => {
-                        let raw_symbol: RawSymbolRef = value.read_symbol()?;
-                        let symbol: SymbolRef = raw_symbol.resolve("a value", context)?;
+                        let raw_symbol: RawSymbolRef<'_> = value.read_symbol()?;
+                        let symbol: SymbolRef<'_> = raw_symbol.resolve("a value", context)?;
                         ValueRef::Symbol(symbol)
                     }
                     IonType::Blob => ValueRef::Blob(value.read_blob()?),

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -81,7 +81,7 @@ impl<'top> HasSpan<'top> for LazyRawBinaryVersionMarker_1_1<'top> {
     }
 }
 
-impl<'top> HasRange for LazyRawBinaryVersionMarker_1_1<'top> {
+impl HasRange for LazyRawBinaryVersionMarker_1_1<'_> {
     fn range(&self) -> Range<usize> {
         self.input.range()
     }
@@ -287,7 +287,7 @@ pub enum DelimitedContents<'top> {
     Fields(&'top [LazyRawFieldExpr<'top, BinaryEncoding_1_1>]),
 }
 
-impl<'top> DelimitedContents<'top> {
+impl DelimitedContents<'_> {
     pub fn is_none(&self) -> bool {
         matches!(self, Self::None)
     }

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -48,7 +48,7 @@ impl<'top> HasSpan<'top> for LazyRawBinaryVersionMarker_1_0<'top> {
     }
 }
 
-impl<'top> HasRange for LazyRawBinaryVersionMarker_1_0<'top> {
+impl HasRange for LazyRawBinaryVersionMarker_1_0<'_> {
     fn range(&self) -> Range<usize> {
         self.input.range()
     }
@@ -79,7 +79,7 @@ pub struct LazyRawBinaryValue_1_0<'top> {
     pub(crate) input: BinaryBuffer<'top>,
 }
 
-impl<'top> Debug for LazyRawBinaryValue_1_0<'top> {
+impl Debug for LazyRawBinaryValue_1_0<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -100,7 +100,7 @@ impl<'top> HasSpan<'top> for LazyRawBinaryValue_1_0<'top> {
     }
 }
 
-impl<'top> HasRange for LazyRawBinaryValue_1_0<'top> {
+impl HasRange for LazyRawBinaryValue_1_0<'_> {
     fn range(&self) -> Range<usize> {
         self.encoded_value.annotated_value_range()
     }
@@ -269,7 +269,7 @@ pub struct EncodedBinaryAnnotations_1_0<'a, 'top> {
     value: &'a LazyRawBinaryValue_1_0<'top>,
 }
 
-impl<'a, 'top> EncodedBinaryAnnotations_1_0<'a, 'top> {
+impl<'top> EncodedBinaryAnnotations_1_0<'_, 'top> {
     /// Returns the input stream index range that contains the bytes representing the complete
     /// annotations wrapper, including its opcode, wrapper length, annotations sequence length,
     /// and the sequence itself.
@@ -330,7 +330,7 @@ pub struct EncodedBinaryValueData_1_0<'a, 'top> {
     value: &'a LazyRawBinaryValue_1_0<'top>,
 }
 
-impl<'a, 'top> EncodedBinaryValueData_1_0<'a, 'top> {
+impl<'top> EncodedBinaryValueData_1_0<'_, 'top> {
     /// Returns the input stream index range that contains the bytes representing the complete value,
     /// including its opcode, length, and body.
     pub fn range(&self) -> Range<usize> {

--- a/src/lazy/bytes_ref.rs
+++ b/src/lazy/bytes_ref.rs
@@ -8,7 +8,7 @@ pub struct BytesRef<'data> {
     data: &'data [u8],
 }
 
-impl<'data> Deref for BytesRef<'data> {
+impl Deref for BytesRef<'_> {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
@@ -16,7 +16,7 @@ impl<'data> Deref for BytesRef<'data> {
     }
 }
 
-impl<'data> BytesRef<'data> {
+impl BytesRef<'_> {
     pub fn to_owned(self) -> Bytes {
         Bytes::from(self.data)
     }
@@ -56,13 +56,13 @@ impl<'data> From<&'data str> for BytesRef<'data> {
     }
 }
 
-impl<'data> PartialEq<[u8]> for BytesRef<'data> {
+impl PartialEq<[u8]> for BytesRef<'_> {
     fn eq(&self, other: &[u8]) -> bool {
         self.data() == other
     }
 }
 
-impl<'data> PartialEq<&[u8]> for BytesRef<'data> {
+impl PartialEq<&[u8]> for BytesRef<'_> {
     fn eq(&self, other: &&[u8]) -> bool {
         self.data() == *other
     }
@@ -74,13 +74,13 @@ impl<'data> PartialEq<BytesRef<'data>> for [u8] {
     }
 }
 
-impl<'a, 'b> PartialEq<BytesRef<'a>> for BytesRef<'b> {
+impl<'a> PartialEq<BytesRef<'a>> for BytesRef<'_> {
     fn eq(&self, other: &BytesRef<'a>) -> bool {
         self == other.data()
     }
 }
 
-impl<'data> Display for BytesRef<'data> {
+impl Display for BytesRef<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut formatter = FmtValueFormatter { output: f };
         formatter
@@ -89,7 +89,7 @@ impl<'data> Display for BytesRef<'data> {
     }
 }
 
-impl<'data> Debug for BytesRef<'data> {
+impl Debug for BytesRef<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         const NUM_BYTES_TO_SHOW: usize = 32;
         let data = self.data;

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -358,7 +358,7 @@ impl<'top> LazyRawFieldExpr<'top, BinaryEncoding_1_0> {
     }
 }
 
-impl<'top, D: Decoder> HasRange for LazyRawFieldExpr<'top, D> {
+impl<D: Decoder> HasRange for LazyRawFieldExpr<'_, D> {
     // This type does not offer a `span()` method to get the bytes of the entire field.
     // In the case of a name/value or name/eexp pair, text parsers would need to provide a span that
     // included the interstitial whitespace and delimiting `:` between the name and value,

--- a/src/lazy/encoder/binary/v1_0/container_writers.rs
+++ b/src/lazy/encoder/binary/v1_0/container_writers.rs
@@ -197,7 +197,7 @@ impl<'value, 'top> BinaryListWriter_1_0<'value, 'top> {
     }
 }
 
-impl<'value, 'top> MakeValueWriter for BinaryListWriter_1_0<'value, 'top> {
+impl<'top> MakeValueWriter for BinaryListWriter_1_0<'_, 'top> {
     type ValueWriter<'a> = BinaryValueWriter_1_0<'a, 'top> where Self: 'a;
 
     fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
@@ -208,7 +208,7 @@ impl<'value, 'top> MakeValueWriter for BinaryListWriter_1_0<'value, 'top> {
     }
 }
 
-impl<'value, 'top> SequenceWriter for BinaryListWriter_1_0<'value, 'top> {
+impl SequenceWriter for BinaryListWriter_1_0<'_, '_> {
     type Resources = ();
 
     fn close(self) -> IonResult<Self::Resources> {
@@ -216,7 +216,7 @@ impl<'value, 'top> SequenceWriter for BinaryListWriter_1_0<'value, 'top> {
     }
 }
 
-impl<'value, 'top> MakeValueWriter for BinarySExpWriter_1_0<'value, 'top> {
+impl<'top> MakeValueWriter for BinarySExpWriter_1_0<'_, 'top> {
     type ValueWriter<'a> = BinaryValueWriter_1_0<'a, 'top> where Self: 'a;
 
     fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
@@ -227,7 +227,7 @@ impl<'value, 'top> MakeValueWriter for BinarySExpWriter_1_0<'value, 'top> {
     }
 }
 
-impl<'value, 'top> SequenceWriter for BinarySExpWriter_1_0<'value, 'top> {
+impl SequenceWriter for BinarySExpWriter_1_0<'_, '_> {
     type Resources = ();
 
     fn close(self) -> IonResult<Self::Resources> {
@@ -306,7 +306,7 @@ impl<'value, 'top> BinaryStructWriter_1_0<'value, 'top> {
     }
 }
 
-impl<'value, 'top> FieldEncoder for BinaryStructWriter_1_0<'value, 'top> {
+impl FieldEncoder for BinaryStructWriter_1_0<'_, '_> {
     fn encode_field_name(&mut self, name: impl AsRawSymbolRef) -> IonResult<()> {
         // Write the field name
         let sid = match name.as_raw_symbol_ref() {
@@ -322,7 +322,7 @@ impl<'value, 'top> FieldEncoder for BinaryStructWriter_1_0<'value, 'top> {
     }
 }
 
-impl<'value, 'top> MakeValueWriter for BinaryStructWriter_1_0<'value, 'top> {
+impl<'top> MakeValueWriter for BinaryStructWriter_1_0<'_, 'top> {
     type ValueWriter<'a> = BinaryValueWriter_1_0<'a, 'top>
     where
         Self: 'a;
@@ -335,7 +335,7 @@ impl<'value, 'top> MakeValueWriter for BinaryStructWriter_1_0<'value, 'top> {
     }
 }
 
-impl<'value, 'top> StructWriter for BinaryStructWriter_1_0<'value, 'top> {
+impl StructWriter for BinaryStructWriter_1_0<'_, '_> {
     fn close(self) -> IonResult<()> {
         self.container_writer.end()
     }

--- a/src/lazy/encoder/binary/v1_0/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_0/value_writer.rs
@@ -262,9 +262,9 @@ impl<'value, 'top> BinaryValueWriter_1_0<'value, 'top> {
     }
 }
 
-impl<'value, 'top> Sealed for BinaryValueWriter_1_0<'value, 'top> {}
+impl Sealed for BinaryValueWriter_1_0<'_, '_> {}
 
-impl<'value, 'top> AnnotatableWriter for BinaryValueWriter_1_0<'value, 'top> {
+impl<'top> AnnotatableWriter for BinaryValueWriter_1_0<'_, 'top> {
     type AnnotatedValueWriter<'a> = BinaryAnnotatedValueWriter_1_0<'a, 'top> where Self: 'a;
 
     fn with_annotations<'a>(
@@ -335,7 +335,7 @@ macro_rules! annotate_and_delegate_1_0 {
     };
 }
 
-impl<'value, 'top> BinaryAnnotatedValueWriter_1_0<'value, 'top> {
+impl BinaryAnnotatedValueWriter_1_0<'_, '_> {
     pub(crate) fn annotate_encoded_value(&mut self, encoded_value: &[u8]) -> IonResult<()> {
         if self.annotations.is_empty() {
             self.output_buffer.extend_from_slice(encoded_value);
@@ -384,11 +384,11 @@ impl<'value, 'top> BinaryAnnotatedValueWriter_1_0<'value, 'top> {
     }
 }
 
-impl<'value, 'top> Sealed for BinaryAnnotatedValueWriter_1_0<'value, 'top> {
+impl Sealed for BinaryAnnotatedValueWriter_1_0<'_, '_> {
     // No methods, precludes implementations outside the crate.
 }
 
-impl<'value, 'top> AnnotatableWriter for BinaryAnnotatedValueWriter_1_0<'value, 'top> {
+impl<'top> AnnotatableWriter for BinaryAnnotatedValueWriter_1_0<'_, 'top> {
     type AnnotatedValueWriter<'a> = BinaryAnnotatedValueWriter_1_0<'a, 'top> where Self: 'a;
 
     fn with_annotations<'a>(

--- a/src/lazy/encoder/binary/v1_1/container_writers.rs
+++ b/src/lazy/encoder/binary/v1_1/container_writers.rs
@@ -31,7 +31,7 @@ enum ContainerEncodingKind<'value, 'top> {
     LengthPrefixed(LengthPrefixedEncoder<'value, 'top>),
 }
 
-impl<'value, 'top> ContainerEncodingKind<'value, 'top> {
+impl<'top> ContainerEncodingKind<'_, 'top> {
     fn target_buffer(&mut self) -> &mut BumpVec<'top, u8> {
         match self {
             ContainerEncodingKind::Delimited(encoder) => encoder.buffer,
@@ -202,7 +202,7 @@ impl<'value, 'top> BinaryListWriter_1_1<'value, 'top> {
     }
 }
 
-impl<'value, 'top> MakeValueWriter for BinaryListWriter_1_1<'value, 'top> {
+impl<'top> MakeValueWriter for BinaryListWriter_1_1<'_, 'top> {
     type ValueWriter<'a> = BinaryValueWriter_1_1<'a, 'top> where Self: 'a;
 
     fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
@@ -210,7 +210,7 @@ impl<'value, 'top> MakeValueWriter for BinaryListWriter_1_1<'value, 'top> {
     }
 }
 
-impl<'value, 'top> SequenceWriter for BinaryListWriter_1_1<'value, 'top> {
+impl SequenceWriter for BinaryListWriter_1_1<'_, '_> {
     type Resources = ();
 
     fn write<V: WriteAsIon>(&mut self, value: V) -> IonResult<&mut Self> {
@@ -267,7 +267,7 @@ impl<'value, 'top> BinarySExpWriter_1_1<'value, 'top> {
     }
 }
 
-impl<'value, 'top> MakeValueWriter for BinarySExpWriter_1_1<'value, 'top> {
+impl<'top> MakeValueWriter for BinarySExpWriter_1_1<'_, 'top> {
     type ValueWriter<'a> = BinaryValueWriter_1_1<'a, 'top> where Self: 'a;
 
     fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
@@ -280,7 +280,7 @@ impl<'value, 'top> MakeValueWriter for BinarySExpWriter_1_1<'value, 'top> {
     }
 }
 
-impl<'value, 'top> SequenceWriter for BinarySExpWriter_1_1<'value, 'top> {
+impl SequenceWriter for BinarySExpWriter_1_1<'_, '_> {
     type Resources = ();
 
     fn write<V: WriteAsIon>(&mut self, value: V) -> IonResult<&mut Self> {
@@ -348,7 +348,7 @@ impl<'value, 'top> BinaryStructWriter_1_1<'value, 'top> {
     }
 }
 
-impl<'value, 'top> FieldEncoder for BinaryStructWriter_1_1<'value, 'top> {
+impl FieldEncoder for BinaryStructWriter_1_1<'_, '_> {
     #[inline]
     fn encode_field_name(&mut self, name: impl AsRawSymbolRef) -> IonResult<()> {
         use crate::raw_symbol_ref::RawSymbolRef::*;
@@ -373,7 +373,7 @@ impl<'value, 'top> FieldEncoder for BinaryStructWriter_1_1<'value, 'top> {
     }
 }
 
-impl<'value, 'top> MakeValueWriter for BinaryStructWriter_1_1<'value, 'top> {
+impl<'top> MakeValueWriter for BinaryStructWriter_1_1<'_, 'top> {
     type ValueWriter<'a> = BinaryValueWriter_1_1<'a, 'top>
     where
         Self: 'a,;
@@ -383,7 +383,7 @@ impl<'value, 'top> MakeValueWriter for BinaryStructWriter_1_1<'value, 'top> {
     }
 }
 
-impl<'value, 'top> StructWriter for BinaryStructWriter_1_1<'value, 'top> {
+impl StructWriter for BinaryStructWriter_1_1<'_, '_> {
     fn close(mut self) -> IonResult<()> {
         if let ContainerEncodingKind::Delimited(_) = &mut self.container_writer.encoder {
             // Write the FlexSym escape (FlexUInt 0). The container writer can emit the closing
@@ -418,7 +418,7 @@ impl<'value, 'top> BinaryEExpWriter_1_1<'value, 'top> {
     }
 }
 
-impl<'value, 'top> MakeValueWriter for BinaryEExpWriter_1_1<'value, 'top> {
+impl<'top> MakeValueWriter for BinaryEExpWriter_1_1<'_, 'top> {
     type ValueWriter<'a> = BinaryValueWriter_1_1<'a, 'top> where Self: 'a;
 
     fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
@@ -426,7 +426,7 @@ impl<'value, 'top> MakeValueWriter for BinaryEExpWriter_1_1<'value, 'top> {
     }
 }
 
-impl<'value, 'top> SequenceWriter for BinaryEExpWriter_1_1<'value, 'top> {
+impl SequenceWriter for BinaryEExpWriter_1_1<'_, '_> {
     type Resources = ();
 
     fn close(self) -> IonResult<Self::Resources> {
@@ -436,7 +436,7 @@ impl<'value, 'top> SequenceWriter for BinaryEExpWriter_1_1<'value, 'top> {
     }
 }
 
-impl<'value, 'top> EExpWriter for BinaryEExpWriter_1_1<'value, 'top> {
+impl EExpWriter for BinaryEExpWriter_1_1<'_, '_> {
     fn write_flex_uint(&mut self, value: impl Into<UInt>) -> IonResult<()> {
         FlexUInt::write(self.buffer, value)?;
         Ok(())

--- a/src/lazy/encoder/binary/v1_1/flex_int.rs
+++ b/src/lazy/encoder/binary/v1_1/flex_int.rs
@@ -74,7 +74,7 @@ impl FlexInt {
     // memory errors and the like), which eliminates some branching, a loop inside
     // `io::Write::write_all`, and the construction of a return value.
     #[inline]
-    pub fn encode_i64(output: &mut BumpVec<u8>, value: i64) {
+    pub fn encode_i64(output: &mut BumpVec<'_, u8>, value: i64) {
         let encoded_size_in_bytes = if value < 0 {
             BYTES_NEEDED_CACHE[value.leading_ones() as usize]
         } else {

--- a/src/lazy/encoder/binary/v1_1/flex_sym.rs
+++ b/src/lazy/encoder/binary/v1_1/flex_sym.rs
@@ -28,7 +28,7 @@ impl<'top> FlexSym<'top> {
     pub const ZERO: u8 = 0x01;
 
     /// Encode the provided `symbol` as a FlexSym and write it to the provided [`BumpVec`].
-    pub fn encode_symbol(output: &mut BumpVec<u8>, symbol: impl AsRawSymbolRef) {
+    pub fn encode_symbol(output: &mut BumpVec<'_, u8>, symbol: impl AsRawSymbolRef) {
         let symbol_token = symbol.as_raw_symbol_ref();
         // Write the field name
         use RawSymbolRef::*;
@@ -49,7 +49,7 @@ impl<'top> FlexSym<'top> {
 
     /// Encodes the empty string, symbol ID zero, or a system symbol as a FlexSym. The caller is
     /// responsible for confirming that `symbol` is one of these three cases before calling.
-    fn encode_special_case(output: &mut BumpVec<u8>, symbol: RawSymbolRef) {
+    fn encode_special_case(output: &mut BumpVec<'_, u8>, symbol: RawSymbolRef<'_>) {
         use RawSymbolRef::*;
         let encoding: &[u8] = match symbol {
             // Per this method's preconditions, this branch must be SymbolId zero.

--- a/src/lazy/encoder/binary/v1_1/flex_uint.rs
+++ b/src/lazy/encoder/binary/v1_1/flex_uint.rs
@@ -274,7 +274,7 @@ impl FlexUInt {
     }
 
     #[inline]
-    pub(crate) fn encode_opcode_and_length(output: &mut BumpVec<u8>, opcode: u8, length: u64) {
+    pub(crate) fn encode_opcode_and_length(output: &mut BumpVec<'_, u8>, opcode: u8, length: u64) {
         // In the common case, the length fits in a single FlexUInt byte. We can perform a single
         // `reserve`/`memcopy` to get both the opcode and the length into the buffer.
         if length < 127 {

--- a/src/lazy/encoder/binary/v1_1/flex_uint.rs
+++ b/src/lazy/encoder/binary/v1_1/flex_uint.rs
@@ -15,7 +15,7 @@ const fn init_bytes_needed_cache() -> [u8; 129] {
     while leading_zeros < BITS_PER_U128 {
         let magnitude_bits_needed = 128 - leading_zeros;
         cache[leading_zeros] =
-            ((magnitude_bits_needed + BITS_PER_ENCODED_BYTE - 1) / BITS_PER_ENCODED_BYTE) as u8;
+            magnitude_bits_needed.div_ceil(BITS_PER_ENCODED_BYTE) as u8;
         leading_zeros += 1;
     }
     // Special case: 128 leading zeros means it's `0i128`, which requires one byte.

--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -739,7 +739,9 @@ impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
 impl<'value, 'top> Sealed for BinaryValueWriter_1_1<'value, 'top> {}
 
 impl<'value, 'top> AnnotatableWriter for BinaryValueWriter_1_1<'value, 'top> {
-    type AnnotatedValueWriter<'a> = BinaryAnnotatedValueWriter_1_1<'a, 'top> where
+    type AnnotatedValueWriter<'a>
+        = BinaryAnnotatedValueWriter_1_1<'a, 'top>
+    where
         Self: 'a;
 
     fn with_annotations<'a>(
@@ -850,7 +852,10 @@ impl<'value, 'top> Sealed for BinaryAnnotatedValueWriter_1_1<'value, 'top> {
 }
 
 impl<'value, 'top> AnnotatableWriter for BinaryAnnotatedValueWriter_1_1<'value, 'top> {
-    type AnnotatedValueWriter<'a> = BinaryAnnotatedValueWriter_1_1<'a, 'top> where Self: 'a;
+    type AnnotatedValueWriter<'a>
+        = BinaryAnnotatedValueWriter_1_1<'a, 'top>
+    where
+        Self: 'a;
 
     fn with_annotations<'a>(
         self,
@@ -2474,7 +2479,7 @@ mod tests {
     #[test]
     fn write_length_prefixed_structs() -> IonResult<()> {
         #[rustfmt::skip]
-        let test_cases: &[(TestStruct, &[u8])] = &[
+        let test_cases: &[(TestStruct<'_>, &[u8])] = &[
             // Empty struct
             (&[], &[0xD0]),
             // Struct with a single FlexUInt field name
@@ -2598,7 +2603,7 @@ mod tests {
     #[test]
     fn write_delimited_structs() -> IonResult<()> {
         #[rustfmt::skip]
-            let test_cases: &[(TestStruct, &[u8])] = &[
+            let test_cases: &[(TestStruct<'_>, &[u8])] = &[
             // Empty struct
             (&[], &[0xF3, 0x01, 0xF0]),
             // Struct with a single symbol ID field name

--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -36,7 +36,7 @@ pub struct BinaryValueWriter_1_1<'value, 'top> {
     value_writer_config: ValueWriterConfig,
 }
 
-impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
+impl BinaryValueWriter_1_1<'_, '_> {
     pub fn new<'a, 'b: 'a>(
         allocator: &'b BumpAllocator,
         encoding_buffer: &'a mut BumpVec<'b, u8>,
@@ -736,9 +736,9 @@ impl<'value, 'top> BinaryValueWriter_1_1<'value, 'top> {
     }
 }
 
-impl<'value, 'top> Sealed for BinaryValueWriter_1_1<'value, 'top> {}
+impl Sealed for BinaryValueWriter_1_1<'_, '_> {}
 
-impl<'value, 'top> AnnotatableWriter for BinaryValueWriter_1_1<'value, 'top> {
+impl<'top> AnnotatableWriter for BinaryValueWriter_1_1<'_, 'top> {
     type AnnotatedValueWriter<'a>
         = BinaryAnnotatedValueWriter_1_1<'a, 'top>
     where
@@ -800,7 +800,7 @@ pub struct BinaryAnnotatedValueWriter_1_1<'value, 'top> {
     value_writer_config: ValueWriterConfig,
 }
 
-impl<'value, 'top> BinaryAnnotatedValueWriter_1_1<'value, 'top> {
+impl<'top> BinaryAnnotatedValueWriter_1_1<'_, 'top> {
     fn encode_annotations(&mut self) {
         match self.annotations.as_slice() {
             [] => {
@@ -847,11 +847,11 @@ impl<'value, 'top> BinaryAnnotatedValueWriter_1_1<'value, 'top> {
     }
 }
 
-impl<'value, 'top> Sealed for BinaryAnnotatedValueWriter_1_1<'value, 'top> {
+impl Sealed for BinaryAnnotatedValueWriter_1_1<'_, '_> {
     // No methods, precludes implementations outside the crate.
 }
 
-impl<'value, 'top> AnnotatableWriter for BinaryAnnotatedValueWriter_1_1<'value, 'top> {
+impl<'top> AnnotatableWriter for BinaryAnnotatedValueWriter_1_1<'_, 'top> {
     type AnnotatedValueWriter<'a>
         = BinaryAnnotatedValueWriter_1_1<'a, 'top>
     where
@@ -2458,7 +2458,7 @@ mod tests {
 
     /// A list of field name/value pairs that will be serialized as a struct in each test.
     type TestStruct<'a> = &'a [(RawSymbolRef<'a>, Element)];
-    impl<'a> WriteAsIon for TestStruct<'a> {
+    impl WriteAsIon for TestStruct<'_> {
         fn write_as_ion<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
             let mut struct_writer = writer.struct_writer()?;
             for (name, value) in self.iter() {

--- a/src/lazy/encoder/binary/v1_1/writer.rs
+++ b/src/lazy/encoder/binary/v1_1/writer.rs
@@ -97,7 +97,7 @@ impl<W: Write> LazyRawBinaryWriter_1_1<W> {
             Some(ptr) => unsafe { ptr_to_mut_ref::<'_, BumpVec<'_, u8>>(ptr) },
             // Otherwise, allocate a new encoding buffer and set the pointer to refer to it.
             None => {
-                let buffer: &mut BumpVec<u8> = self.allocator.alloc_with(|| {
+                let buffer: &mut BumpVec<'_, u8> = self.allocator.alloc_with(|| {
                     // Use half of the bump allocator's backing array as an encoding space for this
                     // top level value. The other half of the bump can be used for incidental
                     // bookkeeping.
@@ -163,7 +163,10 @@ impl<W: Write> LazyRawWriter<W> for LazyRawBinaryWriter_1_1<W> {
 }
 
 impl<W: Write> MakeValueWriter for LazyRawBinaryWriter_1_1<W> {
-    type ValueWriter<'a> = BinaryValueWriter_1_1<'a, 'a> where Self: 'a;
+    type ValueWriter<'a>
+        = BinaryValueWriter_1_1<'a, 'a>
+    where
+        Self: 'a;
 
     fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
         self.value_writer()

--- a/src/lazy/encoder/text/v1_0/value_writer.rs
+++ b/src/lazy/encoder/text/v1_0/value_writer.rs
@@ -89,7 +89,7 @@ impl<'value, W: Write + 'value> TextValueWriter_1_0<'value, W> {
     }
 }
 
-impl<'value, W: Write> TextValueWriter_1_0<'value, W> {
+impl<W: Write> TextValueWriter_1_0<'_, W> {
     fn output(&mut self) -> &mut W {
         &mut self.writer.output
     }
@@ -149,7 +149,7 @@ impl<'value, W: Write> TextAnnotatedValueWriter_1_0<'value, W> {
 
 impl<'value, W: Write + 'value> Sealed for TextAnnotatedValueWriter_1_0<'value, W> {}
 
-impl<'value, W: Write> Sealed for TextValueWriter_1_0<'value, W> {}
+impl<W: Write> Sealed for TextValueWriter_1_0<'_, W> {}
 
 /// Helper type that is home to information and behavior common to the list writer, s-expression writer,
 /// and struct writer.
@@ -296,7 +296,7 @@ impl<'top, W: Write> TextListWriter_1_0<'top, W> {
     }
 }
 
-impl<'top, W: Write> MakeValueWriter for TextListWriter_1_0<'top, W> {
+impl<W: Write> MakeValueWriter for TextListWriter_1_0<'_, W> {
     type ValueWriter<'a> = TextValueWriter_1_0<'a, W> where Self: 'a;
 
     fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
@@ -304,7 +304,7 @@ impl<'top, W: Write> MakeValueWriter for TextListWriter_1_0<'top, W> {
     }
 }
 
-impl<'top, W: Write> SequenceWriter for TextListWriter_1_0<'top, W> {
+impl<W: Write> SequenceWriter for TextListWriter_1_0<'_, W> {
     type Resources = ();
 
     fn write<V: WriteAsIon>(&mut self, value: V) -> IonResult<&mut Self> {
@@ -353,7 +353,7 @@ impl<'a, W: Write> TextSExpWriter_1_0<'a, W> {
     }
 }
 
-impl<'value, W: Write> MakeValueWriter for TextSExpWriter_1_0<'value, W> {
+impl<W: Write> MakeValueWriter for TextSExpWriter_1_0<'_, W> {
     type ValueWriter<'a> = TextValueWriter_1_0<'a, W> where Self: 'a;
 
     fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
@@ -361,7 +361,7 @@ impl<'value, W: Write> MakeValueWriter for TextSExpWriter_1_0<'value, W> {
     }
 }
 
-impl<'a, W: Write> SequenceWriter for TextSExpWriter_1_0<'a, W> {
+impl<W: Write> SequenceWriter for TextSExpWriter_1_0<'_, W> {
     type Resources = ();
 
     delegate! {
@@ -405,7 +405,7 @@ impl<'a, W: Write> TextStructWriter_1_0<'a, W> {
     }
 }
 
-impl<'a, W: Write> FieldEncoder for TextStructWriter_1_0<'a, W> {
+impl<W: Write> FieldEncoder for TextStructWriter_1_0<'_, W> {
     fn encode_field_name(&mut self, name: impl AsRawSymbolRef) -> IonResult<()> {
         // Leading indentation for the current depth
         self.container_writer
@@ -422,7 +422,7 @@ impl<'a, W: Write> FieldEncoder for TextStructWriter_1_0<'a, W> {
     }
 }
 
-impl<'value, W: Write> MakeValueWriter for TextStructWriter_1_0<'value, W> {
+impl<W: Write> MakeValueWriter for TextStructWriter_1_0<'_, W> {
     type ValueWriter<'a> = TextValueWriter_1_0<'a, W>
     where
         Self: 'a;
@@ -438,7 +438,7 @@ impl<'value, W: Write> MakeValueWriter for TextStructWriter_1_0<'value, W> {
     }
 }
 
-impl<'value, W: Write> StructWriter for TextStructWriter_1_0<'value, W> {
+impl<W: Write> StructWriter for TextStructWriter_1_0<'_, W> {
     fn close(self) -> IonResult<()> {
         self.end()
     }
@@ -476,7 +476,7 @@ impl<'value, W: Write + 'value> ValueWriter for TextAnnotatedValueWriter_1_0<'va
     delegate_value_writer_to!(fallible closure |self_: Self| self_.encode_annotations());
 }
 
-impl<'value, W: Write> AnnotatableWriter for TextValueWriter_1_0<'value, W> {
+impl<W: Write> AnnotatableWriter for TextValueWriter_1_0<'_, W> {
     type AnnotatedValueWriter<'a> = TextAnnotatedValueWriter_1_0<'a, W> where Self: 'a;
 
     fn with_annotations<'a>(
@@ -607,7 +607,7 @@ impl<'value, W: Write> ValueWriter for TextValueWriter_1_0<'value, W> {
         // This type exists solely to enable using the IonValueFormatter (which operates on
         // `std::fmt::Write`) to write to a `std::io::Write`.
         struct ClobShim<'a>(&'a [u8]);
-        impl<'a> std::fmt::Display for ClobShim<'a> {
+        impl std::fmt::Display for ClobShim<'_> {
             fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
                 let mut formatter = FmtValueFormatter { output: f };
                 formatter.format_clob(self.0)?;

--- a/src/lazy/encoder/text/v1_0/value_writer.rs
+++ b/src/lazy/encoder/text/v1_0/value_writer.rs
@@ -22,7 +22,7 @@ use crate::{
     v1_0, Decimal, Encoding, Int, IonResult, IonType, RawSymbolRef, Timestamp, ValueWriterConfig,
 };
 
-pub struct TextValueWriter_1_0<'value, W: Write + 'value> {
+pub struct TextValueWriter_1_0<'value, W: Write> {
     pub(crate) writer: &'value mut LazyRawTextWriter_1_0<W>,
     pub(crate) depth: usize,
     value_delimiter: &'static str,

--- a/src/lazy/encoder/text/v1_1/value_writer.rs
+++ b/src/lazy/encoder/text/v1_1/value_writer.rs
@@ -16,11 +16,11 @@ use crate::{v1_1, Decimal, Encoding, Int, IonResult, IonType, Timestamp, ValueWr
 use delegate::delegate;
 use std::io::Write;
 
-pub struct TextValueWriter_1_1<'value, W: Write + 'value> {
+pub struct TextValueWriter_1_1<'value, W: Write> {
     pub(crate) value_writer_1_0: TextValueWriter_1_0<'value, W>,
 }
 
-pub struct TextAnnotatedValueWriter_1_1<'value, W: Write + 'value> {
+pub struct TextAnnotatedValueWriter_1_1<'value, W: Write> {
     value_writer_1_0: TextAnnotatedValueWriter_1_0<'value, W>,
 }
 

--- a/src/lazy/encoder/text/v1_1/value_writer.rs
+++ b/src/lazy/encoder/text/v1_1/value_writer.rs
@@ -166,7 +166,7 @@ pub struct TextListWriter_1_1<'value, W: Write> {
     writer_1_0: TextListWriter_1_0<'value, W>,
 }
 
-impl<'value, W: Write> MakeValueWriter for TextListWriter_1_1<'value, W> {
+impl<W: Write> MakeValueWriter for TextListWriter_1_1<'_, W> {
     type ValueWriter<'a> = TextValueWriter_1_1<'a, W> where Self: 'a;
 
     fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
@@ -176,7 +176,7 @@ impl<'value, W: Write> MakeValueWriter for TextListWriter_1_1<'value, W> {
     }
 }
 
-impl<'value, W: Write> SequenceWriter for TextListWriter_1_1<'value, W> {
+impl<W: Write> SequenceWriter for TextListWriter_1_1<'_, W> {
     type Resources = ();
 
     fn close(self) -> IonResult<Self::Resources> {
@@ -188,7 +188,7 @@ pub struct TextSExpWriter_1_1<'value, W: Write> {
     writer_1_0: TextSExpWriter_1_0<'value, W>,
 }
 
-impl<'value, W: Write> MakeValueWriter for TextSExpWriter_1_1<'value, W> {
+impl<W: Write> MakeValueWriter for TextSExpWriter_1_1<'_, W> {
     type ValueWriter<'a> = TextValueWriter_1_1<'a, W> where Self: 'a;
 
     fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
@@ -198,7 +198,7 @@ impl<'value, W: Write> MakeValueWriter for TextSExpWriter_1_1<'value, W> {
     }
 }
 
-impl<'value, W: Write> SequenceWriter for TextSExpWriter_1_1<'value, W> {
+impl<W: Write> SequenceWriter for TextSExpWriter_1_1<'_, W> {
     type Resources = ();
 
     fn close(self) -> IonResult<Self::Resources> {
@@ -210,13 +210,13 @@ pub struct TextStructWriter_1_1<'value, W: Write> {
     writer_1_0: TextStructWriter_1_0<'value, W>,
 }
 
-impl<'value, W: Write> FieldEncoder for TextStructWriter_1_1<'value, W> {
+impl<W: Write> FieldEncoder for TextStructWriter_1_1<'_, W> {
     fn encode_field_name(&mut self, name: impl AsRawSymbolRef) -> IonResult<()> {
         self.writer_1_0.encode_field_name(name)
     }
 }
 
-impl<'value, W: Write> MakeValueWriter for TextStructWriter_1_1<'value, W> {
+impl<W: Write> MakeValueWriter for TextStructWriter_1_1<'_, W> {
     type ValueWriter<'a> = TextValueWriter_1_1<'a, W> where Self: 'a;
 
     fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
@@ -226,7 +226,7 @@ impl<'value, W: Write> MakeValueWriter for TextStructWriter_1_1<'value, W> {
     }
 }
 
-impl<'value, W: Write> StructWriter for TextStructWriter_1_1<'value, W> {
+impl<W: Write> StructWriter for TextStructWriter_1_1<'_, W> {
     fn close(self) -> IonResult<()> {
         self.writer_1_0.close()
     }

--- a/src/lazy/encoder/value_writer.rs
+++ b/src/lazy/encoder/value_writer.rs
@@ -218,8 +218,8 @@ impl<'field, StructWriterType> FieldWriter<'field, StructWriterType> {
     }
 }
 
-impl<'field, StructWriterType: StructWriter> AnnotatableWriter
-    for FieldWriter<'field, StructWriterType>
+impl<StructWriterType: StructWriter> AnnotatableWriter
+    for FieldWriter<'_, StructWriterType>
 {
     type AnnotatedValueWriter<'a> = AnnotatedFieldWriter<'a, StructWriterType> where Self: 'a;
 
@@ -275,8 +275,8 @@ impl<'field, StructWriterType: StructWriter> AnnotatedFieldWriter<'field, Struct
     }
 }
 
-impl<'field, StructWriterType: StructWriter> AnnotatableWriter
-    for AnnotatedFieldWriter<'field, StructWriterType>
+impl<StructWriterType: StructWriter> AnnotatableWriter
+    for AnnotatedFieldWriter<'_, StructWriterType>
 {
     type AnnotatedValueWriter<'a> = AnnotatedFieldWriter<'a, StructWriterType> where Self: 'a;
 

--- a/src/lazy/encoder/write_as_ion.rs
+++ b/src/lazy/encoder/write_as_ion.rs
@@ -321,7 +321,7 @@ impl<'a, D: Decoder> WriteAsIon for RawValueRef<'a, D> {
             Struct(s) => {
                 let mut struct_writer = value_writer.struct_writer()?;
                 for field_result in s.iter() {
-                    let field: LazyRawFieldExpr<D> = field_result?;
+                    let field: LazyRawFieldExpr<'_, D> = field_result?;
                     match field {
                         LazyRawFieldExpr::NameValue(name, value) => {
                             struct_writer.write(name.read()?, WriteableRawValue::new(value))?;

--- a/src/lazy/encoder/write_as_ion.rs
+++ b/src/lazy/encoder/write_as_ion.rs
@@ -144,14 +144,14 @@ impl_write_as_ion_value!(
     Clob => write_clob,
 );
 
-impl<'b> WriteAsIon for RawSymbolRef<'b> {
+impl WriteAsIon for RawSymbolRef<'_> {
     #[inline]
     fn write_as_ion<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
         writer.write_symbol(self)
     }
 }
 
-impl<'b> WriteAsIon for SymbolRef<'b> {
+impl WriteAsIon for SymbolRef<'_> {
     #[inline]
     fn write_as_ion<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
         writer.write_symbol(self)
@@ -275,7 +275,7 @@ impl WriteAsIon for Value {
     }
 }
 
-impl<'a, D: Decoder> WriteAsIon for LazyValue<'a, D> {
+impl<D: Decoder> WriteAsIon for LazyValue<'_, D> {
     fn write_as_ion<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
         if self.has_annotations() {
             let mut annotations = AnnotationsVec::new();
@@ -290,7 +290,7 @@ impl<'a, D: Decoder> WriteAsIon for LazyValue<'a, D> {
     }
 }
 
-impl<'a, D: Decoder> WriteAsIon for RawValueRef<'a, D> {
+impl<D: Decoder> WriteAsIon for RawValueRef<'_, D> {
     fn write_as_ion<V: ValueWriter>(&self, value_writer: V) -> IonResult<()> {
         use RawValueRef::*;
         match self {
@@ -419,7 +419,7 @@ impl<'a, D: Decoder> WriteableEExpArg<'a, D> {
     }
 }
 
-impl<'a, D: Decoder> WriteAsIon for WriteableEExpArg<'a, D> {
+impl<D: Decoder> WriteAsIon for WriteableEExpArg<'_, D> {
     fn write_as_ion<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
         use EExpArgExpr::*;
         match self.arg_expr.expr() {
@@ -446,7 +446,7 @@ impl<'a, D: Decoder> WriteableEExpArgGroup<'a, D> {
     }
 }
 
-impl<'a, D: Decoder> WriteAsIon for WriteableEExpArgGroup<'a, D> {
+impl<D: Decoder> WriteAsIon for WriteableEExpArgGroup<'_, D> {
     fn write_as_ion<V: ValueWriter>(&self, _writer: V) -> IonResult<()> {
         todo!()
     }
@@ -467,7 +467,7 @@ impl<'a, D: Decoder> WriteableRawValueExpr<'a, D> {
     }
 }
 
-impl<'a, D: Decoder> WriteAsIon for WriteableRawValueExpr<'a, D> {
+impl<D: Decoder> WriteAsIon for WriteableRawValueExpr<'_, D> {
     fn write_as_ion<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
         use RawValueExpr::*;
         match self.raw_value_expr {
@@ -477,7 +477,7 @@ impl<'a, D: Decoder> WriteAsIon for WriteableRawValueExpr<'a, D> {
     }
 }
 
-impl<'a, D: Decoder> WriteAsIon for ValueRef<'a, D> {
+impl<D: Decoder> WriteAsIon for ValueRef<'_, D> {
     fn write_as_ion<V: ValueWriter>(&self, value_writer: V) -> IonResult<()> {
         use ValueRef::*;
         match self {
@@ -498,7 +498,7 @@ impl<'a, D: Decoder> WriteAsIon for ValueRef<'a, D> {
     }
 }
 
-impl<'top, D: Decoder> WriteAsIon for LazyList<'top, D> {
+impl<D: Decoder> WriteAsIon for LazyList<'_, D> {
     fn write_as_ion<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
         let mut list = writer.list_writer()?;
         for value in self {
@@ -508,7 +508,7 @@ impl<'top, D: Decoder> WriteAsIon for LazyList<'top, D> {
     }
 }
 
-impl<'top, D: Decoder> WriteAsIon for LazySExp<'top, D> {
+impl<D: Decoder> WriteAsIon for LazySExp<'_, D> {
     fn write_as_ion<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
         let mut sexp = writer.sexp_writer()?;
         for value in self {
@@ -518,7 +518,7 @@ impl<'top, D: Decoder> WriteAsIon for LazySExp<'top, D> {
     }
 }
 
-impl<'top, D: Decoder> WriteAsIon for LazyStruct<'top, D> {
+impl<D: Decoder> WriteAsIon for LazyStruct<'_, D> {
     fn write_as_ion<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
         let mut struct_writer = writer.struct_writer()?;
         for field_result in self {

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -185,7 +185,8 @@ impl<E: Encoding, Output: Write> Writer<E, Output> {
 }
 
 impl<E: Encoding, Output: Write> MakeValueWriter for Writer<E, Output> {
-    type ValueWriter<'a> = ApplicationValueWriter<'a, <E::Writer<Vec<u8>> as MakeValueWriter>::ValueWriter<'a>>
+    type ValueWriter<'a>
+        = ApplicationValueWriter<'a, <E::Writer<Vec<u8>> as MakeValueWriter>::ValueWriter<'a>>
     where
         Self: 'a;
 
@@ -260,7 +261,10 @@ impl<'a, 'value, 'top> ApplicationValueWriter<'a, BinaryValueWriter_1_1<'value, 
 }
 
 impl<'value, V: ValueWriter> AnnotatableWriter for ApplicationValueWriter<'value, V> {
-    type AnnotatedValueWriter<'a> = ApplicationValueWriter<'a, V::AnnotatedValueWriter<'a>> where Self: 'a;
+    type AnnotatedValueWriter<'a>
+        = ApplicationValueWriter<'a, V::AnnotatedValueWriter<'a>>
+    where
+        Self: 'a;
 
     fn with_annotations<'a>(
         mut self,
@@ -532,7 +536,8 @@ impl<'value, V: ValueWriter> ApplicationStructWriter<'value, V> {
 }
 
 impl<'value, V: ValueWriter> MakeValueWriter for ApplicationStructWriter<'value, V> {
-    type ValueWriter<'a> = ApplicationValueWriter<'a, <V::StructWriter as MakeValueWriter>::ValueWriter<'a>>
+    type ValueWriter<'a>
+        = ApplicationValueWriter<'a, <V::StructWriter as MakeValueWriter>::ValueWriter<'a>>
     where
         Self: 'a;
 
@@ -577,7 +582,7 @@ impl<'value, V: ValueWriter> FieldEncoder for ApplicationStructWriter<'value, V>
         }
 
         // Otherwise, see if the symbol is already in the symbol table.
-        let token: RawSymbolRef = match self.encoding.symbol_table.sid_for(&text) {
+        let token: RawSymbolRef<'_> = match self.encoding.symbol_table.sid_for(&text) {
             // If so, use the existing ID.
             Some(sid) => sid.into(),
             // If it's not but the struct writer is configured to intern new text, add it to the
@@ -632,7 +637,8 @@ impl<'value, V: ValueWriter> ApplicationListWriter<'value, V> {
 }
 
 impl<'value, V: ValueWriter> MakeValueWriter for ApplicationListWriter<'value, V> {
-    type ValueWriter<'a> = ApplicationValueWriter<'a, <V::ListWriter as MakeValueWriter>::ValueWriter<'a>>
+    type ValueWriter<'a>
+        = ApplicationValueWriter<'a, <V::ListWriter as MakeValueWriter>::ValueWriter<'a>>
     where
         Self: 'a;
 
@@ -674,8 +680,10 @@ impl<'value, V: ValueWriter> ApplicationSExpWriter<'value, V> {
 }
 
 impl<'value, V: ValueWriter> MakeValueWriter for ApplicationSExpWriter<'value, V> {
-    type ValueWriter<'a> =
-        ApplicationValueWriter<'a, <V::SExpWriter as MakeValueWriter>::ValueWriter<'a>> where Self: 'a;
+    type ValueWriter<'a>
+        = ApplicationValueWriter<'a, <V::SExpWriter as MakeValueWriter>::ValueWriter<'a>>
+    where
+        Self: 'a;
 
     fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
         ApplicationValueWriter::new(
@@ -723,7 +731,13 @@ impl<'value, V: ValueWriter> SequenceWriter for ApplicationEExpWriter<'value, V>
 }
 
 impl<'value, V: ValueWriter> MakeValueWriter for ApplicationEExpWriter<'value, V> {
-    type ValueWriter<'a> = ApplicationValueWriter<'a, <<V as ValueWriter>::EExpWriter as MakeValueWriter>::ValueWriter<'a>> where Self: 'a;
+    type ValueWriter<'a>
+        = ApplicationValueWriter<
+        'a,
+        <<V as ValueWriter>::EExpWriter as MakeValueWriter>::ValueWriter<'a>,
+    >
+    where
+        Self: 'a;
 
     fn make_value_writer(&mut self) -> Self::ValueWriter<'_> {
         ApplicationValueWriter::new(
@@ -847,7 +861,7 @@ mod tests {
 
     fn annotations_sequence_encoding_test(
         encoding: AnnotationsEncoding,
-        sequence: &[RawSymbolRef],
+        sequence: &[RawSymbolRef<'_>],
         expected_encoding: &[u8],
     ) -> IonResult<()> {
         let mut writer = Writer::new(v1_1::Binary, Vec::new())?;
@@ -942,7 +956,7 @@ mod tests {
     /// For simplicity, the value for each field is the integer 0.
     fn struct_field_encoding_test(
         encoding: FieldNameEncoding,
-        field_names_and_encodings: &[(RawSymbolRef, &[u8])],
+        field_names_and_encodings: &[(RawSymbolRef<'_>, &[u8])],
     ) -> IonResult<()> {
         // Configure a struct writer that uses the requested field name encoding
         let mut writer = Writer::new(v1_1::Binary, Vec::new())?;

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -234,7 +234,7 @@ impl<'a, V: ValueWriter> ApplicationValueWriter<'a, V> {
     }
 }
 
-impl<'a, 'value, 'top> ApplicationValueWriter<'a, BinaryValueWriter_1_1<'value, 'top>> {
+impl ApplicationValueWriter<'_, BinaryValueWriter_1_1<'_, '_>> {
     pub fn with_container_encoding(mut self, container_encoding: ContainerEncoding) -> Self {
         self.value_writer_config = self
             .value_writer_config
@@ -260,7 +260,7 @@ impl<'a, 'value, 'top> ApplicationValueWriter<'a, BinaryValueWriter_1_1<'value, 
     }
 }
 
-impl<'value, V: ValueWriter> AnnotatableWriter for ApplicationValueWriter<'value, V> {
+impl<V: ValueWriter> AnnotatableWriter for ApplicationValueWriter<'_, V> {
     type AnnotatedValueWriter<'a>
         = ApplicationValueWriter<'a, V::AnnotatedValueWriter<'a>>
     where
@@ -297,7 +297,7 @@ impl<'value, V: ValueWriter> AnnotatableWriter for ApplicationValueWriter<'value
     }
 }
 
-impl<'value, V: ValueWriter> ApplicationValueWriter<'value, V> {
+impl<V: ValueWriter> ApplicationValueWriter<'_, V> {
     /// Converts each annotation in `annotations` to a symbol ID, adding symbols to the symbol table
     /// as necessary. If one of the annotations is a symbol ID that is not in the symbol table,
     /// returns an `Err`.
@@ -535,7 +535,7 @@ impl<'value, V: ValueWriter> ApplicationStructWriter<'value, V> {
     }
 }
 
-impl<'value, V: ValueWriter> MakeValueWriter for ApplicationStructWriter<'value, V> {
+impl<V: ValueWriter> MakeValueWriter for ApplicationStructWriter<'_, V> {
     type ValueWriter<'a>
         = ApplicationValueWriter<'a, <V::StructWriter as MakeValueWriter>::ValueWriter<'a>>
     where
@@ -550,7 +550,7 @@ impl<'value, V: ValueWriter> MakeValueWriter for ApplicationStructWriter<'value,
     }
 }
 
-impl<'value, V: ValueWriter> FieldEncoder for ApplicationStructWriter<'value, V> {
+impl<V: ValueWriter> FieldEncoder for ApplicationStructWriter<'_, V> {
     fn encode_field_name(&mut self, name: impl AsRawSymbolRef) -> IonResult<()> {
         let text = match name.as_raw_symbol_ref() {
             // This is an application-level struct writer. It is expected that method calls will
@@ -602,7 +602,7 @@ impl<'value, V: ValueWriter> FieldEncoder for ApplicationStructWriter<'value, V>
     }
 }
 
-impl<'value, V: ValueWriter> StructWriter for ApplicationStructWriter<'value, V> {
+impl<V: ValueWriter> StructWriter for ApplicationStructWriter<'_, V> {
     fn field_writer<'a>(&'a mut self, name: impl Into<RawSymbolRef<'a>>) -> FieldWriter<'a, Self> {
         FieldWriter::new(name.into(), self.value_writer_config, self)
     }
@@ -636,7 +636,7 @@ impl<'value, V: ValueWriter> ApplicationListWriter<'value, V> {
     }
 }
 
-impl<'value, V: ValueWriter> MakeValueWriter for ApplicationListWriter<'value, V> {
+impl<V: ValueWriter> MakeValueWriter for ApplicationListWriter<'_, V> {
     type ValueWriter<'a>
         = ApplicationValueWriter<'a, <V::ListWriter as MakeValueWriter>::ValueWriter<'a>>
     where
@@ -651,7 +651,7 @@ impl<'value, V: ValueWriter> MakeValueWriter for ApplicationListWriter<'value, V
     }
 }
 
-impl<'value, V: ValueWriter> SequenceWriter for ApplicationListWriter<'value, V> {
+impl<V: ValueWriter> SequenceWriter for ApplicationListWriter<'_, V> {
     type Resources = ();
 
     fn close(self) -> IonResult<Self::Resources> {
@@ -679,7 +679,7 @@ impl<'value, V: ValueWriter> ApplicationSExpWriter<'value, V> {
     }
 }
 
-impl<'value, V: ValueWriter> MakeValueWriter for ApplicationSExpWriter<'value, V> {
+impl<V: ValueWriter> MakeValueWriter for ApplicationSExpWriter<'_, V> {
     type ValueWriter<'a>
         = ApplicationValueWriter<'a, <V::SExpWriter as MakeValueWriter>::ValueWriter<'a>>
     where
@@ -694,7 +694,7 @@ impl<'value, V: ValueWriter> MakeValueWriter for ApplicationSExpWriter<'value, V
     }
 }
 
-impl<'value, V: ValueWriter> SequenceWriter for ApplicationSExpWriter<'value, V> {
+impl<V: ValueWriter> SequenceWriter for ApplicationSExpWriter<'_, V> {
     type Resources = ();
 
     fn close(self) -> IonResult<Self::Resources> {
@@ -722,7 +722,7 @@ impl<'value, V: ValueWriter> ApplicationEExpWriter<'value, V> {
     }
 }
 
-impl<'value, V: ValueWriter> SequenceWriter for ApplicationEExpWriter<'value, V> {
+impl<V: ValueWriter> SequenceWriter for ApplicationEExpWriter<'_, V> {
     type Resources = ();
 
     fn close(self) -> IonResult<Self::Resources> {
@@ -730,7 +730,7 @@ impl<'value, V: ValueWriter> SequenceWriter for ApplicationEExpWriter<'value, V>
     }
 }
 
-impl<'value, V: ValueWriter> MakeValueWriter for ApplicationEExpWriter<'value, V> {
+impl<V: ValueWriter> MakeValueWriter for ApplicationEExpWriter<'_, V> {
     type ValueWriter<'a>
         = ApplicationValueWriter<
         'a,
@@ -748,7 +748,7 @@ impl<'value, V: ValueWriter> MakeValueWriter for ApplicationEExpWriter<'value, V
     }
 }
 
-impl<'value, V: ValueWriter> EExpWriter for ApplicationEExpWriter<'value, V> {
+impl<V: ValueWriter> EExpWriter for ApplicationEExpWriter<'_, V> {
     // Default methods
     fn write_flex_uint(&mut self, value: impl Into<UInt>) -> IonResult<()> {
         self.raw_eexp_writer.write_flex_uint(value)

--- a/src/lazy/encoding.rs
+++ b/src/lazy/encoding.rs
@@ -114,8 +114,8 @@ pub struct BinaryEncoding_1_0;
 #[derive(Copy, Clone, Debug, Default)]
 pub struct BinaryEncoding_1_1;
 
-impl<'top> BinaryEncoding<'top> for BinaryEncoding_1_0 {}
-impl<'top> BinaryEncoding<'top> for BinaryEncoding_1_1 {}
+impl BinaryEncoding<'_> for BinaryEncoding_1_0 {}
+impl BinaryEncoding<'_> for BinaryEncoding_1_1 {}
 
 /// The Ion 1.0 text encoding.
 #[derive(Copy, Clone, Debug, Default)]
@@ -249,8 +249,8 @@ pub trait TextEncoding<'top>:
 {
     // No methods, just a marker
 }
-impl<'top> TextEncoding<'top> for TextEncoding_1_0 {}
-impl<'top> TextEncoding<'top> for TextEncoding_1_1 {}
+impl TextEncoding<'_> for TextEncoding_1_0 {}
+impl TextEncoding<'_> for TextEncoding_1_1 {}
 
 /// Marker trait for encodings that support macros.
 pub trait EncodingWithMacroSupport {}
@@ -323,9 +323,9 @@ impl Decoder for BinaryEncoding_1_1 {
 pub trait RawValueLiteral {}
 
 impl<'top, E: TextEncoding<'top>> RawValueLiteral for LazyRawTextValue<'top, E> {}
-impl<'top> RawValueLiteral for LazyRawBinaryValue_1_0<'top> {}
+impl RawValueLiteral for LazyRawBinaryValue_1_0<'_> {}
 impl<'top> RawValueLiteral for &'top LazyRawBinaryValue_1_1<'top> {}
-impl<'top> RawValueLiteral for LazyRawAnyValue<'top> {}
+impl RawValueLiteral for LazyRawAnyValue<'_> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -59,7 +59,7 @@ impl<'top, D: Decoder> EExpArgGroup<'top, D> {
     }
 }
 
-impl<'top, D: Decoder> HasRange for EExpArgGroup<'top, D> {
+impl<D: Decoder> HasRange for EExpArgGroup<'_, D> {
     fn range(&self) -> Range<usize> {
         self.raw_arg_group.range()
     }
@@ -71,7 +71,7 @@ impl<'top, D: Decoder> HasSpan<'top> for EExpArgGroup<'top, D> {
     }
 }
 
-impl<'top, D: Decoder> Debug for EExpArgGroup<'top, D> {
+impl<D: Decoder> Debug for EExpArgGroup<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "(: {:?}", self.raw_arg_group)?;
         for expr in self.expressions() {
@@ -178,7 +178,7 @@ impl<'top, D: Decoder> EExpression<'top, D> {
     }
 }
 
-impl<'top, D: Decoder> Debug for EExpression<'top, D> {
+impl<D: Decoder> Debug for EExpression<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -192,7 +192,7 @@ impl<'top, D: Decoder> Debug for EExpression<'top, D> {
     }
 }
 
-impl<'top, D: Decoder> HasRange for EExpression<'top, D> {
+impl<D: Decoder> HasRange for EExpression<'_, D> {
     fn range(&self) -> Range<usize> {
         self.raw_invocation.range()
     }
@@ -249,7 +249,7 @@ pub struct EExpressionArgsIterator<'top, D: Decoder> {
     index: u32,
 }
 
-impl<'top, D: Decoder> EExpressionArgsIterator<'top, D> {
+impl<D: Decoder> EExpressionArgsIterator<'_, D> {
     pub fn is_exhausted(&self) -> bool {
         self.index == self.num_args
     }

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -116,7 +116,7 @@ pub struct MacroExpr<'top, D: Decoder> {
     variable: Option<TemplateVariableReference<'top>>,
 }
 
-impl<'top, D: Decoder> Debug for MacroExpr<'top, D> {
+impl<D: Decoder> Debug for MacroExpr<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.kind)
     }
@@ -163,7 +163,7 @@ pub enum MacroExprKind<'top, D: Decoder> {
     EExpArgGroup(EExpArgGroup<'top, D>),
 }
 
-impl<'top, D: Decoder> Debug for MacroExprKind<'top, D> {
+impl<D: Decoder> Debug for MacroExprKind<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             MacroExprKind::TemplateMacro(t) => write!(f, "{:?}", t),
@@ -345,7 +345,7 @@ pub enum ValueExpr<'top, D: Decoder> {
     MacroInvocation(MacroExpr<'top, D>),
 }
 
-impl<'top, D: Decoder> Debug for ValueExpr<'top, D> {
+impl<D: Decoder> Debug for ValueExpr<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             ValueExpr::ValueLiteral(v) => write!(f, "value={:?}", v),
@@ -511,7 +511,7 @@ impl<'top, D: Decoder> MacroExpansion<'top, D> {
     }
 }
 
-impl<'top, D: Decoder> Debug for MacroExpansion<'top, D> {
+impl<D: Decoder> Debug for MacroExpansion<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let name = match &self.kind {
             MacroExpansionKind::None => "none",
@@ -563,7 +563,7 @@ pub enum EvaluatorState<'top, D: Decoder> {
     Stacked(StackedMacroEvaluator<'top, D>),
 }
 
-impl<'top, D: Decoder> Default for EvaluatorState<'top, D> {
+impl<D: Decoder> Default for EvaluatorState<'_, D> {
     fn default() -> Self {
         Self::Empty
     }
@@ -920,7 +920,7 @@ impl<'iter, 'top, D: Decoder> EvaluatingIterator<'iter, 'top, D> {
     }
 }
 
-impl<'iter, 'top, D: Decoder> Iterator for EvaluatingIterator<'iter, 'top, D> {
+impl<'top, D: Decoder> Iterator for EvaluatingIterator<'_, 'top, D> {
     type Item = IonResult<LazyExpandedValue<'top, D>>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -1046,7 +1046,7 @@ impl<'top, D: Decoder> MakeStringExpansion<'top, D> {
         let value_ref: &'top ValueRef<'top, _> = context
             .allocator()
             .alloc_with(|| ValueRef::String(StrRef::from(constructed_text)));
-        static EMPTY_ANNOTATIONS: &[SymbolRef] = &[];
+        static EMPTY_ANNOTATIONS: &[SymbolRef<'_>] = &[];
 
         Ok(MacroExpansionStep::FinalStep(Some(
             ValueExpr::ValueLiteral(LazyExpandedValue::from_constructed(
@@ -1499,7 +1499,7 @@ mod tests {
                 // Invoke it
                 (:greet "Waldo")
             "#,
-                r#"
+            r#"
                 "Hello, Waldo"
             "#,
         )
@@ -1526,7 +1526,8 @@ mod tests {
                 "Hello, Waldo"
                 // should raise an error
             "#,
-        ).unwrap()
+        )
+        .unwrap()
     }
 
     #[test]

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -334,11 +334,12 @@ impl MacroTable {
                     ParameterCardinality::ZeroOrMore,
                     RestSyntaxPolicy::Allowed,
                 )])
-                    .unwrap(),
+                .unwrap(),
                 body: TemplateBody {
                     expressions: vec![
                         // The `$ion_encoding::(...)` s-expression
-                /* 0 */ TemplateBodyExpr::element(
+                        /* 0 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::SExp)
                                 // Has the first annotation in annotations storage below; `$ion_encoding`
                                 .with_annotations(0..1),
@@ -346,43 +347,49 @@ impl MacroTable {
                             ExprRange::new(0..8),
                         ),
                         // The `(symbol_table ...)` s-expression.
-                /* 1 */ TemplateBodyExpr::element(
+                        /* 1 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::SExp),
                             ExprRange::new(1..5),
                         ),
                         // The clause name `symbol_table`
-                /* 2 */ TemplateBodyExpr::element(
+                        /* 2 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::Symbol(Symbol::owned(
                                 "symbol_table",
                             ))),
                             ExprRange::new(2..3),
                         ),
-
                         // The list which will contain the expanded variable `symbols`
-                /* 3 */ TemplateBodyExpr::element(TemplateBodyElement::with_value(TemplateValue::List),
-                        ExprRange::new(3..5)),
-
+                        /* 3 */
+                        TemplateBodyExpr::element(
+                            TemplateBodyElement::with_value(TemplateValue::List),
+                            ExprRange::new(3..5),
+                        ),
                         // We do not include the symbol literal `$ion_encoding`, indicating that
                         // we're replacing the existing symbol table.
 
                         // The variable at signature index 0 (`symbols`)
-                /* 4 */ TemplateBodyExpr::variable(0, ExprRange::new(4..5)),
-
+                        /* 4 */
+                        TemplateBodyExpr::variable(0, ExprRange::new(4..5)),
                         // The `(macro_table ...)` s-expression.
-                /* 5 */ TemplateBodyExpr::element(
+                        /* 5 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::SExp),
                             // Contains expression 4 (itself) through 8 (exclusive)
                             ExprRange::new(5..8),
                         ),
                         // The clause name `macro_table`
-                /* 6 */ TemplateBodyExpr::element(
+                        /* 6 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::Symbol(Symbol::owned(
                                 "macro_table",
                             ))),
                             ExprRange::new(6..7),
                         ),
                         // The module name $ion_encoding
-                /* 7 */ TemplateBodyExpr::element(
+                        /* 7 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::Symbol(Symbol::owned(
                                 "$ion_encoding",
                             ))),
@@ -419,11 +426,12 @@ impl MacroTable {
                     ParameterCardinality::ZeroOrMore,
                     RestSyntaxPolicy::Allowed,
                 )])
-                    .unwrap(),
+                .unwrap(),
                 body: TemplateBody {
                     expressions: vec![
                         // The `$ion_encoding::(...)` s-expression
-                /* 0 */ TemplateBodyExpr::element(
+                        /* 0 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::SExp)
                                 // Has the first annotation in annotations storage below; `$ion_encoding`
                                 .with_annotations(0..1),
@@ -431,49 +439,55 @@ impl MacroTable {
                             ExprRange::new(0..9),
                         ),
                         // The `(symbol_table ...)` s-expression.
-                /* 1 */ TemplateBodyExpr::element(
+                        /* 1 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::SExp),
                             // Contains expression 1 (itself) through 5 (exclusive)
                             ExprRange::new(1..6),
                         ),
                         // The clause name `symbol_table`
-                /* 2 */ TemplateBodyExpr::element(
+                        /* 2 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::Symbol(Symbol::owned(
                                 "symbol_table",
                             ))),
                             ExprRange::new(2..3),
                         ),
-
                         // The module name $ion_encoding
-                /* 3 */ TemplateBodyExpr::element(
+                        /* 3 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::Symbol(Symbol::owned(
                                 "$ion_encoding",
                             ))),
                             ExprRange::new(3..4),
                         ),
-
                         // The list which will contain the expanded variable `symbols`
-                /* 4 */ TemplateBodyExpr::element(TemplateBodyElement::with_value(TemplateValue::List),
-                                                          ExprRange::new(4..6)),
-
+                        /* 4 */
+                        TemplateBodyExpr::element(
+                            TemplateBodyElement::with_value(TemplateValue::List),
+                            ExprRange::new(4..6),
+                        ),
                         // The variable at signature index 0 (`symbols`)
-                /* 5 */ TemplateBodyExpr::variable(0, ExprRange::new(5..6)),
-
+                        /* 5 */
+                        TemplateBodyExpr::variable(0, ExprRange::new(5..6)),
                         // The `(macro_table ...)` s-expression.
-                /* 6 */ TemplateBodyExpr::element(
+                        /* 6 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::SExp),
                             // Contains expression 6 (itself) through 9 (exclusive)
                             ExprRange::new(6..9),
                         ),
                         // The clause name `macro_table`
-                /* 7 */ TemplateBodyExpr::element(
+                        /* 7 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::Symbol(Symbol::owned(
                                 "macro_table",
                             ))),
                             ExprRange::new(7..8),
                         ),
                         // The module name $ion_encoding
-                /* 8 */ TemplateBodyExpr::element(
+                        /* 8 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::Symbol(Symbol::owned(
                                 "$ion_encoding",
                             ))),
@@ -510,11 +524,12 @@ impl MacroTable {
                     ParameterCardinality::ZeroOrMore,
                     RestSyntaxPolicy::Allowed,
                 )])
-                    .unwrap(),
+                .unwrap(),
                 body: TemplateBody {
                     expressions: vec![
                         // The `$ion_encoding::(...)` s-expression
-                /* 0 */ TemplateBodyExpr::element(
+                        /* 0 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::SExp)
                                 // Has the first annotation in annotations storage below; `$ion_encoding`
                                 .with_annotations(0..1),
@@ -522,44 +537,49 @@ impl MacroTable {
                             ExprRange::new(0..7),
                         ),
                         // The `(symbol_table ...)` s-expression.
-                /* 1 */ TemplateBodyExpr::element(
+                        /* 1 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::SExp),
                             // Contains expression 1 (itself) through 4 (exclusive)
                             ExprRange::new(1..4),
                         ),
                         // The clause name `symbol_table`
-                /* 2 */ TemplateBodyExpr::element(
+                        /* 2 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::Symbol(Symbol::owned(
                                 "symbol_table",
                             ))),
                             ExprRange::new(2..3),
                         ),
                         // The module name $ion_encoding
-                /* 3 */ TemplateBodyExpr::element(
+                        /* 3 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::Symbol(Symbol::owned(
                                 "$ion_encoding",
                             ))),
                             ExprRange::new(3..4),
                         ),
                         // The `(macro_table ...)` s-expression.
-                /* 4 */ TemplateBodyExpr::element(
+                        /* 4 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::SExp),
                             // Contains expression 4 (itself) through 7 (exclusive)
                             ExprRange::new(4..7),
                         ),
                         // The clause name `macro_table`
-                /* 5 */ TemplateBodyExpr::element(
+                        /* 5 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::Symbol(Symbol::owned(
                                 "macro_table",
                             ))),
                             ExprRange::new(5..6),
                         ),
-
                         // We do not include the symbol literal `$ion_encoding`, indicating that
                         // we're replacing the existing macro table.
 
                         // The variable at signature index 0 (`macro_definitions`)
-                /* 6 */ TemplateBodyExpr::variable(0, ExprRange::new(6..7)),
+                        /* 6 */
+                        TemplateBodyExpr::variable(0, ExprRange::new(6..7)),
                     ],
                     annotations_storage: vec![Symbol::owned("$ion_encoding")],
                 },
@@ -591,11 +611,12 @@ impl MacroTable {
                     ParameterCardinality::ZeroOrMore,
                     RestSyntaxPolicy::Allowed,
                 )])
-                    .unwrap(),
+                .unwrap(),
                 body: TemplateBody {
                     expressions: vec![
                         // The `$ion_encoding::(...)` s-expression
-                /* 0 */ TemplateBodyExpr::element(
+                        /* 0 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::SExp)
                                 // Has the first annotation in annotations storage below; `$ion_encoding`
                                 .with_annotations(0..1),
@@ -603,33 +624,38 @@ impl MacroTable {
                             ExprRange::new(0..8),
                         ),
                         // The `(symbol_table ...)` s-expression.
-                /* 1 */ TemplateBodyExpr::element(
+                        /* 1 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::SExp),
                             // Contains expression 1 (itself) through 4 (exclusive)
                             ExprRange::new(1..4),
                         ),
                         // The clause name `symbol_table`
-                /* 2 */ TemplateBodyExpr::element(
+                        /* 2 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::Symbol(Symbol::owned(
                                 "symbol_table",
                             ))),
                             ExprRange::new(2..3),
                         ),
                         // The module name $ion_encoding
-                /* 3 */ TemplateBodyExpr::element(
+                        /* 3 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::Symbol(Symbol::owned(
                                 "$ion_encoding",
                             ))),
                             ExprRange::new(3..4),
                         ),
                         // The `(macro_table ...)` s-expression.
-                /* 4 */ TemplateBodyExpr::element(
+                        /* 4 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::SExp),
                             // Contains expression 4 (itself) through 8 (exclusive)
                             ExprRange::new(4..8),
                         ),
                         // The clause name `macro_table`
-                /* 5 */ TemplateBodyExpr::element(
+                        /* 5 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::Symbol(Symbol::owned(
                                 "macro_table",
                             ))),
@@ -637,14 +663,16 @@ impl MacroTable {
                         ),
                         // The symbol literal `$ion_encoding`, indicating that we're appending
                         // to the existing macro table.
-                /* 6 */ TemplateBodyExpr::element(
+                        /* 6 */
+                        TemplateBodyExpr::element(
                             TemplateBodyElement::with_value(TemplateValue::Symbol(Symbol::owned(
                                 "$ion_encoding",
                             ))),
                             ExprRange::new(6..7),
                         ),
                         // The variable at signature index 0 (`macro_definitions`)
-                /* 7 */ TemplateBodyExpr::variable(0, ExprRange::new(7..8)),
+                        /* 7 */
+                        TemplateBodyExpr::variable(0, ExprRange::new(7..8)),
                     ],
                     annotations_storage: vec![Symbol::owned("$ion_encoding")],
                 },
@@ -715,7 +743,7 @@ impl MacroTable {
         self.macros_by_name.get(name).copied()
     }
 
-    pub fn macro_with_name(&self, name: &str) -> Option<MacroRef> {
+    pub fn macro_with_name(&self, name: &str) -> Option<MacroRef<'_>> {
         let address = *self.macros_by_name.get(name)?;
         let reference = self.macros_by_address.get(address)?;
         Some(MacroRef { address, reference })
@@ -732,7 +760,7 @@ impl MacroTable {
         Some(Rc::clone(reference))
     }
 
-    pub(crate) fn clone_macro_with_id(&self, macro_id: MacroIdRef) -> Option<Rc<Macro>> {
+    pub(crate) fn clone_macro_with_id(&self, macro_id: MacroIdRef<'_>) -> Option<Rc<Macro>> {
         use MacroIdRef::*;
         match macro_id {
             LocalName(name) => self.clone_macro_with_name(name),

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -204,7 +204,7 @@ impl<'top> EncodingContextRef<'top> {
     }
 }
 
-impl<'top> Deref for EncodingContextRef<'top> {
+impl Deref for EncodingContextRef<'_> {
     type Target = EncodingContext;
 
     fn deref(&self) -> &Self::Target {
@@ -450,7 +450,7 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
         }
         // Otherwise, it's an application value.
         let lazy_value = LazyValue::new(value);
-        return Ok(SystemStreamItem::Value(lazy_value));
+        Ok(SystemStreamItem::Value(lazy_value))
     }
 
     fn interpret_ivm<'top>(
@@ -727,7 +727,7 @@ pub enum ExpandedValueSource<'top, D: Decoder> {
     ),
 }
 
-impl<'top, Encoding: Decoder> Debug for ExpandedValueSource<'top, Encoding> {
+impl<Encoding: Decoder> Debug for ExpandedValueSource<'_, Encoding> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match &self {
             ExpandedValueSource::SingletonEExp(eexp) => write!(f, "singleton eexp {eexp:?}"),
@@ -842,7 +842,7 @@ pub struct LazyExpandedValue<'top, Encoding: Decoder> {
     pub(crate) variable: Option<TemplateVariableReference<'top>>,
 }
 
-impl<'top, Encoding: Decoder> Debug for LazyExpandedValue<'top, Encoding> {
+impl<Encoding: Decoder> Debug for LazyExpandedValue<'_, Encoding> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.read_resolved()?)
     }
@@ -1116,7 +1116,7 @@ pub enum ExpandedValueRef<'top, Encoding: Decoder> {
     Struct(LazyExpandedStruct<'top, Encoding>),
 }
 
-impl<'top, Encoding: Decoder> PartialEq for ExpandedValueRef<'top, Encoding> {
+impl<Encoding: Decoder> PartialEq for ExpandedValueRef<'_, Encoding> {
     fn eq(&self, other: &Self) -> bool {
         use ExpandedValueRef::*;
         match (self, other) {
@@ -1280,7 +1280,7 @@ impl<'top, Encoding: Decoder> ExpandedValueRef<'top, Encoding> {
     }
 }
 
-impl<'top, D: Decoder> Debug for ExpandedValueRef<'top, D> {
+impl<D: Decoder> Debug for ExpandedValueRef<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use ExpandedValueRef::*;
         match self {

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -129,7 +129,7 @@ impl EncodingContext {
         )
     }
 
-    pub fn get_ref(&self) -> EncodingContextRef {
+    pub fn get_ref(&self) -> EncodingContextRef<'_> {
         EncodingContextRef { context: self }
     }
 
@@ -506,7 +506,7 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
     ///
     /// This method will consume and process as many system-level values as possible until it
     /// encounters an application-level value or the end of the stream.
-    pub fn next_value(&mut self) -> IonResult<Option<LazyValue<Encoding>>> {
+    pub fn next_value(&mut self) -> IonResult<Option<LazyValue<'_, Encoding>>> {
         use SystemStreamItem::*;
         loop {
             match self.next_system_item() {

--- a/src/lazy/expanded/sequence.rs
+++ b/src/lazy/expanded/sequence.rs
@@ -246,7 +246,7 @@ impl<'top, D: Decoder> LazyExpandedSExp<'top, D> {
             }
             ExpandedSExpSource::Constructed(_environment, _args) => {
                 // `make_sexp` always produces an unannotated s-expression
-                const EMPTY_ANNOTATIONS: &[SymbolRef] = &[];
+                const EMPTY_ANNOTATIONS: &[SymbolRef<'_>] = &[];
                 ExpandedAnnotationsIterator {
                     source: ExpandedAnnotationsSource::Constructed(EMPTY_ANNOTATIONS.iter()),
                 }

--- a/src/lazy/expanded/sequence.rs
+++ b/src/lazy/expanded/sequence.rs
@@ -31,7 +31,7 @@ pub struct Environment<'top, D: Decoder> {
     expressions: &'top [ValueExpr<'top, D>],
 }
 
-impl<'top, D: Decoder> Debug for Environment<'top, D> {
+impl<D: Decoder> Debug for Environment<'_, D> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Environment::[")?;
         for expr in self.expressions {
@@ -85,7 +85,7 @@ impl<'top, D: Decoder> Environment<'top, D> {
     }
 }
 
-impl<'top, D: Decoder> Default for Environment<'top, D> {
+impl<D: Decoder> Default for Environment<'_, D> {
     fn default() -> Self {
         Self::empty()
     }

--- a/src/lazy/expanded/struct.rs
+++ b/src/lazy/expanded/struct.rs
@@ -34,7 +34,7 @@ pub struct LazyExpandedField<'top, D: Decoder> {
     value: LazyExpandedValue<'top, D>,
 }
 
-impl<'top, D: Decoder> LazyExpandedField<'top, D> {}
+impl<D: Decoder> LazyExpandedField<'_, D> {}
 
 impl<'top, D: Decoder> LazyExpandedField<'top, D> {
     pub fn new(name: LazyExpandedFieldName<'top, D>, value: LazyExpandedValue<'top, D>) -> Self {

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -499,7 +499,7 @@ impl<'top, D: Decoder> Iterator for TemplateStructUnexpandedFieldsIterator<'top,
             .get(name_expr_address)?
             .kind()
             .require_element();
-        let name: SymbolRef = match &name_element.value {
+        let name: SymbolRef<'_> = match &name_element.value {
             TemplateValue::Symbol(s) => s.into(),
             TemplateValue::String(s) => s.text().into(),
             _ => unreachable!("template struct field had a non-text field name"),

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -1044,7 +1044,7 @@ impl<'top, D: Decoder> TemplateExprGroup<'top, D> {
     }
 }
 
-impl<'top, D: Decoder> Debug for TemplateExprGroup<'top, D> {
+impl<D: Decoder> Debug for TemplateExprGroup<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -1073,7 +1073,7 @@ pub struct TemplateMacroInvocation<'top, D: Decoder> {
     arg_expressions_range: ExprRange,
 }
 
-impl<'top, D: Decoder> Debug for TemplateMacroInvocation<'top, D> {
+impl<D: Decoder> Debug for TemplateMacroInvocation<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,

--- a/src/lazy/never.rs
+++ b/src/lazy/never.rs
@@ -161,7 +161,7 @@ impl<'top, D: Decoder> IsExhaustedIterator<'top, D> for NeverArgGroupIterator<'t
     }
 }
 
-impl<'top, D: Decoder> HasRange for NeverArgGroup<'top, D> {
+impl<D: Decoder> HasRange for NeverArgGroup<'_, D> {
     fn range(&self) -> Range<usize> {
         unreachable!("<NeverArgGroup as HasRange>::range")
     }

--- a/src/lazy/raw_stream_item.rs
+++ b/src/lazy/raw_stream_item.rs
@@ -27,7 +27,7 @@ pub type LazyRawStreamItem<'top, D> = RawStreamItem<
     <D as Decoder>::EExp<'top>,
 >;
 
-impl<'top> LazyRawStreamItem<'top, AnyEncoding> {
+impl LazyRawStreamItem<'_, AnyEncoding> {
     pub fn encoding(&self) -> IonEncoding {
         match self {
             LazyRawStreamItem::<AnyEncoding>::VersionMarker(m) => m.encoding(),

--- a/src/lazy/raw_value_ref.rs
+++ b/src/lazy/raw_value_ref.rs
@@ -33,7 +33,7 @@ pub enum RawValueRef<'top, D: Decoder> {
 }
 
 // Provides equality for scalar types, but not containers.
-impl<'top, D: Decoder> PartialEq for RawValueRef<'top, D> {
+impl<D: Decoder> PartialEq for RawValueRef<'_, D> {
     fn eq(&self, other: &Self) -> bool {
         use RawValueRef::*;
         match (self, other) {
@@ -54,7 +54,7 @@ impl<'top, D: Decoder> PartialEq for RawValueRef<'top, D> {
     }
 }
 
-impl<'top, D: Decoder> Debug for RawValueRef<'top, D> {
+impl<D: Decoder> Debug for RawValueRef<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             RawValueRef::Null(ion_type) => write!(f, "null.{}", ion_type),

--- a/src/lazy/reader.rs
+++ b/src/lazy/reader.rs
@@ -104,12 +104,12 @@ impl<Encoding: Decoder, Input: IonInput> Reader<Encoding, Input> {
     /// be attempted when you have control over the format of the data being read.
     #[allow(clippy::should_implement_trait)]
     // ^-- Clippy objects that the method name `next` will be confused for `Iterator::next()`
-    pub fn next(&mut self) -> IonResult<Option<LazyValue<Encoding>>> {
+    pub fn next(&mut self) -> IonResult<Option<LazyValue<'_, Encoding>>> {
         self.system_reader.next_value()
     }
 
     /// Like [`Self::next`], but returns an `IonError` if there are no more values in the stream.
-    pub fn expect_next(&mut self) -> IonResult<LazyValue<Encoding>> {
+    pub fn expect_next(&mut self) -> IonResult<LazyValue<'_, Encoding>> {
         self.next()?
             .ok_or_else(|| IonError::decoding_error("expected another top-level value"))
     }

--- a/src/lazy/reader.rs
+++ b/src/lazy/reader.rs
@@ -147,8 +147,8 @@ pub struct LazyElementIterator<'iter, Encoding: Decoder, Input: IonInput> {
     lazy_reader: &'iter mut Reader<Encoding, Input>,
 }
 
-impl<'iter, Encoding: Decoder, Input: IonInput> Iterator
-    for LazyElementIterator<'iter, Encoding, Input>
+impl<Encoding: Decoder, Input: IonInput> Iterator
+    for LazyElementIterator<'_, Encoding, Input>
 {
     type Item = IonResult<Element>;
 

--- a/src/lazy/sequence.rs
+++ b/src/lazy/sequence.rs
@@ -158,7 +158,7 @@ impl<'top, D: Decoder> TryFrom<LazyList<'top, D>> for Element {
     }
 }
 
-impl<'a, 'top, 'data: 'top, D: Decoder> IntoIterator for &'a LazyList<'top, D> {
+impl<'top, D: Decoder> IntoIterator for &LazyList<'top, D> {
     type Item = IonResult<LazyValue<'top, D>>;
     type IntoIter = ListIterator<'top, D>;
 
@@ -167,7 +167,7 @@ impl<'a, 'top, 'data: 'top, D: Decoder> IntoIterator for &'a LazyList<'top, D> {
     }
 }
 
-impl<'top, 'data: 'top, D: Decoder> IntoIterator for LazyList<'top, D> {
+impl<'top, D: Decoder> IntoIterator for LazyList<'top, D> {
     type Item = IonResult<LazyValue<'top, D>>;
     type IntoIter = ListIterator<'top, D>;
 
@@ -190,7 +190,7 @@ impl<'top, D: Decoder> Iterator for ListIterator<'top, D> {
     }
 }
 
-impl<'top, D: Decoder> Debug for LazyList<'top, D> {
+impl<D: Decoder> Debug for LazyList<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "[")?;
         for value in self {
@@ -209,7 +209,7 @@ pub struct LazySExp<'top, D: Decoder> {
     pub(crate) expanded_sexp: LazyExpandedSExp<'top, D>,
 }
 
-impl<'top, D: Decoder> Debug for LazySExp<'top, D> {
+impl<D: Decoder> Debug for LazySExp<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "(")?;
         for value in self {
@@ -324,7 +324,7 @@ impl<'top, D: Decoder> TryFrom<LazySExp<'top, D>> for Element {
     }
 }
 
-impl<'a, 'top, 'data: 'top, D: Decoder> IntoIterator for &'a LazySExp<'top, D> {
+impl<'top, D: Decoder> IntoIterator for &LazySExp<'top, D> {
     type Item = IonResult<LazyValue<'top, D>>;
     type IntoIter = SExpIterator<'top, D>;
 
@@ -333,7 +333,7 @@ impl<'a, 'top, 'data: 'top, D: Decoder> IntoIterator for &'a LazySExp<'top, D> {
     }
 }
 
-impl<'top, 'data: 'top, D: Decoder> IntoIterator for LazySExp<'top, D> {
+impl<'top, D: Decoder> IntoIterator for LazySExp<'top, D> {
     type Item = IonResult<LazyValue<'top, D>>;
     type IntoIter = SExpIterator<'top, D>;
 

--- a/src/lazy/span.rs
+++ b/src/lazy/span.rs
@@ -16,7 +16,7 @@ pub struct Span<'a> {
     offset: usize,
 }
 
-impl<'a> AsRef<[u8]> for Span<'a> {
+impl AsRef<[u8]> for Span<'_> {
     fn as_ref(&self) -> &[u8] {
         self.bytes()
     }
@@ -28,7 +28,7 @@ impl<'a> From<Span<'a>> for &'a [u8] {
     }
 }
 
-impl<'a, A: AsRef<[u8]>> PartialEq<A> for Span<'a> {
+impl<A: AsRef<[u8]>> PartialEq<A> for Span<'_> {
     fn eq(&self, other: &A) -> bool {
         self.bytes() == other.as_ref()
     }

--- a/src/lazy/str_ref.rs
+++ b/src/lazy/str_ref.rs
@@ -25,7 +25,7 @@ impl<'data> StrRef<'data> {
     }
 }
 
-impl<'data> Deref for StrRef<'data> {
+impl Deref for StrRef<'_> {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
@@ -33,13 +33,13 @@ impl<'data> Deref for StrRef<'data> {
     }
 }
 
-impl<'data> PartialEq<str> for StrRef<'data> {
+impl PartialEq<str> for StrRef<'_> {
     fn eq(&self, other: &str) -> bool {
         self.text() == other
     }
 }
 
-impl<'data> PartialEq<&str> for StrRef<'data> {
+impl PartialEq<&str> for StrRef<'_> {
     fn eq(&self, other: &&str) -> bool {
         self.text() == *other
     }
@@ -51,7 +51,7 @@ impl<'data> PartialEq<StrRef<'data>> for str {
     }
 }
 
-impl<'data> Display for StrRef<'data> {
+impl Display for StrRef<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut formatter = FmtValueFormatter { output: f };
         formatter

--- a/src/lazy/streaming_raw_reader.rs
+++ b/src/lazy/streaming_raw_reader.rs
@@ -448,7 +448,7 @@ impl<R: Read> IonInput for BufReader<R> {
     }
 }
 
-impl<'a> IonInput for StdinLock<'a> {
+impl IonInput for StdinLock<'_> {
     type DataSource = IonStream<Self>;
 
     fn into_data_source(self) -> Self::DataSource {

--- a/src/lazy/streaming_raw_reader.rs
+++ b/src/lazy/streaming_raw_reader.rs
@@ -157,7 +157,10 @@ impl<Encoding: Decoder, Input: IonInput> StreamingRawReader<Encoding, Input> {
             let bytes_read = end_position - starting_position;
             let input = unsafe { &mut *self.input.get() };
             // If we ran out of data before we could get a result...
-            if matches!(result, Err(IonError::Incomplete(_)) | Ok(LazyRawStreamItem::<Encoding>::EndOfStream(_))) {
+            if matches!(
+                result,
+                Err(IonError::Incomplete(_)) | Ok(LazyRawStreamItem::<Encoding>::EndOfStream(_))
+            ) {
                 // ...try to pull more data from the data source. It's ok to modify the buffer in
                 // this case because `result` (which holds a reference to the buffer) will be
                 // discarded.
@@ -498,7 +501,7 @@ mod tests {
         expect_value(actual, RawValueRef::<AnyEncoding>::String(text.into()))
     }
 
-    fn expect_end_of_stream(actual: LazyRawStreamItem<AnyEncoding>) -> IonResult<()> {
+    fn expect_end_of_stream(actual: LazyRawStreamItem<'_, AnyEncoding>) -> IonResult<()> {
         assert!(matches!(
             actual,
             LazyRawStreamItem::<AnyEncoding>::EndOfStream(_)
@@ -630,7 +633,7 @@ mod tests {
         let value = reader.next(context)?.expect_value()?;
         let annotations = value
             .annotations()
-            .collect::<IonResult<Vec<RawSymbolRef>>>()?;
+            .collect::<IonResult<Vec<RawSymbolRef<'_>>>>()?;
         assert_eq!(
             annotations,
             vec![

--- a/src/lazy/struct.rs
+++ b/src/lazy/struct.rs
@@ -55,7 +55,7 @@ pub type LazyBinaryStruct_1_0<'top> = LazyStruct<'top, BinaryEncoding_1_0>;
 
 // Best-effort debug formatting for LazyStruct. Any failures that occur during reading will result
 // in the output being silently truncated.
-impl<'top, D: Decoder> Debug for LazyStruct<'top, D> {
+impl<D: Decoder> Debug for LazyStruct<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{{")?;
         for field in self {
@@ -274,7 +274,7 @@ pub struct LazyField<'top, D: Decoder> {
     pub(crate) expanded_field: LazyExpandedField<'top, D>,
 }
 
-impl<'top, D: Decoder> Debug for LazyField<'top, D> {
+impl<D: Decoder> Debug for LazyField<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -391,7 +391,7 @@ impl<'top, D: Decoder> TryFrom<LazyStruct<'top, D>> for Element {
     }
 }
 
-impl<'a, 'top, 'data: 'top, D: Decoder> IntoIterator for &'a LazyStruct<'top, D> {
+impl<'top, D: Decoder> IntoIterator for &LazyStruct<'top, D> {
     type Item = IonResult<LazyField<'top, D>>;
     type IntoIter = StructIterator<'top, D>;
 
@@ -400,7 +400,7 @@ impl<'a, 'top, 'data: 'top, D: Decoder> IntoIterator for &'a LazyStruct<'top, D>
     }
 }
 
-impl<'top, 'data: 'top, D: Decoder> IntoIterator for LazyStruct<'top, D> {
+impl<'top, D: Decoder> IntoIterator for LazyStruct<'top, D> {
     type Item = IonResult<LazyField<'top, D>>;
     type IntoIter = StructIterator<'top, D>;
 

--- a/src/lazy/system_stream_item.rs
+++ b/src/lazy/system_stream_item.rs
@@ -37,7 +37,7 @@ impl<'top, D: Decoder> SystemStreamItem<'top, D> {
     }
 }
 
-impl<'top, D: Decoder> Debug for SystemStreamItem<'top, D> {
+impl<D: Decoder> Debug for SystemStreamItem<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             SystemStreamItem::VersionMarker(marker) => {

--- a/src/lazy/text/as_utf8.rs
+++ b/src/lazy/text/as_utf8.rs
@@ -24,7 +24,7 @@ impl<const N: usize> AsUtf8 for SmallVec<[u8; N]> {
     }
 }
 
-impl<'data> AsUtf8 for TextBuffer<'data> {
+impl AsUtf8 for TextBuffer<'_> {
     fn as_utf8(&self, position: impl Into<Position>) -> IonResult<&str> {
         bytes_as_utf8(self.bytes(), position)
     }

--- a/src/lazy/text/buffer.rs
+++ b/src/lazy/text/buffer.rs
@@ -54,7 +54,7 @@ use crate::lazy::expanded::template::{Parameter, RestSyntaxPolicy};
 use crate::lazy::text::as_utf8::AsUtf8;
 use bumpalo::collections::Vec as BumpVec;
 
-impl<'a> Debug for TextBuffer<'a> {
+impl Debug for TextBuffer<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         const CHARS_TO_SHOW: usize = 64;
         write!(f, "TextBuffer {{")?;
@@ -116,7 +116,7 @@ pub struct TextBuffer<'top> {
     pub(crate) context: EncodingContextRef<'top>,
 }
 
-impl<'a> PartialEq for TextBuffer<'a> {
+impl PartialEq for TextBuffer<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.offset == other.offset && self.data == other.data
     }
@@ -2541,7 +2541,7 @@ impl<'top> TextBuffer<'top> {
 // As `TextBuffer` is just a wrapper around a `&[u8]`, these implementations mostly delegate
 // to the existing trait impls for `&[u8]`.
 
-impl<'data> nom::InputTake for TextBuffer<'data> {
+impl nom::InputTake for TextBuffer<'_> {
     fn take(&self, count: usize) -> Self {
         self.slice(0, count)
     }
@@ -2556,7 +2556,7 @@ impl<'data> nom::InputTake for TextBuffer<'data> {
     }
 }
 
-impl<'data> nom::InputLength for TextBuffer<'data> {
+impl nom::InputLength for TextBuffer<'_> {
     fn input_len(&self) -> usize {
         self.len()
     }
@@ -2587,7 +2587,7 @@ impl<'data> nom::InputIter for TextBuffer<'data> {
     }
 }
 
-impl<'a, 'b> nom::Compare<&'a str> for TextBuffer<'b> {
+impl<'a> nom::Compare<&'a str> for TextBuffer<'_> {
     fn compare(&self, t: &'a str) -> CompareResult {
         self.data.compare(t.as_bytes())
     }
@@ -2597,31 +2597,31 @@ impl<'a, 'b> nom::Compare<&'a str> for TextBuffer<'b> {
     }
 }
 
-impl<'data> nom::Offset for TextBuffer<'data> {
+impl nom::Offset for TextBuffer<'_> {
     fn offset(&self, second: &Self) -> usize {
         self.data.offset(second.data)
     }
 }
 
-impl<'data> nom::Slice<RangeFrom<usize>> for TextBuffer<'data> {
+impl nom::Slice<RangeFrom<usize>> for TextBuffer<'_> {
     fn slice(&self, range: RangeFrom<usize>) -> Self {
         self.slice_to_end(range.start)
     }
 }
 
-impl<'data> nom::Slice<RangeTo<usize>> for TextBuffer<'data> {
+impl nom::Slice<RangeTo<usize>> for TextBuffer<'_> {
     fn slice(&self, range: RangeTo<usize>) -> Self {
         self.slice(0, range.end)
     }
 }
 
-impl<'data> nom::FindSubstring<&str> for TextBuffer<'data> {
+impl nom::FindSubstring<&str> for TextBuffer<'_> {
     fn find_substring(&self, substr: &str) -> Option<usize> {
         self.data.find_substring(substr)
     }
 }
 
-impl<'data> nom::InputTakeAtPosition for TextBuffer<'data> {
+impl nom::InputTakeAtPosition for TextBuffer<'_> {
     type Item = u8;
 
     fn split_at_position<P, E: ParseError<Self>>(&self, predicate: P) -> IResult<Self, Self, E>

--- a/src/lazy/text/buffer.rs
+++ b/src/lazy/text/buffer.rs
@@ -2005,7 +2005,7 @@ impl<'top> TextBuffer<'top> {
         self,
     ) -> IonParseResult<'top, LazyRawTextValue<'top, E>> {
         is_a("!#%&*+-./;<=>?@^`|~")
-            .map(|text: TextBuffer| LazyRawTextValue {
+            .map(|text: TextBuffer<'_>| LazyRawTextValue {
                 input: text,
                 encoded_value: EncodedTextValue::new(MatchedValue::Symbol(MatchedSymbol::Operator)),
             })
@@ -2040,7 +2040,7 @@ impl<'top> TextBuffer<'top> {
         // If we didn't check for a trailing underscore, it would be a SID (`$1`) and an
         // identifier (`_02`).
         terminated(complete_digit1, peek(not(complete_tag("_"))))
-            .map(|buffer: TextBuffer| {
+            .map(|buffer: TextBuffer<'_>| {
                 // The matched buffer is ascii base 10 digits, parsing must succeed
                 usize::from_str(buffer.as_utf8(self.offset()).unwrap()).unwrap()
             })

--- a/src/lazy/text/matched.rs
+++ b/src/lazy/text/matched.rs
@@ -66,7 +66,7 @@ pub enum MatchedValue<'top, D: Decoder> {
     Struct(&'top [LazyRawFieldExpr<'top, D>]),
 }
 
-impl<'top, D: Decoder> PartialEq for MatchedValue<'top, D> {
+impl<D: Decoder> PartialEq for MatchedValue<'_, D> {
     fn eq(&self, other: &Self) -> bool {
         use MatchedValue::*;
         match (self, other) {

--- a/src/lazy/text/matched.rs
+++ b/src/lazy/text/matched.rs
@@ -181,7 +181,7 @@ impl MatchedInt {
     }
 
     /// Attempts to finish reading the partially parsed integer.
-    pub fn read(&self, matched_input: TextBuffer) -> IonResult<Int> {
+    pub fn read(&self, matched_input: TextBuffer<'_>) -> IonResult<Int> {
         let digits = matched_input.slice_to_end(self.digits_offset as usize);
         let mut sanitized: SmallVec<[u8; Self::STACK_ALLOC_BUFFER_CAPACITY]> =
             SmallVec::with_capacity(Self::STACK_ALLOC_BUFFER_CAPACITY);
@@ -233,7 +233,7 @@ impl MatchedFloat {
     // Floats that take more than 32 bytes of text to represent will heap allocate a larger buffer.
     const STACK_ALLOC_BUFFER_CAPACITY: usize = 32;
 
-    pub fn read(&self, matched_input: TextBuffer) -> IonResult<f64> {
+    pub fn read(&self, matched_input: TextBuffer<'_>) -> IonResult<f64> {
         match self {
             MatchedFloat::PositiveInfinity => return Ok(f64::INFINITY),
             MatchedFloat::NegativeInfinity => return Ok(f64::NEG_INFINITY),
@@ -292,7 +292,7 @@ impl MatchedDecimal {
         }
     }
 
-    pub fn read(&self, matched_input: TextBuffer) -> IonResult<Decimal> {
+    pub fn read(&self, matched_input: TextBuffer<'_>) -> IonResult<Decimal> {
         let mut sanitized: SmallVec<[u8; Self::STACK_ALLOC_BUFFER_CAPACITY]> =
             SmallVec::with_capacity(Self::STACK_ALLOC_BUFFER_CAPACITY);
 
@@ -511,8 +511,8 @@ impl MatchedString {
 }
 
 fn replace_escapes_with_byte_values(
-    matched_input: TextBuffer,
-    sanitized: &mut BumpVec<u8>,
+    matched_input: TextBuffer<'_>,
+    sanitized: &mut BumpVec<'_, u8>,
     // If the text being escaped is in a long string or a clob, then unescaped \r\n and \r get
     // normalized to \n.
     normalize_newlines: bool,
@@ -564,7 +564,7 @@ fn replace_escapes_with_byte_values(
 #[cold]
 fn normalize_newline<'data>(
     remaining: TextBuffer<'data>,
-    sanitized: &mut BumpVec<u8>,
+    sanitized: &mut BumpVec<'_, u8>,
     escape_offset: usize,
 ) -> TextBuffer<'data> {
     // Insert the normalized newline
@@ -585,7 +585,7 @@ fn normalize_newline<'data>(
 /// sequence.
 fn decode_escape_into_bytes<'data>(
     input: TextBuffer<'data>,
-    sanitized: &mut BumpVec<u8>,
+    sanitized: &mut BumpVec<'_, u8>,
     support_unicode_escapes: bool,
 ) -> IonResult<TextBuffer<'data>> {
     // Note that by the time this method has been called, the parser has already confirmed that
@@ -663,7 +663,7 @@ fn decode_escape_into_bytes<'data>(
 fn decode_hex_digits_escape<'data>(
     num_digits: usize,
     input: TextBuffer<'data>,
-    sanitized: &mut BumpVec<u8>,
+    sanitized: &mut BumpVec<'_, u8>,
     support_unicode_escapes: bool,
 ) -> IonResult<TextBuffer<'data>> {
     if input.len() < num_digits {
@@ -745,7 +745,7 @@ fn decode_hex_digits_escape<'data>(
 /// with the specified high surrogate. Appends the UTF-8 encoding of the resulting Unicode scalar
 /// to `sanitized` and returns the remaining text in the buffer.
 fn complete_surrogate_pair<'data>(
-    sanitized: &mut BumpVec<u8>,
+    sanitized: &mut BumpVec<'_, u8>,
     high_surrogate: u32,
     input: TextBuffer<'data>,
 ) -> IonResult<TextBuffer<'data>> {
@@ -920,7 +920,7 @@ impl MatchedTimestamp {
         self
     }
 
-    pub(crate) fn read(&self, matched_input: TextBuffer) -> IonResult<Timestamp> {
+    pub(crate) fn read(&self, matched_input: TextBuffer<'_>) -> IonResult<Timestamp> {
         // The parser has already confirmed that each subfield is made of ASCII digits,
         // so UTF-8 validation and parsing cannot fail. `unwrap()` is used in such cases
         // throughout.
@@ -1542,7 +1542,7 @@ mod tests {
             matched.read(context.allocator(), buffer)
         }
 
-        fn expect_clob_error(context: EncodingContextRef, data: &str) {
+        fn expect_clob_error(context: EncodingContextRef<'_>, data: &str) {
             let actual = read_clob(context, data);
             assert!(
                 actual.is_err(),
@@ -1550,7 +1550,7 @@ mod tests {
             );
         }
 
-        fn expect_clob(context: EncodingContextRef, data: &str, expected: &str) {
+        fn expect_clob(context: EncodingContextRef<'_>, data: &str, expected: &str) {
             let result = read_clob(context, data);
             assert!(
                 result.is_ok(),

--- a/src/lazy/text/parse_result.rs
+++ b/src/lazy/text/parse_result.rs
@@ -121,7 +121,7 @@ impl<'data> From<InvalidInputError<'data>> for IonParseError<'data> {
 
 // We cannot provide an analogous impl for `Incomplete` because it is missing necessary data.
 impl<'data> From<InvalidInputError<'data>> for IonError {
-    fn from(invalid_input_error: InvalidInputError) -> Self {
+    fn from(invalid_input_error: InvalidInputError<'_>) -> Self {
         let mut message = String::from(
             invalid_input_error
                 .description()
@@ -329,9 +329,9 @@ impl<'data, T> AddContext<'data, T> for IonParseResult<'data, T> {
 /// Constructs a `nom::Err::Failure` that contains an `IonParseError` describing the problem
 /// that was encountered.
 pub(crate) fn fatal_parse_error<D: Into<Cow<'static, str>>, O>(
-    input: TextBuffer,
+    input: TextBuffer<'_>,
     description: D,
-) -> IonParseResult<O> {
+) -> IonParseResult<'_, O> {
     Err(nom::Err::Failure(
         InvalidInputError::new(input)
             .with_description(description)
@@ -342,7 +342,11 @@ pub(crate) fn fatal_parse_error<D: Into<Cow<'static, str>>, O>(
 /// An extension trait that allows a [std::result::Result] of any kind to be mapped to an
 /// `IonParseResult` concisely.
 pub(crate) trait OrFatalParseError<T> {
-    fn or_fatal_parse_error<L: Display>(self, input: TextBuffer, label: L) -> IonParseResult<T>;
+    fn or_fatal_parse_error<L: Display>(
+        self,
+        input: TextBuffer<'_>,
+        label: L,
+    ) -> IonParseResult<'_, T>;
 }
 
 /// See the documentation for [OrFatalParseError].
@@ -350,7 +354,11 @@ impl<T, E> OrFatalParseError<T> for Result<T, E>
 where
     E: Debug,
 {
-    fn or_fatal_parse_error<L: Display>(self, input: TextBuffer, label: L) -> IonParseResult<T> {
+    fn or_fatal_parse_error<L: Display>(
+        self,
+        input: TextBuffer<'_>,
+        label: L,
+    ) -> IonParseResult<'_, T> {
         match self {
             Ok(value) => Ok((input, value)),
             Err(error) => fatal_parse_error(input, format!("{label}: {error:?}")),

--- a/src/lazy/text/parse_result.rs
+++ b/src/lazy/text/parse_result.rs
@@ -120,7 +120,7 @@ impl<'data> From<InvalidInputError<'data>> for IonParseError<'data> {
 }
 
 // We cannot provide an analogous impl for `Incomplete` because it is missing necessary data.
-impl<'data> From<InvalidInputError<'data>> for IonError {
+impl From<InvalidInputError<'_>> for IonError {
     fn from(invalid_input_error: InvalidInputError<'_>) -> Self {
         let mut message = String::from(
             invalid_input_error

--- a/src/lazy/text/raw/sequence.rs
+++ b/src/lazy/text/raw/sequence.rs
@@ -65,7 +65,7 @@ impl<'data> LazyRawSequence<'data, TextEncoding_1_0> for LazyRawTextList_1_0<'da
     }
 }
 
-impl<'a, 'data> IntoIterator for &'a LazyRawTextList_1_0<'data> {
+impl<'data> IntoIterator for &LazyRawTextList_1_0<'data> {
     type Item = IonResult<LazyRawValueExpr<'data, TextEncoding_1_0>>;
     type IntoIter = RawTextListIterator_1_0<'data>;
 
@@ -74,7 +74,7 @@ impl<'a, 'data> IntoIterator for &'a LazyRawTextList_1_0<'data> {
     }
 }
 
-impl<'a> Debug for LazyRawTextList_1_0<'a> {
+impl Debug for LazyRawTextList_1_0<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "[")?;
         for value in self {
@@ -102,7 +102,7 @@ impl<'data> RawTextListIterator_1_0<'data> {
     }
 }
 
-impl<'data> RawTextListIterator_1_0<'data> {
+impl RawTextListIterator_1_0<'_> {
     pub(crate) fn find_span(&self) -> IonResult<Range<usize>> {
         // The input has already skipped past the opening delimiter.
         let start = self.input.offset() - 1;
@@ -277,7 +277,7 @@ impl<'data> LazyRawSequence<'data, TextEncoding_1_0> for LazyRawTextSExp_1_0<'da
     }
 }
 
-impl<'a, 'data> IntoIterator for &'a LazyRawTextSExp_1_0<'data> {
+impl<'data> IntoIterator for &LazyRawTextSExp_1_0<'data> {
     type Item = IonResult<LazyRawValueExpr<'data, TextEncoding_1_0>>;
     type IntoIter = RawTextSExpIterator_1_0<'data>;
 
@@ -286,7 +286,7 @@ impl<'a, 'data> IntoIterator for &'a LazyRawTextSExp_1_0<'data> {
     }
 }
 
-impl<'a> Debug for LazyRawTextSExp_1_0<'a> {
+impl Debug for LazyRawTextSExp_1_0<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "(")?;
         for value in self {

--- a/src/lazy/text/raw/struct.rs
+++ b/src/lazy/text/raw/struct.rs
@@ -100,7 +100,7 @@ impl<'top> HasSpan<'top> for LazyRawTextFieldName_1_0<'top> {
     }
 }
 
-impl<'top> HasRange for LazyRawTextFieldName_1_0<'top> {
+impl HasRange for LazyRawTextFieldName_1_0<'_> {
     fn range(&self) -> Range<usize> {
         self.matched.range()
     }

--- a/src/lazy/text/raw/struct.rs
+++ b/src/lazy/text/raw/struct.rs
@@ -209,7 +209,7 @@ mod tests {
         // occupy the specified input ranges.
         type FieldNameAndRange<'a> = (&'a str, Range<usize>);
         type FieldTest<'a> = (&'a str, &'a [FieldNameAndRange<'a>]);
-        let tests: &[FieldTest] = &[
+        let tests: &[FieldTest<'_>] = &[
             // (Ion input, expected ranges of the struct's field names)
             ("{a:1}", &[("a", 1..2)]),
             ("{a: 1}", &[("a", 1..2)]),

--- a/src/lazy/text/raw/v1_1/arg_group.rs
+++ b/src/lazy/text/raw/v1_1/arg_group.rs
@@ -88,7 +88,7 @@ impl<'top, D: Decoder> From<LazyRawValueExpr<'top, D>> for EExpArgExpr<'top, D> 
     }
 }
 
-impl<'top, D: Decoder> HasRange for EExpArgExpr<'top, D> {
+impl<D: Decoder> HasRange for EExpArgExpr<'_, D> {
     fn range(&self) -> Range<usize> {
         match self {
             EExpArgExpr::ValueLiteral(v) => v.range(),
@@ -121,7 +121,7 @@ impl<'top> TextEExpArgGroup<'top> {
     }
 }
 
-impl<'top> HasRange for TextEExpArgGroup<'top> {
+impl HasRange for TextEExpArgGroup<'_> {
     fn range(&self) -> Range<usize> {
         self.input.range()
     }

--- a/src/lazy/text/raw/v1_1/reader.rs
+++ b/src/lazy/text/raw/v1_1/reader.rs
@@ -122,7 +122,7 @@ pub enum MacroIdRef<'data> {
     // TODO: Addresses and qualified names
 }
 
-impl<'data> Display for MacroIdRef<'data> {
+impl Display for MacroIdRef<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             MacroIdRef::LocalName(name) => write!(f, "{}", name),
@@ -131,7 +131,7 @@ impl<'data> Display for MacroIdRef<'data> {
     }
 }
 
-impl<'data> From<usize> for MacroIdRef<'data> {
+impl From<usize> for MacroIdRef<'_> {
     fn from(address: usize) -> Self {
         MacroIdRef::LocalAddress(address)
     }
@@ -156,7 +156,7 @@ impl<'top> HasSpan<'top> for TextEExpression_1_1<'top> {
     }
 }
 
-impl<'top> HasRange for TextEExpression_1_1<'top> {
+impl HasRange for TextEExpression_1_1<'_> {
     fn range(&self) -> Range<usize> {
         self.input.range()
     }
@@ -175,7 +175,7 @@ impl<'top> RawEExpression<'top, TextEncoding_1_1> for TextEExpression_1_1<'top> 
     }
 }
 
-impl<'data> Debug for TextEExpression_1_1<'data> {
+impl Debug for TextEExpression_1_1<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         // This is a text macro and the parser accepted it, so it's valid UTF-8. We can `unwrap()`.
         write!(f, "<macro invocation '{}'>", self.input.as_text().unwrap())
@@ -213,7 +213,7 @@ pub struct LazyRawTextList_1_1<'top> {
     pub(crate) value: LazyRawTextValue_1_1<'top>,
 }
 
-impl<'a> Debug for LazyRawTextList_1_1<'a> {
+impl Debug for LazyRawTextList_1_1<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "[")?;
         for value in self.iter() {
@@ -303,7 +303,7 @@ pub struct LazyRawTextSExp_1_1<'top> {
     pub(crate) value: LazyRawTextValue_1_1<'top>,
 }
 
-impl<'a> Debug for LazyRawTextSExp_1_1<'a> {
+impl Debug for LazyRawTextSExp_1_1<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "(")?;
         for value in self.iter() {
@@ -518,7 +518,7 @@ impl<'top> HasSpan<'top> for LazyRawTextFieldName_1_1<'top> {
     }
 }
 
-impl<'top> HasRange for LazyRawTextFieldName_1_1<'top> {
+impl HasRange for LazyRawTextFieldName_1_1<'_> {
     fn range(&self) -> Range<usize> {
         self.matched.range()
     }
@@ -535,7 +535,7 @@ pub struct LazyRawTextStruct_1_1<'top> {
     pub(crate) value: LazyRawTextValue_1_1<'top>,
 }
 
-impl<'a> Debug for LazyRawTextStruct_1_1<'a> {
+impl Debug for LazyRawTextStruct_1_1<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{{")?;
         for field_result in self.iter() {

--- a/src/lazy/value.rs
+++ b/src/lazy/value.rs
@@ -283,7 +283,7 @@ pub struct AnnotationsIterator<'top, D: Decoder> {
     pub(crate) context: EncodingContextRef<'top>,
 }
 
-impl<'top, D: Decoder> AnnotationsIterator<'top, D> {
+impl<D: Decoder> AnnotationsIterator<'_, D> {
     /// Returns `Ok(true)` if this annotations iterator matches the provided sequence exactly, or
     /// `Ok(false)` if not. If a decoding error occurs while visiting and resolving each annotation,
     /// returns an `Err(IonError)`.

--- a/src/lazy/value_ref.rs
+++ b/src/lazy/value_ref.rs
@@ -37,7 +37,7 @@ pub enum ValueRef<'top, D: Decoder> {
     Struct(LazyStruct<'top, D>),
 }
 
-impl<'top, D: Decoder> PartialEq for ValueRef<'top, D> {
+impl<D: Decoder> PartialEq for ValueRef<'_, D> {
     fn eq(&self, other: &Self) -> bool {
         use ValueRef::*;
         match (self, other) {
@@ -60,7 +60,7 @@ impl<'top, D: Decoder> PartialEq for ValueRef<'top, D> {
     }
 }
 
-impl<'top, D: Decoder> Debug for ValueRef<'top, D> {
+impl<D: Decoder> Debug for ValueRef<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use ValueRef::*;
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(rustdoc::private_intra_doc_links)]
 #![deny(rustdoc::bare_urls)]
+#![deny(rust_2018_idioms)]
 // Warn if example code in the doc tests contains unused imports/variables
 #![doc(test(attr(warn(unused))))]
 //! # Reading and writing `Element`s

--- a/src/raw_symbol_ref.rs
+++ b/src/raw_symbol_ref.rs
@@ -94,29 +94,29 @@ impl<'a> RawSymbolRef<'a> {
 
 /// Implemented by types that can be viewed as a [RawSymbolRef] without allocations.
 pub trait AsRawSymbolRef {
-    fn as_raw_symbol_ref(&self) -> RawSymbolRef;
+    fn as_raw_symbol_ref(&self) -> RawSymbolRef<'_>;
 }
 
 impl<'a> AsRawSymbolRef for RawSymbolRef<'a> {
-    fn as_raw_symbol_ref(&self) -> RawSymbolRef {
+    fn as_raw_symbol_ref(&self) -> RawSymbolRef<'_> {
         *self
     }
 }
 
 impl AsRawSymbolRef for SymbolId {
-    fn as_raw_symbol_ref(&self) -> RawSymbolRef {
+    fn as_raw_symbol_ref(&self) -> RawSymbolRef<'_> {
         RawSymbolRef::SymbolId(*self)
     }
 }
 
 impl AsRawSymbolRef for &str {
-    fn as_raw_symbol_ref(&self) -> RawSymbolRef {
+    fn as_raw_symbol_ref(&self) -> RawSymbolRef<'_> {
         RawSymbolRef::Text(self)
     }
 }
 
 impl AsRawSymbolRef for Symbol {
-    fn as_raw_symbol_ref(&self) -> RawSymbolRef {
+    fn as_raw_symbol_ref(&self) -> RawSymbolRef<'_> {
         match self.text() {
             Some(text) => RawSymbolRef::Text(text),
             None => RawSymbolRef::SymbolId(0),
@@ -128,7 +128,7 @@ impl<T> AsRawSymbolRef for &T
 where
     T: AsRawSymbolRef,
 {
-    fn as_raw_symbol_ref(&self) -> RawSymbolRef {
+    fn as_raw_symbol_ref(&self) -> RawSymbolRef<'_> {
         (*self).as_raw_symbol_ref()
     }
 }
@@ -230,7 +230,7 @@ impl SystemSymbol_1_1 {
 }
 
 impl AsRawSymbolRef for SystemSymbol_1_1 {
-    fn as_raw_symbol_ref(&self) -> RawSymbolRef {
+    fn as_raw_symbol_ref(&self) -> RawSymbolRef<'_> {
         // In Ion 1.1, system symbols have their own address space.
         RawSymbolRef::SystemSymbol_1_1(*self)
     }

--- a/src/raw_symbol_ref.rs
+++ b/src/raw_symbol_ref.rs
@@ -97,7 +97,7 @@ pub trait AsRawSymbolRef {
     fn as_raw_symbol_ref(&self) -> RawSymbolRef<'_>;
 }
 
-impl<'a> AsRawSymbolRef for RawSymbolRef<'a> {
+impl AsRawSymbolRef for RawSymbolRef<'_> {
     fn as_raw_symbol_ref(&self) -> RawSymbolRef<'_> {
         *self
     }
@@ -151,7 +151,7 @@ impl<'a> From<&'a &str> for RawSymbolRef<'a> {
     }
 }
 
-impl<'a> From<SymbolId> for RawSymbolRef<'a> {
+impl From<SymbolId> for RawSymbolRef<'_> {
     fn from(value: SymbolId) -> Self {
         RawSymbolRef::SymbolId(value)
     }

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -82,7 +82,7 @@ impl<'a, 'de> ValueDeserializer<'a, 'de> {
     }
 }
 
-impl<'a, 'de> de::Deserializer<'de> for ValueDeserializer<'a, 'de> {
+impl<'de> de::Deserializer<'de> for ValueDeserializer<'_, 'de> {
     type Error = IonError;
 
     /// Determine whether Deserialize implementations should expect to deserialize their human-readable form.
@@ -539,7 +539,7 @@ impl<'a, 'de> VariantAccess<'a, 'de> {
     }
 }
 
-impl<'a, 'de> EnumAccess<'de> for VariantAccess<'a, 'de> {
+impl<'de> EnumAccess<'de> for VariantAccess<'_, 'de> {
     type Error = IonError;
     type Variant = Self;
 
@@ -551,7 +551,7 @@ impl<'a, 'de> EnumAccess<'de> for VariantAccess<'a, 'de> {
     }
 }
 
-impl<'a, 'de> de::VariantAccess<'de> for VariantAccess<'a, 'de> {
+impl<'de> de::VariantAccess<'de> for VariantAccess<'_, 'de> {
     type Error = IonError;
 
     fn unit_variant(self) -> Result<(), Self::Error> {
@@ -595,7 +595,7 @@ impl<'a, 'de> UnitVariantAccess<'a, 'de> {
     }
 }
 
-impl<'a, 'de> EnumAccess<'de> for UnitVariantAccess<'a, 'de> {
+impl<'de> EnumAccess<'de> for UnitVariantAccess<'_, 'de> {
     type Error = IonError;
     type Variant = Self;
 
@@ -608,7 +608,7 @@ impl<'a, 'de> EnumAccess<'de> for UnitVariantAccess<'a, 'de> {
     }
 }
 
-impl<'a, 'de> de::VariantAccess<'de> for UnitVariantAccess<'a, 'de> {
+impl<'de> de::VariantAccess<'de> for UnitVariantAccess<'_, 'de> {
     type Error = IonError;
 
     fn unit_variant(self) -> Result<(), Self::Error> {

--- a/src/serde/decimal.rs
+++ b/src/serde/decimal.rs
@@ -30,7 +30,7 @@ impl<'de> Deserialize<'de> for Decimal {
     {
         struct DecimalVisitor;
 
-        impl<'de> Visitor<'de> for DecimalVisitor {
+        impl Visitor<'_> for DecimalVisitor {
             type Value = Decimal;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -71,7 +71,7 @@ pub struct ValueSerializer<'a, V: ValueWriter> {
     lifetime: PhantomData<&'a ()>,
 }
 
-impl<'a, V: ValueWriter> ValueSerializer<'a, V> {
+impl<V: ValueWriter> ValueSerializer<'_, V> {
     pub fn new(value_writer: V, is_human_readable: bool) -> Self {
         Self {
             value_writer,

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -31,7 +31,7 @@ impl<'de> Deserialize<'de> for Timestamp {
     {
         struct TimestampVisitor;
 
-        impl<'de> de::Visitor<'de> for TimestampVisitor {
+        impl de::Visitor<'_> for TimestampVisitor {
             type Value = Timestamp;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/shared_symbol_table.rs
+++ b/src/shared_symbol_table.rs
@@ -73,7 +73,6 @@ impl SharedSymbolTable {
 ///   ]
 /// }
 /// ```
-
 impl TryFrom<Element> for SharedSymbolTable {
     type Error = IonError;
 

--- a/src/symbol_ref.rs
+++ b/src/symbol_ref.rs
@@ -62,12 +62,12 @@ where
 /// Allows a `SymbolRef` to be constructed from a source value. This enables non-symbol types to be
 /// viewed as a symbol with little to no runtime overhead.
 pub trait AsSymbolRef {
-    fn as_symbol_ref(&self) -> SymbolRef;
+    fn as_symbol_ref(&self) -> SymbolRef<'_>;
 }
 
 // All text types can be viewed as a `SymbolRef`.
 impl<'a, A: AsRef<str> + 'a> AsSymbolRef for A {
-    fn as_symbol_ref(&self) -> SymbolRef {
+    fn as_symbol_ref(&self) -> SymbolRef<'_> {
         SymbolRef {
             text: Some(self.as_ref()),
         }
@@ -109,7 +109,7 @@ impl<'a> Borrow<str> for SymbolRef<'a> {
 // Owned `Symbol` values can be viewed as a `SymbolRef`. Due to lifetime conflicts in the
 // trait definitions, this cannot be achieved with `AsRef` or `Borrow`.
 impl AsSymbolRef for Symbol {
-    fn as_symbol_ref(&self) -> SymbolRef {
+    fn as_symbol_ref(&self) -> SymbolRef<'_> {
         self.text()
             .map(SymbolRef::with_text)
             .unwrap_or_else(SymbolRef::with_unknown_text)
@@ -117,7 +117,7 @@ impl AsSymbolRef for Symbol {
 }
 
 impl AsSymbolRef for &Symbol {
-    fn as_symbol_ref(&self) -> SymbolRef {
+    fn as_symbol_ref(&self) -> SymbolRef<'_> {
         self.text()
             .map(SymbolRef::with_text)
             .unwrap_or_else(SymbolRef::with_unknown_text)
@@ -125,7 +125,7 @@ impl AsSymbolRef for &Symbol {
 }
 
 impl<'a> AsRawSymbolRef for SymbolRef<'a> {
-    fn as_raw_symbol_ref(&self) -> RawSymbolRef {
+    fn as_raw_symbol_ref(&self) -> RawSymbolRef<'_> {
         match &self.text {
             None => RawSymbolRef::SymbolId(0),
             Some(text) => RawSymbolRef::Text(text),
@@ -151,21 +151,21 @@ mod tests {
 
     #[test]
     fn str_as_symbol_ref() {
-        let symbol_ref: SymbolRef = "foo".as_symbol_ref();
+        let symbol_ref: SymbolRef<'_> = "foo".as_symbol_ref();
         assert_eq!(Some("foo"), symbol_ref.text());
     }
 
     #[test]
     fn symbol_as_symbol_ref() {
         let symbol = Symbol::owned("foo");
-        let symbol_ref: SymbolRef = symbol.as_symbol_ref();
+        let symbol_ref: SymbolRef<'_> = symbol.as_symbol_ref();
         assert_eq!(Some("foo"), symbol_ref.text());
     }
 
     #[test]
     fn symbol_with_unknown_text_as_symbol_ref() {
         let symbol = Symbol::unknown_text();
-        let symbol_ref: SymbolRef = symbol.as_symbol_ref();
+        let symbol_ref: SymbolRef<'_> = symbol.as_symbol_ref();
         assert_eq!(None, symbol_ref.text());
     }
 }

--- a/src/symbol_ref.rs
+++ b/src/symbol_ref.rs
@@ -12,7 +12,7 @@ pub struct SymbolRef<'a> {
     text: Option<&'a str>,
 }
 
-impl<'a> Debug for SymbolRef<'a> {
+impl Debug for SymbolRef<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.text().unwrap_or("$0"))
     }
@@ -49,7 +49,7 @@ impl<'a> SymbolRef<'a> {
     }
 }
 
-impl<'a, A> PartialEq<A> for SymbolRef<'a>
+impl<A> PartialEq<A> for SymbolRef<'_>
 where
     A: AsSymbolRef,
 {
@@ -74,7 +74,7 @@ impl<'a, A: AsRef<str>> AsSymbolRef for A {
     }
 }
 
-impl<'a> Hash for SymbolRef<'a> {
+impl Hash for SymbolRef<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self.text() {
             None => 0.hash(state),
@@ -99,7 +99,7 @@ impl<'a> From<&'a Symbol> for SymbolRef<'a> {
 
 // Note that this method panics if the SymbolRef has unknown text! This is unfortunate but is required
 // in order to allow a HashMap<SymbolRef, _> to do lookups with a &str instead of a &SymbolRef
-impl<'a> Borrow<str> for SymbolRef<'a> {
+impl Borrow<str> for SymbolRef<'_> {
     fn borrow(&self) -> &str {
         self.text()
             .expect("cannot borrow a &str from a SymbolRef with unknown text")
@@ -124,7 +124,7 @@ impl AsSymbolRef for &Symbol {
     }
 }
 
-impl<'a> AsRawSymbolRef for SymbolRef<'a> {
+impl AsRawSymbolRef for SymbolRef<'_> {
     fn as_raw_symbol_ref(&self) -> RawSymbolRef<'_> {
         match &self.text {
             None => RawSymbolRef::SymbolId(0),

--- a/src/symbol_ref.rs
+++ b/src/symbol_ref.rs
@@ -66,7 +66,7 @@ pub trait AsSymbolRef {
 }
 
 // All text types can be viewed as a `SymbolRef`.
-impl<'a, A: AsRef<str> + 'a> AsSymbolRef for A {
+impl<'a, A: AsRef<str>> AsSymbolRef for A {
     fn as_symbol_ref(&self) -> SymbolRef<'_> {
         SymbolRef {
             text: Some(self.as_ref()),

--- a/src/symbol_ref.rs
+++ b/src/symbol_ref.rs
@@ -66,7 +66,7 @@ pub trait AsSymbolRef {
 }
 
 // All text types can be viewed as a `SymbolRef`.
-impl<'a, A: AsRef<str>> AsSymbolRef for A {
+impl<A: AsRef<str>> AsSymbolRef for A {
     fn as_symbol_ref(&self) -> SymbolRef<'_> {
         SymbolRef {
             text: Some(self.as_ref()),

--- a/src/text/text_formatter.rs
+++ b/src/text/text_formatter.rs
@@ -239,7 +239,7 @@ impl<W: io::Write> fmt::Write for IoValueFormatter<W> {
     }
 }
 
-impl<'a, W: std::fmt::Write> FmtValueFormatter<'a, W> {
+impl<W: std::fmt::Write> FmtValueFormatter<'_, W> {
     /// Returns `true` if the provided `token`'s text is an 'identifier'. That is, the text starts
     /// with a `$`, `_` or ASCII letter and is followed by a sequence of `$`, `_`, or ASCII letters
     /// and numbers. Examples:

--- a/src/types/struct.rs
+++ b/src/types/struct.rs
@@ -65,7 +65,7 @@ impl Fields {
     }
 
     /// Iterates over all of the values associated with the given field name.
-    fn get_all<A: AsSymbolRef>(&self, field_name: A) -> FieldValuesIterator {
+    fn get_all<A: AsSymbolRef>(&self, field_name: A) -> FieldValuesIterator<'_> {
         let indexes = self.get_indexes(field_name);
         FieldValuesIterator {
             current: 0,

--- a/tests/conformance_dsl/fragment.rs
+++ b/tests/conformance_dsl/fragment.rs
@@ -97,7 +97,7 @@ impl Fragment {
             }
             Fragment::Binary(_) => unreachable!(),
             Fragment::Ivm(maj, min) => {
-                return Ok(format!("$ion_{}_{}", maj, min).as_bytes().to_owned())
+                Ok(format!("$ion_{}_{}", maj, min).as_bytes().to_owned())
             }
         }
     }
@@ -193,7 +193,7 @@ impl TryFrom<Sequence> for Fragment {
 // special absent symbol sauce.
 pub(crate) struct ProxyElement<'a>(pub &'a Element, pub &'a Context<'a>);
 
-impl<'a> ProxyElement<'a> {
+impl ProxyElement<'_> {
     fn write_struct<V: ValueWriter>(&self, val: &Struct, writer: V) -> ion_rs::IonResult<()> {
         let annotations: Vec<&Symbol> = self.0.annotations().iter().collect();
         let annot_writer = writer.with_annotations(annotations)?;
@@ -342,7 +342,7 @@ impl<T: ion_rs::Decoder> PartialEq<ion_rs::LazyValue<'_, T>> for ProxyElement<'_
     }
 }
 
-impl<'a> WriteAsIon for ProxyElement<'a> {
+impl WriteAsIon for ProxyElement<'_> {
     fn write_as_ion<V: ValueWriter>(&self, writer: V) -> ion_rs::IonResult<()> {
         match self.0.ion_type() {
             IonType::Symbol => self.write_symbol(writer),


### PR DESCRIPTION
*Issue #, if available:* #859

*Description of changes:*

Adds `#![deny(rust_2018_idioms)]` at the crate level, disallowing elided anonymous lifetimes and unnecessary trait lifetime qualifications. Also applies lots of new `clippy` suggestions around lifetime elisions in trait implementations.

There are no logic changes, only mechanical lint suggestion fixes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
