### PR TITLE
Bump-allocates Binary 1.0 values

### DIFF
--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -732,7 +732,7 @@ impl<'top> LazyRawAnyValue<'top> {
 #[derive(Debug, Copy, Clone)]
 pub enum LazyRawValueKind<'top> {
     Text_1_0(LazyRawTextValue_1_0<'top>),
-    Binary_1_0(LazyRawBinaryValue_1_0<'top>),
+    Binary_1_0(&'top LazyRawBinaryValue_1_0<'top>),
     Text_1_1(LazyRawTextValue_1_1<'top>),
     Binary_1_1(&'top LazyRawBinaryValue_1_1<'top>),
 }
@@ -745,8 +745,8 @@ impl<'top> From<LazyRawTextValue_1_0<'top>> for LazyRawAnyValue<'top> {
     }
 }
 
-impl<'top> From<LazyRawBinaryValue_1_0<'top>> for LazyRawAnyValue<'top> {
-    fn from(value: LazyRawBinaryValue_1_0<'top>) -> Self {
+impl<'top> From<&'top LazyRawBinaryValue_1_0<'top>> for LazyRawAnyValue<'top> {
+    fn from(value: &'top LazyRawBinaryValue_1_0<'top>) -> Self {
         LazyRawAnyValue {
             encoding: LazyRawValueKind::Binary_1_0(value),
         }

--- a/src/lazy/binary/raw/sequence.rs
+++ b/src/lazy/binary/raw/sequence.rs
@@ -18,7 +18,7 @@ pub struct LazyRawBinaryList_1_0<'top> {
 }
 
 impl<'top> LazyRawBinaryList_1_0<'top> {
-    pub fn as_value(&self) -> LazyRawBinaryValue_1_0<'top> {
+    pub fn as_value(&self) -> &'top LazyRawBinaryValue_1_0<'top> {
         self.sequence.value
     }
 }
@@ -29,7 +29,7 @@ pub struct LazyRawBinarySExp_1_0<'top> {
 }
 
 impl<'top> LazyContainerPrivate<'top, BinaryEncoding_1_0> for LazyRawBinaryList_1_0<'top> {
-    fn from_value(value: LazyRawBinaryValue_1_0<'top>) -> Self {
+    fn from_value(value: &'top LazyRawBinaryValue_1_0<'top>) -> Self {
         LazyRawBinaryList_1_0 {
             sequence: LazyRawBinarySequence_1_0 { value },
         }
@@ -59,7 +59,7 @@ impl<'top> LazyRawSequence<'top, BinaryEncoding_1_0> for LazyRawBinaryList_1_0<'
 }
 
 impl<'top> LazyContainerPrivate<'top, BinaryEncoding_1_0> for LazyRawBinarySExp_1_0<'top> {
-    fn from_value(value: LazyRawBinaryValue_1_0<'top>) -> Self {
+    fn from_value(value: &'top LazyRawBinaryValue_1_0<'top>) -> Self {
         LazyRawBinarySExp_1_0 {
             sequence: LazyRawBinarySequence_1_0 { value },
         }
@@ -90,7 +90,7 @@ impl<'top> LazyRawSequence<'top, BinaryEncoding_1_0> for LazyRawBinarySExp_1_0<'
 
 #[derive(Copy, Clone)]
 pub struct LazyRawBinarySequence_1_0<'top> {
-    pub(crate) value: LazyRawBinaryValue_1_0<'top>,
+    pub(crate) value: &'top LazyRawBinaryValue_1_0<'top>,
 }
 
 impl<'top> LazyRawBinarySequence_1_0<'top> {

--- a/src/lazy/binary/raw/struct.rs
+++ b/src/lazy/binary/raw/struct.rs
@@ -18,11 +18,11 @@ use crate::{IonResult, RawSymbolRef, SymbolId};
 
 #[derive(Copy, Clone)]
 pub struct LazyRawBinaryStruct_1_0<'top> {
-    pub(crate) value: LazyRawBinaryValue_1_0<'top>,
+    pub(crate) value: &'top LazyRawBinaryValue_1_0<'top>,
 }
 
 impl<'top> LazyRawBinaryStruct_1_0<'top> {
-    pub fn as_value(&self) -> LazyRawBinaryValue_1_0<'top> {
+    pub fn as_value(&self) -> &'top LazyRawBinaryValue_1_0<'top> {
         self.value
     }
 }
@@ -63,7 +63,7 @@ impl<'top> LazyRawBinaryStruct_1_0<'top> {
 }
 
 impl<'top> LazyContainerPrivate<'top, BinaryEncoding_1_0> for LazyRawBinaryStruct_1_0<'top> {
-    fn from_value(value: LazyRawBinaryValue_1_0<'top>) -> Self {
+    fn from_value(value: &'top LazyRawBinaryValue_1_0<'top>) -> Self {
         LazyRawBinaryStruct_1_0 { value }
     }
 }

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -109,11 +109,11 @@ impl HasRange for &'_ LazyRawBinaryValue_1_0<'_> {
 
 impl<'top> LazyRawValue<'top, BinaryEncoding_1_0> for &'top LazyRawBinaryValue_1_0<'top> {
     fn ion_type(&self) -> IonType {
-        self.encoded_value.ion_type()
+        (*self).ion_type()
     }
 
     fn is_null(&self) -> bool {
-        self.encoded_value.header().is_null()
+        (*self).is_null()
     }
 
     fn is_delimited(&self) -> bool {
@@ -121,7 +121,7 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_0> for &'top LazyRawBinaryValue_1
     }
 
     fn has_annotations(&self) -> bool {
-        self.encoded_value.has_annotations()
+        (*self).has_annotations()
     }
 
     fn annotations(&self) -> RawBinaryAnnotationsIterator<'top> {

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -16,6 +16,7 @@ use crate::lazy::binary::raw::sequence::{
 use crate::lazy::binary::raw::type_descriptor::Header;
 use crate::lazy::decoder::{HasRange, HasSpan, LazyRawValue, RawVersionMarker};
 use crate::lazy::encoding::BinaryEncoding_1_0;
+use crate::lazy::expanded::EncodingContextRef;
 use crate::lazy::raw_value_ref::RawValueRef;
 use crate::lazy::span::Span;
 use crate::lazy::str_ref::StrRef;
@@ -91,7 +92,7 @@ impl Debug for LazyRawBinaryValue_1_0<'_> {
 
 pub type ValueParseResult<'top, F> = IonResult<RawValueRef<'top, F>>;
 
-impl<'top> HasSpan<'top> for LazyRawBinaryValue_1_0<'top> {
+impl<'top> HasSpan<'top> for &'top LazyRawBinaryValue_1_0<'top> {
     fn span(&self) -> Span<'top> {
         let range = self.range();
         // Subtract the `offset()` of the BinaryBuffer to get the local indexes for start/end
@@ -100,19 +101,19 @@ impl<'top> HasSpan<'top> for LazyRawBinaryValue_1_0<'top> {
     }
 }
 
-impl HasRange for LazyRawBinaryValue_1_0<'_> {
+impl HasRange for &'_ LazyRawBinaryValue_1_0<'_> {
     fn range(&self) -> Range<usize> {
         self.encoded_value.annotated_value_range()
     }
 }
 
-impl<'top> LazyRawValue<'top, BinaryEncoding_1_0> for LazyRawBinaryValue_1_0<'top> {
+impl<'top> LazyRawValue<'top, BinaryEncoding_1_0> for &'top LazyRawBinaryValue_1_0<'top> {
     fn ion_type(&self) -> IonType {
-        self.ion_type()
+        self.encoded_value.ion_type()
     }
 
     fn is_null(&self) -> bool {
-        self.is_null()
+        self.encoded_value.header().is_null()
     }
 
     fn is_delimited(&self) -> bool {
@@ -120,15 +121,15 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_0> for LazyRawBinaryValue_1_0<'to
     }
 
     fn has_annotations(&self) -> bool {
-        self.has_annotations()
+        self.encoded_value.has_annotations()
     }
 
     fn annotations(&self) -> RawBinaryAnnotationsIterator<'top> {
-        self.annotations()
+        (*self).annotations()
     }
 
     fn read(&self) -> IonResult<RawValueRef<'top, BinaryEncoding_1_0>> {
-        self.read()
+        (*self).read()
     }
 
     fn annotations_span(&self) -> Span<'top> {
@@ -147,10 +148,12 @@ impl<'top> LazyRawValue<'top, BinaryEncoding_1_0> for LazyRawBinaryValue_1_0<'to
     }
 
     fn with_backing_data(&self, span: Span<'top>) -> Self {
-        Self {
-            encoded_value: self.encoded_value,
-            input: BinaryBuffer::new_with_offset(span.bytes(), span.offset()),
-        }
+        let buffer = BinaryBuffer::new_with_offset(self.context(), span.bytes(), span.offset());
+        let allocator = self.context().allocator();
+        allocator.alloc_with(move || LazyRawBinaryValue_1_0 {
+            input: buffer,
+            ..**self
+        })
     }
 
     fn encoding(&self) -> IonEncoding {
@@ -252,7 +255,7 @@ pub trait BinaryValueLiteral<'top, D: Decoder>: LazyRawValue<'top, D> {
     }
 }
 
-impl<'top> BinaryValueLiteral<'top, BinaryEncoding_1_0> for LazyRawBinaryValue_1_0<'top> {
+impl<'top> BinaryValueLiteral<'top, BinaryEncoding_1_0> for &'top LazyRawBinaryValue_1_0<'top> {
     fn opcode_length(&self) -> usize {
         self.encoded_value.opcode_length()
     }
@@ -436,6 +439,10 @@ impl<'top> EncodedBinaryValueData_1_0<'_, 'top> {
 }
 
 impl<'top> LazyRawBinaryValue_1_0<'top> {
+    pub fn context(&self) -> EncodingContextRef<'top> {
+        self.input.context()
+    }
+
     #[cfg(feature = "experimental-tooling-apis")]
     pub fn encoded_annotations(&self) -> Option<EncodedBinaryAnnotations_1_0<'_, 'top>> {
         if self.has_annotations() {
@@ -603,7 +610,7 @@ impl<'top> LazyRawBinaryValue_1_0<'top> {
         }
 
         // Skip the type descriptor and length bytes
-        let input = BinaryBuffer::new(self.value_body());
+        let input = BinaryBuffer::new(self.context(), self.value_body());
 
         let (exponent_var_int, remaining) = input.read_var_int()?;
         let coefficient_size_in_bytes =
@@ -625,7 +632,7 @@ impl<'top> LazyRawBinaryValue_1_0<'top> {
     fn read_timestamp(&self) -> ValueParseResult<'top, BinaryEncoding_1_0> {
         debug_assert!(self.encoded_value.ion_type() == IonType::Timestamp);
 
-        let input = BinaryBuffer::new(self.value_body());
+        let input = BinaryBuffer::new(self.context(), self.value_body());
 
         let (offset, input) = input.read_var_int()?;
         let is_known_offset = !offset.is_negative_zero();
@@ -769,7 +776,9 @@ impl<'top> LazyRawBinaryValue_1_0<'top> {
             encoded_value: self.encoded_value,
             input: self.input,
         };
-        let lazy_sequence = LazyRawBinarySequence_1_0 { value: lazy_value };
+        let allocator = self.context().allocator();
+        let value_ref = allocator.alloc_with(|| lazy_value);
+        let lazy_sequence = LazyRawBinarySequence_1_0 { value: value_ref };
         let lazy_sexp = LazyRawBinarySExp_1_0 {
             sequence: lazy_sequence,
         };
@@ -783,7 +792,9 @@ impl<'top> LazyRawBinaryValue_1_0<'top> {
             encoded_value: self.encoded_value,
             input: self.input,
         };
-        let lazy_sequence = LazyRawBinarySequence_1_0 { value: lazy_value };
+        let allocator = self.context().allocator();
+        let value_ref = allocator.alloc_with(|| lazy_value);
+        let lazy_sequence = LazyRawBinarySequence_1_0 { value: value_ref };
         let lazy_list = LazyRawBinaryList_1_0 {
             sequence: lazy_sequence,
         };
@@ -797,7 +808,9 @@ impl<'top> LazyRawBinaryValue_1_0<'top> {
             encoded_value: self.encoded_value,
             input: self.input,
         };
-        let lazy_struct = LazyRawBinaryStruct_1_0 { value: lazy_value };
+        let allocator = self.context().allocator();
+        let value_ref = allocator.alloc_with(|| lazy_value);
+        let lazy_struct = LazyRawBinaryStruct_1_0 { value: value_ref };
         Ok(RawValueRef::Struct(lazy_struct))
     }
 }

--- a/src/lazy/encoder/binary/v1_1/flex_int.rs
+++ b/src/lazy/encoder/binary/v1_1/flex_int.rs
@@ -169,7 +169,7 @@ impl FlexInt {
 mod tests {
     use crate::lazy::binary::binary_buffer::BinaryBuffer;
     use crate::lazy::encoder::binary::v1_1::flex_int::FlexInt;
-    use crate::{IonError, IonResult};
+    use crate::{EncodingContext, IonError, IonResult, IonVersion};
     const FLEX_INT_TEST_CASES: &[(i64, &[u8])] = &[
         (0i64, &[0b00000001u8]),
         (1, &[0b00000011]),
@@ -331,8 +331,10 @@ mod tests {
 
     #[test]
     fn decode_flex_int() -> IonResult<()> {
+        let context = EncodingContext::for_ion_version(IonVersion::v1_0);
         for (expected_value, encoding) in FLEX_INT_TEST_CASES {
-            let (flex_int, _remaining) = BinaryBuffer::new(encoding).read_flex_int()?;
+            let (flex_int, _remaining) =
+                BinaryBuffer::new(context.get_ref(), encoding).read_flex_int()?;
             let actual_value = flex_int.value();
             assert_eq!(actual_value, *expected_value, "actual value {actual_value} was != expected value {expected_value} for encoding {encoding:x?}")
         }
@@ -352,11 +354,13 @@ mod tests {
 
     #[test]
     fn detect_incomplete_flex_int() {
+        let context = EncodingContext::for_ion_version(IonVersion::v1_0);
         for (_value, expected_encoding) in FLEX_INT_TEST_CASES {
             // Exhaustively check incomplete input detection by trying to read all prefixes of a test
             // value's complete encoding.
             for end in 0..expected_encoding.len() - 1 {
-                let partial_encoding = BinaryBuffer::new(&expected_encoding[..end]);
+                let partial_encoding =
+                    BinaryBuffer::new(context.get_ref(), &expected_encoding[..end]);
                 assert!(matches!(
                     partial_encoding.read_flex_int(),
                     Err(IonError::Incomplete(_))

--- a/src/lazy/encoding.rs
+++ b/src/lazy/encoding.rs
@@ -417,7 +417,7 @@ impl TextEncoding for TextEncoding_1_1 {
 impl Decoder for BinaryEncoding_1_0 {
     const INITIAL_ENCODING_EXPECTED: IonEncoding = IonEncoding::Binary_1_0;
     type Reader<'data> = LazyRawBinaryReader_1_0<'data>;
-    type Value<'top> = LazyRawBinaryValue_1_0<'top>;
+    type Value<'top> = &'top LazyRawBinaryValue_1_0<'top>;
     type SExp<'top> = LazyRawBinarySExp_1_0<'top>;
     type List<'top> = LazyRawBinaryList_1_0<'top>;
     type Struct<'top> = LazyRawBinaryStruct_1_0<'top>;
@@ -482,7 +482,7 @@ impl Decoder for BinaryEncoding_1_1 {
 pub trait RawValueLiteral {}
 
 impl<E: TextEncoding> RawValueLiteral for LazyRawTextValue<'_, E> {}
-impl RawValueLiteral for LazyRawBinaryValue_1_0<'_> {}
+impl<'top> RawValueLiteral for &'top LazyRawBinaryValue_1_0<'top> {}
 impl<'top> RawValueLiteral for &'top LazyRawBinaryValue_1_1<'top> {}
 impl RawValueLiteral for LazyRawAnyValue<'_> {}
 


### PR DESCRIPTION
The `LazyRawBinaryValue_1_0` type contains a lot of data. While it is `Copy`, it is large enough that making copies of it or moving it around the stack causes a noticeable slowdown. Several other types contain a `LazyRawBinaryValue_1_0` transitively, meaning that this impacts many code paths.

This PR changes the `Binary_1_0` implementation of `Decoder` to use a `Value` type of `&'top LazyRawBinaryValue_1_0<'top>` (a bump-allocated reference) instead of `LazyRawBinaryValue<'top>` (a complete value). This allows copies and moves to happen using a pointer (8 bytes) instead of ~100 bytes of struct data.

This approach is already used by the 1.1 equivalent type, `LazyRawBinaryValue_1_1`, with similar benefits.
I'll make follow-on PRs to do this for the text types too.

Improvement over `HEAD`:
![image](https://github.com/user-attachments/assets/4a0b4e68-7489-432c-bdd9-6776f806403e)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
