### PR TITLE
Overhauls system macro table bootstrapping

### DIFF
--- a/benches/read_many_structs.rs
+++ b/benches/read_many_structs.rs
@@ -396,7 +396,7 @@ mod benchmark {
         let name = test_data_1_1.name.as_str();
 
         let empty_context = EncodingContext::for_ion_version(IonVersion::v1_1);
-        let compiled_macro = TemplateCompiler::compile_from_text(
+        let compiled_macro = TemplateCompiler::compile_from_source(
             empty_context.get_ref(),
             &test_data_1_1.template_definition_text,
         )

--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -1317,8 +1317,9 @@ mod tests {
         encode_macro_fn: impl FnOnce(MacroAddress) -> Vec<u8>,
         test_fn: impl FnOnce(BinaryEExpArgsIterator_1_1<'_>) -> IonResult<()>,
     ) -> IonResult<()> {
-        let mut context = EncodingContext::empty();
-        let template_macro = TemplateCompiler::compile_from_text(context.get_ref(), macro_source)?;
+        let mut context = EncodingContext::for_ion_version(IonVersion::v1_1);
+        let template_macro =
+            TemplateCompiler::compile_from_source(context.get_ref(), macro_source)?;
         let macro_address = context.macro_table.add_macro(template_macro)?;
         let opcode_byte = u8::try_from(macro_address).unwrap();
         let binary_ion = encode_macro_fn(opcode_byte as usize);

--- a/src/lazy/encoder/text/v1_1/writer.rs
+++ b/src/lazy/encoder/text/v1_1/writer.rs
@@ -285,7 +285,7 @@ mod tests {
         let mut reader = LazyRawTextReader_1_1::new(encoded_text.as_bytes());
         let mut context = EncodingContext::for_ion_version(IonVersion::v1_1);
         let macro_foo =
-            TemplateCompiler::compile_from_text(context.get_ref(), "(macro foo (x*) null)")?;
+            TemplateCompiler::compile_from_source(context.get_ref(), "(macro foo (x*) null)")?;
         context.macro_table.add_macro(macro_foo)?;
         let context = context.get_ref();
         let _marker = reader.next(context)?.expect_ivm()?;

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -70,7 +70,7 @@ impl<E: Encoding, Output: Write> Writer<E, Output> {
         // TODO: LazyEncoder should define a method to construct a new symtab and/or macro table
         let ion_version = E::ion_version();
         let symbol_table = SymbolTable::new(ion_version);
-        let macro_table = MacroTable::with_system_macros();
+        let macro_table = MacroTable::with_system_macros(ion_version);
         let context = WriterContext::new(symbol_table, macro_table);
         let mut writer = Writer {
             context,

--- a/src/lazy/expanded/encoding_module.rs
+++ b/src/lazy/expanded/encoding_module.rs
@@ -1,5 +1,5 @@
 use crate::lazy::expanded::macro_table::MacroTable;
-use crate::{IonVersion, SymbolTable};
+use crate::SymbolTable;
 
 #[derive(Debug, Clone)]
 pub struct EncodingModule {
@@ -16,13 +16,7 @@ impl EncodingModule {
             symbol_table,
         }
     }
-    pub fn ion_1_1_system_module() -> Self {
-        Self::new(
-            String::from("$ion"),
-            MacroTable::with_system_macros(),
-            SymbolTable::new(IonVersion::v1_1),
-        )
-    }
+
     pub fn name(&self) -> &str {
         &self.name
     }

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -2110,22 +2110,16 @@ mod tests {
             (&[macro_id, 0x0B, 0x0D], (5, 6)), // TODO: non-required cardinalities
         ];
 
-        for test in tests {
-            let mut stream = vec![0xE0, 0x01, 0x00, 0xEA];
-            stream.extend_from_slice(test.0);
-            println!(
-                "stream {:02X?} -> pair ({}, {})",
-                test.0, test.1 .0, test.1 .1
-            );
-            let mut reader = Reader::new(v1_1::Binary, stream.as_slice())?;
+        for (stream, (num1, num2)) in tests.iter().copied() {
+            let mut reader = Reader::new(v1_1::Binary, stream)?;
             reader.register_template_src(template_definition)?;
             assert_eq!(
                 reader.next()?.unwrap().read()?.expect_int()?,
-                Int::from(test.1 .0)
+                Int::from(num1)
             );
             assert_eq!(
                 reader.next()?.unwrap().read()?.expect_int()?,
-                Int::from(test.1 .1)
+                Int::from(num2)
             );
         }
         Ok(())

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -4,7 +4,7 @@ use crate::lazy::any_encoding::{IonEncoding, IonVersion};
 use crate::lazy::decoder::Decoder;
 use crate::lazy::expanded::compiler::TemplateCompiler;
 use crate::lazy::expanded::encoding_module::EncodingModule;
-use crate::lazy::expanded::macro_table::MacroTable;
+use crate::lazy::expanded::macro_table::{MacroTable, ION_1_1_SYSTEM_MACROS};
 use crate::lazy::expanded::template::TemplateMacro;
 use crate::lazy::expanded::{ExpandedStreamItem, ExpandingReader, LazyExpandedValue};
 use crate::lazy::sequence::SExpIterator;
@@ -255,7 +255,7 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
                 let new_encoding_module = match pending_changes.take_new_active_module() {
                     None => EncodingModule::new(
                         "$ion_encoding".to_owned(),
-                        MacroTable::with_system_macros(),
+                        MacroTable::with_system_macros(IonVersion::v1_1),
                         symbol_table,
                     ),
                     Some(mut module) => {
@@ -392,9 +392,7 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
                     macro_table.append_all_macros_from(active_mactab)?;
                 }
                 ValueRef::Symbol(module_name) if module_name == "$ion" => {
-                    let expanded_value = operation.expanded();
-                    let system_mactab = expanded_value.context.system_module.macro_table();
-                    macro_table.append_all_macros_from(system_mactab)?;
+                    macro_table.append_all_macros_from(&ION_1_1_SYSTEM_MACROS)?;
                 }
                 ValueRef::Symbol(_module_name) => {
                     todo!("re-exporting macros from a module other than $ion_encoding")

--- a/src/lazy/text/buffer.rs
+++ b/src/lazy/text/buffer.rs
@@ -2821,7 +2821,7 @@ mod tests {
 
         fn register_macro(&mut self, text: &str) -> &mut Self {
             let new_macro =
-                TemplateCompiler::compile_from_text(self.context.get_ref(), text).unwrap();
+                TemplateCompiler::compile_from_source(self.context.get_ref(), text).unwrap();
             self.context.macro_table.add_macro(new_macro).unwrap();
             self
         }

--- a/src/lazy/text/raw/v1_1/reader.rs
+++ b/src/lazy/text/raw/v1_1/reader.rs
@@ -873,7 +873,7 @@ mod tests {
 
         let mut context = EncodingContext::for_ion_version(IonVersion::v1_1);
         let macro_quux =
-            TemplateCompiler::compile_from_text(context.get_ref(), "(macro quux (x) null)")?;
+            TemplateCompiler::compile_from_source(context.get_ref(), "(macro quux (x) null)")?;
         context.macro_table.add_macro(macro_quux)?;
         let reader = &mut LazyRawTextReader_1_1::new(data.as_bytes());
         let context = context.get_ref();


### PR DESCRIPTION
This patch modifies `EncodingContext` to have an empty macro table when constructed for use in Ion 1.0 readers.

This allows the Ion 1.0 reader to be used in the process of bootstrapping the Ion 1.1 system macro table, which was previously not possible due to the (now eliminated) circular dependency between macros and readers.

System macros that can be expressed in TDL are now constructed from a template definition encoded in Ion 1.0. As a result, the system macro table initialization logic is now substantially easier to read and more straightforward to modify.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
