### PR TITLE
Implements `flatten`, `make_list`, `meta`

### DIFF
--- a/benches/read_many_structs.rs
+++ b/benches/read_many_structs.rs
@@ -438,7 +438,7 @@ mod benchmark {
             let mut context = EncodingContext::for_ion_version(IonVersion::v1_1);
             context
                 .macro_table_mut()
-                .add_macro(compiled_macro.clone())
+                .add_template_macro(compiled_macro.clone())
                 .unwrap();
             let context_ref = context.get_ref();
             b.iter(|| {

--- a/src/lazy/binary/raw/v1_1/immutable_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/immutable_buffer.rs
@@ -1320,7 +1320,7 @@ mod tests {
         let mut context = EncodingContext::for_ion_version(IonVersion::v1_1);
         let template_macro =
             TemplateCompiler::compile_from_source(context.get_ref(), macro_source)?;
-        let macro_address = context.macro_table.add_macro(template_macro)?;
+        let macro_address = context.macro_table.add_template_macro(template_macro)?;
         let opcode_byte = u8::try_from(macro_address).unwrap();
         let binary_ion = encode_macro_fn(opcode_byte as usize);
         let buffer = BinaryBuffer::new(context.get_ref(), &binary_ion);

--- a/src/lazy/encoder/text/v1_1/writer.rs
+++ b/src/lazy/encoder/text/v1_1/writer.rs
@@ -286,7 +286,7 @@ mod tests {
         let mut context = EncodingContext::for_ion_version(IonVersion::v1_1);
         let macro_foo =
             TemplateCompiler::compile_from_source(context.get_ref(), "(macro foo (x*) null)")?;
-        context.macro_table.add_macro(macro_foo)?;
+        context.macro_table.add_template_macro(macro_foo)?;
         let context = context.get_ref();
         let _marker = reader.next(context)?.expect_ivm()?;
         let eexp = reader.next(context)?.expect_eexp()?;

--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -9,9 +9,9 @@ use crate::lazy::decoder::{Decoder, RawValueExpr};
 use crate::lazy::encoding::TextEncoding_1_1;
 use crate::lazy::expanded::compiler::{ExpansionAnalysis, ExpansionSingleton};
 use crate::lazy::expanded::macro_evaluator::{
-    AnnotateExpansion, EExpressionArgGroup, ExprGroupExpansion, IsExhaustedIterator,
-    MacroExpansion, MacroExpansionKind, MacroExpr, MacroExprArgsIterator, MakeSExpExpansion,
-    MakeTextExpansion, RawEExpression, TemplateExpansion, ValueExpr,
+    AnnotateExpansion, EExpressionArgGroup, ExprGroupExpansion, FlattenExpansion,
+    IsExhaustedIterator, MacroExpansion, MacroExpansionKind, MacroExpr, MacroExprArgsIterator,
+    MakeSExpExpansion, MakeTextExpansion, RawEExpression, TemplateExpansion, ValueExpr,
 };
 use crate::lazy::expanded::macro_table::{MacroKind, MacroRef};
 use crate::lazy::expanded::template::TemplateMacroRef;
@@ -125,6 +125,11 @@ impl<'top, D: Decoder> EExpression<'top, D> {
             }
             MacroKind::MakeSExp => MacroExpansionKind::MakeSExp(MakeSExpExpansion::new(arguments)),
             MacroKind::Annotate => MacroExpansionKind::Annotate(AnnotateExpansion::new(arguments)),
+            MacroKind::Flatten => MacroExpansionKind::Flatten(FlattenExpansion::new(
+                self.context,
+                environment,
+                arguments,
+            )),
             MacroKind::Template(template_body) => {
                 let template_ref = TemplateMacroRef::new(invoked_macro.reference(), template_body);
                 environment = self.new_evaluation_environment()?;

--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -11,7 +11,7 @@ use crate::lazy::expanded::compiler::{ExpansionAnalysis, ExpansionSingleton};
 use crate::lazy::expanded::macro_evaluator::{
     AnnotateExpansion, EExpressionArgGroup, ExprGroupExpansion, FlattenExpansion,
     IsExhaustedIterator, MacroExpansion, MacroExpansionKind, MacroExpr, MacroExprArgsIterator,
-    MakeSExpExpansion, MakeTextExpansion, RawEExpression, TemplateExpansion, ValueExpr,
+    MakeTextExpansion, RawEExpression, TemplateExpansion, ValueExpr,
 };
 use crate::lazy::expanded::macro_table::{MacroKind, MacroRef};
 use crate::lazy::expanded::template::TemplateMacroRef;
@@ -123,7 +123,6 @@ impl<'top, D: Decoder> EExpression<'top, D> {
             MacroKind::MakeSymbol => {
                 MacroExpansionKind::MakeSymbol(MakeTextExpansion::symbol_maker(arguments))
             }
-            MacroKind::MakeSExp => MacroExpansionKind::MakeSExp(MakeSExpExpansion::new(arguments)),
             MacroKind::Annotate => MacroExpansionKind::Annotate(AnnotateExpansion::new(arguments)),
             MacroKind::Flatten => MacroExpansionKind::Flatten(FlattenExpansion::new(
                 self.context,

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -726,7 +726,7 @@ impl<'top, D: Decoder> MacroEvaluator<'top, D> {
                 );
                 stacked_evaluator
                     .macro_stack
-                    .extend([original_expansion, new_expansion].into_iter());
+                    .extend([original_expansion, new_expansion]);
                 self.state = EvaluatorState::Stacked(stacked_evaluator)
             }
             // Going from 2+ up

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -114,7 +114,6 @@ pub enum MacroKind {
     ExprGroup,
     MakeString,
     MakeSymbol,
-    MakeSExp,
     Annotate,
     Flatten,
     Template(TemplateBody),
@@ -190,13 +189,6 @@ impl Default for MacroTable {
 }
 
 impl MacroTable {
-    pub const SYSTEM_MACRO_KINDS: &'static [MacroKind] = &[
-        MacroKind::None,
-        MacroKind::ExprGroup,
-        MacroKind::MakeString,
-        MacroKind::MakeSExp,
-        MacroKind::Annotate,
-    ];
     // The system macros range from address 0 to 23
     pub const NUM_SYSTEM_MACROS: usize = 24;
     // When a user defines new macros, this is the first ID that will be assigned. This value

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -150,7 +150,7 @@ impl EncodingContext {
     }
 
     pub fn register_template(&mut self, template_macro: TemplateMacro) -> IonResult<MacroAddress> {
-        self.macro_table.add_macro(template_macro)
+        self.macro_table.add_template_macro(template_macro)
     }
 }
 
@@ -288,7 +288,7 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
 
     fn add_macro(&mut self, template_macro: TemplateMacro) -> IonResult<MacroAddress> {
         let macro_table = &mut self.context_mut().macro_table;
-        macro_table.add_macro(template_macro)
+        macro_table.add_template_macro(template_macro)
     }
 
     pub fn context(&self) -> EncodingContextRef<'_> {

--- a/src/lazy/expanded/sequence.rs
+++ b/src/lazy/expanded/sequence.rs
@@ -331,7 +331,7 @@ fn expand_next_sequence_value<'top, D: Decoder>(
     expand_next_sequence_value_from_resolved(evaluator, &mut resolving_iter)
 }
 
-pub(crate) fn expand_next_sequence_value_from_resolved<'top, D: Decoder>(
+fn expand_next_sequence_value_from_resolved<'top, D: Decoder>(
     evaluator: &mut MacroEvaluator<'top, D>,
     iter: &mut impl Iterator<Item = IonResult<ValueExpr<'top, D>>>,
 ) -> Option<IonResult<LazyExpandedValue<'top, D>>> {
@@ -360,7 +360,7 @@ pub(crate) fn expand_next_sequence_value_from_resolved<'top, D: Decoder>(
 }
 
 /// Represents a sequence (list or sexp) whose contents are being traversed.
-/// This is used in (e.g.) `make_sexp` to store an iterator for each of its
+/// This is used in `flatten` to store an iterator for each of its
 /// sequence arguments in turn.
 #[derive(Debug)]
 pub enum ExpandedSequenceIterator<'top, D: Decoder> {
@@ -373,27 +373,6 @@ impl<'top, D: Decoder> Iterator for ExpandedSequenceIterator<'top, D> {
 
     fn next(&mut self) -> Option<Self::Item> {
         use ExpandedSequenceIterator::*;
-        match self {
-            List(l) => l.next(),
-            SExp(s) => s.next(),
-        }
-    }
-}
-
-/// Represents a sequence (list or sexp) whose contents are being traversed.
-/// This is used in (e.g.) `make_sexp` to store an iterator for each of its
-/// sequence arguments in turn.
-#[derive(Debug)]
-pub enum FlattenedSequence<'top, D: Decoder> {
-    List(&'top mut ExpandedListIterator<'top, D>),
-    SExp(&'top mut ExpandedSExpIterator<'top, D>),
-}
-
-impl<'top, D: Decoder> Iterator for FlattenedSequence<'top, D> {
-    type Item = IonResult<LazyExpandedValue<'top, D>>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        use FlattenedSequence::*;
         match self {
             List(l) => l.next(),
             SExp(s) => s.next(),

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -8,7 +8,7 @@ use compact_str::CompactString;
 use crate::lazy::binary::raw::v1_1::immutable_buffer::ArgGroupingBitmap;
 use crate::lazy::decoder::Decoder;
 use crate::lazy::expanded::compiler::ExpansionAnalysis;
-use crate::lazy::expanded::macro_evaluator::{AnnotateExpansion, MacroEvaluator, MacroExpansion, MacroExpansionKind, MacroExpr, MacroExprArgsIterator, MakeSExpExpansion, TemplateExpansion, ValueExpr, ExprGroupExpansion, MakeTextExpansion, FlattenExpansion};
+use crate::lazy::expanded::macro_evaluator::{AnnotateExpansion, MacroEvaluator, MacroExpansion, MacroExpansionKind, MacroExpr, MacroExprArgsIterator, TemplateExpansion, ValueExpr, ExprGroupExpansion, MakeTextExpansion, FlattenExpansion};
 use crate::lazy::expanded::macro_table::{Macro, MacroKind};
 use crate::lazy::expanded::r#struct::UnexpandedField;
 use crate::lazy::expanded::sequence::Environment;
@@ -1221,7 +1221,6 @@ impl<'top, D: Decoder> TemplateMacroInvocation<'top, D> {
             MacroKind::MakeSymbol => {
                 MacroExpansionKind::MakeSymbol(MakeTextExpansion::symbol_maker(arguments))
             }
-            MacroKind::MakeSExp => MacroExpansionKind::MakeSExp(MakeSExpExpansion::new(arguments)),
             MacroKind::Annotate => MacroExpansionKind::Annotate(AnnotateExpansion::new(arguments)),
             MacroKind::Flatten => MacroExpansionKind::Flatten(FlattenExpansion::new(self.context(), self.environment, arguments)),
             MacroKind::Template(template_body) => {

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -8,7 +8,7 @@ use compact_str::CompactString;
 use crate::lazy::binary::raw::v1_1::immutable_buffer::ArgGroupingBitmap;
 use crate::lazy::decoder::Decoder;
 use crate::lazy::expanded::compiler::ExpansionAnalysis;
-use crate::lazy::expanded::macro_evaluator::{AnnotateExpansion, MacroEvaluator, MacroExpansion, MacroExpansionKind, MacroExpr, MacroExprArgsIterator, MakeSExpExpansion, TemplateExpansion, ValueExpr, ExprGroupExpansion, MakeTextExpansion};
+use crate::lazy::expanded::macro_evaluator::{AnnotateExpansion, MacroEvaluator, MacroExpansion, MacroExpansionKind, MacroExpr, MacroExprArgsIterator, MakeSExpExpansion, TemplateExpansion, ValueExpr, ExprGroupExpansion, MakeTextExpansion, FlattenExpansion};
 use crate::lazy::expanded::macro_table::{Macro, MacroKind};
 use crate::lazy::expanded::r#struct::UnexpandedField;
 use crate::lazy::expanded::sequence::Environment;
@@ -435,6 +435,7 @@ impl<'top> Deref for TemplateMacroRef<'top> {
 }
 
 /// Steps over the child expressions of a list or s-expression found in the body of a template.
+#[derive(Debug)]
 pub struct TemplateSequenceIterator<'top, D: Decoder> {
     context: EncodingContextRef<'top>,
     template: TemplateMacroRef<'top>,
@@ -1222,6 +1223,7 @@ impl<'top, D: Decoder> TemplateMacroInvocation<'top, D> {
             }
             MacroKind::MakeSExp => MacroExpansionKind::MakeSExp(MakeSExpExpansion::new(arguments)),
             MacroKind::Annotate => MacroExpansionKind::Annotate(AnnotateExpansion::new(arguments)),
+            MacroKind::Flatten => MacroExpansionKind::Flatten(FlattenExpansion::new(self.context(), self.environment, arguments)),
             MacroKind::Template(template_body) => {
                 let template_ref = TemplateMacroRef::new(macro_ref, template_body);
                 let new_environment = self.new_evaluation_environment()?;

--- a/src/lazy/sequence.rs
+++ b/src/lazy/sequence.rs
@@ -9,7 +9,7 @@ use crate::lazy::expanded::sequence::{
 use crate::lazy::value::{AnnotationsIterator, LazyValue};
 use crate::{
     try_next, Annotations, Element, ExpandedListSource, ExpandedSExpSource, IntoAnnotatedElement,
-    LazyExpandedValue, LazyRawContainer, Sequence, Value, ValueRef,
+    LazyExpandedValue, LazyRawContainer, Sequence, Value,
 };
 use crate::{IonError, IonResult};
 
@@ -244,11 +244,6 @@ impl<'top, D: Decoder> LazySExp<'top, D> {
             }
             ExpandedSExpSource::Template(env, element) => {
                 LazyExpandedValue::from_template(context, env, element)
-            }
-            ExpandedSExpSource::Constructed(_environment, _args) => {
-                let value_ref = context.allocator().alloc_with(|| ValueRef::SExp(*self));
-                let annotations = &[];
-                LazyExpandedValue::from_constructed(context, annotations, value_ref)
             }
         };
         LazyValue::new(expanded_value)

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -686,7 +686,7 @@ mod tests {
     use crate::lazy::decoder::RawVersionMarker;
     use crate::lazy::system_stream_item::SystemStreamItem;
     use crate::{
-        v1_0, v1_1, AnyEncoding, Catalog, IonResult, SequenceWriter, SymbolRef, ValueWriter, Writer,
+        v1_0, AnyEncoding, Catalog, IonResult, SequenceWriter, SymbolRef, ValueWriter, Writer,
     };
 
     use super::*;

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -413,7 +413,7 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
                 ValueRef::SExp(macro_def_sexp) => {
                     let new_macro =
                         TemplateCompiler::compile_from_sexp(context, &macro_table, macro_def_sexp)?;
-                    macro_table.add_macro(new_macro)?;
+                    macro_table.add_template_macro(new_macro)?;
                 }
                 ValueRef::Symbol(module_name)
                     if module_name == v1_1::constants::DEFAULT_MODULE_NAME =>
@@ -686,8 +686,7 @@ mod tests {
     use crate::lazy::decoder::RawVersionMarker;
     use crate::lazy::system_stream_item::SystemStreamItem;
     use crate::{
-        constants, v1_0, v1_1, AnyEncoding, Catalog, IonResult, SequenceWriter, SymbolRef,
-        ValueWriter, Writer,
+        v1_0, v1_1, AnyEncoding, Catalog, IonResult, SequenceWriter, SymbolRef, ValueWriter, Writer,
     };
 
     use super::*;

--- a/src/lazy/text/buffer.rs
+++ b/src/lazy/text/buffer.rs
@@ -2822,7 +2822,10 @@ mod tests {
         fn register_macro(&mut self, text: &str) -> &mut Self {
             let new_macro =
                 TemplateCompiler::compile_from_source(self.context.get_ref(), text).unwrap();
-            self.context.macro_table.add_macro(new_macro).unwrap();
+            self.context
+                .macro_table
+                .add_template_macro(new_macro)
+                .unwrap();
             self
         }
 

--- a/src/lazy/text/raw/v1_1/reader.rs
+++ b/src/lazy/text/raw/v1_1/reader.rs
@@ -874,7 +874,7 @@ mod tests {
         let mut context = EncodingContext::for_ion_version(IonVersion::v1_1);
         let macro_quux =
             TemplateCompiler::compile_from_source(context.get_ref(), "(macro quux (x) null)")?;
-        context.macro_table.add_macro(macro_quux)?;
+        context.macro_table.add_template_macro(macro_quux)?;
         let reader = &mut LazyRawTextReader_1_1::new(data.as_bytes());
         let context = context.get_ref();
 


### PR DESCRIPTION
Changes:
* Modifies the system macro table to allow macros to easily depend on earlier macros
* Adds an implementation of the `flatten` macro
* Defines `make_list` as a template that leverages `flatten`
* Re-defines `make_sexp` as a template that leverages `flatten`
* Removes old bespoke impl of `make_sexp`
* Defines `meta` as a template that leverages `none`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
