### PR TITLE
Adds initial guard rails to the `ApplicationEExpWriter`

### DIFF
--- a/src/lazy/encoder/value_writer.rs
+++ b/src/lazy/encoder/value_writer.rs
@@ -93,7 +93,9 @@ pub trait ValueWriter: AnnotatableWriter + Sized {
     fn list_writer(self) -> IonResult<Self::ListWriter>;
     fn sexp_writer(self) -> IonResult<Self::SExpWriter>;
     fn struct_writer(self) -> IonResult<Self::StructWriter>;
-    fn eexp_writer<'a>(self, macro_id: impl MacroIdLike<'a>) -> IonResult<Self::EExpWriter>;
+    fn eexp_writer<'a>(self, macro_id: impl MacroIdLike<'a>) -> IonResult<Self::EExpWriter>
+    where
+        Self: 'a;
 
     fn write(self, value: impl WriteAsIon) -> IonResult<()> {
         value.write_as_ion(self)
@@ -198,7 +200,7 @@ macro_rules! delegate_value_writer_to {
                 fn eexp_writer<'a>(
                     self,
                     macro_id: impl MacroIdLike<'a>,
-                 ) -> IonResult<Self::EExpWriter>;
+                 ) -> IonResult<Self::EExpWriter> where Self: 'a;
 
             }
         }
@@ -460,9 +462,9 @@ pub trait SequenceWriter: MakeValueWriter {
     }
 
     fn eexp_writer<'a>(
-        &mut self,
+        &'a mut self,
         macro_id: impl MacroIdLike<'a>,
-    ) -> IonResult<<Self::NestedValueWriter<'_> as ValueWriter>::EExpWriter> {
+    ) -> IonResult<<Self::NestedValueWriter<'a> as ValueWriter>::EExpWriter> {
         self.value_writer().eexp_writer(macro_id)
     }
 

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -32,6 +32,8 @@ use crate::{
     TemplateCompiler, TemplateMacro, Timestamp, UInt, Value,
 };
 
+/// A thin wrapper around a `SymbolTable` that tracks the number of symbols whose definition has
+/// not yet been written to output.
 pub(crate) struct WriterSymbolTable {
     symbols: SymbolTable,
     num_pending: usize,
@@ -72,6 +74,8 @@ impl Deref for WriterSymbolTable {
     }
 }
 
+/// A thin wrapper around a `MacroTable` that tracks the number of macros whose definition has
+/// not yet been written to output.
 pub(crate) struct WriterMacroTable {
     macros: MacroTable,
     num_pending: usize,
@@ -119,25 +123,6 @@ impl Deref for WriterMacroTable {
         &self.macros
     }
 }
-// pub(crate) struct WriterContext {
-//     symbol_table: SymbolTable,
-//     // This will be used when we add 'managed' macro methods to the writer
-//     #[allow(dead_code)]
-//     macro_table: MacroTable,
-//     num_pending_symbols: usize,
-//     num_pending_macros: usize,
-// }
-
-// impl WriterContext {
-//     pub fn new(symbol_table: SymbolTable, macro_table: MacroTable) -> Self {
-//         Self {
-//             symbol_table,
-//             macro_table,
-//             num_pending_symbols: 0,
-//             num_pending_macros: 0,
-//         }
-//     }
-// }
 
 /// An Ion writer that maintains a symbol table and creates new entries as needed.
 #[cfg_attr(feature = "experimental-reader-writer", visibility::make(pub))]

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -1,7 +1,8 @@
-use std::io::Write;
-
 use delegate::delegate;
 use ice_code::ice as cold_path;
+use std::io::Write;
+use std::ops::Deref;
+use std::sync::Arc;
 
 use crate::constants::v1_0::system_symbol_ids;
 use crate::constants::v1_1;
@@ -27,34 +28,114 @@ use crate::result::IonFailure;
 use crate::write_config::WriteConfig;
 use crate::{
     AnyEncoding, ContextWriter, Decimal, Element, ElementWriter, Int, IonInput, IonResult, IonType,
-    IonVersion, MacroTable, RawSymbolRef, Reader, Symbol, SymbolTable, TemplateCompiler, Timestamp,
-    UInt, Value,
+    IonVersion, MacroDef, MacroTable, RawSymbolRef, Reader, Symbol, SymbolId, SymbolTable,
+    TemplateCompiler, TemplateMacro, Timestamp, UInt, Value,
 };
 
-pub(crate) struct WriterContext {
-    symbol_table: SymbolTable,
-    // This will be used when we add 'managed' macro methods to the writer
-    #[allow(dead_code)]
-    macro_table: MacroTable,
-    num_pending_symbols: usize,
-    num_pending_macros: usize,
+pub(crate) struct WriterSymbolTable {
+    symbols: SymbolTable,
+    num_pending: usize,
 }
 
-impl WriterContext {
-    pub fn new(symbol_table: SymbolTable, macro_table: MacroTable) -> Self {
+impl WriterSymbolTable {
+    pub fn reset_num_pending(&mut self) {
+        self.num_pending = 0;
+    }
+
+    pub fn num_pending(&self) -> usize {
+        self.num_pending
+    }
+
+    pub fn pending(&self) -> &[Symbol] {
+        self.symbols.symbols_tail(self.num_pending)
+    }
+
+    pub fn add_symbol_for_text<A: AsRef<str>>(&mut self, text: A) -> SymbolId {
+        self.num_pending += 1;
+        self.symbols.add_symbol_for_text(text)
+    }
+
+    pub fn new(symbols: SymbolTable) -> Self {
         Self {
-            symbol_table,
-            macro_table,
-            num_pending_symbols: 0,
-            num_pending_macros: 0,
+            symbols,
+            num_pending: 0,
         }
     }
 }
 
+// Read-only methods on the underlying SymbolTable can be invoked directly.
+impl Deref for WriterSymbolTable {
+    type Target = SymbolTable;
+
+    fn deref(&self) -> &Self::Target {
+        &self.symbols
+    }
+}
+
+pub(crate) struct WriterMacroTable {
+    macros: MacroTable,
+    num_pending: usize,
+}
+
+impl WriterMacroTable {
+    pub fn new(macros: MacroTable) -> Self {
+        Self {
+            macros,
+            num_pending: 0,
+        }
+    }
+
+    pub fn add_template_macro(&mut self, template_macro: TemplateMacro) -> IonResult<usize> {
+        self.num_pending += 1;
+        self.macros.add_template_macro(template_macro)
+    }
+
+    pub fn reset_num_pending(&mut self) {
+        self.num_pending = 0;
+    }
+
+    pub fn num_pending(&self) -> usize {
+        self.num_pending
+    }
+
+    pub fn pending(&self) -> &[Arc<MacroDef>] {
+        self.macros.macros_tail(self.num_pending)
+    }
+}
+
+// Read-only methods on the underlying MacroTable can be invoked directly.
+impl Deref for WriterMacroTable {
+    type Target = MacroTable;
+
+    fn deref(&self) -> &Self::Target {
+        &self.macros
+    }
+}
+// pub(crate) struct WriterContext {
+//     symbol_table: SymbolTable,
+//     // This will be used when we add 'managed' macro methods to the writer
+//     #[allow(dead_code)]
+//     macro_table: MacroTable,
+//     num_pending_symbols: usize,
+//     num_pending_macros: usize,
+// }
+
+// impl WriterContext {
+//     pub fn new(symbol_table: SymbolTable, macro_table: MacroTable) -> Self {
+//         Self {
+//             symbol_table,
+//             macro_table,
+//             num_pending_symbols: 0,
+//             num_pending_macros: 0,
+//         }
+//     }
+// }
+
 /// An Ion writer that maintains a symbol table and creates new entries as needed.
 #[cfg_attr(feature = "experimental-reader-writer", visibility::make(pub))]
 pub(crate) struct Writer<E: Encoding, Output: Write> {
-    context: WriterContext,
+    symbols: WriterSymbolTable,
+    macros: WriterMacroTable,
     data_writer: E::Writer<Vec<u8>>,
     directive_writer: E::Writer<Vec<u8>>,
     output: Output,
@@ -82,11 +163,11 @@ impl<E: Encoding, Output: Write> Writer<E, Output> {
         data_writer.output_mut().clear();
         // TODO: LazyEncoder should define a method to construct a new symtab and/or macro table
         let ion_version = E::ion_version();
-        let symbol_table = SymbolTable::new(ion_version);
-        let macro_table = MacroTable::with_system_macros(ion_version);
-        let context = WriterContext::new(symbol_table, macro_table);
+        let symbols = WriterSymbolTable::new(SymbolTable::new(ion_version));
+        let macros = WriterMacroTable::new(MacroTable::with_system_macros(ion_version));
         let mut writer = Writer {
-            context,
+            symbols,
+            macros,
             data_writer,
             directive_writer,
             output,
@@ -96,6 +177,10 @@ impl<E: Encoding, Output: Write> Writer<E, Output> {
         Ok(writer)
     }
 
+    pub(crate) fn macro_table(&self) -> &MacroTable {
+        &self.macros
+    }
+
     /// Takes a TDL expression representing a macro definition and returns a `Macro` that can
     /// later be invoked by passing it to [`Writer::eexp_writer()`].
     pub fn compile_macro(&mut self, source: impl IonInput) -> IonResult<Macro> {
@@ -103,19 +188,14 @@ impl<E: Encoding, Output: Write> Writer<E, Output> {
         let macro_def_sexp = reader.expect_next()?.read()?.expect_sexp()?;
 
         let template_macro = TemplateCompiler::compile_from_sexp(
-            &self.context.macro_table,
+            self.macro_table(),
             &MacroTable::empty(),
             macro_def_sexp,
         )?;
 
-        let address = self
-            .context
-            .macro_table
-            .add_template_macro(template_macro)?;
-        self.context.num_pending_macros += 1;
+        let address = self.macros.add_template_macro(template_macro)?;
         let macro_def = self
-            .context
-            .macro_table
+            .macro_table()
             .clone_macro_with_address(address)
             .expect("macro freshly placed at address is missing");
         let macro_handle = Macro::new(macro_def, address);
@@ -125,7 +205,7 @@ impl<E: Encoding, Output: Write> Writer<E, Output> {
     /// Gets a macro with the provided ID from the default module.
     pub fn get_macro<'a>(&self, id: impl Into<MacroIdRef<'a>>) -> IonResult<Macro> {
         let id = id.into();
-        let macro_table = &self.context.macro_table;
+        let macro_table = self.macro_table();
         let Some(address) = macro_table.address_for_id(id) else {
             return IonResult::encoding_error(format!(
                 "no macro with the specified ID ({id:?}) found"
@@ -155,18 +235,18 @@ impl<E: Encoding, Output: Write> Writer<E, Output> {
 
     /// Writes bytes of previously encoded values to the output stream.
     pub fn flush(&mut self) -> IonResult<()> {
-        if self.context.num_pending_symbols > 0 {
+        if self.symbols.num_pending() > 0 {
             match E::ion_version() {
                 IonVersion::v1_0 => self.write_lst_append()?,
                 IonVersion::v1_1 => self.write_append_symbols_directive()?,
             }
-            self.context.num_pending_symbols = 0;
+            self.symbols.reset_num_pending();
         }
 
         // TODO: In Ion 1.1, new symbols and new macros could be added using the same directive.
-        if self.context.num_pending_macros > 0 {
+        if self.macros.num_pending() > 0 {
             self.write_append_macros_directive()?;
-            self.context.num_pending_macros = 0;
+            self.macros.reset_num_pending();
         }
 
         self.directive_writer.flush()?;
@@ -191,19 +271,19 @@ impl<E: Encoding, Output: Write> Writer<E, Output> {
     #[cfg(feature = "experimental-reader-writer")]
     #[inline]
     pub fn symbol_table(&self) -> &SymbolTable {
-        &self.context.symbol_table
+        &self.symbols
     }
 
     #[cfg(not(feature = "experimental-reader-writer"))]
     #[inline]
     pub(crate) fn symbol_table(&self) -> &SymbolTable {
-        &self.context.symbol_table
+        &self.symbols
     }
 
     /// Helper method to encode an LST append containing pending symbols.
     fn write_lst_append(&mut self) -> IonResult<()> {
         let Self {
-            context,
+            symbols,
             directive_writer,
             ..
         } = self;
@@ -218,11 +298,7 @@ impl<E: Encoding, Output: Write> Writer<E, Output> {
 
         let mut new_symbol_list = lst.field_writer(system_symbol_ids::SYMBOLS).list_writer()?;
 
-        let pending_symbols = context
-            .symbol_table
-            .symbols_tail(context.num_pending_symbols)
-            .iter()
-            .map(Symbol::text);
+        let pending_symbols = symbols.pending().iter().map(Symbol::text);
 
         new_symbol_list.write_all(pending_symbols)?;
         new_symbol_list.close()?;
@@ -232,7 +308,7 @@ impl<E: Encoding, Output: Write> Writer<E, Output> {
 
     fn write_append_macros_directive(&mut self) -> IonResult<()> {
         let Self {
-            context,
+            macros,
             directive_writer,
             ..
         } = self;
@@ -254,9 +330,8 @@ impl<E: Encoding, Output: Write> Writer<E, Output> {
             .write_symbol(v1_1::constants::DEFAULT_MODULE_NAME)?;
         symbols_sexp.close()?;
 
-        let pending_macros = context
-            .macro_table
-            .macros_tail(context.num_pending_macros)
+        let pending_macros = macros
+            .pending()
             .iter()
             // Only user-defined template macros can be added to the macro table.
             .map(|m| m.require_template());
@@ -273,7 +348,7 @@ impl<E: Encoding, Output: Write> Writer<E, Output> {
     /// Helper method to encode an LST append containing pending symbols.
     fn write_append_symbols_directive(&mut self) -> IonResult<()> {
         let Self {
-            context,
+            symbols,
             directive_writer,
             ..
         } = self;
@@ -287,11 +362,7 @@ impl<E: Encoding, Output: Write> Writer<E, Output> {
             .write_symbol(v1_1::system_symbols::MODULE)?
             .write_symbol(v1_1::constants::DEFAULT_MODULE_NAME)?;
 
-        let pending_symbols = context
-            .symbol_table
-            .symbols_tail(context.num_pending_symbols)
-            .iter()
-            .map(Symbol::text);
+        let pending_symbols = symbols.pending().iter().map(Symbol::text);
 
         let mut symbol_table = directive.sexp_writer()?;
         symbol_table
@@ -316,7 +387,8 @@ impl<E: Encoding, Output: Write> MakeValueWriter for Writer<E, Output> {
 
         ApplicationValueWriter {
             raw_value_writer,
-            encoding: &mut self.context,
+            symbols: &mut self.symbols,
+            macros: &self.macros,
             value_writer_config: self.value_writer_config,
         }
     }
@@ -332,38 +404,37 @@ impl<E: Encoding, Output: Write> SequenceWriter for Writer<E, Output> {
 }
 
 pub struct ApplicationValueWriter<'a, V: ValueWriter> {
-    encoding: &'a mut WriterContext,
+    symbols: &'a mut WriterSymbolTable,
+    macros: &'a WriterMacroTable,
     raw_value_writer: V,
     value_writer_config: ValueWriterConfig,
 }
 
 impl<'a, V: ValueWriter> ApplicationValueWriter<'a, V> {
     pub(crate) fn new(
-        encoding_context: &'a mut WriterContext,
+        symbols: &'a mut WriterSymbolTable,
+        macros: &'a WriterMacroTable,
         value_writer_config: ValueWriterConfig,
         raw_value_writer: V,
     ) -> Self {
         Self {
-            encoding: encoding_context,
+            symbols,
+            macros,
             value_writer_config,
             raw_value_writer,
         }
     }
 
-    fn symbol_table_mut(&mut self) -> &mut SymbolTable {
-        &mut self.encoding.symbol_table
-    }
-
     #[cfg(feature = "experimental-reader-writer")]
     #[inline]
     pub fn symbol_table(&self) -> &SymbolTable {
-        &self.encoding.symbol_table
+        self.symbols
     }
 
     #[cfg(not(feature = "experimental-reader-writer"))]
     #[inline]
     pub(crate) fn symbol_table(&self) -> &SymbolTable {
-        &self.encoding.symbol_table
+        self.symbols
     }
 }
 
@@ -425,7 +496,8 @@ impl<V: ValueWriter> AnnotatableWriter for ApplicationValueWriter<'_, V> {
         };
 
         Ok(ApplicationValueWriter {
-            encoding: self.encoding,
+            symbols: self.symbols,
+            macros: self.macros,
             raw_value_writer: self.raw_value_writer.with_annotations(annotations)?,
             value_writer_config: self.value_writer_config,
         })
@@ -462,8 +534,7 @@ impl<V: ValueWriter> ApplicationValueWriter<'_, V> {
                         }
                         None => {
                             // ...that we need to add to the symbol table.
-                            self.encoding.num_pending_symbols += 1;
-                            self.symbol_table_mut().add_symbol_for_text(text)
+                            self.symbols.add_symbol_for_text(text)
                         }
                     };
                     *annotation = RawSymbolRef::SymbolId(sid);
@@ -518,7 +589,7 @@ impl<V: ValueWriter> ApplicationValueWriter<'_, V> {
                 }
                 // The token is text...
                 RawSymbolRef::Text(text) => {
-                    match self.symbol_table_mut().sid_for(text) {
+                    match self.symbols.sid_for(text) {
                         Some(sid) => {
                             //...that was already in the symbol table.
                             *annotation = RawSymbolRef::SymbolId(sid);
@@ -561,9 +632,10 @@ impl<'value, V: ValueWriter> ValueWriter for ApplicationValueWriter<'value, V> {
         use SymbolValueEncoding::*;
 
         let Self {
-            encoding,
+            symbols,
             raw_value_writer,
             value_writer_config,
+            ..
         } = self;
 
         // Depending on the symbol value encoding config option, map the provided symbol reference
@@ -571,7 +643,7 @@ impl<'value, V: ValueWriter> ValueWriter for ApplicationValueWriter<'value, V> {
         let symbol_ref = match value.as_raw_symbol_ref() {
             SymbolId(symbol_id) => {
                 // We can write the symbol ID as-is. Make sure it's in the symbol table.
-                if !encoding.symbol_table.sid_is_valid(symbol_id) {
+                if !symbols.sid_is_valid(symbol_id) {
                     return cold_path!(IonResult::encoding_error(format!(
                         "symbol value ID ${symbol_id} is not in the symbol table"
                     )));
@@ -583,19 +655,16 @@ impl<'value, V: ValueWriter> ValueWriter for ApplicationValueWriter<'value, V> {
                 match value_writer_config.symbol_value_encoding() {
                     SymbolIds => {
                         // Map the text to a symbol ID.
-                        match encoding.symbol_table.sid_for(text) {
+                        match symbols.sid_for(text) {
                             // If it's already in the symbol table, use that SID.
                             Some(symbol_id) => SymbolId(symbol_id),
                             // Otherwise, add it to the symbol table.
-                            None => {
-                                encoding.num_pending_symbols += 1;
-                                SymbolId(encoding.symbol_table.add_symbol_for_text(text))
-                            }
+                            None => SymbolId(symbols.add_symbol_for_text(text)),
                         }
                     }
                     NewSymbolsAsInlineText => {
                         // If the text is in the symbol table, use the symbol ID. Otherwise, use the text itself.
-                        match encoding.symbol_table.sid_for(text) {
+                        match symbols.sid_for(text) {
                             Some(symbol_id) => SymbolId(symbol_id),
                             None => Text(text),
                         }
@@ -611,7 +680,8 @@ impl<'value, V: ValueWriter> ValueWriter for ApplicationValueWriter<'value, V> {
 
     fn list_writer(self) -> IonResult<Self::ListWriter> {
         Ok(ApplicationListWriter::new(
-            self.encoding,
+            self.symbols,
+            self.macros,
             self.value_writer_config,
             self.raw_value_writer.list_writer()?,
         ))
@@ -619,7 +689,8 @@ impl<'value, V: ValueWriter> ValueWriter for ApplicationValueWriter<'value, V> {
 
     fn sexp_writer(self) -> IonResult<Self::SExpWriter> {
         Ok(ApplicationSExpWriter::new(
-            self.encoding,
+            self.symbols,
+            self.macros,
             self.value_writer_config,
             self.raw_value_writer.sexp_writer()?,
         ))
@@ -628,7 +699,8 @@ impl<'value, V: ValueWriter> ValueWriter for ApplicationValueWriter<'value, V> {
     fn struct_writer(self) -> IonResult<Self::StructWriter> {
         let config = self.value_writer_config;
         Ok(ApplicationStructWriter::new(
-            self.encoding,
+            self.symbols,
+            self.macros,
             config,
             self.raw_value_writer.struct_writer()?,
         ))
@@ -636,7 +708,8 @@ impl<'value, V: ValueWriter> ValueWriter for ApplicationValueWriter<'value, V> {
 
     fn eexp_writer<'a>(self, macro_id: impl MacroIdLike<'a>) -> IonResult<Self::EExpWriter> {
         Ok(ApplicationEExpWriter::new(
-            self.encoding,
+            self.symbols,
+            self.macros,
             self.value_writer_config,
             self.raw_value_writer.eexp_writer(macro_id)?,
         ))
@@ -644,19 +717,22 @@ impl<'value, V: ValueWriter> ValueWriter for ApplicationValueWriter<'value, V> {
 }
 
 pub struct ApplicationStructWriter<'value, V: ValueWriter> {
-    encoding: &'value mut WriterContext,
+    symbols: &'value mut WriterSymbolTable,
+    macros: &'value WriterMacroTable,
     raw_struct_writer: V::StructWriter,
     value_writer_config: ValueWriterConfig,
 }
 
 impl<'value, V: ValueWriter> ApplicationStructWriter<'value, V> {
     pub(crate) fn new(
-        encoding_context: &'value mut WriterContext,
+        symbols: &'value mut WriterSymbolTable,
+        macros: &'value WriterMacroTable,
         config: ValueWriterConfig,
         raw_struct_writer: V::StructWriter,
     ) -> Self {
         Self {
-            encoding: encoding_context,
+            symbols,
+            macros,
             raw_struct_writer,
             value_writer_config: config,
         }
@@ -682,7 +758,8 @@ impl<V: ValueWriter> ContextWriter for ApplicationStructWriter<'_, V> {
 impl<V: ValueWriter> MakeValueWriter for ApplicationStructWriter<'_, V> {
     fn make_value_writer(&mut self) -> Self::NestedValueWriter<'_> {
         ApplicationValueWriter::new(
-            self.encoding,
+            self.symbols,
+            self.macros,
             self.value_writer_config,
             self.raw_struct_writer.make_value_writer(),
         )
@@ -699,7 +776,7 @@ impl<V: ValueWriter> FieldEncoder for ApplicationStructWriter<'_, V> {
             // has a SID at the application level and wants to write text, they can and should
             // resolve the SID in the symbol table before calling this method.
             RawSymbolRef::SymbolId(symbol_id) => {
-                if !self.encoding.symbol_table.sid_is_valid(symbol_id) {
+                if !self.symbols.sid_is_valid(symbol_id) {
                     return cold_path!(IonResult::encoding_error(format!(
                         "symbol ID ${symbol_id} is not in the symbol table"
                     )));
@@ -721,7 +798,7 @@ impl<V: ValueWriter> FieldEncoder for ApplicationStructWriter<'_, V> {
         }
 
         // Otherwise, see if the symbol is already in the symbol table.
-        let token: RawSymbolRef<'_> = match self.encoding.symbol_table.sid_for(text) {
+        let token: RawSymbolRef<'_> = match self.symbols.sid_for(text) {
             // If so, use the existing ID.
             Some(sid) => sid.into(),
             // If it's not but the struct writer is configured to intern new text, add it to the
@@ -729,8 +806,7 @@ impl<V: ValueWriter> FieldEncoder for ApplicationStructWriter<'_, V> {
             None if self.value_writer_config.field_name_encoding()
                 == FieldNameEncoding::SymbolIds =>
             {
-                self.encoding.num_pending_symbols += 1;
-                self.encoding.symbol_table.add_symbol_for_text(text).into()
+                self.symbols.add_symbol_for_text(text).into()
             }
             // Otherwise, we'll write the text as-is.
             None => text.into(),
@@ -756,19 +832,22 @@ impl<V: ValueWriter> StructWriter for ApplicationStructWriter<'_, V> {
 }
 
 pub struct ApplicationListWriter<'value, V: ValueWriter> {
-    encoding: &'value mut WriterContext,
+    symbols: &'value mut WriterSymbolTable,
+    macros: &'value WriterMacroTable,
     raw_list_writer: V::ListWriter,
     value_writer_config: ValueWriterConfig,
 }
 
 impl<'value, V: ValueWriter> ApplicationListWriter<'value, V> {
     pub(crate) fn new(
-        encoding_context: &'value mut WriterContext,
+        symbols: &'value mut WriterSymbolTable,
+        macros: &'value WriterMacroTable,
         value_writer_config: ValueWriterConfig,
         raw_list_writer: V::ListWriter,
     ) -> Self {
         Self {
-            encoding: encoding_context,
+            symbols,
+            macros,
             value_writer_config,
             raw_list_writer,
         }
@@ -785,7 +864,8 @@ impl<V: ValueWriter> ContextWriter for ApplicationListWriter<'_, V> {
 impl<V: ValueWriter> MakeValueWriter for ApplicationListWriter<'_, V> {
     fn make_value_writer(&mut self) -> Self::NestedValueWriter<'_> {
         ApplicationValueWriter::new(
-            self.encoding,
+            self.symbols,
+            self.macros,
             self.value_writer_config,
             self.raw_list_writer.make_value_writer(),
         )
@@ -801,19 +881,22 @@ impl<V: ValueWriter> SequenceWriter for ApplicationListWriter<'_, V> {
 }
 
 pub struct ApplicationSExpWriter<'value, V: ValueWriter> {
-    encoding: &'value mut WriterContext,
+    symbols: &'value mut WriterSymbolTable,
+    macros: &'value WriterMacroTable,
     raw_sexp_writer: V::SExpWriter,
     value_writer_config: ValueWriterConfig,
 }
 
 impl<'value, V: ValueWriter> ApplicationSExpWriter<'value, V> {
     pub(crate) fn new(
-        encoding: &'value mut WriterContext,
+        symbols: &'value mut WriterSymbolTable,
+        macros: &'value WriterMacroTable,
         value_writer_config: ValueWriterConfig,
         raw_sexp_writer: V::SExpWriter,
     ) -> Self {
         Self {
-            encoding,
+            symbols,
+            macros,
             value_writer_config,
             raw_sexp_writer,
         }
@@ -830,7 +913,8 @@ impl<V: ValueWriter> ContextWriter for ApplicationSExpWriter<'_, V> {
 impl<V: ValueWriter> MakeValueWriter for ApplicationSExpWriter<'_, V> {
     fn make_value_writer(&mut self) -> Self::NestedValueWriter<'_> {
         ApplicationValueWriter::new(
-            self.encoding,
+            self.symbols,
+            self.macros,
             self.value_writer_config,
             self.raw_sexp_writer.make_value_writer(),
         )
@@ -846,19 +930,22 @@ impl<V: ValueWriter> SequenceWriter for ApplicationSExpWriter<'_, V> {
 }
 
 pub struct ApplicationEExpWriter<'value, V: ValueWriter> {
-    encoding: &'value mut WriterContext,
+    symbols: &'value mut WriterSymbolTable,
+    macros: &'value WriterMacroTable,
     raw_eexp_writer: V::EExpWriter,
     value_writer_config: ValueWriterConfig,
 }
 
 impl<'value, V: ValueWriter> ApplicationEExpWriter<'value, V> {
     pub(crate) fn new(
-        encoding: &'value mut WriterContext,
+        symbols: &'value mut WriterSymbolTable,
+        macros: &'value WriterMacroTable,
         value_writer_config: ValueWriterConfig,
         raw_eexp_writer: V::EExpWriter,
     ) -> Self {
         Self {
-            encoding,
+            symbols,
+            macros,
             value_writer_config,
             raw_eexp_writer,
         }
@@ -886,7 +973,8 @@ impl<V: ValueWriter> ContextWriter for ApplicationEExpWriter<'_, V> {
 impl<V: ValueWriter> MakeValueWriter for ApplicationEExpWriter<'_, V> {
     fn make_value_writer(&mut self) -> Self::NestedValueWriter<'_> {
         ApplicationValueWriter::new(
-            self.encoding,
+            self.symbols,
+            self.macros,
             self.value_writer_config,
             self.raw_eexp_writer.make_value_writer(),
         )

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -822,7 +822,7 @@ impl TemplateCompiler {
                     return IonResult::decoding_error("found annotations on a macro invocation");
                 }
                 // ...add the macro invocation to the template body.
-                Self::compile_macro(tdl_context, definition, macro_ref, arguments)
+                Self::compile_macro_invocation(tdl_context, definition, macro_ref, arguments)
             }
             // If it's an argument expr group (`..`)...
             TdlSExpKind::ArgExprGroup(parameter, arguments) => {
@@ -843,7 +843,7 @@ impl TemplateCompiler {
 
     /// Adds a `lazy_sexp` that has been determined to represent a macro invocation to the
     /// TemplateBody.
-    fn compile_macro<'top, D: Decoder>(
+    fn compile_macro_invocation<'top, D: Decoder>(
         tdl_context: TdlContext<'_>,
         definition: &mut TemplateBody,
         macro_ref: Arc<MacroDef>,
@@ -933,7 +933,7 @@ impl TemplateCompiler {
         if arguments.is_empty() {
             return if param.accepts_none() {
                 // ...and then insert a placeholder `none` invocation.
-                Self::compile_macro(
+                Self::compile_macro_invocation(
                     tdl_context,
                     definition,
                     ION_1_1_SYSTEM_MACROS
@@ -1008,7 +1008,7 @@ impl TemplateCompiler {
                 ));
             }
             // ...and then insert a placeholder `none` invocation.
-            Self::compile_macro(
+            Self::compile_macro_invocation(
                 tdl_context,
                 definition,
                 ION_1_1_SYSTEM_MACROS
@@ -1038,7 +1038,7 @@ impl TemplateCompiler {
                 tdl_context,
                 definition,
                 /*is_quoted=*/ false,
-                None,
+                Some(&parameter),
                 argument,
             )?;
         }

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -426,7 +426,7 @@ pub struct Macro {
 }
 
 impl Macro {
-    pub fn new(definition: Arc<MacroDef>, address: MacroAddress) -> Self {
+    pub(crate) fn new(definition: Arc<MacroDef>, address: MacroAddress) -> Self {
         Self {
             definition,
             address,
@@ -447,6 +447,10 @@ impl Macro {
 
     pub fn signature(&self) -> &MacroSignature {
         self.definition.signature()
+    }
+
+    pub(crate) fn definition(&self) -> &Arc<MacroDef> {
+        &self.definition
     }
 }
 
@@ -850,6 +854,13 @@ impl MacroTable {
     pub(crate) fn macros_tail(&self, num_tail_macros: usize) -> &[Arc<MacroDef>] {
         let num_macros = self.macros_by_address.len();
         &self.macros_by_address[num_macros - num_tail_macros..]
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = Macro> + '_ {
+        self.macros_by_address
+            .iter()
+            .enumerate()
+            .map(|(index, macro_def)| Macro::new(Arc::clone(macro_def), index))
     }
 }
 

--- a/src/lazy/reader.rs
+++ b/src/lazy/reader.rs
@@ -8,7 +8,7 @@ use crate::lazy::system_reader::SystemReader;
 use crate::lazy::value::LazyValue;
 use crate::read_config::ReadConfig;
 use crate::result::IonFailure;
-use crate::{try_or_some_err, IonError, IonResult};
+use crate::{try_or_some_err, IonError, IonResult, MacroTable, SymbolTable};
 
 /// An Ion reader that only reads each value that it visits upon request (that is: lazily).
 ///
@@ -106,6 +106,14 @@ impl<Encoding: Decoder, Input: IonInput> Reader<Encoding, Input> {
     pub fn expect_next(&mut self) -> IonResult<LazyValue<'_, Encoding>> {
         self.next()?
             .ok_or_else(|| IonError::decoding_error("expected another top-level value"))
+    }
+    
+    pub fn symbol_table(&self) -> &SymbolTable {
+        self.system_reader.symbol_table()
+    }
+    
+    pub fn macro_table(&self) -> &MacroTable {
+        self.system_reader.macro_table()
     }
 }
 

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -189,6 +189,10 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
         self.expanding_reader.context().symbol_table()
     }
 
+    pub fn macro_table(&self) -> &MacroTable {
+        self.expanding_reader.context().macro_table()
+    }
+
     pub fn pending_context_changes(&self) -> &PendingContextChanges {
         self.expanding_reader.pending_context_changes()
     }

--- a/src/lazy/text/raw/v1_1/reader.rs
+++ b/src/lazy/text/raw/v1_1/reader.rs
@@ -168,6 +168,7 @@ pub(crate) mod system_macros {
 
 /// An identifier that has been resolved/validated in the `MacroTable`.
 /// When writing an e-expression, a `MacroIdRef<'_>` will be turned into a `ResolvedId`.
+#[derive(Clone, Copy)]
 pub struct ResolvedId<'a> {
     name: Option<&'a str>,
     address: MacroAddress,
@@ -189,7 +190,7 @@ impl<'a> ResolvedId<'a> {
 
 /// Types that may be able to be resolved to a macro ID.
 /// This is used by the writer to accept user-specified types to an ID based on the current encoding context.
-pub trait MacroIdLike<'a>: Sized {
+pub trait MacroIdLike<'a>: Sized + Copy {
     fn as_macro_id_ref(&self) -> MacroIdRef<'a>;
 
     fn prefer_name(&self) -> MacroIdRef<'a> {

--- a/tests/conformance_dsl/context.rs
+++ b/tests/conformance_dsl/context.rs
@@ -254,6 +254,7 @@ impl<'a> Context<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ion_rs::IonData;
 
     #[test]
     // Test to ensure that when we render fragments, we don't insert new IVMs breaking the context
@@ -274,11 +275,11 @@ mod tests {
             .input(IonEncoding::Text)
             .expect("failed to render fragments");
 
-        let fragments_str = String::from_utf8(bytes).expect("Invalid input string generated");
-        assert_eq!(
-            fragments_str,
-            "$ion_1_1 $ion::(module _ (macro_table (macro m (v '!' ) ('%' v ) ) ) ) (:m 1)"
-                .to_string(),
-        );
+        let expected_sequence = Element::read_all(
+            "$ion_1_1 $ion::(module _ (macro_table (macro m (v '!' ) ('%' v ) ) ) ) (:m 1)",
+        )
+        .expect("valid Ion");
+        let actual_sequence = Element::read_all(bytes).expect("Writer must generate valid Ion.");
+        assert!(IonData::from(expected_sequence).eq(&IonData::from(actual_sequence)))
     }
 }

--- a/tests/conformance_dsl/fragment.rs
+++ b/tests/conformance_dsl/fragment.rs
@@ -22,7 +22,7 @@
 
 use super::context::Context;
 use super::*;
-use ion_rs::{ion_seq, Encoding, WriteConfig};
+use ion_rs::{ion_seq, v1_1, AnyEncoding, Encoding, Reader, WriteConfig};
 use ion_rs::{Element, SExp, Sequence, Struct, Symbol};
 use ion_rs::{RawSymbolRef, SequenceWriter, StructWriter, ValueWriter, WriteAsIon, Writer};
 
@@ -392,7 +392,7 @@ impl WriteAsIon for ProxyElement<'_> {
     }
 }
 
-/// Implments the TopLevel fragment.
+/// Implements the TopLevel fragment.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct TopLevel {
     elems: Vec<Element>,
@@ -408,18 +408,51 @@ impl FragmentImpl for TopLevel {
         let mut buffer = Vec::with_capacity(1024);
         let mut writer = Writer::new(config, buffer)?;
 
-        for elem in self.elems.as_slice() {
-            writer.write(ProxyElement(elem, ctx))?;
-        }
+        self.write(ctx, &mut writer)?;
+
         buffer = writer.close()?;
         Ok(buffer)
     }
 
-    fn write<E: ion_rs::Encoding, O: std::io::Write>(
+    fn write<E: Encoding, O: std::io::Write>(
         &self,
         ctx: &Context,
-        writer: &mut ion_rs::Writer<E, O>,
+        writer: &mut Writer<E, O>,
     ) -> InnerResult<()> {
+        // The Writer is asked to serialize Elements that represent system values.
+        // In many cases, it will emit a macro table containing macros that are not in its own
+        // encoding context. For example, this snippet:
+        //
+        //     (mactab (macro m (v!) v))
+        //
+        // will emit a system value that the reader will understand defines macro `m`.
+        // However, the writer emitting the system value does not have macro `m` in its own
+        // encoding context. If the test later invokes `m` like this:
+        //
+        //     (toplevel ('#$:m' 5))
+        //
+        // the Writer will raise an error reporting that the test is trying to invoke a
+        // non-existent macro.
+        //
+        // As a workaround, when serializing top-level Elements, the writer does an initial
+        // serialization pass to load any necessary encoding context changes.
+        //
+        // Serialize the data once...
+        let serialized = v1_1::Text::encode_all(self.elems.as_slice())?;
+        // ...then read the data, constructing a macro table in the Reader...
+        let mut reader = Reader::new(AnyEncoding, serialized)?;
+        while let Some(_) = reader.next()? {}
+        let macro_table = reader.macro_table();
+        if ctx.version() == IonVersion::V1_1 {
+            // For each macro in the Reader...
+            for mac in macro_table.iter() {
+                // ...try to register the macro in the Writer. For simplicity, we skip over
+                // system macros that are already defined.
+                let _result = writer.register_macro(&mac);
+            }
+        }
+
+        // Now that the Writer has the necessary context, it can encode the ProxyElements.
         for elem in self.elems.as_slice() {
             writer.write(ProxyElement(elem, ctx))?;
         }

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -94,6 +94,10 @@ mod ion_tests {
         skip!("ion-tests/conformance/system_macros/add_macros.ion"),
         skip!("ion-tests/conformance/ion_literal.ion"),
         skip!("ion-tests/conformance/system_symbols.ion"),
+        // Uses testing DSL syntax that may not be legal? This test file is removed in the latest ion-tests.
+        skip!(
+            "ion-tests/conformance/ion_encoding/module/macro/cardinality/invoke_cardinality_ee.ion"
+        ),
         // Error: found operation name with non-symbol type: sexp
         skip!("ion-tests/conformance/ion_encoding/module/load_symtab.ion"),
         skip!("ion-tests/conformance/ion_encoding/module/symtab.ion"),


### PR DESCRIPTION
The `ApplicationEExpWriter` is intended to be the common validation layer for user interactions with the underlying `Encoding::RawEExpWriter` type. It resolves the provided ID to a macro, then verifies that each argument aligns with that macro's signature. This PR begins the process of implementing that. 

Specifically, it implements the initial macro ID resolution, raising an error if/when the user attempts to write an e-expression with an unrecognized ID. This caused several conformance tests to break because the `Writer` is asked to emit macro definitions that it does not have in its own encoding context. I have added a workaround for this that I'll highlight in the PR tour. We can implement a more robust fix down the road.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
