### PR TITLE
Removes location calculation from buffer and feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,6 @@ rust-version = "1.82"
 default = []
 experimental-ion-hash = ["digest", "experimental-reader-writer"]
 
-# Access location information of the input Ion from underlying buffer.
-source-location = []
-lazy-source-location = []
-
 # Feature for indicating particularly bleeding edge APIs or functionality in the library.
 # These are not guaranteed any sort of API stability and may also have non-standard
 # Ion behavior (e.g., draft Ion 1.1 capabilities).

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -290,7 +290,6 @@ impl<'top> EncodingContextRef<'top> {
             .expect("`values` macro in system macro table")
     }
 
-    #[cfg(feature = "lazy-source-location")]
     pub fn location(&self, value_start: usize) -> Option<(usize, usize)> {
         match unsafe { &*self.io_buffer_source.get() } {
             IoBufferSource::IoBuffer(ref buffer) => Some((buffer.row(), buffer.column())),

--- a/src/lazy/text/buffer.rs
+++ b/src/lazy/text/buffer.rs
@@ -103,13 +103,6 @@ pub(crate) const WHITESPACE_BYTES: &[u8] = b" \t\r\n\x09\x0B\x0C";
 pub struct TextBuffer<'top> {
     // `data` is a slice of remaining data in the larger input stream.
     input_span: Span<'top>,
-    #[cfg(feature = "source-location")]
-    // `row` is the row position of the input data in this buffer.
-    row: usize,
-    #[cfg(feature = "source-location")]
-    // `prev_newline_offset` is the previously encountered newline byte's offset value.
-    // this is useful in calculating the column position of the input data in this buffer.
-    prev_newline_offset: usize,
     pub(crate) context: EncodingContextRef<'top>,
     is_final_data: bool,
 }
@@ -130,10 +123,6 @@ impl<'top> TextBuffer<'top> {
         TextBuffer {
             context,
             input_span,
-            #[cfg(feature = "source-location")]
-            row: 1,
-            #[cfg(feature = "source-location")]
-            prev_newline_offset: 0,
             is_final_data,
         }
     }
@@ -153,10 +142,6 @@ impl<'top> TextBuffer<'top> {
         TextBuffer {
             context,
             input_span: Span::with_offset(offset, bytes),
-            #[cfg(feature = "source-location")]
-            row: 1,
-            #[cfg(feature = "source-location")]
-            prev_newline_offset: 0,
             is_final_data,
         }
     }
@@ -219,20 +204,6 @@ impl<'top> TextBuffer<'top> {
         self.input_span.offset()
     }
 
-    #[cfg(feature = "source-location")]
-    /// Returns the row position for this buffer.
-    /// _Note: Row positions are calculated based on newline characters `\n` and `\r`. `\r\n` together in this order is considered a single newline._
-    pub fn row(&self) -> usize {
-        self.row
-    }
-
-    #[cfg(feature = "source-location")]
-    /// Returns the column position for this buffer.
-    /// _Note: Column positions are calculated based on current offset and previous newline byte offset._
-    pub fn column(&self) -> usize {
-        self.offset() - self.prev_newline_offset + 1
-    }
-
     /// Returns the number of bytes in the buffer.
     pub fn len(&self) -> usize {
         self.input_span.len()
@@ -273,50 +244,12 @@ impl<'top> TextBuffer<'top> {
     /// Matches one or more whitespace characters.
     pub fn match_whitespace1(&mut self) -> IonMatchResult<'top> {
         let result = take_while(1.., WHITESPACE_BYTES).parse_next(self)?;
-        #[cfg(feature = "source-location")]
-        self.update_location_metadata(result.bytes());
         Ok(result)
-    }
-
-    #[cfg(feature = "source-location")]
-    /// Updates the location metadata based on the matched whitespace bytes in the consumed buffer
-    fn update_location_metadata(&mut self, data: &'top [u8]) {
-        if !data.is_empty() {
-            // Calculate `rows` based on occurrence of newline bytes. If we encounter:
-            // 1. b'\r' then increment row count by 1.
-            // 2.a. If there was no b'\r' encountered before b'\n' then increment row count by 1.
-            // 2.b. If there was no b'\r' encountered before b'\n' then don't increment as b'\r\n' should be counted as 1 based on windows line ending pattern.
-            // Calculate `prev_newline_offset` based on the index/offset value of the last seen newline byte.
-            // Adding 1 to the index because we want to include everything after the newline -
-            // if newline is at index 5, we want to start counting from index 6 (5 + 1).
-            let (_, rows, prev_newline_offset) = data.iter().enumerate().fold(
-                (false, 0, 0),
-                |(follows_cr, rows, offset), (i, b)| {
-                    match (b, follows_cr) {
-                        // When there's a '\r', add a row and update the offset as this newline offset value
-                        (b'\r', _) => (true, rows + 1, i + 1),
-                        // When there's a '\n' not after '\r', add a row and update the offset as this newline offset value
-                        (b'\n', false) => (false, rows + 1, i + 1),
-                        // When there's '\n' immediately following '\r', update the offset without adding a row
-                        (b'\n', true) => (false, rows, i + 1),
-                        _ => (false, rows, offset),
-                    }
-                },
-            );
-            // Set the previous newline offset by subtracting non newline match length from current offset,
-            // where non newline match length is the non newline bytes found after last newline byte.
-            if rows > 0 {
-                self.prev_newline_offset = self.offset() - (data.len() - prev_newline_offset);
-                self.row += rows;
-            }
-        }
     }
 
     /// Matches zero or more whitespace characters.
     pub fn match_whitespace0(&mut self) -> IonMatchResult<'top> {
         let result = take_while(0.., WHITESPACE_BYTES).parse_next(self)?;
-        #[cfg(feature = "source-location")]
-        self.update_location_metadata(result.bytes());
         Ok(result)
     }
 
@@ -374,8 +307,6 @@ impl<'top> TextBuffer<'top> {
         )
             .take()
             .parse_next(self)?;
-        #[cfg(feature = "source-location")]
-        self.update_location_metadata(result.bytes());
         Ok(result)
     }
 
@@ -1686,9 +1617,6 @@ impl<'top> TextBuffer<'top> {
                 let relative_match_end = remaining.offset() - self.offset();
                 let matched_input = self.slice(0, relative_match_end);
                 self.consume(relative_match_end);
-                // This input may contain newline characters hence update the location metadata.
-                #[cfg(feature = "source-location")]
-                self.update_location_metadata(matched_input_buffer.bytes());
                 return Ok((matched_input, contained_escapes));
             } else {
                 // Otherwise, advance by one and try again.
@@ -2074,16 +2002,7 @@ impl<'data> Stream for TextBuffer<'data> {
     }
 
     fn reset(&mut self, checkpoint: &Self::Checkpoint) {
-        #[cfg(feature = "source-location")]
-        let (current_row, prev_column_value) = (self.row, self.prev_newline_offset);
-
         *self = *checkpoint;
-
-        #[cfg(feature = "source-location")]
-        {
-            self.row = current_row;
-            self.prev_newline_offset = prev_column_value;
-        }
     }
 
     fn raw(&self) -> &dyn Debug {
@@ -2277,31 +2196,6 @@ mod tests {
                 self.input,
                 &self.input[..match_length]
             );
-        }
-
-        #[cfg(feature = "source-location")]
-        fn expect_match_location<'data, P, O>(
-            &'data self,
-            parser: P,
-            expected_location: (usize, usize),
-        ) where
-            P: Parser<TextBuffer<'data>, O, IonParseError<'data>>,
-        {
-            let result = self.try_match(parser).unwrap_or_else(|e| {
-                panic!("Unexpected parse fail for input <{}>\n{e}", self.input)
-            });
-            let match_length = result.1;
-            // Inputs have a trailing newline and `0` that should _not_ be part of the match
-            assert_eq!(
-                match_length,
-                self.input.len(),
-                "\nInput: '{}'\nMatched: '{}'\n",
-                self.input,
-                &self.input[..match_length]
-            );
-
-            // Assert the location metadata
-            assert_eq!(expected_location, (result.0.row(), result.0.column()));
         }
 
         fn expect_mismatch<'data, P, Output>(&'data self, parser: P)
@@ -2936,78 +2830,6 @@ mod tests {
         let (matched, contains_escapes) = input.match_text_until_unescaped_str(r#"'''"#).unwrap();
         assert_eq!(matched.as_text().unwrap(), " foo bar \\''' baz");
         assert!(contains_escapes);
-    }
-
-    #[rstest]
-    #[case::no_whitespace("", (1,1))]
-    #[case::no_crlf_1("\t", (1,2))]
-    #[case::no_crlf_2("\t\t", (1,3))]
-    #[case::cr("\r", (2,1))]
-    #[case::lf("\n", (2,1))]
-    // all combinations of 3 newline bytes; check number of rows
-    #[case::lf_3("\n\n\n", (4,1))]
-    #[case::lf_lf_cr("\n\n\r", (4,1))]
-    #[case::lf_cr_lf("\n\r\n", (3,1))]
-    #[case::lf_cr_cr("\n\r\r", (4,1))]
-    #[case::cr_lf_lf("\r\n\n", (3,1))]
-    #[case::cr_lf_cr("\r\n\r", (3,1))]
-    #[case::cr_cr_lf("\r\r\n", (3,1))]
-    #[case::cr_3("\r\r\r", (4,1))]
-    #[case::newlines("\n\r", (3,1))]
-    #[case::crlf("\r\n\r\n", (3,1))]
-    #[case::mixed("\r\n\n\r\n", (4,1))]
-    // tabs before newline does not affect column count
-    #[case::tabs_before_newline_1("\t\t\t\n", (2,1))]
-    #[case::tabs_before_newline_2("\n\t\n", (3,1))]
-    // tabs after newline affects the column count
-    #[case::tabs_after_newline_1("\n\t\t\t", (2,4))]
-    #[case::tabs_after_newline_2("\t\n\t\t", (2,3))]
-    #[case::tabs_after_newline_3("\n\t\n\t", (3,2))]
-    #[case::mix_tabs_and_newlines("\n\t\n", (3,1))]
-    #[cfg(feature = "source-location")]
-    fn expect_whitespace(#[case] input: &str, #[case] expected_location: (usize, usize)) {
-        MatchTest::new_1_0(input).expect_match_location(
-            match_length(TextBuffer::match_whitespace0),
-            expected_location,
-        );
-    }
-
-    #[rstest]
-    #[case::empty_input("", (1,1))]
-    #[case::inline_comment("//comment", (1,10))]
-    #[case::newline_before_inline_comment("\n//comment", (2,10))]
-    #[case::newline_after_inline_comment("//comment\n", (2,1))]
-    #[case::two_inline_comments("//comment\n//comment", (2,10))]
-    #[case::comment("/*comment*/", (1,12))]
-    #[case::newline_before_comment("\n/*comment*/", (2,12))]
-    #[case::newline_after_comment("/*comment*/\n", (2,1))]
-    #[case::newline_inside_comment("/*multiline \n comment*/", (2,11))]
-    #[case::newlines_inside_comment("/*this is a \n multiline \n comment*/", (3,11))]
-    #[cfg(feature = "source-location")]
-    fn expect_whitespace_with_comment(
-        #[case] input: &str,
-        #[case] expected_location: (usize, usize),
-    ) {
-        MatchTest::new_1_0(input).expect_match_location(
-            match_length(TextBuffer::match_optional_comments_and_whitespace),
-            expected_location,
-        );
-    }
-
-    #[rstest]
-    #[case::single_segment_empty("''''''", (1, 7))]
-    #[case::single_segment_with_newlines("'''\n\n\r\n'''", (4, 4))]
-    #[case::single_segment_long_string("'''long string'''", (1, 18))]
-    #[case::single_segment_with_tabs("'''long\tstring'''", (1, 18))]
-    #[case::two_segment_long_string("'''long''' '''string'''", (1, 24))]
-    #[case::two_segment_with_newline_between("'''long''' \n '''string'''", (2, 14))]
-    #[case::two_segment_with_newlines("'''long\n''' '''string\n'''", (3, 4))]
-    #[case::two_segment_long_string_mixed("'''long\n''' \n '''string\n'''", (4, 4))]
-    #[case::single_segment_with_whitespace("'''long \n\r\n\t hello'''", (3, 11))]
-    #[cfg(feature = "source-location")]
-    fn expect_newline_long_text(#[case] input: &str, #[case] expected_location: (usize, usize)) {
-        MatchTest::new_1_0(input)
-            .expect_match_location(match_length(TextBuffer::match_string), expected_location);
     }
 
     #[test]

--- a/src/lazy/value.rs
+++ b/src/lazy/value.rs
@@ -240,7 +240,6 @@ impl<'top, D: Decoder> LazyValue<'top, D> {
         self.expanded_value.context()
     }
 
-    #[cfg(feature = "lazy-source-location")]
     pub fn location(&self) -> Option<(usize, usize)> {
         let context = self.expanded_value.context();
         // set the value start and end positions, this help in location calculation
@@ -249,11 +248,6 @@ impl<'top, D: Decoder> LazyValue<'top, D> {
         } else {
             context.location(0)
         }
-    }
-
-    #[cfg(not(feature = "lazy-source-location"))]
-    pub fn location(&self) -> Option<(usize, usize)> {
-        None
     }
   
     pub fn to_owned(&self) -> LazyElement<D> {
@@ -585,7 +579,6 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "lazy-source-location")]
     #[rstest]
     #[case::no_crlf("{foo: 1, bar: 2}\"hello\"", (1,17))]
     #[case::cr_lf_lf("{foo: 1, bar: 2}\r\n\n\"hello\"", (3,1))]
@@ -624,7 +617,6 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "lazy-source-location")]
     #[rstest]
     #[case::no_crlf(vec!["{foo: 1, bar: 2}","\"hello\""], (1,17))]
     #[case::cr_lf_lf(vec!["{foo: 1, ", "bar: 2}\r\n\n\"hello\""], (3,1))]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR removes the previous implementation for location calculation in text buffer. It also removes feature flag `lazy-source-location` since the current implementation for location shows performance as close to main branch.

*List of changes:*
- Removed all implementation of location calculation in text buffer.
- Removed `lazy-source-location` feature flag from current implementation. The performance for lazy /current approach is close to the main branch(~2% regression to main branch, only for scanning data, for reads same performance)

*Benchmarks:*
Lazy Bookkeeping on Flushes (compared to old text buffer solution (#922))
* Significant performance improvements over previous implementation of location support
*  Scan operations: ~17% improvement
*  Read operations: ~15-16% improvement
*  Read 'format' field: ~16-17% improvement
*  Performance nearly matching main branch across all operations

The full benchmark result can be found [here](https://gist.github.com/desaikd/c4000023bee5e0222182788c1d216765)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
