### PR TITLE
Adds experimental-location feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ default = []
 experimental-ion-hash = ["digest", "experimental-reader-writer"]
 
 # Access location information of the input Ion from underlying buffer.
-experimental-location = []
+source-location = []
 
 # Feature for indicating particularly bleeding edge APIs or functionality in the library.
 # These are not guaranteed any sort of API stability and may also have non-standard

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ rust-version = "1.80"
 default = []
 experimental-ion-hash = ["digest", "experimental-reader-writer"]
 
+# Access location information of the input Ion from underlying buffer.
+experimental-location = []
+
 # Feature for indicating particularly bleeding edge APIs or functionality in the library.
 # These are not guaranteed any sort of API stability and may also have non-standard
 # Ion behavior (e.g., draft Ion 1.1 capabilities).


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR works on adding an `experimental-location` feature flag for the location-metadata implementation. This allows users to opt-in based on their performance requirements.

*List of changes:*
- define `experimnetal-location` feature flag in the `Cargo.toml`.
- add configuration wherever row and column properties are used or updated in the `TextBuffer`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
