### PR TITLE
Add expression group transcription to conformance DSL

### DIFF
--- a/tests/conformance_dsl/fragment.rs
+++ b/tests/conformance_dsl/fragment.rs
@@ -406,7 +406,7 @@ impl WriteAsIon for ProxyElement<'_> {
                                         .as_sexp()
                                         .unwrap() // Verified above
                                         .iter()
-                                        .skip(1);
+                                        .skip(1); // Skip past expression group marker.
                                     group_writer
                                         .write_all(group_args.map(|e| ProxyElement(e, self.1)))?;
                                     let _ = group_writer.close();

--- a/tests/conformance_dsl/mod.rs
+++ b/tests/conformance_dsl/mod.rs
@@ -528,6 +528,8 @@ mod tests {
             "(ion_1_1 (toplevel ('#$:make_list' (1 2))) (produces [1, 2]) )",
             "(ion_1_1 (mactab (macro twice (x*) (.values (%x) (%x)))) (toplevel ('#$:twice' foo)) (produces foo foo))",
             "(ion_1_1 (toplevel ('#$:make_list' (1 2) ('#$:make_list' (3 4)))) (produces [1, 2, 3, 4]) )",
+            "(ion_1_1 (toplevel ('#$:values' ('#$::' 1 2 3))) (produces 1 2 3))",
+            "(ion_1_1 (toplevel ('#$:values' ('#$::'))) (produces ))"
         ];
 
         for test in tests {

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -51,7 +51,7 @@ mod ion_tests {
             "Ion 1.1 binary" // PANIC: not yet implemented: implement half-precision floats
         ),
         // Issue parsing the comments left in decimal.ion, see ion-rust#972
-        skip!( "ion-tests/conformance/data_model/decimal.ion"),
+        skip!("ion-tests/conformance/data_model/decimal.ion"),
         // Mismatched produces due to symbol id transcription.
         skip!("ion-tests/conformance/core/toplevel_produces.ion"),
         // Unrecognized encoding 'int8' (only flex_uint appears to be supported)


### PR DESCRIPTION
*Issue #, if available:* #935

*Description of changes:*
Prior to this PR using an expression group within a `toplevel` clause would fail. The existing code captured the `::` for a normal expression group, but due to the DSL's transcription syntax we need to capture `#$::` and construct an expression group through the eexp writer.

This PR captures the `#$::` notation, and constructs the expression group via the writer.

Two tests were also added to the conformance DSL unit tests to ensure the behavior as well.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
