### PR TITLE
Implement AsRef<Element> for Element

### DIFF
--- a/examples/read_all_values.rs
+++ b/examples/read_all_values.rs
@@ -21,7 +21,10 @@ mod lazy_reader_example {
     pub fn read_all_values() -> IonResult<()> {
         let args: Vec<String> = std::env::args().collect();
         let path = args.get(1).unwrap_or_else(|| {
-            eprintln!("USAGE:\n\n    {} [Binary Ion file]\n", args.first().unwrap());
+            eprintln!(
+                "USAGE:\n\n    {} [Binary Ion file]\n",
+                args.first().unwrap()
+            );
             eprintln!("No mode was specified.");
             exit(1);
         });

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -1009,6 +1009,12 @@ where
     }
 }
 
+impl AsRef<Element> for Element {
+    fn as_ref(&self) -> &Element {
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use chrono::*;

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -311,8 +311,12 @@ impl<'top> EncodingContextRef<'top> {
                     } else {
                         // If the value starts before or at the last newline,
                         // we need to find the correct row and column
-                        if let Some(last_newline_pos) = handle.newlines().iter().enumerate()
-                            .rfind(|&(_index, pos)| pos <= &value_start) {
+                        if let Some(last_newline_pos) = handle
+                            .newlines()
+                            .iter()
+                            .enumerate()
+                            .rfind(|&(_index, pos)| pos <= &value_start)
+                        {
                             // Found the last newline before or at the value start
                             // Row is the index of this newline + 2 (1-indexed and we're on the next line)
                             // Column is the distance from this newline to the value start
@@ -323,8 +327,8 @@ impl<'top> EncodingContextRef<'top> {
                         }
                     }
                 }
-            },
-            IoBufferSource::None => None
+            }
+            IoBufferSource::None => None,
         }
     }
 }

--- a/src/lazy/reader.rs
+++ b/src/lazy/reader.rs
@@ -384,7 +384,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature="experimental-ion-1-1"))]
+#[cfg(all(test, feature = "experimental-ion-1-1"))]
 mod tests_1_1 {
     use crate::lazy::text::raw::v1_1::reader::MacroAddress;
     use crate::{v1_1, IonResult, MacroTable, Reader};

--- a/src/lazy/value.rs
+++ b/src/lazy/value.rs
@@ -255,7 +255,7 @@ impl<'top, D: Decoder> LazyValue<'top, D> {
     pub fn location(&self) -> Option<(usize, usize)> {
         None
     }
-  
+
     pub fn to_owned(&self) -> LazyElement<D> {
         // Clone the `EncodingContext`, which will also bump the reference counts for the resources
         // it owns.
@@ -480,7 +480,10 @@ mod tests {
     use rstest::*;
 
     use crate::lazy::binary::test_utilities::to_binary_ion;
-    use crate::{ion_list, ion_sexp, ion_struct, v1_0, Decimal, IonResult, IonType, Reader, Symbol, Timestamp};
+    use crate::{
+        ion_list, ion_sexp, ion_struct, v1_0, Decimal, IonResult, IonType, Reader, Symbol,
+        Timestamp,
+    };
     use crate::{Element, IntoAnnotatedElement};
 
     #[test]
@@ -646,9 +649,9 @@ mod tests {
         #[case] ion_text: Vec<&str>,
         #[case] expected_location: (usize, usize),
     ) -> IonResult<()> {
+        use crate::IonStream;
         use std::io;
         use std::io::{Cursor, Read};
-        use crate::IonStream;
 
         let input_chunks = ion_text.as_slice();
         // Wrapping each string in an `io::Chain`

--- a/tests/conformance_dsl/context.rs
+++ b/tests/conformance_dsl/context.rs
@@ -1,7 +1,10 @@
 use crate::conformance_dsl::*;
 
-use ion_rs::{Catalog, Element, ElementReader, Sequence, Reader, IonSlice, SharedSymbolTable, Symbol, SymbolId};
 use ion_rs::{v1_0, v1_1};
+use ion_rs::{
+    Catalog, Element, ElementReader, IonSlice, Reader, Sequence, SharedSymbolTable, Symbol,
+    SymbolId,
+};
 
 /// A Context forms a scope for tracking all of the document fragments and any parent Contexts that
 /// also need to be considered. Through this context the ability to generate the full test
@@ -19,9 +22,19 @@ pub(crate) struct Context<'a> {
 impl<'a> Context<'a> {
     /// Creates a new Context with the provided version, encoding and fragments. A parent context
     /// is not set.
-    pub fn new(version: IonVersion, encoding: IonEncoding, fragments: &'a Vec<Fragment>) -> Result<Self> {
+    pub fn new(
+        version: IonVersion,
+        encoding: IonEncoding,
+        fragments: &'a Vec<Fragment>,
+    ) -> Result<Self> {
         let symbol_tables = build_ion_tests_symtables()?;
-        Ok(Self { version, encoding, fragments, parent_ctx: None, symbol_tables })
+        Ok(Self {
+            version,
+            encoding,
+            fragments,
+            parent_ctx: None,
+            symbol_tables,
+        })
     }
 
     /// Creates a new Context with the provided fragments, based on the supplied `parent`. The
@@ -41,7 +54,10 @@ impl<'a> Context<'a> {
     /// version. `IonVersion::Unspecified` will be returned only when no IVM is emitted in the test
     /// document, and no version has been set for the context.
     pub fn version(&self) -> IonVersion {
-        let parent_ver = self.parent_ctx.map(|c| c.version()).unwrap_or(IonVersion::Unspecified);
+        let parent_ver = self
+            .parent_ctx
+            .map(|c| c.version())
+            .unwrap_or(IonVersion::Unspecified);
         let frag_ver = self.fragment_version();
         let my_ver = if frag_ver == IonVersion::Unspecified {
             self.version
@@ -65,7 +81,10 @@ impl<'a> Context<'a> {
 
     /// Determine the encoding for all fragments in the path to this Context.
     pub fn encoding(&self) -> IonEncoding {
-        let parent_enc = self.parent_ctx.map(|c| c.encoding).unwrap_or(IonEncoding::Unspecified);
+        let parent_enc = self
+            .parent_ctx
+            .map(|c| c.encoding)
+            .unwrap_or(IonEncoding::Unspecified);
         Self::resolve_encoding(parent_enc, self.encoding)
     }
 
@@ -80,7 +99,10 @@ impl<'a> Context<'a> {
 
     /// Determine the encoding requirements for this Context's fragments.
     pub fn fragment_encoding(&self) -> IonEncoding {
-        let enc = self.fragments.iter().find(|f| matches!(f, Fragment::Text(_) | Fragment::Binary(_)));
+        let enc = self
+            .fragments
+            .iter()
+            .find(|f| matches!(f, Fragment::Text(_) | Fragment::Binary(_)));
         match enc {
             Some(Fragment::Text(_)) => IonEncoding::Text,
             Some(Fragment::Binary(_)) => IonEncoding::Binary,
@@ -91,7 +113,7 @@ impl<'a> Context<'a> {
     /// Force an ion encoding (text or binary) for this Context. All encodings through the path of
     /// a test must match.
     pub fn set_encoding(&mut self, enc: IonEncoding) {
-        self.encoding  = enc;
+        self.encoding = enc;
     }
 
     /// Given 2 encodings, one for a parent context, and one for the child, validate and return the
@@ -118,8 +140,13 @@ impl<'a> Context<'a> {
 
     /// Returns the symbol at the provided offset `offset` within the symbol table named `symtab`,
     /// if either the symbol table, or the offset, is not valid then None is returned.
-    pub fn get_symbol_from_table<S: AsRef<str>>(&self, symtab: S, offset: SymbolId) -> Option<Symbol> {
-        self.symbol_tables.iter()
+    pub fn get_symbol_from_table<S: AsRef<str>>(
+        &self,
+        symtab: S,
+        offset: SymbolId,
+    ) -> Option<Symbol> {
+        self.symbol_tables
+            .iter()
             .filter(|st| st.name() == symtab.as_ref())
             .max_by_key(|sst| sst.version())
             .and_then(|st| st.symbols().get(offset - 1).cloned())
@@ -134,7 +161,10 @@ impl<'a> Context<'a> {
             IonEncoding::Binary => (to_binary(self, self.fragments.iter())?, encoding),
             IonEncoding::Unspecified => (to_text(self, self.fragments.iter())?, IonEncoding::Text),
         };
-        let (mut parent_input, _) = self.parent_ctx.map(|c| c.input(encoding)).unwrap_or(Ok((vec!(), encoding)))?;
+        let (mut parent_input, _) = self
+            .parent_ctx
+            .map(|c| c.input(encoding))
+            .unwrap_or(Ok((vec![], encoding)))?;
         parent_input.extend(data.clone());
         Ok((parent_input, data_encoding))
     }
@@ -144,9 +174,8 @@ impl<'a> Context<'a> {
         let (data, data_encoding) = self.input(encoding)?;
         let data_slice = IonSlice::new(data);
 
-
         if self.fragments.is_empty() {
-            let empty: Vec<Element> = vec!();
+            let empty: Vec<Element> = vec![];
             return Ok(empty.into());
         }
 
@@ -156,20 +185,25 @@ impl<'a> Context<'a> {
         };
 
         match (version, data_encoding) {
-            (IonVersion::V1_0, IonEncoding::Binary) =>
-                Ok(Reader::new(v1_0::Binary, data_slice)?.read_all_elements()?),
-            (IonVersion::V1_0, IonEncoding::Text) =>
-                Ok(Reader::new(v1_0::Text, data_slice)?.read_all_elements()?),
-            (IonVersion::V1_0, IonEncoding::Unspecified) =>
-                Ok(Reader::new(v1_0::Binary, data_slice)?.read_all_elements()?),
-            (IonVersion::V1_1, IonEncoding::Binary) =>
-                Ok(Reader::new(v1_1::Binary, data_slice)?.read_all_elements()?),
-            (IonVersion::V1_1, IonEncoding::Text) =>
-                Ok(Reader::new(v1_1::Text, data_slice)?.read_all_elements()?),
-            (IonVersion::V1_1, IonEncoding::Unspecified) =>
-                Ok(Reader::new(v1_1::Binary, data_slice)?.read_all_elements()?),
+            (IonVersion::V1_0, IonEncoding::Binary) => {
+                Ok(Reader::new(v1_0::Binary, data_slice)?.read_all_elements()?)
+            }
+            (IonVersion::V1_0, IonEncoding::Text) => {
+                Ok(Reader::new(v1_0::Text, data_slice)?.read_all_elements()?)
+            }
+            (IonVersion::V1_0, IonEncoding::Unspecified) => {
+                Ok(Reader::new(v1_0::Binary, data_slice)?.read_all_elements()?)
+            }
+            (IonVersion::V1_1, IonEncoding::Binary) => {
+                Ok(Reader::new(v1_1::Binary, data_slice)?.read_all_elements()?)
+            }
+            (IonVersion::V1_1, IonEncoding::Text) => {
+                Ok(Reader::new(v1_1::Text, data_slice)?.read_all_elements()?)
+            }
+            (IonVersion::V1_1, IonEncoding::Unspecified) => {
+                Ok(Reader::new(v1_1::Binary, data_slice)?.read_all_elements()?)
+            }
             _ => unreachable!(),
         }
     }
-
 }

--- a/tests/conformance_dsl/fragment.rs
+++ b/tests/conformance_dsl/fragment.rs
@@ -359,18 +359,19 @@ impl WriteAsIon for ProxyElement<'_> {
                         let text = symbol.text().unwrap();
                         if text.starts_with("#$:") {
                             let macro_id = text.strip_prefix("#$:").unwrap(); // SAFETY: Tested above.
-                            let mut args = if let Ok(symbol_id) = macro_id.parse::<ion_rs::SymbolId>() {
-                                writer.eexp_writer(symbol_id)?
-                            } else {
-                                // TODO: Need to handle text macro IDs when generating a binary
-                                // test document.
-                                writer.eexp_writer(macro_id)?
-                            };
+                            let mut args =
+                                if let Ok(symbol_id) = macro_id.parse::<ion_rs::SymbolId>() {
+                                    writer.eexp_writer(symbol_id)?
+                                } else {
+                                    // TODO: Need to handle text macro IDs when generating a binary
+                                    // test document.
+                                    writer.eexp_writer(macro_id)?
+                                };
                             for arg in sexp.iter().skip(1) {
                                 args.write(ProxyElement(arg, self.1))?;
                             }
                             args.close()?;
-                            return Ok(())
+                            return Ok(());
                         }
                     }
                     _ => {}

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -8,7 +8,6 @@ use test_generator::test_resources;
 
 use std::sync::LazyLock;
 
-
 mod ion_tests {
     use super::*;
 
@@ -23,9 +22,12 @@ mod ion_tests {
     }
 
     impl SkipItem {
-        fn canonicalize(&self) -> Option<Self>{
+        fn canonicalize(&self) -> Option<Self> {
             match std::fs::canonicalize(self.source) {
-                Ok(path_buf) => Some(Self { canonicalized_source: Some(path_buf.to_string_lossy().to_string()), ..*self }),
+                Ok(path_buf) => Some(Self {
+                    canonicalized_source: Some(path_buf.to_string_lossy().to_string()),
+                    ..*self
+                }),
                 Err(_) => None,
             }
         }
@@ -44,7 +46,8 @@ mod ion_tests {
 
     type SkipList = &'static [SkipItem];
     static GLOBAL_CONFORMANCE_SKIPLIST: SkipList = &[
-        skip!("ion-tests/conformance/data_model/float.ion",
+        skip!(
+            "ion-tests/conformance/data_model/float.ion",
             "Ion 1.1 binary" // PANIC: not yet implemented: implement half-precision floats
         ),
         // Mismatched produces due to symbol id transcription.
@@ -57,7 +60,8 @@ mod ion_tests {
         skip!("ion-tests/conformance/eexp/basic_system_macros.ion"),
         // Mismatched produces, due to out-of-date encoding block
         skip!("ion-tests/conformance/ion_encoding/mactab.ion"),
-        skip!("ion-tests/conformance/ion_encoding/module/macro/cardinality/invoke_cardinality_ee.ion",
+        skip!(
+            "ion-tests/conformance/ion_encoding/module/macro/cardinality/invoke_cardinality_ee.ion",
             "? parameters", // Parameter used incorrectly in tdl.
             "* parameters"  // Parameter used incorrectly in tdl.
         ),
@@ -71,7 +75,8 @@ mod ion_tests {
         skip!("ion-tests/conformance/ion_encoding/module/macro/template/if.ion"),
         // Incorrectly constructed macro table / module.
         skip!("ion-tests/conformance/ion_encoding/module/macro/trivial/literal_value.ion"),
-        skip!("ion-tests/conformance/ion_encoding/module/macro/trivial/invoke_ee.ion",
+        skip!(
+            "ion-tests/conformance/ion_encoding/module/macro/trivial/invoke_ee.ion",
             "Invocation by address" // Cannot find macro with id "M"; invalid macro invocation
                                     // syntax.
         ),
@@ -92,17 +97,20 @@ mod ion_tests {
         skip!("ion-tests/conformance/ion_encoding/module/load_symtab.ion"),
         skip!("ion-tests/conformance/ion_encoding/module/symtab.ion"),
         // Error: Too few arguments.
-        skip!("ion-tests/conformance/ion_encoding/module/macro/cardinality/invoke_cardinality_tl.ion"),
+        skip!(
+            "ion-tests/conformance/ion_encoding/module/macro/cardinality/invoke_cardinality_tl.ion"
+        ),
         // Error: "Invalid macro name:"
         skip!("ion-tests/conformance/ion_encoding/module/macro/trivial/signature.ion"),
-        skip!("ion-tests/conformance/ion_encoding/module/macro/trivial/invoke_tl.ion",
-            "Invalid bare reference",            // Expected Signal "no such macro: noSuchMacro"
-            "Malformed macro references",        // ExpectedSignal "Malformed macro-ref"
-            "Invoking constant macros",          // Expected Signal "Too many arguments"
+        skip!(
+            "ion-tests/conformance/ion_encoding/module/macro/trivial/invoke_tl.ion",
+            "Invalid bare reference", // Expected Signal "no such macro: noSuchMacro"
+            "Malformed macro references", // ExpectedSignal "Malformed macro-ref"
+            "Invoking constant macros", // Expected Signal "Too many arguments"
             "Local macros shadow system macros", // Could not find macro with id $ion
-            "Qualified references",              // Mismatched Produce
-            "Local references",                  // Mismatched Produce
-            "Local names shadow `use`d names"    // found operation name with non-symbol type: sexp
+            "Qualified references",   // Mismatched Produce
+            "Local references",       // Mismatched Produce
+            "Local names shadow `use`d names"  // found operation name with non-symbol type: sexp
         ),
         // Error: ExpectedSIgnal: invalid argument
         skip!("ion-tests/conformance/system_macros/add_symbols.ion"),
@@ -146,14 +154,21 @@ mod ion_tests {
 
     #[test_resources("ion-tests/conformance/**/*.ion")]
     fn conformance(file_name: &str) {
-        let file_name: String = std::fs::canonicalize(file_name).unwrap().to_string_lossy().into();
+        let file_name: String = std::fs::canonicalize(file_name)
+            .unwrap()
+            .to_string_lossy()
+            .into();
         let mut total_tests: usize = 0;
         let mut total_skipped: usize = 0;
 
         // Having a file_name in the skip list just means we ignore some part of it.. not
         // necessarily the whole file. If we don't specify a list of test names, then we ignore the
         // whole thing.
-        let skip_item = CANONICAL_SKIP_LIST.iter().find(|item| item.canonicalized_source.as_ref().is_some_and(|source| *source == file_name));
+        let skip_item = CANONICAL_SKIP_LIST.iter().find(|item| {
+            item.canonicalized_source
+                .as_ref()
+                .is_some_and(|source| *source == file_name)
+        });
         if skip_item.is_some_and(|item| item.tests.is_empty()) {
             println!("SKIPPING: {}", file_name);
             return;
@@ -180,6 +195,9 @@ mod ion_tests {
             test.run().expect("test failed");
         }
 
-        println!("SUMMARY: {} : Total Tests {} :  Skipped {}", file_name, total_tests, total_skipped);
+        println!(
+            "SUMMARY: {} : Total Tests {} :  Skipped {}",
+            file_name, total_tests, total_skipped
+        );
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

None.

**Description of changes:**

The main substance of this commit is the first commit, in [src/element/mod.rs](https://github.com/amazon-ion/ion-rust/compare/main...popematt:ion-rust:main?expand=1#diff-91c614c02808b6b0727c79965075d97b2882d5c7c06267d31273a99596bb6f17). I literally just added a trivial implementation of `AsRef<Element>`. I was surprised there isn't already a blanket implementation like `impl AsRef<T> for T`, but it looks like it's due to [a restriction in Rust's type system](https://doc.rust-lang.org/std/convert/trait.AsRef.html#reflexivity).

Why is this change needed? This will allow us, in `ion-schema-rust`, to define things that can be generic over `Element` and `&Element` because we can just accept `AsRef<Element>`.

In the second commit, it's all `cargo fmt` changes related to the recent release of Rust 1.85.0.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
