### PR TITLE
Make special case parsing logic for ints 1-3 bytes in length

### DIFF
--- a/src/binary/uint.rs
+++ b/src/binary/uint.rs
@@ -1,5 +1,4 @@
 use std::io::Write;
-use std::mem;
 
 use crate::result::{IonFailure, IonResult};
 use crate::{Int, IonError, UInt};
@@ -18,20 +17,30 @@ impl DecodedUInt {
     /// If the length of `uint_bytes` is greater than the size of a `u128`, returns `Err`.
     #[inline]
     pub(crate) fn uint_from_slice(uint_bytes: &[u8]) -> IonResult<u128> {
-        if uint_bytes.len() > mem::size_of::<u128>() {
-            return IonResult::decoding_error(
+        const MAX_BYTES: usize = size_of::<u128>();
+        // The `uint_from_slice_unchecked` method will work for a uint of any size up to and including
+        // 16 bytes. However, because the slice is of an unknown length, the `memcpy` performed by
+        // that method does not get inlined by the compiler. Here we check for some common int sizes
+        // and construct the int manually to allow the hot path to be inlined.
+        match uint_bytes.len() {
+            // If it's 1-3 bytes, avoid the `memcpy` used in the general-purpose conversion logic
+            1 => Ok(uint_bytes[0] as u128),
+            2 => Ok(u16::from_le_bytes([uint_bytes[1], uint_bytes[0]]) as u128),
+            3 => Ok(u32::from_le_bytes([uint_bytes[2], uint_bytes[1], uint_bytes[0], 0u8]) as u128),
+            // General-purpose conversion from bytes to u128.
+            ..=MAX_BYTES => Ok(Self::uint_from_slice_unchecked(uint_bytes)),
+            // Oversized
+            _ => IonResult::decoding_error(
                 "integer size is currently limited to the range of an i128",
-            );
+            ),
         }
-
-        Ok(Self::uint_from_slice_unchecked(uint_bytes))
     }
 
     /// Interprets all of the bytes in the provided slice as big-endian unsigned integer bytes.
     /// Panics if the length of `uint_bytes` is greater than the size of a `u128`.
     #[inline]
     pub(crate) fn uint_from_slice_unchecked(uint_bytes: &[u8]) -> u128 {
-        const BUFFER_SIZE: usize = mem::size_of::<u128>();
+        const BUFFER_SIZE: usize = size_of::<u128>();
         let mut buffer = [0u8; BUFFER_SIZE];
         // Copy the big-endian bytes into the end of the buffer
         buffer[BUFFER_SIZE - uint_bytes.len()..].copy_from_slice(uint_bytes);
@@ -76,11 +85,11 @@ impl TryFrom<DecodedUInt> for Int {
 /// A buffer for storing a UInt's Big Endian bytes.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UIntBeBytes {
-    bytes: [u8; mem::size_of::<u128>()],
+    bytes: [u8; size_of::<u128>()],
 }
 
 impl UIntBeBytes {
-    pub fn new(bytes: [u8; mem::size_of::<u128>()]) -> Self {
+    pub fn new(bytes: [u8; size_of::<u128>()]) -> Self {
         Self { bytes }
     }
 }


### PR DESCRIPTION
When decoding a binary Ion 1.0 encoding primitive `UInt`, the reader uses a general-purpose helper method that copies the input bytes into a fixed-size buffer and converts the whole thing into a `u128`. Because it works on a slice of any length, the compiler will choose not to inline the resulting `memcpy`. This causes integer-reading to show up prominently in profiles.

This change special cases 1-, 2-, and 3-byte integers to avoid the `memcpy` and inline all the logic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
