### PR TITLE
Implement conformance DSL's annot clause for denotes

### DIFF
--- a/tests/conformance_dsl/mod.rs
+++ b/tests/conformance_dsl/mod.rs
@@ -557,4 +557,22 @@ mod tests {
             Ok(_) => panic!("Unexpected successful test evaluation"),
         }
     }
+
+    #[test]
+    fn test_data_model_annot() {
+        let tests: &[&str] = &[
+            "(ion_1_1 (toplevel ('#$:make_list' (1 2))) (produces [1, 2]) )",
+            "(ion_1_1 (mactab (macro twice (x*) (.values (%x) (%x)))) (toplevel ('#$:twice' foo)) (produces foo foo))",
+            "(ion_1_1 (toplevel ('#$:make_list' (1 2) ('#$:make_list' (3 4)))) (produces [1, 2, 3, 4]) )",
+            r#"(ion_1_1 (text "(:annotate (:: $ion) true)") (denotes (annot true $ion)))"#,
+        ];
+
+        for test in tests {
+            println!("Testing: {}", test);
+            Document::from_str(test)
+                .unwrap_or_else(|e| panic!("Failed to load document: <<{}>>\n{:?}", test, e))
+                .run()
+                .unwrap_or_else(|e| panic!("Test failed for simple doc: <<{}>>\n{:?}", test, e));
+        }
+    }
 }

--- a/tests/conformance_dsl/model.rs
+++ b/tests/conformance_dsl/model.rs
@@ -46,6 +46,7 @@ impl TryFrom<&Element> for SymbolToken {
 
     fn try_from(other: &Element) -> InnerResult<Self> {
         match other.ion_type() {
+            IonType::Symbol => Ok(SymbolToken::Text(other.as_symbol().unwrap().text().unwrap_or("").to_string())),
             IonType::String => Ok(SymbolToken::Text(other.as_string().unwrap().to_owned())),
             IonType::Int => Ok(SymbolToken::Address(other.as_usize().unwrap())),
             IonType::SExp => {
@@ -82,7 +83,7 @@ impl TryFrom<&Element> for SymbolToken {
 /// clause.
 ///
 /// [Grammar]: https://github.com/amazon-ion/ion-tests/tree/master/conformance#grammar
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum ModelValue {
     Null(IonType),
     Bool(bool),
@@ -97,6 +98,7 @@ pub(crate) enum ModelValue {
     Struct(Vec<(SymbolToken, ModelValue)>),
     Blob(Vec<u8>),
     Clob(Vec<u8>),
+    Annot(Box<ModelValue>, Vec<SymbolToken>),
 }
 
 impl TryFrom<&Element> for ModelValue {
@@ -157,6 +159,7 @@ impl TryFrom<&ModelValue> for Element {
             ModelValue::Struct(_) => todo!(),
             ModelValue::Blob(_) => todo!(),
             ModelValue::Clob(_) => todo!(),
+            ModelValue::Annot(_, _) => todo!(), // Not used currently.
         };
         Ok(element)
     }
@@ -300,6 +303,21 @@ impl TryFrom<&Sequence> for ModelValue {
             }
             "Blob" => Ok(ModelValue::Blob(parse_bytes_exp(elems.iter().skip(1))?)),
             "Clob" => Ok(ModelValue::Clob(parse_bytes_exp(elems.iter().skip(1))?)),
+            "annot" => {
+                let mut elems = elems;
+                let value = elems
+                    .get(1)
+                    .ok_or(ConformanceErrorKind::ExpectedModelValue)
+                    .and_then(|e| ModelValue::try_from(e))
+                    ;
+                let annots: Result<Vec<SymbolToken>, _> = elems
+                    .iter()
+                    .skip(2)
+                    .map(|e| SymbolToken::try_from(e))
+                    .collect()
+                    ;
+                Ok(ModelValue::Annot(Box::new(value?), annots?))
+            }
             _ => unreachable!(),
         }
     }
@@ -422,6 +440,28 @@ pub(crate) fn compare_values<T: ion_rs::Decoder>(
                     return Ok(false);
                 }
             }
+            Ok(true)
+        }
+        ModelValue::Annot(value, annots) => {
+            let other_annots: Result<Vec<SymbolRef>, _> = other.annotations().collect();
+            let other_annots = other_annots?;
+
+            if other_annots.len() != annots.len() {
+                return Ok(false)
+            }
+
+            let annots_match = other_annots
+                .iter()
+                .zip(annots.iter())
+                .fold(true, |acc, (a, e)| acc && (a == &e.as_symbol_ref()));
+            if !annots_match {
+                return Ok(false)
+            }
+
+            if !compare_values(ctx, value, other)? {
+                return Ok(false)
+            }
+
             Ok(true)
         }
         _ => {
@@ -687,5 +727,40 @@ fn ion_type_from_str(name: &str) -> Option<IonType> {
         "blob" => Some(IonType::Blob),
         "clob" => Some(IonType::Clob),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ion_rs::Element;
+
+    #[test]
+    /// Tests to ensure that the parsing of `annot` clauses for denotes' data model is correct.
+    fn test_annot() {
+        struct test_case {
+            source: &'static str,
+            value: ModelValue,
+            annots: &'static [&'static str],
+        }
+        let tests: &[test_case] = &[
+            test_case{ source: "(annot true a)", value: ModelValue::Bool(true), annots: &["a"] },
+            test_case{ source: "(annot false a b c)", value: ModelValue::Bool(false), annots: &["a", "b", "c"] },
+            test_case{ source: "(annot (Bool true) a b c)", value: ModelValue::Bool(true), annots: &["a", "b", "c"] },
+            test_case{ source: "(annot (Int 5) a)", value: ModelValue::Int(5.into()), annots: &["a"] },
+        ];
+
+        for test in tests {
+            println!("Testing: {}", test.source);
+            let element = Element::read_one(test.source).expect("unable to read ion clause");
+            let model_value = ModelValue::try_from(&element).expect("unable to convert elements to model value");
+            let expected_annots: Vec<SymbolToken> = test.annots.iter().map(|a| SymbolToken::Text(a.to_string())).collect();
+            if let ModelValue::Annot(value, annots) = model_value {
+                assert_eq!(Box::leak(value), &test.value);
+                assert_eq!(annots, expected_annots);
+            } else {
+                panic!("Parsed annot clause to unexpected value");
+            }
+        }
     }
 }

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -87,7 +87,7 @@ mod ion_tests {
         skip!("ion-tests/conformance/system_macros/sum.ion"),
         // System macro make_timestamp not yet implemented
         skip!("ion-tests/conformance/system_macros/make_timestamp.ion"),
-        // Annot clause not currently supported.
+        // $0 is not resolving: "expected text but found a symbol with undefined text"
         skip!("ion-tests/conformance/system_macros/annotate.ion"),
         // error reading struct: `make_field`'s first argument must be a text value
         skip!("ion-tests/conformance/system_macros/make_field.ion"),


### PR DESCRIPTION
*Issue #, if available:* #928

*Description of changes:*
This PR implements the `annot` clause as part of the data model clauses used by `denotes`.

There is currently 1 use of the clause in the conformance tests. The current use of it is unfortunately still skipped due to how ion-rust seems to be handling `$0` (at least with text resolution). I need to look more into this to see what the actual issue is.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
