### PR TITLE
Transcribe eexp invocations for arguments of transcribed invocations.

### DIFF
--- a/tests/conformance_dsl/fragment.rs
+++ b/tests/conformance_dsl/fragment.rs
@@ -367,7 +367,7 @@ impl WriteAsIon for ProxyElement<'_> {
                                 writer.eexp_writer(macro_id)?
                             };
                             for arg in sexp.iter().skip(1) {
-                                args.write(arg)?;
+                                args.write(ProxyElement(arg, self.1))?;
                             }
                             args.close()?;
                             return Ok(())

--- a/tests/conformance_dsl/mod.rs
+++ b/tests/conformance_dsl/mod.rs
@@ -474,7 +474,8 @@ mod tests {
     fn test_eexp_transcription() {
         let tests: &[&str] = &[
             "(ion_1_1 (toplevel ('#$:make_list' (1 2))) (produces [1, 2]) )",
-            "(ion_1_1 (mactab (macro twice (x*) (.values (%x) (%x)))) (toplevel ('#$:twice' foo)) (produces foo foo))"
+            "(ion_1_1 (mactab (macro twice (x*) (.values (%x) (%x)))) (toplevel ('#$:twice' foo)) (produces foo foo))",
+            "(ion_1_1 (toplevel ('#$:make_list' (1 2) ('#$:make_list' (3 4)))) (produces [1, 2, 3, 4]) )",
         ];
 
         for test in tests {


### PR DESCRIPTION
*Issue #, if available:* #931

*Description of changes:*
This PR is simple, and just wraps any argument of an e-exp invocation in `ProxyElement` when transcribing, in order to allow arguments to support being transcribed invocations.

Prior to this PR, providing a conformance DSL eexp invocation such as `(toplevel ('#$foo' ('#$bar)))` would end up being serialized as `(:foo ('#$bar'))`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
