### PR TITLE
Switches from "encoding module" to "default module"

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -49,7 +49,7 @@ pub(crate) mod v1_1 {
     use phf::phf_map;
 
     pub mod constants {
-        pub const DEFAULT_MODULE_NAME: &'static str = "_";
+        pub const DEFAULT_MODULE_NAME: &str = "_";
     }
     pub static SYSTEM_SYMBOLS: &[&str] = &[
         // <unknown text>               $0

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -48,6 +48,9 @@ pub(crate) mod v1_1 {
     use crate::types::SymbolAddress;
     use phf::phf_map;
 
+    pub mod constants {
+        pub const DEFAULT_MODULE_NAME: &'static str = "_";
+    }
     pub static SYSTEM_SYMBOLS: &[&str] = &[
         // <unknown text>               $0
         "$ion",                     //  $1
@@ -123,6 +126,7 @@ pub(crate) mod v1_1 {
         pub const ION: SystemSymbol_1_1 = SystemSymbol_1_1::new_unchecked(1);
         pub const ENCODING: SystemSymbol_1_1 = SystemSymbol_1_1::new_unchecked(10);
         pub const SYMBOL_TABLE: SystemSymbol_1_1 = SystemSymbol_1_1::new_unchecked(15);
+        pub const MODULE: SystemSymbol_1_1 = SystemSymbol_1_1::new_unchecked(16);
         pub const EMPTY_TEXT: SystemSymbol_1_1 = SystemSymbol_1_1::new_unchecked(21);
         pub const ADD_SYMBOLS: SystemSymbol_1_1 = SystemSymbol_1_1::new_unchecked(45);
         pub const ADD_MACROS: SystemSymbol_1_1 = SystemSymbol_1_1::new_unchecked(47);

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -59,7 +59,7 @@ pub(crate) mod v1_1 {
         "symbols",                  //  $7
         "max_id",                   //  $8
         "$ion_shared_symbol_table", //  $9
-        "$ion_encoding",            // $10
+        "encoding",                 // $10
         "$ion_literal",             // $11
         "$ion_shared_module",       // $12
         "macro",                    // $13
@@ -120,7 +120,8 @@ pub(crate) mod v1_1 {
     pub mod system_symbols {
         use crate::raw_symbol_ref::SystemSymbol_1_1;
 
-        pub const ION_ENCODING: SystemSymbol_1_1 = SystemSymbol_1_1::new_unchecked(10);
+        pub const ION: SystemSymbol_1_1 = SystemSymbol_1_1::new_unchecked(1);
+        pub const ENCODING: SystemSymbol_1_1 = SystemSymbol_1_1::new_unchecked(10);
         pub const SYMBOL_TABLE: SystemSymbol_1_1 = SystemSymbol_1_1::new_unchecked(15);
         pub const EMPTY_TEXT: SystemSymbol_1_1 = SystemSymbol_1_1::new_unchecked(21);
         pub const ADD_SYMBOLS: SystemSymbol_1_1 = SystemSymbol_1_1::new_unchecked(45);

--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -1269,15 +1269,15 @@ mod tests {
         RawSymbolRef::SymbolId(5)
     ])]
     #[case::one_flex_syms_with_system_symbol(AnnotationsEncoding::FlexSym, &[0xE7, 0x01, 0x6A], 1, 2, &[
-        RawSymbolRef::Text("$ion_encoding"),
+        RawSymbolRef::Text("encoding"),
     ])]
     #[case::two_flex_syms_with_system_symbols(AnnotationsEncoding::FlexSym, &[0xE8, 0x01, 0x60, 0x01, 0x6A], 1, 4, &[
         RawSymbolRef::SymbolId(0),
-        RawSymbolRef::Text("$ion_encoding"),
+        RawSymbolRef::Text("encoding"),
     ])]
     #[case::three_flex_syms_with_system_symbols(AnnotationsEncoding::FlexSym, &[0xE9, 0x0D, 0x01, 0x60, 0x01, 0x6A, 0x01, 0xA1], 2, 6, &[
         RawSymbolRef::SymbolId(0),
-        RawSymbolRef::Text("$ion_encoding"),
+        RawSymbolRef::Text("encoding"),
         RawSymbolRef::Text("make_field"),
     ])]
     fn read_annotations_sequence(
@@ -1623,8 +1623,7 @@ mod tests {
 
         // Construct an encoding directive that defines this number of macros. Each macro will expand
         // to its own address.
-        let mut macro_definitions =
-            String::from("$ion_encoding::(\n  (macro_table $ion_encoding\n");
+        let mut macro_definitions = String::from("$ion::\n(module _\n  (macro_table _\n");
         for address in MacroTable::FIRST_USER_MACRO_ID..MAX_TEST_MACRO_ADDRESS {
             writeln!(macro_definitions, "    (macro m{address} () {address})")?;
         }

--- a/src/lazy/binary/raw/v1_1/reader.rs
+++ b/src/lazy/binary/raw/v1_1/reader.rs
@@ -347,7 +347,7 @@ mod tests {
             0xE3, 0x01, 0x00, 0x00,
 
             // System symbols
-            0xEE, 0x0A, // $ion_encoding
+            0xEE, 0x0A, // encoding
             0xEE, 0x0E, // macro_table
             0xEE, 0x15, // empty text
             0xEE, 0x41, // make_field
@@ -364,7 +364,7 @@ mod tests {
             RawSymbolRef::SymbolId(1),
             RawSymbolRef::SymbolId(257),
             RawSymbolRef::SymbolId(65_793),
-            RawSymbolRef::Text("$ion_encoding"),
+            RawSymbolRef::Text("encoding"),
             RawSymbolRef::Text("macro_table"),
             RawSymbolRef::Text(""),
             RawSymbolRef::Text("make_field"),

--- a/src/lazy/binary/raw/v1_1/struct.rs
+++ b/src/lazy/binary/raw/v1_1/struct.rs
@@ -335,10 +335,11 @@ mod tests {
         let mut writer = Writer::new(v1_1::Binary, Vec::new())?;
         let encoding_directive = Element::read_one(
             r#"
-                $ion_encoding::(
-                    (symbol_table $ion_encoding)
+                $ion::
+                (module _
+                    (symbol_table _)
                     (macro_table
-                        $ion_encoding
+                        _
                         (macro greet (name) (.make_string "hello, " (%name)))
                     )
                 )

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -165,8 +165,10 @@ impl<E: Encoding, Output: Write> Writer<E, Output> {
 
         let mut directive = directive_writer
             .value_writer()
-            .with_annotations(v1_1::system_symbols::ION_ENCODING)?
+            .with_annotations(v1_1::system_symbols::ION)?
             .sexp_writer()?;
+
+        directive.write_symbol("module")?.write_symbol("_")?;
 
         let pending_symbols = context
             .symbol_table
@@ -177,7 +179,7 @@ impl<E: Encoding, Output: Write> Writer<E, Output> {
         let mut symbol_table = directive.sexp_writer()?;
         symbol_table
             .write_symbol(v1_1::system_symbols::SYMBOL_TABLE)?
-            .write_symbol(v1_1::system_symbols::ION_ENCODING)?
+            .write_symbol("_")?
             .write_list(pending_symbols)?;
         symbol_table.close()?;
         directive.close()

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -168,7 +168,9 @@ impl<E: Encoding, Output: Write> Writer<E, Output> {
             .with_annotations(v1_1::system_symbols::ION)?
             .sexp_writer()?;
 
-        directive.write_symbol("module")?.write_symbol("_")?;
+        directive
+            .write_symbol(v1_1::system_symbols::MODULE)?
+            .write_symbol(v1_1::constants::DEFAULT_MODULE_NAME)?;
 
         let pending_symbols = context
             .symbol_table
@@ -179,7 +181,7 @@ impl<E: Encoding, Output: Write> Writer<E, Output> {
         let mut symbol_table = directive.sexp_writer()?;
         symbol_table
             .write_symbol(v1_1::system_symbols::SYMBOL_TABLE)?
-            .write_symbol("_")?
+            .write_symbol(v1_1::constants::DEFAULT_MODULE_NAME)?
             .write_list(pending_symbols)?;
         symbol_table.close()?;
         directive.close()

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -1,5 +1,6 @@
 //! Compiles template definition language (TDL) expressions into a form suitable for fast incremental
 //! evaluation.
+use crate::constants::v1_1;
 use crate::element::iterators::SymbolsIterator;
 use crate::lazy::decoder::Decoder;
 use crate::lazy::expanded::macro_table::ION_1_1_SYSTEM_MACROS;
@@ -461,7 +462,9 @@ impl TemplateCompiler {
             // If the module is `$ion`, this refers to the system module.
             "$ion" => ION_1_1_SYSTEM_MACROS.clone_macro_with_id(macro_id),
             // If the module is `_`, this refers to the active encoding module.
-            "_" => context.macro_table().clone_macro_with_id(macro_id),
+            v1_1::constants::DEFAULT_MODULE_NAME => {
+                context.macro_table().clone_macro_with_id(macro_id)
+            }
             _ => todo!("qualified references to modules other than `_` (found `{module_name}`"),
         }
     }

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -460,11 +460,9 @@ impl TemplateCompiler {
         match module_name {
             // If the module is `$ion`, this refers to the system module.
             "$ion" => ION_1_1_SYSTEM_MACROS.clone_macro_with_id(macro_id),
-            // If the module is `$ion_encoding`, this refers to the active encoding module.
-            "$ion_encoding" => context.macro_table().clone_macro_with_id(macro_id),
-            _ => todo!(
-                "qualified references to modules other than $ion_encoding (found {module_name}"
-            ),
+            // If the module is `_`, this refers to the active encoding module.
+            "_" => context.macro_table().clone_macro_with_id(macro_id),
+            _ => todo!("qualified references to modules other than `_` (found `{module_name}`"),
         }
     }
 
@@ -1725,9 +1723,10 @@ mod tests {
 
         let ion = r#"
             $ion_1_1
-            $ion_encoding::(
+            $ion::
+            (module _
                 (macro_table
-                    $ion_encoding
+                    _
                     (macro hello (name) (.make_string "hello " (%name)))
                     (macro hello_world () (.hello "world")) // Depends on macro 'hello'
                 )

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -1350,7 +1350,8 @@ mod tests {
         stream_eq(
             r#"
                 // Define macro `double`
-                $ion_encoding::(
+                $ion::
+                (module _
                     (macro_table
                         $ion
                         (macro double (x) (.$ion::values (%x) (%x)))
@@ -1359,7 +1360,8 @@ mod tests {
 
                 // `double` exists until the *end* of the encoding directive below. Define a new
                 // macro that depends on `double`.
-                $ion_encoding::(
+                $ion::
+                (module _
                     (macro_table
                         (macro quadruple (y)
                             (.$ion::values
@@ -1367,7 +1369,7 @@ mod tests {
                                 // to it without qualification.
                                 (.double (%y))
                                 // We could also refer to it with a qualification.
-                                (.$ion_encoding::double (%y))))
+                                (._::double (%y))))
                     )
                 )
 
@@ -1388,23 +1390,25 @@ mod tests {
         stream_eq(
             r#"
                 // Define macro `double`
-                $ion_encoding::(
+                $ion::
+                (module _
                     (macro_table
-                        $ion_encoding
+                        _
                         (macro double (x) (.values (%x) (%x)))
                     )
                 )
 
-                $ion_encoding::(
+                $ion::
+                (module _
                     (macro_table
-                        $ion_encoding // Re-export the active encoding module's macros
+                        _ // Re-export the active encoding module's macros
                         (macro quadruple (y)
                             (.$ion::values
                                 // Because `double` has been added to the local namespace,
                                 // we can refer to it without a qualified reference.
                                 (.double (%y))
                                 // However, we can also refer to it using a qualified reference.
-                                (.$ion_encoding::double (%y))))
+                                (._::double (%y))))
                     )
                 )
 
@@ -1456,7 +1460,8 @@ mod tests {
     fn multiple_arg_expr_groups() -> IonResult<()> {
         stream_eq(
             r#"
-                $ion_encoding::(
+                $ion::
+                (module _
                     (macro_table
                         (macro foo (x+ y* z+)
                             (.make_string (.. (%x) "-" (%y) "-" (%z))))
@@ -1540,7 +1545,8 @@ mod tests {
         stream_eq(
             r#"
                 // Define some symbols
-                $ion_encoding::(
+                $ion::
+                (module _
                     (symbol_table ["foo", "bar"]) // $1, $2
                 )
                 // Use them
@@ -1608,7 +1614,8 @@ mod tests {
         // TODO: update symbol IDs when reading and writing system symbols are implemented
         stream_eq(
             r#"
-                $ion_encoding::(
+                $ion::
+                (module _
                     (symbol_table ["foo", "bar", "baz"]) // $1, $2, $3
                 )
                 $1
@@ -1686,7 +1693,8 @@ mod tests {
         // TODO: update symbol IDs when reading and writing system symbols are implemented
         stream_eq(
             r#"
-                $ion_encoding::(
+                $ion::
+                (module _
                     (symbol_table ["foo", "bar", "baz"]) // $1, $2, $3
                 )
                 $1
@@ -1727,7 +1735,8 @@ mod tests {
         eval_template_invocation(
             r#"
                 (macro def_macros (macros*)
-                    $ion_encoding::(
+                    $ion::
+                    (module _
                         (macro_table (%macros))
                     )
                 )"#,

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -292,11 +292,12 @@ impl MacroTable {
             template(
                 r#"
                         (macro set_symbols (symbols*)
-                             $ion_encoding::(
+                             $ion::
+                             (module _
                                // Set a new symbol table
                                (symbol_table [(%symbols)])
                                // Include the active encoding module macros
-                               (macro_table $ion_encoding)
+                               (macro_table _)
                              )
                        )
                     "#,
@@ -304,11 +305,12 @@ impl MacroTable {
             template(
                 r#"
                         (macro add_symbols (symbols*)
-                             $ion_encoding::(
+                             $ion::
+                             (module _
                                // Set a new symbol table
-                               (symbol_table $ion_encoding [(%symbols)])
+                               (symbol_table _ [(%symbols)])
                                // Include the active encoding module macros
-                               (macro_table $ion_encoding)
+                               (macro_table _)
                              )
                        )
                     "#,
@@ -316,9 +318,10 @@ impl MacroTable {
             template(
                 r#"
                        (macro set_macros (macro_definitions*)
-                           $ion_encoding::(
+                           $ion::
+                           (module _
                                // Include the active encoding module symbols
-                               (symbol_table $ion_encoding)
+                               (symbol_table _)
                                // Set a new macro table
                                (macro_table (%macro_definitions))
                            )
@@ -328,11 +331,12 @@ impl MacroTable {
             template(
                 r#"
                        (macro add_macros (macro_definitions*)
-                           $ion_encoding::(
+                           $ion::
+                           (module _
                                // Include the active encoding module symbols
-                               (symbol_table $ion_encoding)
+                               (symbol_table _)
                                // Set a new macro table
-                               (macro_table $ion_encoding (%macro_definitions))
+                               (macro_table _ (%macro_definitions))
                            )
                        )
                     "#,

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -686,7 +686,8 @@ mod tests {
     use crate::lazy::decoder::RawVersionMarker;
     use crate::lazy::system_stream_item::SystemStreamItem;
     use crate::{
-        v1_0, v1_1, AnyEncoding, Catalog, IonResult, SequenceWriter, SymbolRef, ValueWriter, Writer,
+        constants, v1_0, v1_1, AnyEncoding, Catalog, IonResult, SequenceWriter, SymbolRef,
+        ValueWriter, Writer,
     };
 
     use super::*;
@@ -1101,9 +1102,8 @@ mod tests {
             .value_writer()
             .with_annotations("$ion")?
             .sexp_writer()?;
-        directive
-            .write_symbol(v1_1::system_symbols::MODULE.text())?
-            .write_symbol(v1_1::constants::DEFAULT_MODULE_NAME)?;
+        // We avoid using 1.1 text constants here because access to them is feature gated.
+        directive.write_symbol("module")?.write_symbol("_")?;
         let mut symbol_table = directive.sexp_writer()?;
         symbol_table.write_symbol("symbol_table")?;
         symbol_table.write_list(["foo", "bar", "baz"])?;

--- a/src/lazy/system_stream_item.rs
+++ b/src/lazy/system_stream_item.rs
@@ -15,7 +15,7 @@ pub enum SystemStreamItem<'top, D: Decoder> {
     VersionMarker(D::VersionMarker<'top>),
     /// An Ion 1.0-style symbol table encoded as a struct annotated with `$ion_symbol_table`.
     SymbolTable(LazyStruct<'top, D>),
-    /// An Ion 1.1 encoding directive; an s-expression annotated with `$ion_encoding`.
+    /// An Ion 1.1 encoding directive; an s-expression annotated with `$ion`.
     EncodingDirective(LazySExp<'top, D>),
     /// An application-level Ion value
     Value(LazyValue<'top, D>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ pub use crate::text::text_formatter::{FmtValueFormatter, IoValueFormatter};
 // Private modules that serve to organize implementation details.
 pub(crate) mod binary;
 pub(crate) mod catalog;
-mod constants;
+pub(crate) mod constants;
 mod ion_data;
 mod raw_symbol_ref;
 mod shared_symbol_table;
@@ -384,6 +384,12 @@ pub mod v1_0 {
 pub mod v1_1 {
     #[cfg(feature = "experimental-tooling-apis")]
     v1_1_tooling_apis!(pub);
+
+    #[cfg(feature = "experimental-tooling-apis")]
+    pub use crate::constants::v1_1::system_symbols;
+
+    #[cfg(feature = "experimental-tooling-apis")]
+    pub use crate::constants::v1_1::constants;
 
     #[cfg(not(feature = "experimental-tooling-apis"))]
     v1_1_tooling_apis!(pub(crate));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,14 +382,11 @@ pub mod v1_0 {
 
 #[cfg(feature = "experimental-ion-1-1")]
 pub mod v1_1 {
-    #[cfg(feature = "experimental-tooling-apis")]
-    v1_1_tooling_apis!(pub);
-
-    #[cfg(feature = "experimental-tooling-apis")]
+    pub use crate::constants::v1_1::constants;
     pub use crate::constants::v1_1::system_symbols;
 
     #[cfg(feature = "experimental-tooling-apis")]
-    pub use crate::constants::v1_1::constants;
+    v1_1_tooling_apis!(pub);
 
     #[cfg(not(feature = "experimental-tooling-apis"))]
     v1_1_tooling_apis!(pub(crate));

--- a/tests/conformance_dsl/fragment.rs
+++ b/tests/conformance_dsl/fragment.rs
@@ -96,9 +96,7 @@ impl Fragment {
                 Ok(bytes.to_owned())
             }
             Fragment::Binary(_) => unreachable!(),
-            Fragment::Ivm(maj, min) => {
-                Ok(format!("$ion_{}_{}", maj, min).as_bytes().to_owned())
-            }
+            Fragment::Ivm(maj, min) => Ok(format!("$ion_{}_{}", maj, min).as_bytes().to_owned()),
         }
     }
 
@@ -151,7 +149,7 @@ impl TryFrom<Clause> for Fragment {
                 // Rather than treat Encoding special, we expand it to a (toplevel ..) as described
                 // in the spec.
                 let inner: Element = SExp(Sequence::new(other.body)).into();
-                let inner = inner.with_annotations(["$ion_encoding"]);
+                let inner = inner.with_annotations(["$ion"]);
                 Fragment::TopLevel(TopLevel { elems: vec![inner] })
             }
             ClauseType::MacTab => {

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -62,7 +62,7 @@ mod implementation {
     fn test_encoding() {
         let test: &str = r#"
              (ion_1_1
-                 (encoding (macro_table (macro m () 1)))
+                 (encoding module _ (macro_table (macro m () 1)))
                  (text "(:m)")
                  (produces 1)
              )"#;


### PR DESCRIPTION
Builds on PR #872.

Switches encoding directive syntax from:
```ion
$ion_encoding::(/*...*/)
```
to:
```ion
$ion::(module _ /*...*/)
```
in anticipation of multi-module support.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
