### PR TITLE
Stop providing misleading row/column locations for binary Ion

### DIFF
--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -1118,6 +1118,15 @@ impl<'top> LazyRawValue<'top, AnyEncoding> for LazyRawAnyValue<'top> {
             },
         }
     }
+
+    fn encoding(&self) -> IonEncoding {
+        match self.encoding {
+            LazyRawValueKind::Text_1_0(_) => IonEncoding::Text_1_0,
+            LazyRawValueKind::Binary_1_0(_) => IonEncoding::Binary_1_0,
+            LazyRawValueKind::Text_1_1(_) => IonEncoding::Text_1_1,
+            LazyRawValueKind::Binary_1_1(_) => IonEncoding::Binary_1_1,
+        }
+    }
 }
 
 // ===== Annotations =====

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -292,6 +292,10 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_1> for &'top LazyRawBinaryValue_1
             ..**self
         })
     }
+
+    fn encoding(&self) -> IonEncoding {
+        IonEncoding::Binary_1_1
+    }
 }
 
 /// Nested expressions parsed and cached while reading (e.g.) a [`LazyRawBinaryValue_1_1`].

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -152,6 +152,10 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_0> for LazyRawBinaryValue_1_0<'to
             input: BinaryBuffer::new_with_offset(span.bytes(), span.offset()),
         }
     }
+
+    fn encoding(&self) -> IonEncoding {
+        IonEncoding::Binary_1_0
+    }
 }
 
 #[cfg_attr(not(feature = "experimental-tooling-apis"), allow(dead_code))]

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -610,6 +610,8 @@ pub trait LazyRawValue<'top, D: Decoder>:
     /// This method is used when converting a `LazyValue` (which may be backed by a slice of the
     /// input buffer) to a `LazyElement` (which needs to be backed by heap data).
     fn with_backing_data(&self, span: Span<'top>) -> Self;
+
+    fn encoding(&self) -> IonEncoding;
 }
 
 pub trait RawSequenceIterator<'top, D: Decoder>:

--- a/src/lazy/text/value.rs
+++ b/src/lazy/text/value.rs
@@ -7,7 +7,7 @@ use crate::lazy::raw_value_ref::RawValueRef;
 use crate::lazy::span::Span;
 use crate::lazy::text::buffer::TextBuffer;
 use crate::lazy::text::encoded_value::EncodedTextValue;
-use crate::{IonEncoding, IonResult, IonType, RawSymbolRef};
+use crate::{IonEncoding, IonResult, IonType, IonVersion, RawSymbolRef};
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
@@ -229,6 +229,13 @@ impl<'top, Encoding: TextEncoding> LazyRawValue<'top, Encoding>
         Self {
             input: TextBuffer::from_span(self.input.context(), span, true),
             ..*self
+        }
+    }
+
+    fn encoding(&self) -> IonEncoding {
+        match <Encoding as Decoder>::INITIAL_ENCODING_EXPECTED.version() {
+            IonVersion::v1_0 => IonEncoding::Text_1_0,
+            IonVersion::v1_1 => IonEncoding::Text_1_1,
         }
     }
 }

--- a/src/lazy/value.rs
+++ b/src/lazy/value.rs
@@ -242,11 +242,19 @@ impl<'top, D: Decoder> LazyValue<'top, D> {
     }
 
     pub fn location(&self) -> SourceLocation {
-        let context = self.expanded_value.context();
-        // set the value start and end positions, this help in location calculation
-        context
-            .location_for_span(self.expanded_value.span())
-            .unwrap_or_default()
+        if let Some(raw) = self.raw() {
+            if raw.encoding().is_text() {
+                self.expanded_value
+                    .context()
+                    .location_for_span(self.expanded_value.span())
+                    .unwrap_or_default()
+            } else {
+                // No row/column for binary Ion
+                SourceLocation::empty()
+            }
+        } else {
+            SourceLocation::empty()
+        }
     }
 
     pub fn to_owned(&self) -> LazyElement<D> {
@@ -473,13 +481,15 @@ impl<'top, D: Decoder> TryFrom<AnnotationsIterator<'top, D>> for Annotations {
 mod tests {
     use num_traits::Float;
     use rstest::*;
+    use std::io;
+    use std::io::{Cursor, Read};
 
     use crate::lazy::binary::test_utilities::to_binary_ion;
     use crate::lazy::expanded::lazy_element::LazyElement;
     use crate::location::SourceLocation;
     use crate::{
-        ion_list, ion_sexp, ion_struct, v1_0, Decimal, Encoding, IonResult, IonType, LazyValue,
-        Reader, Symbol, Timestamp,
+        ion_list, ion_sexp, ion_struct, v1_0, AnyEncoding, Decimal, Decoder, IonResult, IonType,
+        LazyValue, Reader, Symbol, Timestamp,
     };
     use crate::{Element, IntoAnnotatedElement};
 
@@ -677,6 +687,22 @@ mod tests {
     }
 
     #[rstest]
+    #[case::no_crlf( "{}\"hello\"",       [(1, 1), (1, 3)])]
+    #[case::cr_lf_lf("{}\r\n\n\"hello\"", [(1, 1), (3, 1)] )]
+    #[case::lf_lf_cr("{}\n\n\r\"hello\"", [(1, 1), (4, 1)] )]
+    #[case::cr_lf_cr("{}\r\n\r\"hello\"", [(1, 1), (3, 1)] )]
+    #[case::cr_cr_cr("{}\r\r\r\"hello\"", [(1, 1), (4, 1)] )]
+    #[case::cr_cr_lf("{}\r\r\n\"hello\"", [(1, 1), (3, 1)] )]
+    #[case::lf_cr_cr("{}\n\r\r\"hello\"", [(1, 1), (4, 1)] )]
+    #[case::lf_cr_lf("{}\n\r\n\"hello\"", [(1, 1), (3, 1)] )]
+    #[case::lf_lf_lf("{}\n\n\n\"hello\"", [(1, 1), (4, 1)] )]
+    #[case::nl_after("{}\"hello\"\n\n",   [(1, 1), (1, 3)])]
+    #[case::tabs(    "{}\n\t\t\"hello\"", [(1, 1), (2, 3)] )]
+    #[case::tabs_after("{}\"hello\"\t\t", [(1, 1), (1, 3)])]
+    #[case::mix_tabs_and_newlines("{}\n\t\n\"hello\"",[(1, 1), (3, 1)])]
+    #[case::long_string("{}\n\n'''long \n\r\n\t hello'''", [(1, 1), (3, 1)])]
+    #[case::comment("{}\n\n /*multiline \n comment*/'''long \n\r\n\t hello'''", [(1, 1), (4, 11)])]
+    #[case::on_same_line_as_preceding_multiline_value("{\n}\"hello\"", [(1, 1), (2, 2)])]
     #[case::values_in_struct("{foo:1,bar:2}", [(1, 1), (1, 6), (1, 12)])]
     #[case::values_in_multiline_struct("{\n  foo:1,\n  bar:2,\n}", [(1, 1), (2, 7), (3, 7)])]
     #[case::values_in_lists("[1,2,3,4]", [(1, 1), (1, 2), (1, 4), (1, 6), (1, 8)])]
@@ -714,12 +740,39 @@ mod tests {
         [(1, 1), (1, 6), (1, 12), (2, 1), (3, 7), (4, 7), (4, 8), (4, 10), (4, 12),
         (6, 1), (6, 6), (6, 12), (7, 1), (8, 7), (9, 7), (9, 8), (9, 10), (9, 12)],
     )]
-    fn location_test_for_inner_value<const N: usize>(
-        #[case] ion_text: &str,
+    #[cfg_attr(
+        feature = "experimental-ion-1-1",
+        case::multiple_top_level_containers_ion_1_1(
+            "$ion_1_1\n{foo:1,bar:2}\n{\n  foo:1,\n  bar:[a,b,c],\n}\n{foo:1,bar:2}\n{\n  foo:1,\n  bar:[a,b,c],\n}",
+            [(2, 1), (2, 6), (2, 12), (3, 1), (4, 7), (5, 7), (5, 8), (5, 10), (5, 12),
+            (7, 1), (7, 6), (7, 12), (8, 1), (9, 7), (10, 7), (10, 8), (10, 10), (10, 12)],
+        )
+    )]
+    #[case::binary_1_0_data(
+        [
+            0xE0u8, 0x01, 0x00, 0xEA, // IVM
+            0x85, 65, 10, 66, 10, 67, // String: "A\nB\nC"
+            0x85, 68, 10, 69, 10, 70, // String: "D\nE\nF"
+        ],
+        [/* no locations */],
+    )]
+    #[cfg_attr(
+        feature = "experimental-ion-1-1",
+        case::binary_1_1_data(
+            [
+                0xE0u8, 0x01, 0x01, 0xEA, // IVM
+                0x95, 65, 10, 66, 10, 67, // String: "A\nB\nC"
+                0x95, 68, 10, 69, 10, 70, // String: "D\nE\nF"
+            ],
+            [/* no locations */],
+        )
+    )]
+    fn location_test_slice_input<const N: usize, I: AsRef<[u8]>>(
+        #[case] ion_input: I,
         #[case] expected_locations: [(usize, usize); N],
     ) -> IonResult<()> {
         let values: Vec<_> =
-            Reader::new(v1_0::Text, ion_text.as_bytes())?.collect::<IonResult<_>>()?;
+            Reader::new(AnyEncoding, ion_input.as_ref())?.collect::<IonResult<_>>()?;
         let actual_locations: Vec<_> = get_locations_of_lazy_elements(values)?
             .into_iter()
             // Only collect those where location is Some(...)
@@ -729,27 +782,109 @@ mod tests {
         Ok(())
     }
 
-    #[ignore] // https://github.com/amazon-ion/ion-rust/issues/951
-    #[test]
-    fn row_and_column_should_not_be_present_for_binary_ion() -> IonResult<()> {
-        let ion_bytes = [
-            0xE0u8, 0x01, 0x00, 0xEA, // IVM
-            0x85, 65, 10, 66, 10, 67, // String: "A\nB\nC"
-            0x85, 68, 10, 69, 10, 70, // String: "D\nE\nF"
-        ];
-        let values: Vec<_> =
-            Reader::new(v1_0::Binary, ion_bytes.as_slice())?.collect::<IonResult<_>>()?;
+    #[rstest]
+    #[case::no_crlf( "{}\"hello\"",       [(1, 1), (1, 3)])]
+    #[case::lf_lf_lf("{}\n\n\n\"hello\"", [(1, 1), (4, 1)] )]
+    #[case::lf_lf_cr("{}\n\n\r\"hello\"", [(1, 1), (4, 1)] )]
+    #[case::lf_cr_cr("{}\n\r\r\"hello\"", [(1, 1), (4, 1)] )]
+    // FIXME: Currently failing because of https://github.com/amazon-ion/ion-rust/issues/955
+    // #[case::lf_cr_lf("{}\n\r\n\"hello\"", [(1, 1), (3, 1)] )]
+    // #[case::cr_lf_lf("{}\r\n\n\"hello\"", [(1, 1), (3, 1)] )]
+    // #[case::cr_lf_cr("{}\r\n\r\"hello\"", [(1, 1), (3, 1)] )]
+    // #[case::cr_cr_lf("{}\r\r\n\"hello\"", [(1, 1), (3, 1)] )]
+    #[case::cr_cr_cr("{}\r\r\r\"hello\"", [(1, 1), (4, 1)] )]
+    #[case::nl_after("{}\"hello\"\n\n",   [(1, 1), (1, 3)])]
+    #[case::tabs(    "{}\n\t\t\"hello\"", [(1, 1), (2, 3)] )]
+    #[case::tabs_after("{}\"hello\"\t\t", [(1, 1), (1, 3)])]
+    #[case::mix_tabs_and_newlines("{}\n\t\n\"hello\"",[(1, 1), (3, 1)])]
+    #[case::long_string("{}\n\n'''long \n\r\n\t hello'''", [(1, 1), (3, 1)])]
+    #[case::comment("{}\n\n /*multiline \n comment*/'''long \n\r\n\t hello'''", [(1, 1), (4, 11)])]
+    #[case::on_same_line_as_preceding_multiline_value("{\n}\"hello\"", [(1, 1), (2, 2)])]
+    #[case::values_in_struct("{foo:1,bar:2}", [(1, 1), (1, 6), (1, 12)])]
+    #[case::values_in_multiline_struct("{\n  foo:1,\n  bar:2,\n}", [(1, 1), (2, 7), (3, 7)])]
+    #[case::values_in_lists("[1,2,3,4]", [(1, 1), (1, 2), (1, 4), (1, 6), (1, 8)])]
+    #[case::values_in_multiline_lists(
+        "[\n  1,\n  2,\n  3,\n  4\n]",
+        [(1, 1), (2, 3), (3, 3), (4, 3), (5, 3)],
+    )]
+    #[case::values_in_sexps("(1 2 3 4)", [(1, 1), (1, 2), (1, 4), (1, 6), (1, 8)])]
+    #[case::values_in_multiline_sexps(
+        "(foo (bar 123)\n     (bar 456)\n     (bar 789))",
+        // (      foo     (       bar     123   )
+        [(1, 1), (1, 2), (1, 6), (1, 7), (1, 11),
+        //                (       bar     456   )
+                         (2, 6), (2, 7), (2, 11),
+        //                (       bar     789   )  )
+                         (3, 6), (3, 7), (3, 11)],
+    )]
+    #[case::deeply_nested_containers(
+        "{\n  foo:{a:1,b:2},\n  bar:[a,b,c],\n  baz:(foo (bar)\n           (quux)),\n}",
+        // {
+        [(1, 1),
+        // foo: {       a:1,     b:2    },
+               (2, 7), (2, 10), (2, 14),
+        // bar: [       a,      b,       c      ],
+               (3, 7), (3, 8), (3, 10), (3, 12),
+        // baz: (       foo     (        bar    )
+               (4, 7), (4, 8), (4, 12), (4, 13),
+        //                      (        quux   ) )
+                               (5, 12), (5, 13),
+        // }
+        ],
+    )]
+    #[case::multiple_top_level_containers(
+        "{foo:1,bar:2}\n{\n  foo:1,\n  bar:[a,b,c],\n}\n{foo:1,bar:2}\n{\n  foo:1,\n  bar:[a,b,c],\n}",
+        [(1, 1), (1, 6), (1, 12), (2, 1), (3, 7), (4, 7), (4, 8), (4, 10), (4, 12),
+        (6, 1), (6, 6), (6, 12), (7, 1), (8, 7), (9, 7), (9, 8), (9, 10), (9, 12)],
+    )]
+    #[cfg_attr(
+        feature = "experimental-ion-1-1",
+        case::multiple_top_level_containers_ion_1_1(
+            "$ion_1_1\n{foo:1,bar:2}\n{\n  foo:1,\n  bar:[a,b,c],\n}\n{foo:1,bar:2}\n{\n  foo:1,\n  bar:[a,b,c],\n}",
+            [(2, 1), (2, 6), (2, 12), (3, 1), (4, 7), (5, 7), (5, 8), (5, 10), (5, 12),
+            (7, 1), (7, 6), (7, 12), (8, 1), (9, 7), (10, 7), (10, 8), (10, 10), (10, 12)],
+        )
+    )]
+    // FIXME: Currently failing because of https://github.com/amazon-ion/ion-rust/issues/954
+    // #[case::binary_1_0_data(
+    //     [
+    //         0xE0u8, 0x01, 0x00, 0xEA, // IVM
+    //         0x85, 65, 10, 66, 10, 67, // String: "A\nB\nC"
+    //         0x85, 68, 10, 69, 10, 70, // String: "D\nE\nF"
+    //     ],
+    //     [/* no locations */],
+    // )]
+    // #[cfg_attr(
+    //     feature = "experimental-ion-1-1",
+    //     case::binary_1_1_data(
+    //         [
+    //             0xE0u8, 0x01, 0x01, 0xEA, // IVM
+    //             0x95, 65, 10, 66, 10, 67, // String: "A\nB\nC"
+    //             0x95, 68, 10, 69, 10, 70, // String: "D\nE\nF"
+    //         ],
+    //         [/* no locations */],
+    //     )
+    // )]
+    fn location_test_stream_input<const N: usize, I: AsRef<[u8]>>(
+        #[case] ion_input: I,
+        #[case] expected_locations: [(usize, usize); N],
+    ) -> IonResult<()> {
+        // Wrapping each byte in an `io::Chain`
+        let mut input: Box<dyn Read> = Box::new(io::empty());
+        for input_byte in ion_input.as_ref().iter().copied() {
+            input = Box::new(input.chain(Cursor::new([input_byte])));
+        }
+        let values: Vec<_> = Reader::new(AnyEncoding, input)?.collect::<IonResult<_>>()?;
         let actual_locations: Vec<_> = get_locations_of_lazy_elements(values)?
             .into_iter()
             // Only collect those where location is Some(...)
             .filter_map(|it| it.row_column())
             .collect();
-        let expected: [(usize, usize); 0] = [];
-        assert_eq!(&expected, actual_locations.as_slice());
+        assert_eq!(&expected_locations, actual_locations.as_slice());
         Ok(())
     }
 
-    fn get_locations_of_lazy_elements<E: Encoding>(
+    fn get_locations_of_lazy_elements<E: Decoder>(
         values: Vec<LazyElement<E>>,
     ) -> IonResult<Vec<SourceLocation>> {
         let mut locations = vec![];


### PR DESCRIPTION
**Issue #, if available:**

fixes #951 

**Description of changes:**

Adds an `encoding()` method to lazy raw values so that a lazy value can call `self.raw().encoding()` and determine what `IonEncoding` (if any) is backing the current lazy value, and then avoid returning a row/column location for values that are backed by binary Ion.

I also significantly refactored the value location tests, and in doing so, I discovered a few more bugs. The affected test cases are commented out, and I opened #954 and #955.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
