### PR TITLE
Fix #955 by removing support for cr-only line endings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ sha2 = { version = "0.9", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_with = { version = "3.7.0", optional = true }
 visibility = "0.1.1"
+memchr = "2.7.4"
 
 [dev-dependencies]
 rstest = "0.19.0"

--- a/src/lazy/value.rs
+++ b/src/lazy/value.rs
@@ -596,106 +596,15 @@ mod tests {
     }
 
     #[rstest]
-    #[case::no_crlf("{foo: 1, bar: 2}\"hello\"", (1,17))]
-    #[case::cr_lf_lf("{foo: 1, bar: 2}\r\n\n\"hello\"", (3,1))]
-    #[case::lf_lf_cr("{foo: 1, bar: 2}\n\n\r\"hello\"", (4,1))]
-    #[case::cr_lf_cr("{foo: 1, bar: 2}\r\n\r\"hello\"", (3,1))]
-    #[case::cr_cr_cr("{foo: 1, bar: 2}\r\r\r\"hello\"", (4,1))]
-    #[case::cr_cr_lf("{foo: 1, bar: 2}\r\r\n\"hello\"", (3,1))]
-    #[case::lf_cr_cr("{foo: 1, bar: 2}\n\r\r\"hello\"", (4,1))]
-    #[case::lf_cr_lf("{foo: 1, bar: 2}\n\r\n\"hello\"", (3,1))]
-    #[case::lf_lf_lf("{foo: 1, bar: 2}\n\n\n\"hello\"", (4,1))]
-    #[case::newlines_after("{foo: 1, bar: 2}\"hello\"\n\n", (1, 17))]
-    #[case::tabs("{foo: 1, bar: 2}\n\t\t\t\"hello\"", (2,4))]
-    #[case::tabs_after("{foo: 1, bar: 2}\"hello\"\t\t", (1,17))]
-    #[case::mix_tabs_and_newlines("{foo: 1, bar: 2}\n\t\n\"hello\"", (3,1))]
-    #[case::long_string("{foo: 1, bar: 2}\n\n'''long \n\r\n\t hello'''", (3, 1))]
-    #[case::comment("{foo: 1, bar: 2}\n\n /*multiline \n comment*/'''long \n\r\n\t hello'''", (4, 11))]
-    #[case::on_same_line_as_preceding_multiline_value("{\n  foo: 1,\n  bar: 2\n}\"hello\"", (4, 2))]
-    fn location_test_for_second_tlv(
-        #[case] ion_text: &str,
-        #[case] expected_location: (usize, usize),
-    ) -> IonResult<()> {
-        let mut reader = Reader::new(v1_0::Text, ion_text)?;
-        let result1 = reader.expect_next();
-
-        let expected_source_location =
-            SourceLocation::new(expected_location.0, expected_location.1);
-        assert!(result1.is_ok());
-        if let Ok(lazy_value1) = result1 {
-            let _val = lazy_value1.read();
-            // first tlv will always be (1,1) per the examples here
-            assert_eq!(lazy_value1.location(), SourceLocation::new(1, 1));
-        }
-        let result2 = reader.expect_next();
-        assert!(result2.is_ok());
-        if let Ok(lazy_value2) = result2 {
-            let _val = lazy_value2.read();
-            assert_eq!(lazy_value2.location(), expected_source_location);
-        }
-        Ok(())
-    }
-
-    #[rstest]
-    #[case::no_crlf(vec!["{foo: 1, bar: 2}","\"hello\""], (1,17))]
-    #[case::cr_lf_lf(vec!["{foo: 1, ", "bar: 2}\r\n\n\"hello\""], (3,1))]
-    #[case::lf_lf_cr(vec!["{foo: 1, bar: 2}","\n\n\r\"hello\""], (4,1))]
-    #[case::cr_lf_cr(vec!["{foo: 1, bar: 2}\r\n\r","\"hello\""], (3,1))]
-    #[case::cr_cr_cr(vec!["{foo: 1, bar: 2}\r\r\r","\"hello\""], (4,1))]
-    #[case::cr_cr_lf(vec!["{foo: 1, bar: 2}\r\r\n\"he","llo\""], (3,1))]
-    #[case::lf_cr_cr(vec!["{foo: 1, bar: 2}\n\r\r\"hello\""], (4,1))]
-    #[case::lf_cr_lf(vec!["{foo: 1, bar: 2}\n\r\n\"hello\""], (3,1))]
-    #[case::lf_lf_lf(vec!["{foo: 1, bar: 2}\n\n\n\"hello\""], (4,1))]
-    #[case::newlines_after(vec!["{foo: 1, bar: 2}\"hello\"\n\n"], (1, 17))]
-    #[case::tabs(vec!["{foo: 1, bar: 2}\n\t\t\t\"hello\""], (2,4))]
-    #[case::tabs_after(vec!["{foo: 1, bar: 2}\"hello\"","\t\t"], (1,17))]
-    #[case::mix_tabs_and_newlines(vec!["{foo: 1, bar: 2}\n\t\n\"hello\""], (3,1))]
-    #[case::long_string(vec!["{foo: 1, bar: 2}\n\n'''long \n\r\n\t hello'''"], (3, 1))]
-    #[case::comment(vec!["{foo: 1, bar: 2}\n\n", "/*multiline \n comment*/","'''long \n\r\n\t hello'''"], (4, 11))]
-    #[case::on_same_line_as_preceding_multiline_value(vec!["{\n  foo: 1,\n  bar: 2\n}\"hello\""], (4, 2))]
-    fn location_test_for_second_tlv_in_stream(
-        #[case] ion_text: Vec<&str>,
-        #[case] expected_location: (usize, usize),
-    ) -> IonResult<()> {
-        use crate::IonStream;
-        use std::io;
-        use std::io::{Cursor, Read};
-
-        let expected_source_location =
-            SourceLocation::new(expected_location.0, expected_location.1);
-        let input_chunks = ion_text.as_slice();
-        // Wrapping each string in an `io::Chain`
-        let mut input: Box<dyn Read> = Box::new(io::empty());
-        for input_chunk in input_chunks {
-            input = Box::new(input.chain(Cursor::new(input_chunk)));
-        }
-        let mut reader = Reader::new(v1_0::Text, IonStream::new(input))?;
-        let result1 = reader.expect_next();
-        assert!(result1.is_ok());
-        if let Ok(lazy_value1) = result1 {
-            let _val = lazy_value1.read();
-            // first tlv will always be (1,1) per the examples here
-            assert_eq!(lazy_value1.location(), SourceLocation::new(1, 1));
-        }
-        let result2 = reader.expect_next();
-        assert!(result2.is_ok());
-        if let Ok(lazy_value2) = result2 {
-            let _val = lazy_value2.read();
-            assert_eq!(lazy_value2.location(), expected_source_location);
-        }
-        Ok(())
-    }
-
-    #[rstest]
     #[case::no_crlf( "{}\"hello\"",       [(1, 1), (1, 3)])]
     #[case::cr_lf_lf("{}\r\n\n\"hello\"", [(1, 1), (3, 1)] )]
-    #[case::lf_lf_cr("{}\n\n\r\"hello\"", [(1, 1), (4, 1)] )]
-    #[case::cr_lf_cr("{}\r\n\r\"hello\"", [(1, 1), (3, 1)] )]
-    #[case::cr_cr_cr("{}\r\r\r\"hello\"", [(1, 1), (4, 1)] )]
-    #[case::cr_cr_lf("{}\r\r\n\"hello\"", [(1, 1), (3, 1)] )]
-    #[case::lf_cr_cr("{}\n\r\r\"hello\"", [(1, 1), (4, 1)] )]
+    #[case::lf_lf_cr("{}\n\n\r\"hello\"", [(1, 1), (3, 2)] )]
+    #[case::lf_cr_cr("{}\n\r\r\"hello\"", [(1, 1), (2, 3)] )]
     #[case::lf_cr_lf("{}\n\r\n\"hello\"", [(1, 1), (3, 1)] )]
-    #[case::lf_lf_lf("{}\n\n\n\"hello\"", [(1, 1), (4, 1)] )]
+    #[case::cr_lf_lf("{}\r\n\n\"hello\"", [(1, 1), (3, 1)] )]
+    #[case::cr_lf_cr("{}\r\n\r\"hello\"", [(1, 1), (2, 2)] )]
+    #[case::cr_cr_lf("{}\r\r\n\"hello\"", [(1, 1), (2, 1)] )]
+    #[case::cr_cr_cr("{}\r\r\r\"hello\"", [(1, 1), (1, 6)] )]
     #[case::nl_after("{}\"hello\"\n\n",   [(1, 1), (1, 3)])]
     #[case::tabs(    "{}\n\t\t\"hello\"", [(1, 1), (2, 3)] )]
     #[case::tabs_after("{}\"hello\"\t\t", [(1, 1), (1, 3)])]
@@ -785,14 +694,13 @@ mod tests {
     #[rstest]
     #[case::no_crlf( "{}\"hello\"",       [(1, 1), (1, 3)])]
     #[case::lf_lf_lf("{}\n\n\n\"hello\"", [(1, 1), (4, 1)] )]
-    #[case::lf_lf_cr("{}\n\n\r\"hello\"", [(1, 1), (4, 1)] )]
-    #[case::lf_cr_cr("{}\n\r\r\"hello\"", [(1, 1), (4, 1)] )]
-    // FIXME: Currently failing because of https://github.com/amazon-ion/ion-rust/issues/955
-    // #[case::lf_cr_lf("{}\n\r\n\"hello\"", [(1, 1), (3, 1)] )]
-    // #[case::cr_lf_lf("{}\r\n\n\"hello\"", [(1, 1), (3, 1)] )]
-    // #[case::cr_lf_cr("{}\r\n\r\"hello\"", [(1, 1), (3, 1)] )]
-    // #[case::cr_cr_lf("{}\r\r\n\"hello\"", [(1, 1), (3, 1)] )]
-    #[case::cr_cr_cr("{}\r\r\r\"hello\"", [(1, 1), (4, 1)] )]
+    #[case::lf_lf_cr("{}\n\n\r\"hello\"", [(1, 1), (3, 2)] )]
+    #[case::lf_cr_cr("{}\n\r\r\"hello\"", [(1, 1), (2, 3)] )]
+    #[case::lf_cr_lf("{}\n\r\n\"hello\"", [(1, 1), (3, 1)] )]
+    #[case::cr_lf_lf("{}\r\n\n\"hello\"", [(1, 1), (3, 1)] )]
+    #[case::cr_lf_cr("{}\r\n\r\"hello\"", [(1, 1), (2, 2)] )]
+    #[case::cr_cr_lf("{}\r\r\n\"hello\"", [(1, 1), (2, 1)] )]
+    #[case::cr_cr_cr("{}\r\r\r\"hello\"", [(1, 1), (1, 6)] )]
     #[case::nl_after("{}\"hello\"\n\n",   [(1, 1), (1, 3)])]
     #[case::tabs(    "{}\n\t\t\"hello\"", [(1, 1), (2, 3)] )]
     #[case::tabs_after("{}\"hello\"\t\t", [(1, 1), (1, 3)])]


### PR DESCRIPTION
*Issue #, if available:*

fix #955 

*Description of changes:*

* Removes support for `\r` line endings. This means we only need to look for `\n`, and it's impossible to have an incomplete line ending.
* Uses `memchr` to look for `\n`, which should improve the performance, but I have not tested it specifically.
* Also removes some redundant tests (equivalent test cases were already added to the other test functions in #952)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
