### PR TITLE
Optimize the layout of `Decimal`

### DIFF
--- a/src/binary/decimal.rs
+++ b/src/binary/decimal.rs
@@ -7,7 +7,7 @@ use arrayvec::ArrayVec;
 use crate::binary::int::DecodedInt;
 use crate::binary::var_int::VarInt;
 use crate::binary::var_uint::VarUInt;
-use crate::decimal::coefficient::Coefficient;
+use crate::decimal::coefficient::Sign;
 use crate::ion_data::IonEq;
 use crate::result::{IonFailure, IonResult};
 use crate::{Decimal, Int, IonError};
@@ -16,7 +16,8 @@ const MAX_INLINE_LENGTH: usize = 13;
 
 const DECIMAL_BUFFER_SIZE: usize = 32;
 const DECIMAL_POSITIVE_ZERO: Decimal = Decimal {
-    coefficient: Coefficient::ZERO,
+    coefficient_value: Int::ZERO,
+    coefficient_sign: Sign::Positive,
     exponent: 0,
 };
 
@@ -50,7 +51,7 @@ where
 
         bytes_written += VarInt::write_i64(self, decimal.exponent)?;
 
-        match decimal.coefficient.as_int() {
+        match decimal.coefficient().as_int() {
             Some(int) if int == Int::ZERO => {
                 // From the spec: "The subfield should not be present (that is, it
                 // has zero length) when the coefficient’s value is (positive)

--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -239,7 +239,7 @@ impl BinaryValueWriter_1_1<'_, '_> {
         let encoded_coefficient_size = if is_positive_zero {
             // If the coefficient is zero but the exponent was non-zero, write nothing; an implicit zero is positive.
             0
-        } else if value.coefficient.is_negative_zero() {
+        } else if value.coefficient().is_negative_zero() {
             // If the coefficient is negative zero (of any exponent), write a zero byte; an explicit zero is negative.
             self.push_byte(0x00);
             1

--- a/src/types/decimal/coefficient.rs
+++ b/src/types/decimal/coefficient.rs
@@ -60,6 +60,13 @@ impl Coefficient {
         }
     }
 
+    pub(crate) fn from_sign_and_value(sign: Sign, magnitude: impl Into<Int>) -> Self {
+        Self {
+            sign,
+            magnitude: magnitude.into(),
+        }
+    }
+
     pub fn sign(&self) -> Sign {
         self.sign
     }

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -59,14 +59,14 @@ impl Mantissa {
             // Exact equality test
             || d1.eq(d2)
             // Coefficient zeros' signs don't have to match for fractional seconds.
-            || (d1.coefficient.is_zero() && d2.coefficient.is_zero() && d1.exponent == d2.exponent)
+            || (d1.coefficient().is_zero() && d2.coefficient().is_zero() && d1.exponent == d2.exponent)
     }
 
     fn decimals_compare(d1: &Decimal, d2: &Decimal) -> Ordering {
         // See the [EmptyMantissa] trait for details about `is_empty()`
         if d1.is_empty() && d2.is_empty() {
             Ordering::Equal
-        } else if d1.coefficient.is_zero() && d2.coefficient.is_zero() {
+        } else if d1.coefficient().is_zero() && d2.coefficient().is_zero() {
             // Coefficient zeros' signs don't have to be compared for fractional seconds.
             d1.exponent.cmp(&d2.exponent)
         } else {
@@ -85,7 +85,7 @@ trait EmptyMantissa {
 
 impl EmptyMantissa for Decimal {
     fn is_empty(&self) -> bool {
-        self.coefficient.is_zero() && self.exponent == 0
+        self.coefficient().is_zero() && self.exponent == 0
     }
 }
 
@@ -223,7 +223,7 @@ impl Timestamp {
                 const NANOSECONDS_EXPONENT: i64 = -9;
                 const NANOSECONDS_PER_SECOND: u128 = 1_000_000_000;
                 let exponent_delta = decimal.exponent - NANOSECONDS_EXPONENT;
-                let magnitude = match &decimal.coefficient.magnitude().data {
+                let magnitude = match &decimal.coefficient().magnitude().data {
                     m if *m >= NANOSECONDS_PER_SECOND => {
                         // The coefficient is more precise than nanoseconds. We need to truncate a
                         // copy of it.
@@ -357,7 +357,7 @@ impl Timestamp {
             }
             Mantissa::Arbitrary(decimal) => {
                 let exponent = decimal.exponent;
-                let coefficient = &decimal.coefficient;
+                let coefficient = &decimal.coefficient();
                 if exponent >= 0 {
                     // We know that the coefficient is non-zero (the mantissa was not empty),
                     // so having a positive exponent would result in an illegal fractional
@@ -367,7 +367,7 @@ impl Timestamp {
                     );
                 }
 
-                let num_digits = decimal.coefficient.number_of_decimal_digits();
+                let num_digits = decimal.coefficient().number_of_decimal_digits();
                 let abs_exponent = decimal.exponent.unsigned_abs();
                 // At this point, we know that the abs_exponent is greater than num_digits because
                 // the decimal has to be < 1.
@@ -383,7 +383,7 @@ impl Timestamp {
                         "fractional seconds cannot have a negative coefficient (other than -0)",
                     );
                 } else {
-                    write!(output, "{}", decimal.coefficient)?;
+                    write!(output, "{}", decimal.coefficient())?;
                 }
                 Ok(())
             }


### PR DESCRIPTION
Cuts `Decimal` from 48 bytes (23 bytes padding) to 32 bytes (7 bytes padding). See the layout comment in the PR for details.

Many types contain a `Decimal`, including `Timestamp` and `ValueRef`, so this removes 16 bytes from many types. Binary 1.0 benchmarks showed that scanning is ~5% faster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
