### PR TITLE
Reset encoding context whenever IVM encountered & update conformance DSL fragment rendering.

### DIFF
--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -539,14 +539,10 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
         marker: <Encoding as Decoder>::VersionMarker<'top>,
     ) -> IonResult<SystemStreamItem<'top, Encoding>> {
         let new_version = marker.stream_version_after_marker()?;
-        // If this is the first item in the stream or we're changing versions, we need to ensure
-        // the encoding context is set up for this version.
-        if marker.range().start == 0 || new_version != marker.stream_version_before_marker() {
-            // SAFETY: Version markers do not hold a reference to the symbol table.
-            let pending_changes = unsafe { &mut *self.pending_context_changes.get() };
-            pending_changes.switch_to_version = Some(new_version);
-            pending_changes.has_changes = true;
-        }
+        // SAFETY: Version markers do not hold a reference to the symbol table.
+        let pending_changes = unsafe { &mut *self.pending_context_changes.get() };
+        pending_changes.switch_to_version = Some(new_version);
+        pending_changes.has_changes = true;
         Ok(SystemStreamItem::VersionMarker(marker))
     }
 

--- a/tests/conformance_dsl/context.rs
+++ b/tests/conformance_dsl/context.rs
@@ -1,6 +1,6 @@
 use crate::conformance_dsl::*;
 
-use ion_rs::{Catalog, Element, ElementReader, Sequence, Reader, IonSlice, SharedSymbolTable, Symbol, SymbolId};
+use ion_rs::{Catalog, Element, ElementReader, Sequence, Reader, SharedSymbolTable, Symbol, SymbolId};
 use ion_rs::{v1_0, v1_1};
 
 /// A Context forms a scope for tracking all of the document fragments and any parent Contexts that
@@ -125,25 +125,66 @@ impl<'a> Context<'a> {
             .and_then(|st| st.symbols().get(offset - 1).cloned())
     }
 
+    pub fn write_input<E: ion_rs::Encoding, O: std::io::Write>(&self, writer: &mut ion_rs::Writer<E, O>) -> InnerResult<()> {
+        self.parent_ctx.map(|ctx| {
+            let mut new_ctx = ctx.clone();
+            new_ctx.set_encoding(self.encoding());
+            new_ctx.write_input(writer)
+        }).unwrap_or(Ok(()))?;
+
+        for frag in self.fragments.iter() {
+            frag.write(self, writer)?;
+        }
+        writer.flush()?;
+        Ok(())
+    }
+
     /// Returns a Vec<u8> containing the serialized data consisting of all fragments in the path
     /// for this context.
     pub fn input(&self, child_encoding: IonEncoding) -> InnerResult<(Vec<u8>, IonEncoding)> {
-        let encoding = Self::resolve_encoding(self.encoding(), child_encoding);
-        let (data, data_encoding) = match encoding {
-            IonEncoding::Text => (to_text(self, self.fragments.iter())?, encoding),
-            IonEncoding::Binary => (to_binary(self, self.fragments.iter())?, encoding),
-            IonEncoding::Unspecified => (to_text(self, self.fragments.iter())?, IonEncoding::Text),
+        use ion_rs::Writer;
+        let encoding = match Self::resolve_encoding(self.encoding(), child_encoding) {
+            IonEncoding::Unspecified => IonEncoding::Text,
+            x => x,
         };
-        let (mut parent_input, _) = self.parent_ctx.map(|c| c.input(encoding)).unwrap_or(Ok((vec!(), encoding)))?;
-        parent_input.extend(data.clone());
-        Ok((parent_input, data_encoding))
+        let version = match self.version() {
+            IonVersion::Unspecified => IonVersion::V1_1,
+            x => x,
+        };
+
+        let buffer = vec![];
+        match (encoding, version) {
+            (IonEncoding::Text, IonVersion::V1_0) => {
+                let mut writer = Writer::new(v1_0::Text, buffer)?;
+                self.write_input(&mut writer)?;
+                let output = writer.close()?;
+                Ok((output, encoding))
+            }
+            (IonEncoding::Text, IonVersion::V1_1) => {
+                let mut writer = Writer::new(v1_1::Text, buffer)?;
+                self.write_input(&mut writer)?;
+                let output = writer.close()?;
+                Ok((output, encoding))
+            }
+            (IonEncoding::Binary, IonVersion::V1_0) => {
+                let mut writer = Writer::new(v1_0::Binary, buffer)?;
+                self.write_input(&mut writer)?;
+                let output = writer.close()?;
+                Ok((output, encoding))
+            }
+            (IonEncoding::Binary, IonVersion::V1_1) => {
+                let mut writer = Writer::new(v1_1::Binary, buffer)?;
+                self.write_input(&mut writer)?;
+                let output = writer.close()?;
+                Ok((output, encoding))
+            }
+            _ => unreachable!(),
+        }
     }
 
     /// Returns the Sequence of Elements representing the test document.
     pub fn read_all(&self, encoding: IonEncoding) -> InnerResult<Sequence> {
         let (data, data_encoding) = self.input(encoding)?;
-        let data_slice = IonSlice::new(data);
-
 
         if self.fragments.is_empty() {
             let empty: Vec<Element> = vec!();
@@ -157,19 +198,44 @@ impl<'a> Context<'a> {
 
         match (version, data_encoding) {
             (IonVersion::V1_0, IonEncoding::Binary) =>
-                Ok(Reader::new(v1_0::Binary, data_slice)?.read_all_elements()?),
+                Ok(Reader::new(v1_0::Binary, data)?.read_all_elements()?),
             (IonVersion::V1_0, IonEncoding::Text) =>
-                Ok(Reader::new(v1_0::Text, data_slice)?.read_all_elements()?),
+                Ok(Reader::new(v1_0::Text, data)?.read_all_elements()?),
             (IonVersion::V1_0, IonEncoding::Unspecified) =>
-                Ok(Reader::new(v1_0::Binary, data_slice)?.read_all_elements()?),
+                Ok(Reader::new(v1_0::Binary, data)?.read_all_elements()?),
             (IonVersion::V1_1, IonEncoding::Binary) =>
-                Ok(Reader::new(v1_1::Binary, data_slice)?.read_all_elements()?),
+                Ok(Reader::new(v1_1::Binary, data)?.read_all_elements()?),
             (IonVersion::V1_1, IonEncoding::Text) =>
-                Ok(Reader::new(v1_1::Text, data_slice)?.read_all_elements()?),
+                Ok(Reader::new(v1_1::Text, data)?.read_all_elements()?),
             (IonVersion::V1_1, IonEncoding::Unspecified) =>
-                Ok(Reader::new(v1_1::Binary, data_slice)?.read_all_elements()?),
+                Ok(Reader::new(v1_1::Binary, data)?.read_all_elements()?),
             _ => unreachable!(),
         }
     }
 
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    // Test to ensure that when we render fragments, we don't insert new IVMs breaking the context
+    // established by previous fragments.
+    fn unbroken_fragment_encoding_context() {
+        let elems = Element::read_all("mactab (macro m (v!) (%v))").expect("unable to parse mactab into elements");
+        let frags: Vec<Fragment> = vec!{
+            Clause::try_from(elems).expect("unable to convert elements to clause")
+                .try_into().expect("unable to convert clause to fragment"),
+            Fragment::Text("(:m 1)".to_string()),
+        };
+        let context = Context::new(IonVersion::V1_1, IonEncoding::Text, &frags).expect("unable to create context");
+        let (bytes, _) = context.input(IonEncoding::Text).expect("failed to render fragments");
+
+        let fragments_str = String::from_utf8(bytes).expect("Invalid input string generated");
+        assert_eq!(
+            fragments_str,
+            "$ion_1_1 $ion::(module _ (macro_table (macro m (v '!' ) ('%' v ) ) ) ) (:m 1)".to_string(),
+        );
+    }
 }

--- a/tests/conformance_dsl/document.rs
+++ b/tests/conformance_dsl/document.rs
@@ -6,33 +6,6 @@ use super::*;
 
 use ion_rs::{Element, Sequence};
 
-/// Convert a collection of Fragments into a binary encoded ion stream.
-pub(crate) fn to_binary<'a, T: IntoIterator<Item = &'a Fragment>>(
-    ctx: &'a Context,
-    fragments: T,
-) -> InnerResult<Vec<u8>> {
-    let mut bin_encoded = vec![];
-    for frag in fragments {
-        let bin = frag.to_binary(ctx)?;
-        bin_encoded.extend(bin);
-    }
-    Ok(bin_encoded)
-}
-
-/// Convert a collection of Fragments into a text encoded ion stream.
-pub(crate) fn to_text<'a, T: IntoIterator<Item = &'a Fragment>>(
-    ctx: &'a Context,
-    fragments: T,
-) -> InnerResult<Vec<u8>> {
-    let mut txt_encoded = vec![];
-    for frag in fragments {
-        let txt = frag.to_text(ctx)?;
-        txt_encoded.extend(txt);
-        txt_encoded.push(0x20); // Text fragments need to be separated by whitespace.
-    }
-    Ok(txt_encoded)
-}
-
 /// The root clause for a test. A document contains an optional name, set of fragments, and a
 /// continuation. All tests defined by this document are evaluated through the `run` function.
 #[derive(Debug, Default)]

--- a/tests/conformance_dsl/fragment.rs
+++ b/tests/conformance_dsl/fragment.rs
@@ -38,7 +38,7 @@ trait FragmentImpl {
     fn write<E: ion_rs::Encoding, O: std::io::Write>(
         &self,
         ctx: &Context,
-        writer: &mut ion_rs::Writer<E, O>
+        writer: &mut ion_rs::Writer<E, O>,
     ) -> InnerResult<()>;
 }
 
@@ -58,9 +58,12 @@ pub(crate) enum Fragment {
 static EMPTY_TOPLEVEL: Fragment = Fragment::TopLevel(TopLevel { elems: vec![] });
 
 impl Fragment {
-
     /// Write the fragment to the test document using the provided writer
-    pub(crate) fn write<E: ion_rs::Encoding, O: std::io::Write>(&self, ctx: &Context, writer: &mut ion_rs::Writer<E, O>) -> InnerResult<()> {
+    pub(crate) fn write<E: ion_rs::Encoding, O: std::io::Write>(
+        &self,
+        ctx: &Context,
+        writer: &mut ion_rs::Writer<E, O>,
+    ) -> InnerResult<()> {
         match self {
             Fragment::TopLevel(toplevel) => toplevel.write(ctx, writer),
             Fragment::Text(txt) => {
@@ -74,17 +77,21 @@ impl Fragment {
                 Ok(())
             }
             Fragment::Ivm(maj, min) => match ctx.encoding() {
-                IonEncoding::Binary  => {
+                IonEncoding::Binary => {
                     writer.flush()?;
-                    let _ = writer.output_mut().write(&[0xE0, *maj as u8, *min as u8, 0xEA])?;
+                    let _ = writer
+                        .output_mut()
+                        .write(&[0xE0, *maj as u8, *min as u8, 0xEA])?;
                     Ok(())
                 }
                 _ => {
                     writer.flush()?;
-                    let _ = writer.output_mut().write(format!("$ion_{}_{} ", maj, min).as_bytes())?;
+                    let _ = writer
+                        .output_mut()
+                        .write(format!("$ion_{}_{} ", maj, min).as_bytes())?;
                     Ok(())
                 }
-            }
+            },
         }
     }
 
@@ -411,7 +418,7 @@ impl FragmentImpl for TopLevel {
     fn write<E: ion_rs::Encoding, O: std::io::Write>(
         &self,
         ctx: &Context,
-        writer: &mut ion_rs::Writer<E, O>
+        writer: &mut ion_rs::Writer<E, O>,
     ) -> InnerResult<()> {
         for elem in self.elems.as_slice() {
             writer.write(ProxyElement(elem, ctx))?;

--- a/tests/conformance_dsl/fragment.rs
+++ b/tests/conformance_dsl/fragment.rs
@@ -22,7 +22,7 @@
 
 use super::context::Context;
 use super::*;
-use ion_rs::{ion_seq, v1_0, v1_1, Encoding, WriteConfig};
+use ion_rs::{ion_seq, Encoding, WriteConfig};
 use ion_rs::{Element, SExp, Sequence, Struct, Symbol};
 use ion_rs::{RawSymbolRef, SequenceWriter, StructWriter, ValueWriter, WriteAsIon, Writer};
 
@@ -34,6 +34,12 @@ trait FragmentImpl {
         ctx: &Context,
         config: impl Into<WriteConfig<E>>,
     ) -> InnerResult<Vec<u8>>;
+
+    fn write<E: ion_rs::Encoding, O: std::io::Write>(
+        &self,
+        ctx: &Context,
+        writer: &mut ion_rs::Writer<E, O>
+    ) -> InnerResult<()>;
 }
 
 /// Fragments represent parts of the ion document read for testing.
@@ -52,50 +58,33 @@ pub(crate) enum Fragment {
 static EMPTY_TOPLEVEL: Fragment = Fragment::TopLevel(TopLevel { elems: vec![] });
 
 impl Fragment {
-    /// Encode the fragment as binary ion.
-    pub fn to_binary(&self, ctx: &Context) -> InnerResult<Vec<u8>> {
-        match ctx.version() {
-            IonVersion::V1_1 => self.write_as_binary(ctx, v1_1::Binary),
-            _ => self.write_as_binary(ctx, v1_0::Binary),
-        }
-    }
 
-    /// Encode the fragment as text ion.
-    pub fn to_text(&self, ctx: &Context) -> InnerResult<Vec<u8>> {
-        match ctx.version() {
-            IonVersion::V1_1 => self.write_as_text(ctx, v1_1::Text),
-            _ => self.write_as_text(ctx, v1_0::Text),
-        }
-    }
-
-    /// Internal. Writes the fragment as binary ion using the provided WriteConfig.
-    fn write_as_binary<E: Encoding>(
-        &self,
-        ctx: &Context,
-        config: impl Into<WriteConfig<E>>,
-    ) -> InnerResult<Vec<u8>> {
+    /// Write the fragment to the test document using the provided writer
+    pub(crate) fn write<E: ion_rs::Encoding, O: std::io::Write>(&self, ctx: &Context, writer: &mut ion_rs::Writer<E, O>) -> InnerResult<()> {
         match self {
-            Fragment::TopLevel(toplevel) => toplevel.encode(ctx, config),
-            Fragment::Binary(bin) => Ok(bin.clone()),
-            Fragment::Text(_) => unreachable!(),
-            Fragment::Ivm(maj, min) => Ok([0xE0, *maj as u8, *min as u8, 0xEA].to_vec()),
-        }
-    }
-
-    /// Internal. Writes the fragment as text ion using the provided WriteConfig.
-    fn write_as_text<E: Encoding>(
-        &self,
-        ctx: &Context,
-        config: impl Into<WriteConfig<E>>,
-    ) -> InnerResult<Vec<u8>> {
-        match self {
-            Fragment::TopLevel(toplevel) => toplevel.encode(ctx, config),
+            Fragment::TopLevel(toplevel) => toplevel.write(ctx, writer),
             Fragment::Text(txt) => {
-                let bytes = txt.as_bytes();
-                Ok(bytes.to_owned())
+                writer.flush()?;
+                let _ = writer.output_mut().write(txt.as_bytes())?;
+                Ok(())
             }
-            Fragment::Binary(_) => unreachable!(),
-            Fragment::Ivm(maj, min) => Ok(format!("$ion_{}_{}", maj, min).as_bytes().to_owned()),
+            Fragment::Binary(bytes) => {
+                writer.flush()?;
+                let _ = writer.output_mut().write(bytes)?;
+                Ok(())
+            }
+            Fragment::Ivm(maj, min) => match ctx.encoding() {
+                IonEncoding::Binary  => {
+                    writer.flush()?;
+                    let _ = writer.output_mut().write(&[0xE0, *maj as u8, *min as u8, 0xEA])?;
+                    Ok(())
+                }
+                _ => {
+                    writer.flush()?;
+                    let _ = writer.output_mut().write(format!("$ion_{}_{} ", maj, min).as_bytes())?;
+                    Ok(())
+                }
+            }
         }
     }
 
@@ -183,6 +172,12 @@ impl TryFrom<Sequence> for Fragment {
     fn try_from(other: Sequence) -> InnerResult<Self> {
         let clause = Clause::try_from(other)?;
         Fragment::try_from(clause)
+    }
+}
+
+pub trait FragmentWriter {
+    fn write(&mut self, _frag: &Fragment) -> InnerResult<usize> {
+        todo!()
     }
 }
 
@@ -410,5 +405,16 @@ impl FragmentImpl for TopLevel {
         }
         buffer = writer.close()?;
         Ok(buffer)
+    }
+
+    fn write<E: ion_rs::Encoding, O: std::io::Write>(
+        &self,
+        ctx: &Context,
+        writer: &mut ion_rs::Writer<E, O>
+    ) -> InnerResult<()> {
+        for elem in self.elems.as_slice() {
+            writer.write(ProxyElement(elem, ctx))?;
+        }
+        Ok(())
     }
 }

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -60,7 +60,8 @@ mod ion_tests {
         skip!("ion-tests/conformance/eexp/basic_system_macros.ion"),
         // Mismatched produces, due to out-of-date encoding block
         skip!("ion-tests/conformance/ion_encoding/mactab.ion"),
-        skip!("ion-tests/conformance/ion_encoding/module/macro/cardinality/invoke_cardinality_ee.ion",
+        skip!(
+            "ion-tests/conformance/ion_encoding/module/macro/cardinality/invoke_cardinality_ee.ion",
             "? parameters", // NEED: Conformance DSL support for expression groups.
             "+ parameters", // NEED: Conformance DSL support for expression groups.
             "* parameters"  // NEED: Conformande DSL support for expression groups.

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -49,7 +49,7 @@ mod ion_tests {
         ),
         // Mismatched produces due to symbol id transcription.
         skip!("ion-tests/conformance/core/toplevel_produces.ion"),
-        // Unrecognized encoding 'int8'
+        // Unrecognized encoding 'int8' (only flex_uint appears to be supported)
         skip!("ion-tests/conformance/demos/metaprogramming.ion"),
         // error: flatten only accepts sequences
         skip!("ion-tests/conformance/eexp/arg_inlining.ion"),
@@ -58,8 +58,9 @@ mod ion_tests {
         // Mismatched produces, due to out-of-date encoding block
         skip!("ion-tests/conformance/ion_encoding/mactab.ion"),
         skip!("ion-tests/conformance/ion_encoding/module/macro/cardinality/invoke_cardinality_ee.ion",
-            "? parameters", // Parameter used incorrectly in tdl.
-            "* parameters"  // Parameter used incorrectly in tdl.
+            "? parameters", // NEED: Conformance DSL support for expression groups.
+            "+ parameters", // NEED: Conformance DSL support for expression groups.
+            "* parameters"  // NEED: Conformande DSL support for expression groups.
         ),
         // Incorrectly constructed macro table.
         skip!("ion-tests/conformance/ion_encoding/module/macro/template/literal_form.ion"),


### PR DESCRIPTION
*Issue #, if available:* #937, #936.

*Description of changes:*
This PR addresses 2 issues found during work on conformance testing. The first, is that when reading with AnyEncoding the encoding context would not be reset unless a new ion version was used. The second issue, was that the conformance DSL was rendering each fragment using a new writer, which lead to each fragment having its own IVM.

The redundant IVMs caused issues with the conformance DSL's reader which uses the required version and encoding. When testing some failures (due to context reset) in the CLI we found that the AnyEncoding was not resetting the encoding context as expected.

This PR addresses each by:
* Removing a check that would only reset the context at the start of a stream, or when a new IVM with a different ion version was encountered.
* Refactored the conformance DSL's fragment rendering to render all fragments using the same writer in order to maintain encoding context.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
