### PR TITLE
Container tooling

### DIFF
--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -65,6 +65,7 @@ use crate::lazy::text::value::{
     LazyRawTextVersionMarker_1_1, RawTextAnnotationsIterator,
 };
 use crate::symbol_table::{SystemSymbolTable, SYSTEM_SYMBOLS_1_0, SYSTEM_SYMBOLS_1_1};
+use crate::LazyRawValueKind::{Binary_1_0, Binary_1_1, Text_1_0, Text_1_1};
 use crate::{try_next, Encoding, IonResult, IonType, RawStreamItem, RawSymbolRef};
 
 /// An implementation of the `LazyDecoder` trait that can read any encoding of Ion.
@@ -1044,6 +1045,15 @@ impl<'top> LazyRawValue<'top, AnyEncoding> for LazyRawAnyValue<'top> {
             Binary_1_0(v) => v.is_null(),
             Text_1_1(v) => v.is_null(),
             Binary_1_1(v) => v.is_null(),
+        }
+    }
+
+    fn is_delimited(&self) -> bool {
+        match &self.encoding {
+            Text_1_0(v) => v.is_delimited(),
+            Binary_1_0(v) => v.is_delimited(),
+            Text_1_1(v) => v.is_delimited(),
+            Binary_1_1(v) => v.is_delimited(),
         }
     }
 

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -144,6 +144,10 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_1> for &'top LazyRawBinaryValue_1
         self.encoded_value.header().is_null()
     }
 
+    fn is_delimited(&self) -> bool {
+        !self.delimited_contents.is_none()
+    }
+
     fn has_annotations(&self) -> bool {
         self.encoded_value.has_annotations()
     }

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -115,6 +115,10 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_0> for LazyRawBinaryValue_1_0<'to
         self.is_null()
     }
 
+    fn is_delimited(&self) -> bool {
+        false
+    }
+
     fn has_annotations(&self) -> bool {
         self.has_annotations()
     }
@@ -220,6 +224,19 @@ pub trait EncodedBinaryValue<'top, D: Decoder>: LazyRawValue<'top, D> {
         let body_length = self.body_length();
         let body_bytes = &value_span.bytes()[value_span.len() - body_length..];
         Span::with_offset(value_span.range().end - body_length, body_bytes)
+    }
+
+    fn delimited_end_span(&self) -> Span<'top> {
+        let bytes = self.span().bytes();
+        let end = bytes.len();
+        let range = if !self.is_delimited() {
+            end..end
+        } else {
+            debug_assert!(bytes[end - 1] == 0xF0);
+            end - 1..end
+        };
+        let end_bytes = bytes.get(range).unwrap();
+        Span::with_offset(self.range().end - end_bytes.len(), end_bytes)
     }
 }
 

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -411,7 +411,7 @@ pub(crate) mod private {
     }
 
     pub trait LazyRawStructPrivate<'top, D: Decoder> {
-        /// Creates an iterator that converts each raw struct field into an `UnexpandedField`, a
+        /// Creates an iterator that converts each raw struct field into an `FieldExpr`, a
         /// common representation for both raw fields and template fields that is used in the
         /// expansion process.
         fn field_exprs(

--- a/src/lazy/encoder/binary/v1_1/flex_sym.rs
+++ b/src/lazy/encoder/binary/v1_1/flex_sym.rs
@@ -95,7 +95,7 @@ impl<'top> FlexSym<'top> {
             Ordering::Equal => {
                 // Get the first byte following the leading FlexInt
                 let flex_int_len = value.size_in_bytes();
-                if input.len() < flex_int_len {
+                if input.len() <= flex_int_len {
                     return IonResult::incomplete("reading a FlexSym", offset);
                 }
                 let byte = input[flex_int_len];

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -799,7 +799,7 @@ impl<'top, D: Decoder> MacroEvaluator<'top, D> {
     }
 
     pub fn for_macro_expr(macro_expr: MacroExpr<'top, D>) -> IonResult<Self> {
-        let expansion = MacroExpansion::initialize(macro_expr)?;
+        let expansion = macro_expr.expand()?;
         Ok(Self::for_expansion(expansion))
     }
 
@@ -920,7 +920,7 @@ impl<'top, D: Decoder> StackedMacroEvaluator<'top, D> {
     /// current encoding context and push the resulting `MacroExpansion` onto the stack.
     pub fn push(&mut self, invocation: impl Into<MacroExpr<'top, D>>) -> IonResult<()> {
         let macro_expr = invocation.into();
-        let expansion = match MacroExpansion::initialize(macro_expr) {
+        let expansion = match macro_expr.expand() {
             Ok(expansion) => expansion,
             Err(e) => return Err(e),
         };

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -887,8 +887,11 @@ impl<'top, Encoding: Decoder> LazyExpandedValue<'top, Encoding> {
         }
     }
 
-    pub(crate) fn via_variable(mut self, variable_ref: TemplateVariableReference<'top>) -> Self {
-        self.variable = Some(variable_ref);
+    pub(crate) fn via_variable(
+        mut self,
+        variable_ref: Option<TemplateVariableReference<'top>>,
+    ) -> Self {
+        self.variable = variable_ref;
         self
     }
 

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -46,9 +46,7 @@ use crate::lazy::decoder::{Decoder, LazyRawValue};
 use crate::lazy::encoding::RawValueLiteral;
 use crate::lazy::expanded::compiler::TemplateCompiler;
 use crate::lazy::expanded::e_expression::EExpression;
-use crate::lazy::expanded::macro_evaluator::{
-    MacroEvaluator, MacroExpansion, MacroExpr, RawEExpression,
-};
+use crate::lazy::expanded::macro_evaluator::{MacroEvaluator, MacroExpr, RawEExpression};
 use crate::lazy::expanded::macro_table::{Macro, MacroTable, ION_1_1_SYSTEM_MACROS};
 use crate::lazy::expanded::r#struct::LazyExpandedStruct;
 use crate::lazy::expanded::sequence::Environment;
@@ -981,7 +979,7 @@ impl<'top, Encoding: Decoder> LazyExpandedValue<'top, Encoding> {
         &self,
         eexp: &EExpression<'top, Encoding>,
     ) -> IonResult<ValueRef<'top, Encoding>> {
-        let new_expansion = MacroExpansion::initialize(MacroExpr::from_eexp(*eexp))?;
+        let new_expansion = MacroExpr::from_eexp(*eexp).expand()?;
         new_expansion.expand_singleton()?.read_resolved()
     }
 

--- a/src/lazy/expanded/sequence.rs
+++ b/src/lazy/expanded/sequence.rs
@@ -4,7 +4,6 @@ use crate::lazy::expanded::macro_evaluator::{MacroEvaluator, RawEExpression, Val
 use crate::lazy::expanded::template::{TemplateElement, TemplateSequenceIterator};
 use crate::lazy::expanded::{
     EncodingContextRef, ExpandedAnnotationsIterator, ExpandedAnnotationsSource, LazyExpandedValue,
-    TemplateVariableReference,
 };
 use crate::{try_or_some_err, IonResult, IonType};
 use std::fmt::Debug;
@@ -457,6 +456,7 @@ impl<'top, D: Decoder> Iterator for ExpandedSequenceIterator<'top, D> {
 }
 
 #[cfg(test)]
+#[cfg(feature = "experimental-tooling-apis")]
 mod tests {
     use super::*;
     use crate::{v1_1, ExpandedValueRef, Int, MacroExprKind, Reader};

--- a/src/lazy/expanded/sequence.rs
+++ b/src/lazy/expanded/sequence.rs
@@ -236,7 +236,6 @@ impl<'top, D: Decoder> Iterator for ListValueExprIterator<'top, D> {
 pub struct SExpValueExprIterator<'top, D: Decoder> {
     context: EncodingContextRef<'top>,
     source: ExpandedSExpIteratorSource<'top, D>,
-    variable_ref: Option<TemplateVariableReference<'top>>,
 }
 
 impl<'top, D: Decoder> Iterator for SExpValueExprIterator<'top, D> {
@@ -270,7 +269,6 @@ pub enum ExpandedSExpSource<'top, D: Decoder> {
 pub struct LazyExpandedSExp<'top, D: Decoder> {
     pub(crate) source: ExpandedSExpSource<'top, D>,
     pub(crate) context: EncodingContextRef<'top>,
-    pub(crate) variable_ref: Option<TemplateVariableReference<'top>>,
 }
 
 impl<'top, D: Decoder> LazyExpandedSExp<'top, D> {
@@ -321,11 +319,7 @@ impl<'top, D: Decoder> LazyExpandedSExp<'top, D> {
     #[cfg(feature = "experimental-tooling-apis")]
     pub fn value_exprs(&self) -> SExpValueExprIterator<'top, D> {
         let ExpandedSExpIterator { context, source } = self.iter();
-        SExpValueExprIterator {
-            context,
-            source,
-            variable_ref: self.variable_ref,
-        }
+        SExpValueExprIterator { context, source }
     }
 
     pub fn from_literal(
@@ -333,11 +327,7 @@ impl<'top, D: Decoder> LazyExpandedSExp<'top, D> {
         sexp: D::SExp<'top>,
     ) -> LazyExpandedSExp<'top, D> {
         let source = ExpandedSExpSource::ValueLiteral(sexp);
-        Self {
-            source,
-            context,
-            variable_ref: None,
-        }
+        Self { source, context }
     }
 
     pub fn from_template(
@@ -346,11 +336,7 @@ impl<'top, D: Decoder> LazyExpandedSExp<'top, D> {
         element: TemplateElement<'top>,
     ) -> LazyExpandedSExp<'top, D> {
         let source = ExpandedSExpSource::Template(environment, element);
-        Self {
-            source,
-            context,
-            variable_ref: None,
-        }
+        Self { source, context }
     }
 }
 

--- a/src/lazy/expanded/sequence.rs
+++ b/src/lazy/expanded/sequence.rs
@@ -167,6 +167,12 @@ impl<'top, D: Decoder> LazyExpandedList<'top, D> {
             source,
         }
     }
+
+    #[cfg(feature = "experimental-tooling-apis")]
+    pub fn iter_value_expr(&self) -> ListValueExprIterator<'top, D> {
+        let ExpandedListIterator { context, source } = self.iter();
+        ListValueExprIterator { context, source }
+    }
 }
 
 /// The source of child values iterated over by an [`ExpandedListIterator`].
@@ -179,7 +185,6 @@ pub enum ExpandedListIteratorSource<'top, D: Decoder> {
         <D::List<'top> as LazyRawSequence<'top, D>>::Iterator,
     ),
     Template(TemplateSequenceIterator<'top, D>),
-    // TODO: Constructed
 }
 
 /// Iterates over the child values of a [`LazyExpandedList`].
@@ -198,6 +203,50 @@ impl<'top, D: Decoder> Iterator for ExpandedListIterator<'top, D> {
                 expand_next_sequence_value(self.context, evaluator, iter)
             }
             ExpandedListIteratorSource::Template(iter) => iter.next(),
+        }
+    }
+}
+
+/// Like an [`ExpandedListIterator`], but will yield macro invocations before also yielding
+/// that macro's expansion.
+#[derive(Debug)]
+pub struct ListValueExprIterator<'top, D: Decoder> {
+    context: EncodingContextRef<'top>,
+    source: ExpandedListIteratorSource<'top, D>,
+}
+
+impl<'top, D: Decoder> Iterator for ListValueExprIterator<'top, D> {
+    type Item = IonResult<ValueExpr<'top, D>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        use ExpandedListIteratorSource::*;
+        match &mut self.source {
+            ValueLiteral(evaluator, iter) => {
+                expand_next_sequence_value_expr(self.context, evaluator, iter)
+            }
+            Template(iter) => iter.next_value_expr(),
+        }
+    }
+}
+
+/// Like an [`ExpandedSExpIterator`], but will yield macro invocations before also yielding
+/// that macro's expansion.
+#[derive(Debug)]
+pub struct SExpValueExprIterator<'top, D: Decoder> {
+    context: EncodingContextRef<'top>,
+    source: ExpandedSExpIteratorSource<'top, D>,
+}
+
+impl<'top, D: Decoder> Iterator for SExpValueExprIterator<'top, D> {
+    type Item = IonResult<ValueExpr<'top, D>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        use ExpandedSExpIteratorSource::*;
+        match &mut self.source {
+            ValueLiteral(evaluator, iter) => {
+                expand_next_sequence_value_expr(self.context, evaluator, iter)
+            }
+            Template(iter) => iter.next_value_expr(),
         }
     }
 }
@@ -266,6 +315,12 @@ impl<'top, D: Decoder> LazyExpandedSExp<'top, D> {
         }
     }
 
+    #[cfg(feature = "experimental-tooling-apis")]
+    pub fn iter_value_expr(&self) -> SExpValueExprIterator<'top, D> {
+        let ExpandedSExpIterator { context, source } = self.iter();
+        SExpValueExprIterator { context, source }
+    }
+
     pub fn from_literal(
         context: EncodingContextRef<'top>,
         sexp: D::SExp<'top>,
@@ -317,6 +372,26 @@ impl<'top, D: Decoder> Iterator for ExpandedSExpIterator<'top, D> {
             Template(iter) => iter.next(),
         }
     }
+}
+
+fn expand_next_sequence_value_expr<'top, D: Decoder>(
+    context: EncodingContextRef<'top>,
+    evaluator: &mut MacroEvaluator<'top, D>,
+    iter: &mut impl Iterator<Item = IonResult<LazyRawValueExpr<'top, D>>>,
+) -> Option<IonResult<ValueExpr<'top, D>>> {
+    if let Some(value) = try_or_some_err!(evaluator.next()) {
+        return Some(Ok(ValueExpr::ValueLiteral(value)));
+    }
+
+    // At this point, the evaluator is empty.
+
+    let value_expr = try_or_some_err!(iter.next()?.and_then(|raw_expr| raw_expr.resolve(context)));
+
+    if let ValueExpr::MacroInvocation(invocation) = value_expr {
+        evaluator.push(try_or_some_err!(invocation.expand()));
+    }
+
+    Some(Ok(value_expr))
 }
 
 /// For both lists and s-expressions, yields the next sequence value by either continuing a macro
@@ -377,5 +452,94 @@ impl<'top, D: Decoder> Iterator for ExpandedSequenceIterator<'top, D> {
             List(l) => l.next(),
             SExp(s) => s.next(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{v1_1, ExpandedValueRef, Int, MacroExprKind, Reader};
+
+    fn expect_int<'top, D: Decoder>(
+        value_exprs: &mut impl Iterator<Item = IonResult<ValueExpr<'top, D>>>,
+        expected_value: impl Into<Int>,
+    ) -> IonResult<()> {
+        assert!(matches!(
+            value_exprs.next().unwrap()?,
+            ValueExpr::ValueLiteral(v) if v.read()? == ExpandedValueRef::Int(expected_value.into())
+        ));
+        Ok(())
+    }
+
+    fn expect_eexp<'top, D: Decoder>(
+        value_exprs: &mut impl Iterator<Item = IonResult<ValueExpr<'top, D>>>,
+        expected_macro_name: &str,
+    ) -> IonResult<()> {
+        assert!(matches!(
+            value_exprs.next().unwrap()?,
+            ValueExpr::MacroInvocation(i) if matches!(
+                i.kind(),
+                MacroExprKind::EExp(e) if e.invoked_macro.name() == Some(expected_macro_name)
+            )
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn list_iter_value_expr() -> IonResult<()> {
+        let source = r#"
+                $ion_1_1
+                (:add_macros
+                    (macro three_values ()
+                        (.values 1 2 3)
+                    )
+                )
+                [0, (:three_values), 4, (:flatten (5 6)), 7]
+            "#;
+        let mut reader = Reader::new(v1_1::Text, source)?;
+        let list = reader.expect_next()?.read()?.expect_list()?;
+        let value_exprs = &mut list.expanded_list.iter_value_expr();
+
+        expect_int(value_exprs, 0)?;
+        expect_eexp(value_exprs, "three_values")?;
+        expect_int(value_exprs, 1)?;
+        expect_int(value_exprs, 2)?;
+        expect_int(value_exprs, 3)?;
+        expect_int(value_exprs, 4)?;
+        expect_eexp(value_exprs, "flatten")?;
+        expect_int(value_exprs, 5)?;
+        expect_int(value_exprs, 6)?;
+        expect_int(value_exprs, 7)?;
+        assert!(value_exprs.next().is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn sexp_iter_value_expr() -> IonResult<()> {
+        let source = r#"
+                $ion_1_1
+                (:add_macros
+                    (macro three_values ()
+                        (.values 1 2 3)
+                    )
+                )
+                (0 (:three_values) 4 (:flatten (5 6)) 7)
+            "#;
+        let mut reader = Reader::new(v1_1::Text, source)?;
+        let sexp = reader.expect_next()?.read()?.expect_sexp()?;
+        let value_exprs = &mut sexp.expanded_sexp.iter_value_expr();
+
+        expect_int(value_exprs, 0)?;
+        expect_eexp(value_exprs, "three_values")?;
+        expect_int(value_exprs, 1)?;
+        expect_int(value_exprs, 2)?;
+        expect_int(value_exprs, 3)?;
+        expect_int(value_exprs, 4)?;
+        expect_eexp(value_exprs, "flatten")?;
+        expect_int(value_exprs, 5)?;
+        expect_int(value_exprs, 6)?;
+        expect_int(value_exprs, 7)?;
+        assert!(value_exprs.next().is_none());
+        Ok(())
     }
 }

--- a/src/lazy/expanded/struct.rs
+++ b/src/lazy/expanded/struct.rs
@@ -4,7 +4,6 @@ use crate::lazy::decoder::{Decoder, LazyRawFieldName, LazyRawStruct};
 use crate::lazy::expanded::macro_evaluator::{
     MacroEvaluator, MacroExpr, MacroExprArgsIterator, ValueExpr,
 };
-use crate::lazy::expanded::r#struct::tooling::FieldExprIterator;
 use crate::lazy::expanded::sequence::Environment;
 use crate::lazy::expanded::template::{
     TemplateElement, TemplateMacroRef, TemplateStructFieldExprIterator, TemplateStructIndex,
@@ -16,6 +15,9 @@ use crate::lazy::expanded::{
 use crate::result::IonFailure;
 use crate::{try_next, try_or_some_err, EExpression, HasRange, IonResult, RawSymbolRef, SymbolRef};
 use std::ops::Range;
+
+#[cfg(feature = "experimental-tooling-apis")]
+use crate::lazy::expanded::r#struct::tooling::FieldExprIterator;
 
 /// A unified type embodying all possible field representations coming from both input data
 /// (i.e. raw structs of some encoding) and template bodies.

--- a/src/lazy/expanded/struct.rs
+++ b/src/lazy/expanded/struct.rs
@@ -752,7 +752,7 @@ mod tooling {
     #[cfg(test)]
     mod tests {
         use super::*;
-        use crate::{v1_1, Int, MacroExprKind, Reader, ValueRef};
+        use crate::{v1_1, Element, MacroExprKind, Reader};
 
         #[test]
         fn field_kinds() -> IonResult<()> {
@@ -780,7 +780,7 @@ mod tooling {
             fn expect_name_value<'top, D: Decoder>(
                 fields: &mut impl Iterator<Item = IonResult<FieldSource<'top, D>>>,
                 expected_name: &str,
-                expected_value: impl Into<Int>,
+                expected_value: impl Into<Element>,
             ) -> IonResult<()> {
                 let field = fields.next().unwrap()?;
                 let expected_value = expected_value.into();
@@ -789,7 +789,7 @@ mod tooling {
                         field,
                         FieldSource::NameValue(name, value)
                             if name.read()?.text() == Some(expected_name)
-                            && value.read_resolved()? == ValueRef::Int(expected_value)
+                            && Element::try_from(value.read_resolved()?)? == expected_value,
                     ),
                     "{field:?} did not match name={expected_name:?}, value={expected_value:?}"
                 );
@@ -813,6 +813,8 @@ mod tooling {
             expect_name_value(fields, "dog", 1)?;
             expect_name_value(fields, "cat", 2)?;
             expect_name_value(fields, "mouse", 3)?;
+            expect_name_value(fields, "quux", true)?;
+            assert!(fields.next().is_none());
             Ok(())
         }
     }

--- a/src/lazy/expanded/struct.rs
+++ b/src/lazy/expanded/struct.rs
@@ -35,11 +35,10 @@ pub enum FieldExpr<'top, D: Decoder> {
 impl<'top, D: Decoder> FieldExpr<'top, D> {
     pub fn name(&self) -> Option<&LazyExpandedFieldName<'top, D>> {
         use FieldExpr::*;
-        let name = match self {
-            NameValue(name, _) | NameMacro(name, _) => name,
-            EExp(_) => return None,
-        };
-        Some(name)
+        match self {
+            NameValue(name, _) | NameMacro(name, _) => Some(name),
+            EExp(_) => None,
+        }
     }
 
     pub fn name_is(&self, text: &str) -> IonResult<bool> {

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -703,14 +703,11 @@ impl TemplateBodyExpr {
                 ))
             }
             TemplateBodyExprKind::Variable(variable_ref) => {
-                let mut expr = environment.require_expr(variable_ref.signature_index());
+                let expr = environment.require_expr(variable_ref.signature_index());
+                let template_variable_ref = variable_ref.resolve(host_template.macro_ref());
                 // If this is a value (and therefore needs no further evaluation), tag it as having
                 // come from this variable in the template body.
-                if let ValueExpr::ValueLiteral(ref mut value) = expr {
-                    *value =
-                        value.via_variable(variable_ref.resolve(host_template.macro_ref()))
-                }
-                expr
+                expr.via_variable(Some(template_variable_ref))
             }
             TemplateBodyExprKind::ExprGroup(parameter) => {
                 let template_arg_group = TemplateExprGroup::new(

--- a/src/lazy/text/value.rs
+++ b/src/lazy/text/value.rs
@@ -178,6 +178,10 @@ impl<'top, E: TextEncoding<'top>> LazyRawValue<'top, E> for LazyRawTextValue<'to
         self.encoded_value.is_null()
     }
 
+    fn is_delimited(&self) -> bool {
+        false
+    }
+
     fn has_annotations(&self) -> bool {
         self.has_annotations() // Inherent impl
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,6 +217,7 @@ macro_rules! v1_x_reader_writer {
             lazy::expanded::template::TemplateMacro,
             lazy::expanded::template::TemplateBodyExpr,
             lazy::expanded::template::TemplateBodyExprKind,
+            lazy::expanded::template::TemplateMacroInvocation,
             lazy::expanded::macro_table::Macro,
             lazy::expanded::macro_evaluator::MacroEvaluator,
             lazy::expanded::macro_evaluator::MacroExpansionKind,
@@ -294,7 +295,8 @@ macro_rules! v1_x_tooling_apis {
             lazy::expanded::r#struct::{
                 LazyExpandedStruct, ExpandedStructSource,
                 LazyExpandedField,
-                LazyExpandedFieldName
+                LazyExpandedFieldName,
+                FieldExpr,
             },
             lazy::expanded::e_expression::{EExpression, EExpressionArgsIterator, EExpArgGroup, EExpArgGroupIterator},
             lazy::expanded::sequence::{Environment, ExpandedListSource, ExpandedSExpSource, LazyExpandedList, LazyExpandedSExp},


### PR DESCRIPTION
This PR adds lots of new tooling methods and bookkeeping:
* Tags each value with the variable that produced it, if any.
* Renames `UnexpandedField` to `FieldExpr`, which is much clearer.
* Adds container iterators that yield both macro invocations _and_ their expansions, allowing tooling to see both and work with whatever they need.
* Adds `Span` accessor for the delimited `END` byte.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
