### PR TITLE
Adds location information to text buffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ compact_str = "0.8.0"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "wasmbind"] }
 delegate = "0.12.0"
 thiserror = "1.0"
-winnow = { version = "0.6.24", features = ["simd"] }
+winnow = { version = "=0.6.24", features = ["simd"] }
 num-integer = "0.1.44"
 num-traits = "0.2"
 arrayvec = "0.7"

--- a/src/lazy/text/buffer.rs
+++ b/src/lazy/text/buffer.rs
@@ -362,6 +362,7 @@ impl<'top> TextBuffer<'top> {
         )
             .take()
             .parse_next(self)?;
+        self.update_location_metadata(result.data);
         Ok(result)
     }
 
@@ -2940,6 +2941,8 @@ mod tests {
     #[case::comment("/*comment*/", (1,12))]
     #[case::newline_before_comment("\n/*comment*/", (2,12))]
     #[case::newline_after_comment("/*comment*/\n", (2,1))]
+    #[case::newline_inside_comment("/*multiline \n comment*/", (2,11))]
+    #[case::newlines_inside_comment("/*this is a \n multiline \n comment*/", (3,11))]
     fn expect_whitespace_with_comment(#[case] input: &str, #[case] expected_location: (usize, usize)) {
         MatchTest::new_1_0(input).expect_match_location(match_length(TextBuffer::match_optional_comments_and_whitespace), expected_location);
     }


### PR DESCRIPTION
*Issue https://github.com/amazon-ion/ion-rust/issues/904*

*Description of changes:*
This PR adds location information to the underlying text buffer. The location information includes row and column value for the buffer input data.

*Row Calculation*
Row numbers start at 1 and increment with each newline character encountered in the input. This maintains consistency with common text editor line numbering.
Row calculations will be based on occurrence of newline characters `\r` and `\n`. These characters have different implications in different OS systems. In order to correctly count the row position:
1. Consider `\r\n` as a single count if they appear together in the input.
2. Count the total occurrences of `\r` and `\n` characters individually.
3. Subtract count in step 1 from count in step 2. This will be the final count of newline characters.

*Column Calculation*
Column numbers also start at 1 and represent the number of characters(here the character count to consider is byte count/offset) consumed within the current row, including whitespaces. The column count will be based on the previous newline offset position. At any given point the column count represent `CURRENT_OFFSET_VALUE - PREVIOUS_NEWLINE_OFFSET_VALUE`. 

*List of changes:*
- Modifies winnow parser methods for row and column calculation. This includes modifying following parser methods:
  - `match_whitespace0`
  - `match_whitespace1` 
  - `match_text_until_unescaped_str`
- Adds `update_location_metadata`  which helps all the parser methods to update location metadata appropriately on newline parsing.
  - This method does the book keeping for row count and previous newline offset value.
- Requires the checkpoint reset to reset row and previous newline offset values. (This is similar to how `offset` property is reset) 
- Adds unit tests to verify buffer properties row and column results into correct numbers.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
