### PR TITLE
Adds location support with `LazyValue` API

### DIFF
--- a/src/lazy/binary/raw/reader.rs
+++ b/src/lazy/binary/raw/reader.rs
@@ -118,7 +118,9 @@ impl<'data> LazyRawReader<'data, BinaryEncoding_1_0> for LazyRawBinaryReader_1_0
     fn new(context: EncodingContextRef<'data>, data: &'data [u8], is_final_data: bool) -> Self {
         Self::resume(
             context,
-            RawReaderState::new(data, 0, is_final_data, IonEncoding::Binary_1_0),
+            RawReaderState::new(data, 0,         #[cfg(feature = "source-location")]
+            0,         #[cfg(feature = "source-location")]
+            0, is_final_data, IonEncoding::Binary_1_0),
         )
     }
 
@@ -137,6 +139,10 @@ impl<'data> LazyRawReader<'data, BinaryEncoding_1_0> for LazyRawBinaryReader_1_0
         RawReaderState::new(
             &self.data.buffer.bytes()[self.data.bytes_to_skip..],
             stream_offset,
+            #[cfg(feature = "source-location")]
+            0,
+            #[cfg(feature = "source-location")]
+            0,
             // The binary readers do not care whether the data is final because they can detect
             // incomplete values in any case. They always report `false` for simplicity.
             false,
@@ -150,6 +156,16 @@ impl<'data> LazyRawReader<'data, BinaryEncoding_1_0> for LazyRawBinaryReader_1_0
 
     fn position(&self) -> usize {
         self.data.buffer.offset() + self.data.bytes_to_skip
+    }
+
+    #[cfg(feature = "source-location")]
+    fn row(&self) -> usize {
+        0
+    }
+
+    #[cfg(feature = "source-location")]
+    fn prev_newline_offset(&self) -> usize {
+        0
     }
 
     fn encoding(&self) -> IonEncoding {

--- a/src/lazy/binary/raw/v1_1/reader.rs
+++ b/src/lazy/binary/raw/v1_1/reader.rs
@@ -83,7 +83,9 @@ impl<'data> LazyRawReader<'data, BinaryEncoding_1_1> for LazyRawBinaryReader_1_1
     fn new(context: EncodingContextRef<'data>, data: &'data [u8], is_final_data: bool) -> Self {
         Self::resume(
             context,
-            RawReaderState::new(data, 0, is_final_data, IonEncoding::Binary_1_1),
+            RawReaderState::new(data, 0,         #[cfg(feature = "source-location")]
+            0,         #[cfg(feature = "source-location")]
+            0, is_final_data, IonEncoding::Binary_1_1),
         )
     }
 
@@ -95,6 +97,10 @@ impl<'data> LazyRawReader<'data, BinaryEncoding_1_1> for LazyRawBinaryReader_1_1
         RawReaderState::new(
             self.input.bytes(),
             self.position(),
+            #[cfg(feature = "source-location")]
+            0,
+            #[cfg(feature = "source-location")]
+            0,
             // The binary reader doesn't care about `is_final`, so we just use `false`.
             false,
             self.encoding(),
@@ -107,6 +113,16 @@ impl<'data> LazyRawReader<'data, BinaryEncoding_1_1> for LazyRawBinaryReader_1_1
 
     fn position(&self) -> usize {
         self.input.offset()
+    }
+
+    #[cfg(feature = "source-location")]
+    fn row(&self) -> usize {
+        0
+    }
+
+    #[cfg(feature = "source-location")]
+    fn prev_newline_offset(&self) -> usize {
+        0
     }
 
     fn encoding(&self) -> IonEncoding {

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -292,6 +292,11 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_1> for &'top LazyRawBinaryValue_1
             ..**self
         })
     }
+
+    #[cfg(feature = "source-location")]
+    fn location(&self) -> (usize, usize) {
+        (0, 0)
+    }
 }
 
 /// Nested expressions parsed and cached while reading (e.g.) a [`LazyRawBinaryValue_1_1`].

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -152,6 +152,11 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_0> for LazyRawBinaryValue_1_0<'to
             input: BinaryBuffer::new_with_offset(span.bytes(), span.offset()),
         }
     }
+
+    #[cfg(feature = "source-location")]
+    fn location(&self) -> (usize, usize) {
+        (0,0)
+    }
 }
 
 pub trait BinaryValueLiteral<'top, D: Decoder>: LazyRawValue<'top, D> {

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -481,9 +481,12 @@ pub trait LazyRawReader<'data, D: Decoder>: Sized {
     /// a comment, or whitespace that the reader will traverse as part of matching the next item.
     fn position(&self) -> usize;
 
+    #[cfg(feature = "source-location")]
     fn row(&self) -> usize;
 
+    #[cfg(feature = "source-location")]
     fn prev_newline_offset(&self) -> usize;
+
     /// The Ion encoding of the stream that the reader has been processing.
     ///
     /// Note that:
@@ -611,6 +614,9 @@ pub trait LazyRawValue<'top, D: Decoder>:
     /// This method is used when converting a `LazyValue` (which may be backed by a slice of the
     /// input buffer) to a `LazyElement` (which needs to be backed by heap data).
     fn with_backing_data(&self, span: Span<'top>) -> Self;
+
+    #[cfg(feature = "source-location")]
+    fn location(&self) -> (usize, usize);
 }
 
 pub trait RawSequenceIterator<'top, D: Decoder>:

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -481,6 +481,9 @@ pub trait LazyRawReader<'data, D: Decoder>: Sized {
     /// a comment, or whitespace that the reader will traverse as part of matching the next item.
     fn position(&self) -> usize;
 
+    fn row(&self) -> usize;
+
+    fn prev_newline_offset(&self) -> usize;
     /// The Ion encoding of the stream that the reader has been processing.
     ///
     /// Note that:

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -1117,6 +1117,14 @@ impl<'top, Encoding: Decoder> LazyExpandedValue<'top, Encoding> {
         }
         None
     }
+
+    #[cfg(feature = "source-location")]
+    pub fn location(&self) -> Option<(usize, usize)> {
+        if let ExpandedValueSource::ValueLiteral(value) = &self.source {
+            return Some(value.location());
+        }
+        None
+    }
 }
 
 impl<'top, Encoding: Decoder> From<LazyExpandedValue<'top, Encoding>>

--- a/src/lazy/text/buffer.rs
+++ b/src/lazy/text/buffer.rs
@@ -597,7 +597,9 @@ impl<'top> TextBuffer<'top> {
     pub fn match_value<E: TextEncoding>(&mut self) -> IonParseResult<'top, E::Value<'top>> {
         use ValueTokenKind::*;
 
+        #[allow(unused)]
         let mut preserve_row = 0;
+        #[allow(unused)]
         let mut preserve_prev_column_offset = 0;
 
         #[cfg(feature = "source-location")]

--- a/src/lazy/text/raw/v1_1/reader.rs
+++ b/src/lazy/text/raw/v1_1/reader.rs
@@ -39,7 +39,7 @@ impl<'data> LazyRawReader<'data, TextEncoding_1_1> for LazyRawTextReader_1_1<'da
     fn new(context: EncodingContextRef<'data>, data: &'data [u8], is_final_data: bool) -> Self {
         Self::resume(
             context,
-            RawReaderState::new(data, 0, is_final_data, IonEncoding::Text_1_1),
+            RawReaderState::new(data, 0, #[cfg(feature = "source-location")] 0, #[cfg(feature = "source-location")] 0, is_final_data, IonEncoding::Text_1_1),
         )
     }
 
@@ -49,6 +49,10 @@ impl<'data> LazyRawReader<'data, TextEncoding_1_1> for LazyRawTextReader_1_1<'da
                 context,
                 saved_state.offset(),
                 saved_state.data(),
+                #[cfg(feature = "source-location")]
+                saved_state.row(),
+                #[cfg(feature = "source-location")]
+                saved_state.prev_newline_offset(),
                 saved_state.is_final_data(),
             ),
         }
@@ -58,6 +62,10 @@ impl<'data> LazyRawReader<'data, TextEncoding_1_1> for LazyRawTextReader_1_1<'da
         RawReaderState::new(
             self.input.bytes(),
             self.position(),
+            #[cfg(feature = "source-location")]
+            self.row(),
+            #[cfg(feature = "source-location")]
+            self.input.prev_newline_offset(),
             self.input.is_final_data(),
             self.encoding(),
         )
@@ -96,6 +104,16 @@ impl<'data> LazyRawReader<'data, TextEncoding_1_1> for LazyRawTextReader_1_1<'da
 
     fn position(&self) -> usize {
         self.input.offset()
+    }
+
+    #[cfg(feature = "source-location")]
+    fn row(&self) -> usize {
+        self.input.row()
+    }
+
+    #[cfg(feature = "source-location")]
+    fn prev_newline_offset(&self) -> usize {
+        self.input.prev_newline_offset()
     }
 
     fn encoding(&self) -> IonEncoding {

--- a/src/lazy/text/value.rs
+++ b/src/lazy/text/value.rs
@@ -73,6 +73,16 @@ impl<'top, Encoding: TextEncoding> LazyRawTextValue<'top, Encoding> {
         Span::with_offset(start, bytes)
     }
 
+    #[cfg(feature = "source-location")]
+    fn row(&self) -> usize {
+        self.input.row()
+    }
+
+    #[cfg(feature = "source-location")]
+    fn column(&self) -> usize {
+        self.input.column()
+    }
+
     /// Returns the total number of bytes used to represent the current value, including its
     /// annotations (if any) and its value.
     pub fn total_length(&self) -> usize {
@@ -230,6 +240,11 @@ impl<'top, Encoding: TextEncoding> LazyRawValue<'top, Encoding>
             input: TextBuffer::from_span(self.input.context(), span, true),
             ..*self
         }
+    }
+
+    #[cfg(feature = "source-location")]
+    fn location(&self) -> (usize, usize) {
+        (self.row(), self.column())
     }
 }
 


### PR DESCRIPTION
*Issue #909*

*Description of changes:*
This PR works on adding support for location metadata in `LazyValue` API.

*List of changes:*
- Modifies top level matching logic in buffer to preserve `row` and `prev_newline_offset` count.
- Adds a way to store row and `prev_newline_offset` value in the `RawReaderState`. This helps in preserving saved state whenever resume is used on the streaming reader. 
- Since streaming reader uses readers for each encoding get these values for encoding `Reader` types.
- Add location (usize, usize) to `LazyValue`
- Adds unit tests for location support

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
