### PR TITLE
Adds IonDataHash to enable Hash for IonData

### DIFF
--- a/src/element/annotations.rs
+++ b/src/element/annotations.rs
@@ -1,5 +1,5 @@
 use crate::element::iterators::{AnnotationsIntoIter, SymbolsIterator};
-use crate::ion_data::{IonDataHash, IonOrd};
+use crate::ion_data::{IonDataHash, IonDataOrd};
 use crate::Symbol;
 use std::cmp::Ordering;
 use std::hash::Hasher;
@@ -142,7 +142,7 @@ impl IntoIterator for Annotations {
     }
 }
 
-impl IonOrd for Annotations {
+impl IonDataOrd for Annotations {
     fn ion_cmp(&self, other: &Self) -> Ordering {
         self.symbols.ion_cmp(&other.symbols)
     }

--- a/src/element/annotations.rs
+++ b/src/element/annotations.rs
@@ -1,7 +1,8 @@
 use crate::element::iterators::{AnnotationsIntoIter, SymbolsIterator};
-use crate::ion_data::IonOrd;
+use crate::ion_data::{IonDataHash, IonOrd};
 use crate::Symbol;
 use std::cmp::Ordering;
+use std::hash::Hasher;
 
 /// An ordered sequence of symbols that convey additional, application-specific information about
 /// their associated Ion value.
@@ -144,6 +145,12 @@ impl IntoIterator for Annotations {
 impl IonOrd for Annotations {
     fn ion_cmp(&self, other: &Self) -> Ordering {
         self.symbols.ion_cmp(&other.symbols)
+    }
+}
+
+impl IonDataHash for Annotations {
+    fn ion_data_hash<H: Hasher>(&self, state: &mut H) {
+        self.symbols.ion_data_hash(state)
     }
 }
 

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -32,7 +32,7 @@ use crate::{Blob, Bytes, Clob, List, SExp, Struct};
 // Re-export the Value variant types and traits so they can be accessed directly from this module.
 use crate::element::builders::{SequenceBuilder, StructBuilder};
 use crate::element::reader::ElementReader;
-use crate::ion_data::{IonDataHash, IonEq, IonOrd};
+use crate::ion_data::{IonDataHash, IonEq, IonDataOrd};
 use crate::lazy::any_encoding::AnyEncoding;
 use crate::lazy::encoding::Encoding;
 use crate::lazy::reader::Reader;
@@ -74,7 +74,7 @@ impl IonEq for Value {
     }
 }
 
-impl IonOrd for Value {
+impl IonDataOrd for Value {
     fn ion_cmp(&self, other: &Self) -> Ordering {
         use Value::*;
 
@@ -359,7 +359,7 @@ impl IonEq for Element {
 // 1. Ion type -- It is a logical way to group Ion values, and it is the cheapest comparison
 // 2. Annotations -- the vast majority of Ion values have few annotations, so this should usually be cheap
 // 3. Value -- compared using IonOrd
-impl IonOrd for Element {
+impl IonDataOrd for Element {
     fn ion_cmp(&self, other: &Self) -> Ordering {
         let ord = self.ion_type().ion_cmp(&other.ion_type());
         if !ord.is_eq() {

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -32,7 +32,7 @@ use crate::{Blob, Bytes, Clob, List, SExp, Struct};
 // Re-export the Value variant types and traits so they can be accessed directly from this module.
 use crate::element::builders::{SequenceBuilder, StructBuilder};
 use crate::element::reader::ElementReader;
-use crate::ion_data::{IonDataHash, IonEq, IonDataOrd};
+use crate::ion_data::{IonDataHash, IonDataOrd, IonEq};
 use crate::lazy::any_encoding::AnyEncoding;
 use crate::lazy::encoding::Encoding;
 use crate::lazy::reader::Reader;

--- a/src/element/sequence.rs
+++ b/src/element/sequence.rs
@@ -1,7 +1,7 @@
 use crate::element::builders::SequenceBuilder;
 use crate::element::iterators::SequenceIterator;
 use crate::element::Element;
-use crate::ion_data::{IonDataHash, IonEq, IonOrd};
+use crate::ion_data::{IonDataHash, IonEq, IonDataOrd};
 use crate::lazy::encoding::Encoding;
 use crate::write_config::WriteConfig;
 use crate::IonResult;
@@ -189,7 +189,7 @@ impl IonEq for Sequence {
     }
 }
 
-impl IonOrd for Sequence {
+impl IonDataOrd for Sequence {
     fn ion_cmp(&self, other: &Self) -> Ordering {
         self.elements.ion_cmp(&other.elements)
     }

--- a/src/element/sequence.rs
+++ b/src/element/sequence.rs
@@ -1,7 +1,7 @@
 use crate::element::builders::SequenceBuilder;
 use crate::element::iterators::SequenceIterator;
 use crate::element::Element;
-use crate::ion_data::{IonDataHash, IonEq, IonDataOrd};
+use crate::ion_data::{IonDataHash, IonDataOrd, IonEq};
 use crate::lazy::encoding::Encoding;
 use crate::write_config::WriteConfig;
 use crate::IonResult;

--- a/src/element/sequence.rs
+++ b/src/element/sequence.rs
@@ -1,13 +1,14 @@
 use crate::element::builders::SequenceBuilder;
 use crate::element::iterators::SequenceIterator;
 use crate::element::Element;
-use crate::ion_data::{IonEq, IonOrd};
+use crate::ion_data::{IonDataHash, IonEq, IonOrd};
 use crate::lazy::encoding::Encoding;
 use crate::write_config::WriteConfig;
 use crate::IonResult;
 use std::cmp::Ordering;
 use std::collections::VecDeque;
 use std::fmt::{Debug, Formatter};
+use std::hash::Hasher;
 use std::io;
 
 /// An iterable, addressable series of Ion [`Element`]s.
@@ -191,6 +192,12 @@ impl IonEq for Sequence {
 impl IonOrd for Sequence {
     fn ion_cmp(&self, other: &Self) -> Ordering {
         self.elements.ion_cmp(&other.elements)
+    }
+}
+
+impl IonDataHash for Sequence {
+    fn ion_data_hash<H: Hasher>(&self, state: &mut H) {
+        self.elements.ion_data_hash(state)
     }
 }
 

--- a/src/ion_data/ion_data_hash.rs
+++ b/src/ion_data/ion_data_hash.rs
@@ -1,0 +1,58 @@
+use std::hash::Hasher;
+use std::ops::Deref;
+
+/// Trait used for delegating [`Hash`] in [`IonData`](crate::IonData).
+/// Implementations of [`IonDataHash`] must be consistent with [`IonEq`](crate::ion_data::IonEq).
+///
+/// This is _not_ the Ion Hash algorithm. Do not write any code that depends on a specific hash
+/// being produced by a particular value. Do not expect that the hashes will be stable between
+/// two runs of the same application. The only guarantee is that it is consistent with
+/// [`IonEq`](crate::ion_data::IonEq)
+///
+/// This is called `IonDataHash` to avoid ambiguity with the Ion Hash algorithm and its
+/// implementation in this crate.
+pub(crate) trait IonDataHash {
+    fn ion_data_hash<H: Hasher>(&self, state: &mut H);
+}
+
+impl<R: Deref> IonDataHash for R
+where
+    R::Target: IonDataHash,
+{
+    fn ion_data_hash<H: Hasher>(&self, state: &mut H) {
+        R::Target::ion_data_hash(self, state)
+    }
+}
+
+impl<T: IonDataHash> IonDataHash for [T] {
+    fn ion_data_hash<H: Hasher>(&self, state: &mut H) {
+        state.write_usize(self.len());
+        for element in self {
+            T::ion_data_hash(element, state)
+        }
+    }
+}
+
+/// In a roundabout way, implements IonDataHash for [`f64`].
+///
+/// We cannot implement [`IonDataHash`] directly on [`f64`]. If [`IonDataHash`] is implemented directly
+/// on [`f64`], then _any_ blanket impl of [`IonDataHash`] for a standard library trait will cause
+/// `error[E0119]: conflicting implementations of trait` because [`f64`] is an external type (and
+/// "upstream crates may add a new impl of trait `std::ops::Deref` for type `f64` in future versions").
+pub(crate) fn ion_data_hash_f64<H: Hasher>(this: f64, state: &mut H) {
+    if this.is_nan() {
+        // `this` could be positive or negative, signalling or quiet NaN.
+        // Ensure that all NaNs are treated equivalently, as with IonEq.
+        state.write_u64(f64::NAN.to_bits())
+    } else {
+        state.write_u64(this.to_bits())
+    }
+}
+
+/// In a roundabout way, implements IonDataHash for [`bool`].
+///
+/// See docs for [`crate::ion_data::ion_data_hash_f64`] for general rationale. Even though the implementation is trivial,
+/// this function exists to help convey the intention of using Ion equivalence at the call site.
+pub(crate) fn ion_data_hash_bool<H: Hasher>(this: bool, state: &mut H) {
+    state.write_u8(this as u8)
+}

--- a/src/ion_data/ion_ord.rs
+++ b/src/ion_data/ion_ord.rs
@@ -2,25 +2,28 @@ use std::cmp::Ordering;
 use std::ops::Deref;
 
 /// Trait used for delegating [Ord] and [PartialOrd] in [IonData](crate::IonData).
-/// Implementations of [IonOrd] must be consistent with [IonEq](crate::ion_data::IonEq).
+/// Implementations of [IonDataOrd] must be consistent with [IonEq](crate::ion_data::IonEq).
 /// Since there is no total ordering in the Ion specification, do not write any code that depends on
 /// a specific order being preserved. Only depend on the fact that a total ordering does exist.
-pub(crate) trait IonOrd {
+///
+/// This trait is named `IonDataOrd` (rather than `IonOrd`) to indicate that it is an implementation
+/// detail of `IonData` rather than being part of any Ion specification.
+pub(crate) trait IonDataOrd {
     // Intentionally not public—this trait is exposed via `impl Ord for IonData`.
     // Called ion_cmp to avoid shadowing with Ord::cmp
     fn ion_cmp(&self, other: &Self) -> Ordering;
 }
 
-impl<R: Deref> IonOrd for R
+impl<R: Deref> IonDataOrd for R
 where
-    R::Target: IonOrd,
+    R::Target: IonDataOrd,
 {
     fn ion_cmp(&self, other: &Self) -> Ordering {
         R::Target::ion_cmp(self, other)
     }
 }
 
-impl<T: IonOrd> IonOrd for [T] {
+impl<T: IonDataOrd> IonDataOrd for [T] {
     fn ion_cmp(&self, other: &Self) -> Ordering {
         let mut i0 = self.iter();
         let mut i1 = other.iter();
@@ -42,8 +45,8 @@ impl<T: IonOrd> IonOrd for [T] {
 
 /// Checks Ion ordering for [`f64`].
 ///
-/// We cannot implement [`IonOrd`] directly on [`f64`]. If [`IonOrd`] is implemented directly on
-/// [`f64`], then _any_ blanket impl of [`IonOrd`] for a standard library trait will cause
+/// We cannot implement [`IonDataOrd`] directly on [`f64`]. If [`IonDataOrd`] is implemented directly on
+/// [`f64`], then _any_ blanket impl of [`IonDataOrd`] for a standard library trait will cause
 /// `error[E0119]: conflicting implementations of trait` because [`f64`] is an external type (and
 /// "upstream crates may add a new impl of trait `std::ops::Deref` for type `f64` in future versions").
 pub(crate) fn ion_cmp_f64(this: &f64, that: &f64) -> Ordering {

--- a/src/ion_data/mod.rs
+++ b/src/ion_data/mod.rs
@@ -128,7 +128,7 @@ impl<T: WriteAsIon> WriteAsIon for IonData<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::ion_data::{IonDataHash, IonEq, IonDataOrd};
+    use crate::ion_data::{IonDataHash, IonDataOrd, IonEq};
     use crate::lazy::encoding::TextEncoding_1_0;
     use crate::{Element, IonData, Symbol, WriteConfig};
     use rstest::*;

--- a/src/ion_data/mod.rs
+++ b/src/ion_data/mod.rs
@@ -11,7 +11,7 @@ use std::ops::Deref;
 use crate::{Encoding, IonResult, ValueWriter, WriteAsIon, WriteConfig};
 pub(crate) use ion_data_hash::{ion_data_hash_bool, ion_data_hash_f64, IonDataHash};
 pub(crate) use ion_eq::{ion_eq_bool, ion_eq_f64, IonEq};
-pub(crate) use ion_ord::{ion_cmp_bool, ion_cmp_f64, IonOrd};
+pub(crate) use ion_ord::{ion_cmp_bool, ion_cmp_f64, IonDataOrd};
 
 /// A wrapper for lifting Ion compatible data into using Ion-oriented comparisons (versus the Rust
 /// value semantics). This enables the default semantics to be what a Rust user expects for native
@@ -84,15 +84,15 @@ impl<T: Display> Display for IonData<T> {
     }
 }
 
-impl<T: IonEq + IonOrd> PartialOrd for IonData<T> {
+impl<T: IonEq + IonDataOrd> PartialOrd for IonData<T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<T: IonEq + IonOrd> Ord for IonData<T> {
+impl<T: IonEq + IonDataOrd> Ord for IonData<T> {
     fn cmp(&self, other: &Self) -> Ordering {
-        IonOrd::ion_cmp(&self.0, &other.0)
+        IonDataOrd::ion_cmp(&self.0, &other.0)
     }
 }
 
@@ -128,7 +128,7 @@ impl<T: WriteAsIon> WriteAsIon for IonData<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::ion_data::{IonDataHash, IonEq, IonOrd};
+    use crate::ion_data::{IonDataHash, IonEq, IonDataOrd};
     use crate::lazy::encoding::TextEncoding_1_0;
     use crate::{Element, IonData, Symbol, WriteConfig};
     use rstest::*;
@@ -150,7 +150,7 @@ mod tests {
     #[case::vec_element(|s| Element::read_all(s).unwrap().into() )]
     #[case::rc_vec_element(|s| Rc::new(Element::read_all(s).unwrap()).into() )]
     #[case::box_pin_rc_vec_box_arc_element(|s| Box::new(Pin::new(Rc::new(vec![Box::new(Arc::new(Element::read_one(s).unwrap()))]))).into() )]
-    fn can_wrap_data<T: IonEq + IonOrd + IonDataHash + Debug>(
+    fn can_wrap_data<T: IonEq + IonDataOrd + IonDataHash + Debug>(
         #[case] the_fn: impl Fn(&'static str) -> IonData<T>,
     ) {
         let id1: IonData<_> = the_fn("nan");

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -1,4 +1,4 @@
-use crate::ion_data::{IonDataHash, IonEq, IonDataOrd};
+use crate::ion_data::{IonDataHash, IonDataOrd, IonEq};
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -1,4 +1,4 @@
-use crate::ion_data::{IonDataHash, IonEq, IonOrd};
+use crate::ion_data::{IonDataHash, IonEq, IonDataOrd};
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 
@@ -36,7 +36,7 @@ impl IonEq for Bytes {
     }
 }
 
-impl IonOrd for Bytes {
+impl IonDataOrd for Bytes {
     fn ion_cmp(&self, other: &Self) -> Ordering {
         self.cmp(other)
     }

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -1,5 +1,6 @@
-use crate::ion_data::{IonEq, IonOrd};
+use crate::ion_data::{IonDataHash, IonEq, IonOrd};
 use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
 
 /// An owned, immutable byte array.
 /// ```rust
@@ -38,6 +39,12 @@ impl IonEq for Bytes {
 impl IonOrd for Bytes {
     fn ion_cmp(&self, other: &Self) -> Ordering {
         self.cmp(other)
+    }
+}
+
+impl IonDataHash for Bytes {
+    fn ion_data_hash<H: Hasher>(&self, state: &mut H) {
+        self.data.hash(state);
     }
 }
 

--- a/src/types/decimal/coefficient.rs
+++ b/src/types/decimal/coefficient.rs
@@ -14,8 +14,8 @@ use crate::{Int, UInt};
 /// When the magnitude is zero, the `Sign` can be used to distinguish between -0 and 0.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum Sign {
-    Negative,
-    Positive,
+    Negative = -1,
+    Positive = 1,
 }
 
 /// A signed integer that can be used as the coefficient of a [`Decimal`](crate::Decimal) value.
@@ -292,5 +292,11 @@ mod coefficient_tests {
         // Zeros
         assert_eq!(Int::try_from(Coefficient::new(0)), Ok(Int::from(0)));
         assert!(Int::try_from(Coefficient::negative_zero()).is_err());
+    }
+
+    #[test]
+    fn test_casting_sign() {
+        assert_eq!(-1, Sign::Negative as i8);
+        assert_eq!(1, Sign::Positive as i8);
     }
 }

--- a/src/types/decimal/mod.rs
+++ b/src/types/decimal/mod.rs
@@ -3,7 +3,7 @@
 use std::cmp::Ordering;
 
 use crate::decimal::coefficient::{Coefficient, Sign};
-use crate::ion_data::{IonDataHash, IonEq, IonDataOrd};
+use crate::ion_data::{IonDataHash, IonDataOrd, IonEq};
 use crate::result::{IonError, IonFailure};
 use crate::{Int, IonResult, UInt};
 use num_traits::Zero;

--- a/src/types/decimal/mod.rs
+++ b/src/types/decimal/mod.rs
@@ -3,7 +3,7 @@
 use std::cmp::Ordering;
 
 use crate::decimal::coefficient::{Coefficient, Sign};
-use crate::ion_data::{IonDataHash, IonEq, IonOrd};
+use crate::ion_data::{IonDataHash, IonEq, IonDataOrd};
 use crate::result::{IonError, IonFailure};
 use crate::{Int, IonResult, UInt};
 use num_traits::Zero;
@@ -215,7 +215,7 @@ impl IonEq for Decimal {
     }
 }
 
-impl IonOrd for Decimal {
+impl IonDataOrd for Decimal {
     // Numerical order (least to greatest) and then by number of significant figures (least to greatest)
     fn ion_cmp(&self, other: &Self) -> Ordering {
         let sign_cmp = self.coefficient.sign().cmp(&other.coefficient.sign());

--- a/src/types/decimal/mod.rs
+++ b/src/types/decimal/mod.rs
@@ -3,12 +3,13 @@
 use std::cmp::Ordering;
 
 use crate::decimal::coefficient::{Coefficient, Sign};
-use crate::ion_data::{IonEq, IonOrd};
+use crate::ion_data::{IonDataHash, IonEq, IonOrd};
 use crate::result::{IonError, IonFailure};
 use crate::{Int, IonResult, UInt};
 use num_traits::Zero;
 use std::convert::{TryFrom, TryInto};
 use std::fmt::{Display, Formatter};
+use std::hash::{Hash, Hasher};
 use std::ops::Neg;
 
 pub mod coefficient;
@@ -233,6 +234,14 @@ impl IonOrd for Decimal {
         // Finally, compare the number of significant figures.
         // Since we know the numeric value is the same, we only need to look at the exponents here.
         self.exponent.cmp(&other.exponent).reverse()
+    }
+}
+
+impl IonDataHash for Decimal {
+    fn ion_data_hash<H: Hasher>(&self, state: &mut H) {
+        state.write_i8(self.coefficient.sign() as i8);
+        self.coefficient.magnitude().hash(state);
+        state.write_i64(self.exponent);
     }
 }
 

--- a/src/types/integer.rs
+++ b/src/types/integer.rs
@@ -1,4 +1,4 @@
-use crate::ion_data::{IonDataHash, IonEq, IonDataOrd};
+use crate::ion_data::{IonDataHash, IonDataOrd, IonEq};
 use crate::result::IonFailure;
 use crate::types::CountDecimalDigits;
 use crate::{IonError, IonResult};

--- a/src/types/integer.rs
+++ b/src/types/integer.rs
@@ -1,10 +1,11 @@
-use crate::ion_data::{IonEq, IonOrd};
+use crate::ion_data::{IonDataHash, IonEq, IonOrd};
 use crate::result::IonFailure;
 use crate::types::CountDecimalDigits;
 use crate::{IonError, IonResult};
 use num_traits::Zero;
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
+use std::hash::{Hash, Hasher};
 use std::mem;
 use std::ops::{Add, Neg};
 
@@ -301,6 +302,12 @@ impl IonEq for Int {
 impl IonOrd for Int {
     fn ion_cmp(&self, other: &Self) -> Ordering {
         self.cmp(other)
+    }
+}
+
+impl IonDataHash for Int {
+    fn ion_data_hash<H: Hasher>(&self, state: &mut H) {
+        self.hash(state)
     }
 }
 

--- a/src/types/integer.rs
+++ b/src/types/integer.rs
@@ -1,4 +1,4 @@
-use crate::ion_data::{IonDataHash, IonEq, IonOrd};
+use crate::ion_data::{IonDataHash, IonEq, IonDataOrd};
 use crate::result::IonFailure;
 use crate::types::CountDecimalDigits;
 use crate::{IonError, IonResult};
@@ -299,7 +299,7 @@ impl IonEq for Int {
     }
 }
 
-impl IonOrd for Int {
+impl IonDataOrd for Int {
     fn ion_cmp(&self, other: &Self) -> Ordering {
         self.cmp(other)
     }

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -1,10 +1,11 @@
 use crate::element::builders::SequenceBuilder;
 use crate::element::iterators::SequenceIterator;
-use crate::ion_data::IonEq;
+use crate::ion_data::{IonDataHash, IonEq};
 use crate::text::text_formatter::FmtValueFormatter;
 use crate::{Element, Sequence};
 use delegate::delegate;
 use std::fmt::{Display, Formatter};
+use std::hash::Hasher;
 
 /// An in-memory representation of an Ion list.
 /// ```
@@ -43,6 +44,12 @@ impl IonEq for List {
     fn ion_eq(&self, other: &Self) -> bool {
         // The inner `Sequence` of both Lists are IonEq
         self.0.ion_eq(&other.0)
+    }
+}
+
+impl IonDataHash for List {
+    fn ion_data_hash<H: Hasher>(&self, state: &mut H) {
+        self.0.ion_data_hash(state)
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -31,7 +31,7 @@ pub use string::Str;
 pub use symbol::Symbol;
 pub use timestamp::{HasMinute, Mantissa, Timestamp, TimestampBuilder, TimestampPrecision};
 
-use crate::ion_data::{IonDataHash, IonOrd};
+use crate::ion_data::{IonDataHash, IonDataOrd};
 use std::cmp::Ordering;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -87,7 +87,7 @@ impl IonType {
     }
 }
 
-impl IonOrd for IonType {
+impl IonDataOrd for IonType {
     fn ion_cmp(&self, other: &Self) -> Ordering {
         self.cmp(other)
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -31,14 +31,15 @@ pub use string::Str;
 pub use symbol::Symbol;
 pub use timestamp::{HasMinute, Mantissa, Timestamp, TimestampBuilder, TimestampPrecision};
 
-use crate::ion_data::IonOrd;
+use crate::ion_data::{IonDataHash, IonOrd};
 use std::cmp::Ordering;
 use std::fmt;
+use std::hash::{Hash, Hasher};
 
 /// Represents the Ion data type of a given value. To learn more about each data type,
 /// read [the Ion Data Model](https://amazon-ion.github.io/ion-docs/docs/spec.html#the-ion-data-model)
 /// section of the spec.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 pub enum IonType {
     Null,
     Bool,
@@ -89,6 +90,12 @@ impl IonType {
 impl IonOrd for IonType {
     fn ion_cmp(&self, other: &Self) -> Ordering {
         self.cmp(other)
+    }
+}
+
+impl IonDataHash for IonType {
+    fn ion_data_hash<H: Hasher>(&self, state: &mut H) {
+        self.hash(state)
     }
 }
 

--- a/src/types/sexp.rs
+++ b/src/types/sexp.rs
@@ -1,10 +1,11 @@
 use crate::element::builders::SequenceBuilder;
 use crate::element::iterators::SequenceIterator;
-use crate::ion_data::IonEq;
+use crate::ion_data::{IonDataHash, IonEq};
 use crate::text::text_formatter::FmtValueFormatter;
 use crate::{Element, Sequence};
 use delegate::delegate;
 use std::fmt::{Display, Formatter};
+use std::hash::Hasher;
 
 /// An in-memory representation of an Ion s-expression
 /// ```
@@ -43,6 +44,12 @@ impl IonEq for SExp {
     fn ion_eq(&self, other: &Self) -> bool {
         // The inner `Sequence` of both Lists are IonEq
         self.0.ion_eq(&other.0)
+    }
+}
+
+impl IonDataHash for SExp {
+    fn ion_data_hash<H: Hasher>(&self, state: &mut H) {
+        self.0.ion_data_hash(state)
     }
 }
 

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -1,4 +1,4 @@
-use crate::ion_data::{IonDataHash, IonEq, IonDataOrd};
+use crate::ion_data::{IonDataHash, IonDataOrd, IonEq};
 use crate::text::text_formatter::FmtValueFormatter;
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -1,4 +1,4 @@
-use crate::ion_data::{IonDataHash, IonEq, IonOrd};
+use crate::ion_data::{IonDataHash, IonEq, IonDataOrd};
 use crate::text::text_formatter::FmtValueFormatter;
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
@@ -127,7 +127,7 @@ impl IonEq for Str {
     }
 }
 
-impl IonOrd for Str {
+impl IonDataOrd for Str {
     fn ion_cmp(&self, other: &Self) -> Ordering {
         self.cmp(other)
     }

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -1,7 +1,8 @@
-use crate::ion_data::{IonEq, IonOrd};
+use crate::ion_data::{IonDataHash, IonEq, IonOrd};
 use crate::text::text_formatter::FmtValueFormatter;
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
+use std::hash::{Hash, Hasher};
 
 /// An owned, immutable in-memory representation of an Ion `string`.
 ///
@@ -129,5 +130,11 @@ impl IonEq for Str {
 impl IonOrd for Str {
     fn ion_cmp(&self, other: &Self) -> Ordering {
         self.cmp(other)
+    }
+}
+
+impl IonDataHash for Str {
+    fn ion_data_hash<H: Hasher>(&self, state: &mut H) {
+        self.hash(state)
     }
 }

--- a/src/types/struct.rs
+++ b/src/types/struct.rs
@@ -1,6 +1,6 @@
 use crate::element::builders::StructBuilder;
 use crate::element::Element;
-use crate::ion_data::{IonDataHash, IonEq, IonOrd};
+use crate::ion_data::{IonDataHash, IonEq, IonDataOrd};
 use crate::symbol_ref::AsSymbolRef;
 use crate::text::text_formatter::FmtValueFormatter;
 use crate::Symbol;
@@ -326,7 +326,7 @@ impl IonEq for Struct {
     }
 }
 
-impl IonOrd for Struct {
+impl IonDataOrd for Struct {
     fn ion_cmp(&self, other: &Self) -> Ordering {
         let mut these_fields = self.fields.by_index.iter().collect::<Vec<_>>();
         let mut those_fields = other.fields.by_index.iter().collect::<Vec<_>>();
@@ -356,7 +356,7 @@ fn ion_cmp_field(this: &&(Symbol, Element), that: &&(Symbol, Element)) -> Orderi
     if !ord.is_eq() {
         return ord;
     }
-    IonOrd::ion_cmp(&this.1, &that.1)
+    IonDataOrd::ion_cmp(&this.1, &that.1)
 }
 
 impl IonDataHash for Struct {

--- a/src/types/struct.rs
+++ b/src/types/struct.rs
@@ -1,6 +1,6 @@
 use crate::element::builders::StructBuilder;
 use crate::element::Element;
-use crate::ion_data::{IonEq, IonOrd};
+use crate::ion_data::{IonDataHash, IonEq, IonOrd};
 use crate::symbol_ref::AsSymbolRef;
 use crate::text::text_formatter::FmtValueFormatter;
 use crate::Symbol;
@@ -8,6 +8,7 @@ use smallvec::SmallVec;
 use std::cmp::Ordering;
 use std::collections::{HashMap, VecDeque};
 use std::fmt::{Display, Formatter};
+use std::hash::Hasher;
 
 // A convenient type alias for a vector capable of storing a single `usize` inline
 // without heap allocation. This type should not be used in public interfaces directly.
@@ -356,6 +357,17 @@ fn ion_cmp_field(this: &&(Symbol, Element), that: &&(Symbol, Element)) -> Orderi
         return ord;
     }
     IonOrd::ion_cmp(&this.1, &that.1)
+}
+
+impl IonDataHash for Struct {
+    fn ion_data_hash<H: Hasher>(&self, state: &mut H) {
+        let mut these_fields = self.fields.by_index.iter().collect::<Vec<_>>();
+        these_fields.sort_by(ion_cmp_field);
+        for (name, value) in these_fields {
+            name.ion_data_hash(state);
+            value.ion_data_hash(state);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/types/struct.rs
+++ b/src/types/struct.rs
@@ -1,6 +1,6 @@
 use crate::element::builders::StructBuilder;
 use crate::element::Element;
-use crate::ion_data::{IonDataHash, IonEq, IonDataOrd};
+use crate::ion_data::{IonDataHash, IonDataOrd, IonEq};
 use crate::symbol_ref::AsSymbolRef;
 use crate::text::text_formatter::FmtValueFormatter;
 use crate::Symbol;

--- a/src/types/symbol.rs
+++ b/src/types/symbol.rs
@@ -1,4 +1,4 @@
-use crate::ion_data::{IonDataHash, IonEq, IonDataOrd};
+use crate::ion_data::{IonDataHash, IonDataOrd, IonEq};
 use crate::result::IonFailure;
 use crate::{IonResult, SymbolRef};
 use std::borrow::Borrow;

--- a/src/types/symbol.rs
+++ b/src/types/symbol.rs
@@ -1,4 +1,4 @@
-use crate::ion_data::{IonEq, IonOrd};
+use crate::ion_data::{IonDataHash, IonEq, IonOrd};
 use crate::result::IonFailure;
 use crate::{IonResult, SymbolRef};
 use std::borrow::Borrow;
@@ -132,6 +132,12 @@ impl IonEq for Symbol {
 impl IonOrd for Symbol {
     fn ion_cmp(&self, other: &Self) -> Ordering {
         self.cmp(other)
+    }
+}
+
+impl IonDataHash for Symbol {
+    fn ion_data_hash<H: Hasher>(&self, state: &mut H) {
+        self.hash(state)
     }
 }
 

--- a/src/types/symbol.rs
+++ b/src/types/symbol.rs
@@ -1,4 +1,4 @@
-use crate::ion_data::{IonDataHash, IonEq, IonOrd};
+use crate::ion_data::{IonDataHash, IonEq, IonDataOrd};
 use crate::result::IonFailure;
 use crate::{IonResult, SymbolRef};
 use std::borrow::Borrow;
@@ -129,7 +129,7 @@ impl IonEq for Symbol {
     }
 }
 
-impl IonOrd for Symbol {
+impl IonDataOrd for Symbol {
     fn ion_cmp(&self, other: &Self) -> Ordering {
         self.cmp(other)
     }

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -1,5 +1,5 @@
 use crate::decimal::coefficient::Sign;
-use crate::ion_data::{IonDataHash, IonEq, IonDataOrd};
+use crate::ion_data::{IonDataHash, IonDataOrd, IonEq};
 use crate::result::{IonError, IonFailure, IonResult};
 use crate::types::{CountDecimalDigits, Decimal};
 use chrono::{
@@ -785,8 +785,7 @@ impl IonDataHash for Timestamp {
 
             let fractional_seconds_scale = self.fractional_seconds_scale();
             match fractional_seconds_scale {
-                None |
-                Some(0) => {}
+                None | Some(0) => {}
                 Some(1..=9) => {
                     fractional_seconds_scale.unwrap().hash(state);
                     self.fractional_seconds_as_nanoseconds()

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -1,5 +1,5 @@
 use crate::decimal::coefficient::Sign;
-use crate::ion_data::{IonDataHash, IonEq, IonOrd};
+use crate::ion_data::{IonDataHash, IonEq, IonDataOrd};
 use crate::result::{IonError, IonFailure, IonResult};
 use crate::types::{CountDecimalDigits, Decimal};
 use chrono::{
@@ -727,7 +727,7 @@ impl IonEq for Timestamp {
     }
 }
 
-impl IonOrd for Timestamp {
+impl IonDataOrd for Timestamp {
     fn ion_cmp(&self, other: &Self) -> Ordering {
         // Compare by point in time
         let ord = self.cmp(other);


### PR DESCRIPTION
**Issue #, if available:**

None, but this is needed for Ion Schema Rust.

**Description of changes:**

* Adds `IonDataHash` trait with implementations for `Element`, `Value`, etc.
* Implements `Hash` for `IonData` using `IonDataHash`.
* Adds regular `Hash` for some other types where it makes sense, such as the `IonType` and `TimestampPrecision` enums.
* Adds integer values to `coefficient::Sign` so that it can be cast to an integer value. (I could have just added `derive(Hash)`, but this seemed like a useful little improvement.)


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
