### PR TITLE
Add deconstructing conversions for owned Elements

### DIFF
--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -23,6 +23,12 @@ pub struct Bytes {
     data: Vec<u8>,
 }
 
+impl From<Bytes> for Vec<u8> {
+    fn from(data: Bytes) -> Self {
+        data.data
+    }
+}
+
 impl IonEq for Bytes {
     fn ion_eq(&self, other: &Self) -> bool {
         self == other


### PR DESCRIPTION
Allows deconstruction owned `Element`s and `Bytes` into their contained data.

See also previous enhancements to ergonomics of owned `Element`s
Cf. https://github.com/amazon-ion/ion-rust/pull/858
Cf. https://github.com/amazon-ion/ion-rust/pull/866

---


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
