### PR TITLE
Fixes location metadata to support nested values

### DIFF
--- a/src/lazy/streaming_raw_reader.rs
+++ b/src/lazy/streaming_raw_reader.rs
@@ -2,6 +2,7 @@ use crate::lazy::any_encoding::IonEncoding;
 use crate::lazy::decoder::{Decoder, LazyRawReader};
 use crate::lazy::expanded::EncodingContextRef;
 use crate::lazy::raw_stream_item::LazyRawStreamItem;
+use crate::location::SourceLocationState;
 use crate::{IonError, IonResult, LazyRawValue, Span};
 use std::cell::{OnceCell, UnsafeCell};
 use std::fs::File;
@@ -265,14 +266,7 @@ pub trait IoBufferHandle {
     /// Creates an inexpensive copy of the I/O buffer with no lifetime.
     fn save_io_buffer(&self) -> IoBuffer;
 
-    /// Represents the row position for the I/O buffer.
-    fn row(&self) -> usize;
-
-    /// Represents the previous newline offset for the I/O buffer.
-    fn prev_newline_offset(&self) -> usize;
-
-    /// Represents offsets of all the newlines for the I/O buffer.
-    fn newlines(&self) -> &[usize];
+    fn source_location_state(&self) -> &SourceLocationState;
 }
 
 /// An input source--typically an implementation of either `AsRef<[u8]>` or `io::Read`--from which
@@ -310,8 +304,9 @@ pub struct IonSlice<SliceType> {
     source: SliceType,
     // The offset of the first byte that hasn't yet been consumed.
     position: usize,
-    // The offset of the last byte that was consumed before the most recent consume operation.
-    prev_position: usize,
+    /// State for calculating the source location of values. (TODO: this is always used in conjunction
+    /// with the shared_stream_data, so consider combining them into a single abstraction.)
+    source_location_state: OnceCell<SourceLocationState>,
     // When a LazyValue is saved, this is initialized by cloning the source data into an `Rc`.
     // Once initialized, that source data can be cheaply shared by all values in the buffer without
     // requiring a lifetime.
@@ -324,7 +319,7 @@ impl<SliceType: AsRef<[u8]>> IonSlice<SliceType> {
         Self {
             source: bytes,
             position: 0,
-            prev_position: 0,
+            source_location_state: OnceCell::new(),
             shared_stream_data: OnceCell::new(),
         }
     }
@@ -356,62 +351,17 @@ impl<SliceType: AsRef<[u8]>> IoBufferHandle for IonSlice<SliceType> {
         // The offset within the bytes where the content of this IoBuffer begins.
         let local_offset = self.position;
         let local_end = bytes.len();
-        IoBuffer::new(stream_position, bytes, local_offset, local_end)
+        let mut iob = IoBuffer::new(stream_position, bytes, local_offset, local_end);
+        iob.source_location_state = self.source_location_state().clone();
+        iob
     }
 
-    fn row(&self) -> usize {
-        // Update row for location metadata
-        let available_range = ..self.prev_position;
-        let data = &self.stream_bytes()[available_range];
-        if !data.is_empty() {
-            // Calculate `rows` based on occurrence of newline bytes. If we encounter:
-            // 1. b'\r' then increment row count by 1.
-            // 2.a. If there was no b'\r' encountered before b'\n' then increment row count by 1.
-            // 2.b. If there was no b'\r' encountered before b'\n' then don't increment as b'\r\n' should be counted as 1 based on windows line ending pattern.
-            let (_, rows) = data.iter().fold((false, 0), |(follows_cr, rows), b| {
-                match (b, follows_cr) {
-                    // When there's a '\r', add a row
-                    (b'\r', _) => (true, rows + 1),
-                    // When there's a '\n' not after '\r', add a row
-                    (b'\n', false) => (false, rows + 1),
-                    // When there's '\n' immediately following '\r' without adding a row
-                    (b'\n', true) => (false, rows),
-                    _ => (false, rows),
-                }
-            });
-
-            rows + 1
-        } else {
-            1
-        }
-    }
-
-    fn prev_newline_offset(&self) -> usize {
-        // Update previous newline offset for location metadata
-        let available_range = ..self.prev_position;
-        let data = &self.stream_bytes()[available_range];
-        if !data.is_empty() {
-            // Calculate `prev_newline_offset` based on the index/offset value of the last seen newline byte.
-            // Adding 1 to the index because we want to include everything after the newline -
-            // if newline is at index 5, we want to start counting from index 6 (5 + 1).
-            let prev_newline_offset = data.iter().enumerate().fold(0, |offset, (i, b)| {
-                match b {
-                    // When there's a '\r' or '\n', update the offset as this newline offset value
-                    b'\r' | b'\n' => i + 1,
-                    _ => offset,
-                }
-            });
-
-            prev_newline_offset
-        } else {
-            1
-        }
-    }
-
-    fn newlines(&self) -> &[usize] {
-        // This will act as a no-op, as for `IonSlice` we don't need to rely on newlines.
-        // It is only used by `IonStream`, to help keep track of all past newlines offsets.
-        &[]
+    fn source_location_state(&self) -> &SourceLocationState {
+        self.source_location_state.get_or_init(|| {
+            let mut sls = SourceLocationState::new();
+            sls.update_from_source(0, self.stream_bytes());
+            sls
+        })
     }
 }
 
@@ -431,8 +381,6 @@ impl<SliceType: AsRef<[u8]>> IonDataSource for IonSlice<SliceType> {
     }
 
     fn consume(&mut self, number_of_bytes: usize) {
-        self.prev_position = self.position;
-
         self.position += number_of_bytes;
         // In debug/test builds, this will fail noisily if something attempts to consume more data
         // than the backing array contains.
@@ -462,8 +410,8 @@ pub struct IoBuffer {
     local_offset: usize,
     // The index of the first unoccupied byte in the buffer *at or after* `local_offset`.
     local_end: usize,
-    // Represents all previous newline offsets for the buffer.
-    prev_newline_offsets: Vec<usize>,
+    /// State used for calculating source locations for values.
+    source_location_state: SourceLocationState,
 }
 
 impl IoBuffer {
@@ -488,7 +436,7 @@ impl IoBuffer {
             bytes,
             local_offset,
             local_end,
-            prev_newline_offsets: Vec::new(),
+            source_location_state: SourceLocationState::new(),
         }
     }
 
@@ -498,7 +446,7 @@ impl IoBuffer {
             bytes: Self::alloc_zeroed(capacity),
             local_offset: 0,
             local_end: 0,
-            prev_newline_offsets: Vec::new(),
+            source_location_state: SourceLocationState::new(),
         }
     }
 
@@ -526,57 +474,16 @@ impl IoBuffer {
         &self.bytes[self.local_offset..self.local_end]
     }
 
-    pub(crate) fn prev_newline_offset(&self) -> usize {
-        // gets the last newline offset, otherwise returns default value `0`.
-        self.prev_newline_offsets.last().copied().unwrap_or(0)
-    }
-
-    pub fn row(&self) -> usize {
-        self.prev_newline_offsets.len() + 1
-    }
-
-    pub fn column(&self) -> usize {
-        self.stream_offset - self.prev_newline_offset() + 1
-    }
-
     fn update_location_metadata(&mut self, range: (usize, usize)) {
         let data = &self.bytes[range.0..range.1];
         if !data.is_empty() {
-            // Calculate `rows` based on occurrence of newline bytes. If we encounter:
-            // 1. b'\r' then increment row count by 1.
-            // 2.a. If there was no b'\r' encountered before b'\n' then increment row count by 1.
-            // 2.b. If there was no b'\r' encountered before b'\n' then don't increment as b'\r\n' should be counted as 1 based on windows line ending pattern.
-            // Calculate `prev_newline_offset` based on the index/offset value of the last seen newline byte.
-            // Adding 1 to the index because we want to include everything after the newline -
-            // if newline is at index 5, we want to start counting from index 6 (5 + 1).
-            let (_, prev_newline_offsets) = data.iter().enumerate().fold(
-                (false, vec![]),
-                |(follows_cr, mut offset), (i, b)| {
-                    match (b, follows_cr) {
-                        // When there's a '\r', add a row and update the offset as this newline offset value
-                        (b'\r', _) => {
-                            offset.push(self.stream_offset + range.0 + i + 1);
-                            (true, offset)
-                        }
-                        // When there's a '\n' not after '\r', add a row and update the offset as this newline offset value
-                        (b'\n', false) => {
-                            offset.push(self.stream_offset + range.0 + i + 1);
-                            (false, offset)
-                        }
-                        // When there's '\n' immediately following '\r', update the offset without adding a row
-                        (b'\n', true) => {
-                            offset.pop();
-                            offset.push(self.stream_offset + range.0 + i + 1);
-                            (false, offset)
-                        }
-                        _ => (false, offset),
-                    }
-                },
-            );
-
-            // set all previous newline offsets by extending with these `prev_newline_offset`
-            self.prev_newline_offsets.extend(prev_newline_offsets);
+            self.source_location_state
+                .update_from_source(self.stream_offset + range.0, data);
         }
+    }
+
+    pub(crate) fn source_location_state(&self) -> &SourceLocationState {
+        &self.source_location_state
     }
 
     pub fn read_from<R: Read>(&mut self, input: &mut R) -> IonResult<usize> {
@@ -677,16 +584,8 @@ impl<R: Read> IoBufferHandle for IonStream<R> {
         self.buffer.clone()
     }
 
-    fn row(&self) -> usize {
-        self.buffer.row()
-    }
-
-    fn prev_newline_offset(&self) -> usize {
-        self.buffer.prev_newline_offset()
-    }
-
-    fn newlines(&self) -> &[usize] {
-        &self.buffer.prev_newline_offsets
+    fn source_location_state(&self) -> &SourceLocationState {
+        &self.buffer.source_location_state
     }
 }
 

--- a/src/location.rs
+++ b/src/location.rs
@@ -1,40 +1,129 @@
+use crate::Span;
+use std::cell::RefCell;
+use std::rc::Rc;
+
 /// Represents the source location (row, column) of this element in the original Ion text.
 ///
 /// The source location metadata is primarily intended for error reporting and debugging purposes,
 /// helping applications provide meaningful feedback to users about the source of issues.
-///
-/// # Returns
-/// * `Some((row, column))` - Position where this element was found in the source text
-/// * `None` - Location information is not available
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 pub struct SourceLocation {
-    location: Option<(usize, usize)>,
+    location: (usize, usize),
 }
 
 impl SourceLocation {
-    pub fn new(row: usize, column: usize) -> SourceLocation {
+    pub(crate) fn new(row: usize, column: usize) -> SourceLocation {
         Self {
-            location: Some((row, column)),
+            location: (row, column),
         }
     }
 
-    pub fn empty() -> SourceLocation {
-        Self { location: None }
+    pub(crate) fn empty() -> SourceLocation {
+        Self { location: (0, 0) }
     }
 
     pub fn is_empty(&self) -> bool {
-        self.location.is_none()
+        self.location == (0, 0)
     }
 
-    pub fn location(&self) -> Option<(usize, usize)> {
-        self.location
+    /// If this `SourceLocation` instance has row-column information, returns a tuple containing
+    /// the 1-based row and column numbers. Otherwise, returns [`None`].
+    pub fn row_column(&self) -> Option<(usize, usize)> {
+        match self.location {
+            (0, 0) => None,
+            other => Some(other),
+        }
     }
 
-    pub fn row(&self) -> usize {
-        self.location.unwrap_or((0, 0)).0
+    /// If this `SourceLocation` instance has row-column information, returns the 1-based row number.
+    /// Otherwise, returns [`None`].
+    pub fn row(&self) -> Option<usize> {
+        match self.location {
+            (0, 0) => None,
+            (row, _) => Some(row),
+        }
     }
 
-    pub fn column(&self) -> usize {
-        self.location.unwrap_or((0, 0)).1
+    /// If this `SourceLocation` instance has row-column information, returns the 1-based column number.
+    /// Otherwise, returns [`None`].
+    pub fn column(&self) -> Option<usize> {
+        match self.location {
+            (0, 0) => None,
+            (_, col) => Some(col),
+        }
+    }
+}
+
+/// Encapsulates location tracking state and functionality.
+///
+/// This struct is cheap to clone because all of its state is behind a reference-counted pointer.
+#[derive(Debug, Clone)]
+pub(crate) struct SourceLocationState {
+    /// A non-empty vec containing the offset of the start of each row.
+    /// The first row always starts at offset 0.
+    row_start_offsets: Rc<RefCell<Vec<usize>>>,
+}
+impl SourceLocationState {
+    pub fn new() -> Self {
+        Self {
+            row_start_offsets: Rc::from(RefCell::new(vec![0])),
+        }
+    }
+
+    /// Updates the location tracking state from the given source data.
+    pub fn update_from_source<T: AsRef<[u8]>>(&mut self, stream_offset: usize, data: T) {
+        let data = data.as_ref();
+        if !data.is_empty() {
+            // Calculate `rows` based on occurrence of newline bytes. If we encounter:
+            // 1. b'\r' then increment row count by 1.
+            // 2.a. If there was no b'\r' encountered before b'\n' then increment row count by 1.
+            // 2.b. If there was no b'\r' encountered before b'\n' then don't increment as b'\r\n' should be counted as 1 based on windows line ending pattern.
+            // Calculate `prev_newline_offset` based on the index/offset value of the last seen newline byte.
+            // Adding 1 to the index because we want to include everything after the newline -
+            // if newline is at index 5, we want to start counting from index 6 (5 + 1).
+            let (_, prev_newline_offsets) = data.iter().enumerate().fold(
+                (false, vec![]),
+                |(follows_cr, mut offset), (i, b)| {
+                    match (b, follows_cr) {
+                        // When there's a '\r', add a row and update the offset as this newline offset value
+                        (b'\r', _) => {
+                            offset.push(stream_offset + i + 1);
+                            (true, offset)
+                        }
+                        // When there's a '\n' not after '\r', add a row and update the offset as this newline offset value
+                        (b'\n', false) => {
+                            offset.push(stream_offset + i + 1);
+                            (false, offset)
+                        }
+                        // When there's '\n' immediately following '\r', update the offset without adding a row
+                        (b'\n', true) => {
+                            offset.pop();
+                            offset.push(stream_offset + i + 1);
+                            (false, offset)
+                        }
+                        _ => (false, offset),
+                    }
+                },
+            );
+            self.row_start_offsets
+                .borrow_mut()
+                .extend(prev_newline_offsets);
+        }
+    }
+
+    pub fn calculate_location_for_span(&self, span: Span<'_>) -> SourceLocation {
+        let range = span.range();
+        let (row, row_start_offset) = self
+            .row_start_offsets
+            .borrow()
+            .iter()
+            .copied()
+            .enumerate()
+            .rfind(|&(_, newline_offset)| newline_offset <= range.start)
+            // Always safe to unwrap because of the invariant that `newlines` is never empty.
+            .unwrap();
+        let column = range.start - row_start_offset;
+        // Both of these are 0-based counts, and must be incremented to be 1-based row/column
+        SourceLocation::new(row + 1, column + 1)
     }
 }

--- a/src/location.rs
+++ b/src/location.rs
@@ -8,22 +8,27 @@ use std::rc::Rc;
 /// helping applications provide meaningful feedback to users about the source of issues.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 pub struct SourceLocation {
+    /// A 1-based row and column pair.
+    /// INVARIANT: both components must be `0` or both must be non-zero.
     location: (usize, usize),
 }
 
 impl SourceLocation {
+    /// Constructs a new SourceLocation. If either of `row` or `column` is `0`, returns an instance
+    /// with no row/column value (i.e. both row and column are zero). This maintains the invariant
+    /// that the location field must be `(0, 0)` or must have two non-zero values.
     pub(crate) fn new(row: usize, column: usize) -> SourceLocation {
+        if row == 0 || column == 0 {
+            return Self::empty();
+        }
         Self {
             location: (row, column),
         }
     }
 
+    /// Constructs a new `SourceLocation` instance that has no row/column available.
     pub(crate) fn empty() -> SourceLocation {
         Self { location: (0, 0) }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.location == (0, 0)
     }
 
     /// If this `SourceLocation` instance has row-column information, returns a tuple containing
@@ -51,6 +56,26 @@ impl SourceLocation {
             (0, 0) => None,
             (_, col) => Some(col),
         }
+    }
+}
+
+#[cfg(test)]
+mod source_location_tests {
+    use crate::location::SourceLocation;
+    #[test]
+    fn empty_source_location() {
+        let location = SourceLocation::empty();
+        assert_eq!(None, location.row_column());
+        assert_eq!(None, location.row());
+        assert_eq!(None, location.column());
+    }
+
+    #[test]
+    fn non_empty_source_location() {
+        let location = SourceLocation::new(2, 3);
+        assert_eq!(Some((2, 3)), location.row_column());
+        assert_eq!(Some(2), location.row());
+        assert_eq!(Some(3), location.column());
     }
 }
 


### PR DESCRIPTION
**Issue #, if available:**

None.

**Description of changes:**

I discovered that the source location was being reported correctly for top-level values, but that any nested value simply reported the location of its top-level ancestor. This fixes that issue, and in the process, it also fixes #944.

I benchmarked this change, and it is performance-neutral compared to the current tip of `main`.

In the process of working on this, I also realized that row/column location is incorrectly available for Ion binary. I have added a test case to reproduce the problem in `value.rs`, but annotated it as `#[ignore]` because I don't yet know what is the right solution. See #951.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
