### PR TITLE
`List` and `SExp` now impl `From<Vec<Element>>` and `FromIterator<Element>`

### DIFF
--- a/src/element/sequence.rs
+++ b/src/element/sequence.rs
@@ -157,8 +157,6 @@ impl<'a> IntoIterator for &'a Sequence {
     }
 }
 
-// TODO: This currently clones elements. We should change `Sequence` to wrap a VecDeque so we can
-//       pop from the front.
 impl IntoIterator for Sequence {
     type Item = Element;
     // TODO: Change once `impl Trait` type aliases are stable

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -78,7 +78,19 @@ impl Display for List {
 
 impl From<Sequence> for List {
     fn from(sequence: Sequence) -> Self {
-        List(sequence)
+        Self(sequence)
+    }
+}
+
+impl From<Vec<Element>> for List {
+    fn from(elements: Vec<Element>) -> Self {
+        Self(elements.into())
+    }
+}
+
+impl FromIterator<Element> for List {
+    fn from_iter<T: IntoIterator<Item = Element>>(iter: T) -> Self {
+        Vec::from_iter(iter).into()
     }
 }
 
@@ -90,7 +102,7 @@ impl From<List> for Sequence {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ion_list, IonResult};
+    use crate::{ion_list, Element, IonResult, List};
 
     #[test]
     fn for_element_in_list() -> IonResult<()> {
@@ -101,6 +113,24 @@ mod tests {
             sum += element.expect_int()?.expect_i64()?;
         }
         assert_eq!(sum, 6i64);
+        Ok(())
+    }
+
+    #[test]
+    fn list_from_vec() -> IonResult<()> {
+        let elements = vec![Element::int(1), Element::int(2), Element::int(3)];
+        let actual: List = elements.into();
+        let expected = ion_list![1, 2, 3];
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn list_from_iter() -> IonResult<()> {
+        let elements = vec![Element::int(1), Element::int(2), Element::int(3)];
+        let actual: List = elements.into_iter().collect();
+        let expected = ion_list![1, 2, 3];
+        assert_eq!(actual, expected);
         Ok(())
     }
 }

--- a/src/types/sexp.rs
+++ b/src/types/sexp.rs
@@ -82,6 +82,18 @@ impl From<Sequence> for SExp {
     }
 }
 
+impl From<Vec<Element>> for SExp {
+    fn from(elements: Vec<Element>) -> Self {
+        Self(elements.into())
+    }
+}
+
+impl FromIterator<Element> for SExp {
+    fn from_iter<T: IntoIterator<Item = Element>>(iter: T) -> Self {
+        Vec::from_iter(iter).into()
+    }
+}
+
 impl From<SExp> for Sequence {
     fn from(value: SExp) -> Self {
         value.0
@@ -90,7 +102,7 @@ impl From<SExp> for Sequence {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ion_sexp, IonResult};
+    use crate::{ion_sexp, Element, IonResult, SExp};
 
     #[test]
     fn for_element_in_sexp() -> IonResult<()> {
@@ -101,6 +113,24 @@ mod tests {
             sum += element.expect_int()?.expect_i64()?;
         }
         assert_eq!(sum, 6i64);
+        Ok(())
+    }
+
+    #[test]
+    fn sexp_from_vec() -> IonResult<()> {
+        let elements = vec![Element::int(1), Element::int(2), Element::int(3)];
+        let actual: SExp = elements.into();
+        let expected = ion_sexp!(1 2 3);
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn sexp_from_iter() -> IonResult<()> {
+        let elements = vec![Element::int(1), Element::int(2), Element::int(3)];
+        let actual: SExp = elements.into_iter().collect();
+        let expected = ion_sexp!(1 2 3);
+        assert_eq!(actual, expected);
         Ok(())
     }
 }


### PR DESCRIPTION
Fixes #811.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
