### PR TITLE
Statically computes text value kind lookup table

### DIFF
--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -943,10 +943,7 @@ impl<'top, D: Decoder> StackedMacroEvaluator<'top, D> {
     /// current encoding context and push the resulting `MacroExpansion` onto the stack.
     pub fn push(&mut self, invocation: impl Into<MacroExpr<'top, D>>) -> IonResult<()> {
         let macro_expr = invocation.into();
-        let expansion = match macro_expr.expand() {
-            Ok(expansion) => expansion,
-            Err(e) => return Err(e),
-        };
+        let expansion = macro_expr.expand()?;
         self.macro_stack.push(expansion);
         Ok(())
     }
@@ -989,10 +986,7 @@ impl<'top, D: Decoder> StackedMacroEvaluator<'top, D> {
                 Some(expansion) => expansion,
             };
             // Ask that expansion to continue its evaluation by one step.
-            let step = match current_expansion.next_step() {
-                Ok(step) => step,
-                Err(e) => return Err(e),
-            };
+            let step = current_expansion.next_step()?;
             current_expansion.is_complete = step.is_final();
             use ValueExpr::*;
             let maybe_output_value = match step.value_expr() {

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -558,10 +558,7 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
             // It's another macro invocation, we'll add it to the evaluator so it will be evaluated
             // on the next call and then we'll return the e-expression itself.
             EExp(e_exp) => {
-                let resolved_e_exp = match e_exp.resolve(context_ref) {
-                    Ok(resolved) => resolved,
-                    Err(e) => return Err(e),
-                };
+                let resolved_e_exp = e_exp.resolve(context_ref)?;
 
                 // Get the current evaluator or make a new one
                 let evaluator = match self.evaluator_ptr.get() {
@@ -639,10 +636,7 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
                 }
                 // It's another macro invocation, we'll start evaluating it.
                 EExp(e_exp) => {
-                    let resolved_e_exp = match e_exp.resolve(context_ref) {
-                        Ok(resolved) => resolved,
-                        Err(e) => return Err(e),
-                    };
+                    let resolved_e_exp = e_exp.resolve(context_ref)?;
 
                     // If this e-expression invokes a template with a non-system, singleton expansion, we can use the
                     // e-expression to back a LazyExpandedValue. It will only be evaluated if the user calls `read()`.
@@ -664,11 +658,7 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
                     };
 
                     // Try to get a value by starting to evaluate the e-expression.
-                    let next_value = match evaluator.next() {
-                        Ok(value) => value,
-                        Err(e) => return Err(e),
-                    };
-                    if let Some(value) = next_value {
+                    if let Some(value) = evaluator.next()? {
                         // If we get a value and the evaluator isn't empty yet, save its pointer
                         // so we can try to get more out of it when `next_at_or_above_depth` is called again.
                         if !evaluator.is_empty() {

--- a/src/lazy/expanded/struct.rs
+++ b/src/lazy/expanded/struct.rs
@@ -93,7 +93,7 @@ impl<'top, D: Decoder> LazyExpandedField<'top, D> {
         self.name
     }
 
-    pub fn to_field_expr(&self) -> FieldExpr<'top, D> {
+    pub fn to_field_expr(self) -> FieldExpr<'top, D> {
         FieldExpr::NameValue(self.name(), self.value())
     }
 }

--- a/src/lazy/text/mod.rs
+++ b/src/lazy/text/mod.rs
@@ -4,4 +4,5 @@ pub mod encoded_value;
 pub mod matched;
 pub mod parse_result;
 pub mod raw;
+mod token_kind;
 pub mod value;

--- a/src/lazy/text/token_kind.rs
+++ b/src/lazy/text/token_kind.rs
@@ -1,0 +1,46 @@
+#[derive(Debug, Clone, Copy)]
+pub enum ValueTokenKind {
+    // An ASCII decimal digit, 0-9 inclusive, as well as `-` and `+`
+    // Could be the start of an int, float, decimal, or timestamp.
+    NumberOrTimestamp,
+    // An ASCII letter, [a-zA-Z] inclusive.
+    // Could be the start of a null, bool, identifier, or float (`nan`).
+    Letter,
+    // A `$` or `_`, which could be either a symbol ID (`$10`)
+    // or an identifier (`$foo`, `_`).
+    Symbol,
+    // A `"` or `'`, which could be either a string or symbol.
+    QuotedText,
+    // `[`
+    List,
+    // `(`
+    SExp,
+    // `{`
+    LobOrStruct,
+    // Any other byte
+    Invalid(u8),
+}
+
+/// A table of `ValueTokenKind` instances that can be queried by using the
+/// byte in question as an index.
+pub(crate) static TEXT_ION_TOKEN_KINDS: &[ValueTokenKind] = &init_value_token_cache();
+
+pub(crate) const fn init_value_token_cache() -> [ValueTokenKind; 256] {
+    let mut jump_table = [ValueTokenKind::Invalid(0); 256];
+    let mut index: usize = 0;
+    while index < 256 {
+        let byte = index as u8;
+        jump_table[index] = match byte {
+            b'0'..=b'9' | b'-' | b'+' => ValueTokenKind::NumberOrTimestamp,
+            b'a'..=b'z' | b'A'..=b'Z' => ValueTokenKind::Letter,
+            b'$' | b'_' => ValueTokenKind::Symbol,
+            b'"' | b'\'' => ValueTokenKind::QuotedText,
+            b'[' => ValueTokenKind::List,
+            b'(' => ValueTokenKind::SExp,
+            b'{' => ValueTokenKind::LobOrStruct,
+            other_byte => ValueTokenKind::Invalid(other_byte),
+        };
+        index += 1;
+    }
+    jump_table
+}


### PR DESCRIPTION
Builds on #892, the PR to port to `winnow`.

I thought there might be a performance boost to be had by computing the mapping from a text value's first byte to the value's kind at compile time and using a lookup table at runtime. Strangely, it didn't change the performance at all--benchmark results are identical.

I'm inclined to merge this anyway just so people don't spend time following the same line of reasoning in the future. Subjectively, it's a bit tidier.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
