### PR TITLE
Makes Symbol::static_text a const fn

### DIFF
--- a/src/types/symbol.rs
+++ b/src/types/symbol.rs
@@ -99,7 +99,7 @@ impl Symbol {
         }
     }
 
-    pub fn static_text(text: &'static str) -> Symbol {
+    pub const fn static_text(text: &'static str) -> Symbol {
         Symbol {
             text: SymbolText::Static(text),
         }
@@ -223,6 +223,9 @@ impl Borrow<str> for Symbol {
 #[cfg(test)]
 mod symbol_tests {
     use super::*;
+
+    /// This is a test to ensure that the static_text function is const.
+    const TEST_STATIC_TEXT_IS_CONST: Symbol = Symbol::static_text("foo");
 
     #[test]
     fn ordering_and_eq() {


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

Makes `static_text(text: &'static str) -> Symbol` a `const` function.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
