### PR TITLE
Implement expression group transcription for conformance DSL.

### DIFF
--- a/tests/conformance_dsl/clause.rs
+++ b/tests/conformance_dsl/clause.rs
@@ -31,10 +31,10 @@ pub(crate) enum ClauseType {
     Ivm,
     /// Specify a ion data to be inserted into the document, using inline ion syntax.
     TopLevel,
-    /// Provide ion data defining the contents of an '$ion_encoding' directive.
-    Encoding,
     /// Provide ion data defining the contents of a macro table wrapped by a module within an encoding directive.
     MacTab,
+    /// Provide a set of strings to be inserted into the symbol table.
+    SymTab,
     /// Define data that is expected to be produced by the test's document, using inline ion
     /// syntax.
     Produces,
@@ -80,8 +80,8 @@ impl FromStr for ClauseType {
             "absent" => Ok(Absent),
             "ivm" => Ok(Ivm),
             "signals" => Ok(Signals),
-            "encoding" => Ok(Encoding),
             "mactab" => Ok(MacTab),
+            "symtab" => Ok(SymTab),
             _ => Err(ConformanceErrorKind::UnknownClause(s.to_owned())),
         }
     }
@@ -91,7 +91,7 @@ impl ClauseType {
     /// Utility function to test if the Clause is a fragment node.
     pub fn is_fragment(&self) -> bool {
         use ClauseType::*;
-        matches!(self, Text | Binary | Ivm | TopLevel | Encoding | MacTab)
+        matches!(self, Text | Binary | Ivm | TopLevel | MacTab | SymTab)
     }
 
     /// Utility function to test if the Clause is an expectation node.

--- a/tests/conformance_dsl/context.rs
+++ b/tests/conformance_dsl/context.rs
@@ -277,7 +277,7 @@ mod tests {
         let fragments_str = String::from_utf8(bytes).expect("Invalid input string generated");
         assert_eq!(
             fragments_str,
-            "$ion_1_1 $ion::(module _ (macro_table (macro m (v '!' ) ('%' v ) ) ) ) (:m 1)"
+            "$ion_1_1 $ion::(module _ (macro_table _ (macro m (v '!' ) ('%' v ) ) ) ) (:m 1)"
                 .to_string(),
         );
     }

--- a/tests/conformance_dsl/fragment.rs
+++ b/tests/conformance_dsl/fragment.rs
@@ -240,7 +240,9 @@ impl ProxyElement<'_> {
     fn is_expr_group(&self) -> bool {
         use ion_rs::Value;
         match self.0.value() {
-            Value::SExp(seq) => seq.get(0).is_some_and(|x| Some("#$:") == x.as_symbol().and_then(|s| s.text())),
+            Value::SExp(seq) => seq
+                .get(0)
+                .is_some_and(|x| Some("#$:") == x.as_symbol().and_then(|s| s.text())),
             _ => false,
         }
     }
@@ -353,8 +355,8 @@ impl<T: ion_rs::Decoder> PartialEq<ion_rs::LazyValue<'_, T>> for ProxyElement<'_
 
 impl WriteAsIon for ProxyElement<'_> {
     fn write_as_ion<V: ValueWriter>(&self, writer: V) -> ion_rs::IonResult<()> {
-        use ion_rs::Value::*;
         use ion_rs::EExpWriter;
+        use ion_rs::Value::*;
         match self.0.value() {
             Symbol(_) => self.write_symbol(writer),
             Struct(strukt) => self.write_struct(strukt, writer),

--- a/tests/conformance_dsl/mod.rs
+++ b/tests/conformance_dsl/mod.rs
@@ -557,4 +557,19 @@ mod tests {
             Ok(_) => panic!("Unexpected successful test evaluation"),
         }
     }
+
+    #[test]
+    fn test_exp_group() {
+        let test = r#"
+            (ion_1_1
+                (toplevel ('#$:values' ('#$:' 0 1 2)))
+                (produces 0 1 2)
+            )"#;
+        println!("Testing: {}", test);
+        let doc = Document::from_str(test)
+            .unwrap_or_else(|e| panic!("Failed to load document: <<{}>>\n{:?}", test, e));
+        println!("Document: {:?}", doc);
+        doc.run()
+            .unwrap_or_else(|e| panic!("Test failed for exp group expansion:\n{:?}", e));
+    }
 }

--- a/tests/conformance_dsl/mod.rs
+++ b/tests/conformance_dsl/mod.rs
@@ -478,20 +478,6 @@ mod tests {
     }
 
     #[test]
-    fn test_encoding() {
-        let test: &str = r#"
-             (ion_1_1
-                 (encoding module _ (macro_table (macro m () 1)))
-                 (text "(:m)")
-                 (produces 1)
-             )"#;
-        Document::from_str(test)
-            .unwrap_or_else(|e| panic!("Failed to load document:\n{:?}", e))
-            .run()
-            .unwrap_or_else(|e| panic!("Test failed: {:?}", e));
-    }
-
-    #[test]
     fn test_simple_docs() {
         let tests: &[&str] = &[
             "(document (produces ))",

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -50,16 +50,19 @@ mod ion_tests {
             "ion-tests/conformance/data_model/float.ion",
             "Ion 1.1 binary" // PANIC: not yet implemented: implement half-precision floats
         ),
+        // Issue parsing the comments left in decimal.ion, see ion-rust#972
+        skip!( "ion-tests/conformance/data_model/decimal.ion"),
         // Mismatched produces due to symbol id transcription.
         skip!("ion-tests/conformance/core/toplevel_produces.ion"),
         // Unrecognized encoding 'int8' (only flex_uint appears to be supported)
         skip!("ion-tests/conformance/demos/metaprogramming.ion"),
+        // Context tracking in Conformance DSL cannot register macros added via set_macros
+        // invocation.
+        skip!("ion-tests/conformance/demos/telemetry_log.ion"),
         // error: flatten only accepts sequences
         skip!("ion-tests/conformance/eexp/arg_inlining.ion"),
         // Out dated macro invocation in TDL syntax
         skip!("ion-tests/conformance/eexp/basic_system_macros.ion"),
-        // Mismatched produces, due to out-of-date encoding block
-        skip!("ion-tests/conformance/ion_encoding/mactab.ion"),
         skip!(
             "ion-tests/conformance/ion_encoding/module/macro/cardinality/invoke_cardinality_ee.ion",
             "? parameters", // NEED: Conformance DSL support for expression groups.
@@ -76,11 +79,6 @@ mod ion_tests {
         skip!("ion-tests/conformance/ion_encoding/module/macro/template/if.ion"),
         // Incorrectly constructed macro table / module.
         skip!("ion-tests/conformance/ion_encoding/module/macro/trivial/literal_value.ion"),
-        skip!(
-            "ion-tests/conformance/ion_encoding/module/macro/trivial/invoke_ee.ion",
-            "Invocation by address" // Cannot find macro with id "M"; invalid macro invocation
-                                    // syntax.
-        ),
         // Error: Unrecognized encoding (of various forms: flex_sym, uint8, uint16, uint32, etc)
         skip!("ion-tests/conformance/eexp/binary/tagless_types.ion"),
         // Error: Unexpected EOF and unrecognized encodings.
@@ -107,16 +105,6 @@ mod ion_tests {
         ),
         // Error: "Invalid macro name:"
         skip!("ion-tests/conformance/ion_encoding/module/macro/trivial/signature.ion"),
-        skip!(
-            "ion-tests/conformance/ion_encoding/module/macro/trivial/invoke_tl.ion",
-            "Invalid bare reference", // Expected Signal "no such macro: noSuchMacro"
-            "Malformed macro references", // ExpectedSignal "Malformed macro-ref"
-            "Invoking constant macros", // Expected Signal "Too many arguments"
-            "Local macros shadow system macros", // Could not find macro with id $ion
-            "Qualified references",   // Mismatched Produce
-            "Local references",       // Mismatched Produce
-            "Local names shadow `use`d names"  // found operation name with non-symbol type: sexp
-        ),
         // Error: ExpectedSIgnal: invalid argument
         skip!("ion-tests/conformance/system_macros/add_symbols.ion"),
         skip!("ion-tests/conformance/system_macros/set_macros.ion"),
@@ -140,8 +128,22 @@ mod ion_tests {
         skip!("ion-tests/conformance/system_macros/annotate.ion"),
         // error reading struct: `make_field`'s first argument must be a text value
         skip!("ion-tests/conformance/system_macros/make_field.ion"),
+        // system macro `use` not yet implemented.
+        skip!("ion-tests/conformance/system_macros/use.ion"),
         // Expected Signal: invalid macro definition
         skip!("ion-tests/conformance/tdl/expression_groups.ion"),
+        // Macro export not supported: "expected keyword 'macro', but found export"
+        skip!("ion-tests/conformance/tdl/if_multi.ion"),
+        // "could not resolve macro ID \"for\""
+        skip!("ion-tests/conformance/tdl/for.ion"),
+        // "expected keyword 'macro', but found export",
+        skip!("ion-tests/conformance/tdl/if_none.ion"),
+        // "expected keyword 'macro', but found export"
+        skip!("ion-tests/conformance/tdl/if_single.ion"),
+        // "expected keyword 'macro', but found export"
+        skip!("ion-tests/conformance/tdl/if_some.ion"),
+        // Expected signal "invalid macro definition".
+        skip!("ion-tests/conformance/tdl/variable_expansion.ion"),
         // Mismatched encodings for nested contexts.
         skip!("ion-tests/conformance/ivm.ion"),
         // Decoding error "expected struct but found a null.struct"


### PR DESCRIPTION
*Issue #, if available:* #935 

*Description of changes:*
This PR adds support for transcribing expression groups in the `toplevel` clause of the DSL, similar to expression invocations.

Additionally, a small change was also made to the `mactab` clause to automatically include the current unnamed module when re-defining it in order to keep `$ion` imported.

Example usage:
```
(ion_1_1
   (toplevel ('#$:values' ('#$:' 0 1 2)))
   (produces 0 1 2)
)
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
