### PR TITLE
Expose `EExpArgGroup` and related types, version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
     "**/ion-tests/iontestdata/**",
     "*.pdf"
 ]
-version = "1.0.0-rc.9"
+version = "1.0.0-rc.10"
 edition = "2021"
 rust-version = "1.80"
 

--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -280,6 +280,12 @@ pub struct AnyEExpArgGroup<'top> {
     kind: AnyEExpArgGroupKind<'top>,
 }
 
+impl<'a> AnyEExpArgGroup<'a> {
+    pub fn kind(&self) -> AnyEExpArgGroupKind<'a> {
+        self.kind
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 pub enum AnyEExpArgGroupKind<'top> {
     Text_1_1(TextEExpArgGroup<'top>),

--- a/src/lazy/binary/raw/v1_1/e_expression.rs
+++ b/src/lazy/binary/raw/v1_1/e_expression.rs
@@ -451,6 +451,11 @@ impl<'top> BinaryEExpArgGroup<'top> {
         self.delimited_values = Some(delimited_values);
         self
     }
+
+    pub fn header_span(&self) -> Span<'_> {
+        let header_input = self.input.slice(0, self.header_size as usize);
+        Span::from(header_input)
+    }
 }
 
 impl HasRange for BinaryEExpArgGroup<'_> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,7 @@ macro_rules! v1_x_reader_writer {
             lazy::expanded::macro_evaluator::ValueExpr,
             lazy::expanded::macro_evaluator::MacroExpr,
             lazy::expanded::macro_evaluator::MacroExprKind,
+            lazy::expanded::macro_evaluator::MacroExprArgsIterator,
         };
     };
 }
@@ -268,6 +269,7 @@ macro_rules! v1_x_tooling_apis {
                 LazyRawAnyStruct, LazyRawStructKind,
                 LazyRawAnyFieldName, LazyRawFieldNameKind,
                 LazyRawAnyEExpression, LazyRawAnyEExpressionKind,
+                AnyEExpArgGroup, AnyEExpArgGroupKind, AnyEExpArgGroupIterator
             },
             lazy::decoder::{
                 LazyRawSequence,


### PR DESCRIPTION
* Version bump to `1.0.0-rc.10`
* Exposes types needed for the `ion-cli` to traverse eexp argument groups
* Enables reading e-expressions in delimited struct field value position

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
