### PR TITLE
Implement symtab clause for conformance DSL

### DIFF
--- a/tests/conformance_dsl/clause.rs
+++ b/tests/conformance_dsl/clause.rs
@@ -35,6 +35,8 @@ pub(crate) enum ClauseType {
     Encoding,
     /// Provide ion data defining the contents of a macro table wrapped by a module within an encoding directive.
     MacTab,
+    /// Provide string arguments which are used to populate the current symbol table.
+    SymTab,
     /// Define data that is expected to be produced by the test's document, using inline ion
     /// syntax.
     Produces,
@@ -82,6 +84,7 @@ impl FromStr for ClauseType {
             "signals" => Ok(Signals),
             "encoding" => Ok(Encoding),
             "mactab" => Ok(MacTab),
+            "symtab" => Ok(SymTab),
             _ => Err(ConformanceErrorKind::UnknownClause(s.to_owned())),
         }
     }

--- a/tests/conformance_dsl/fragment.rs
+++ b/tests/conformance_dsl/fragment.rs
@@ -167,6 +167,26 @@ impl TryFrom<Clause> for Fragment {
                     elems: vec![module.with_annotations(["$ion"])],
                 })
             }
+            ClauseType::SymTab => {
+                use ion_rs::{ion_struct, Sequence, SequenceBuilder};
+                let symbols = other
+                    .body
+                    .iter()
+                    .try_fold(Sequence::builder(), |seq: SequenceBuilder, elem| {
+                        elem.as_string()
+                            .ok_or(ConformanceErrorKind::ExpectedString)
+                            .map(|s| seq.push(s))
+                    })?
+                    .build_list();
+
+                let table: Element = ion_struct! {
+                    "symbols": symbols,
+                }
+                .into();
+                Fragment::TopLevel(TopLevel {
+                    elems: vec![table.with_annotations(["$ion_symbol_table"])],
+                })
+            }
             _ => return Err(ConformanceErrorKind::ExpectedFragment),
         };
         Ok(frag)
@@ -503,5 +523,82 @@ impl FragmentImpl for TopLevel {
             writer.write(ProxyElement(elem, ctx))?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_symtab_strings() {
+        let source = r#"(symtab 1 2 3)"#;
+        let clause_elem = Element::read_one(source).expect("unable to read source");
+        let seq = clause_elem.as_sequence().expect("could not read sequence");
+        let clause: Clause = seq
+            .try_into()
+            .expect("unable to convert elements into clause");
+
+        assert_eq!(
+            ConformanceErrorKind::ExpectedString,
+            Fragment::try_from(clause).unwrap_err()
+        );
+    }
+
+    #[test]
+    fn parse_symtab() {
+        struct TestCase {
+            source: &'static str,
+            symbols: &'static [&'static str],
+        }
+
+        let tests = &[
+            TestCase {
+                source: r#"(symtab "a")"#,
+                symbols: &["a"],
+            },
+            TestCase {
+                source: r#"(symtab "a" "b" "c")"#,
+                symbols: &["a", "b", "c"],
+            },
+        ];
+
+        for test in tests {
+            println!("Testing: {:?}", test.source);
+            let clause_elem = Element::read_one(test.source).expect("unable to read source");
+            let seq = clause_elem.as_sequence().expect("could not read sequence");
+            let clause: Clause = seq
+                .try_into()
+                .expect("unable to convert elements into clause");
+            let frag: Fragment = clause
+                .try_into()
+                .expect("unable to convert clause into fragment");
+
+            let Fragment::TopLevel(toplevel) = frag else {
+                panic!("SymTab clause did not parse into a top-level fragment");
+            };
+
+            let element = toplevel
+                .elems
+                .first()
+                .expect("No sub-elements of toplevel fragment");
+            let annotations = element.annotations();
+
+            assert_eq!(annotations.len(), 1);
+            assert_eq!(annotations.first(), Some("$ion_symbol_table"));
+
+            let strukt = element
+                .as_struct()
+                .expect("could not turn element into struct");
+            let field = strukt.get("symbols").expect("unable to find symbol field");
+            let symbols = field.as_list().expect("symbols field is not a list");
+
+            assert_eq!(symbols.len(), test.symbols.len());
+            let symbols_match = symbols
+                .iter()
+                .zip(test.symbols)
+                .fold(true, |acc, (a, b)| acc && (a == &Element::string(*b)));
+            assert!(symbols_match);
+        }
     }
 }

--- a/tests/conformance_dsl/mod.rs
+++ b/tests/conformance_dsl/mod.rs
@@ -26,7 +26,7 @@ pub(crate) mod prelude {
 }
 
 /// Specific errors used during parsing and test evaluation.
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default, Debug, PartialEq)]
 pub(crate) enum ConformanceErrorKind {
     #[default]
     UnknownError,

--- a/tests/conformance_dsl/mod.rs
+++ b/tests/conformance_dsl/mod.rs
@@ -557,4 +557,13 @@ mod tests {
             Ok(_) => panic!("Unexpected successful test evaluation"),
         }
     }
+
+    #[test]
+    fn test_symtab() {
+        let source = r#"(ion_1_1 (symtab "a" "b") (text "$2") (produces b))"#;
+        let doc = Document::from_str(source)
+            .unwrap_or_else(|e| panic!("Failed to load document: <<{}>>\n{:?}", source, e));
+        println!("Document: {:?}", doc);
+        doc.run().expect("test document failed");
+    }
 }

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -51,7 +51,7 @@ mod ion_tests {
             "Ion 1.1 binary" // PANIC: not yet implemented: implement half-precision floats
         ),
         // Issue parsing the comments left in decimal.ion, see ion-rust#972
-        skip!( "ion-tests/conformance/data_model/decimal.ion"),
+        skip!("ion-tests/conformance/data_model/decimal.ion"),
         // Mismatched produces due to symbol id transcription.
         skip!("ion-tests/conformance/core/toplevel_produces.ion"),
         // Unrecognized encoding 'int8' (only flex_uint appears to be supported)


### PR DESCRIPTION
*Issue #, if available:* #971

*Description of changes:*
This PR implements the `symtab` clause, which is the symbol table partner to `mactab`, providing a shorthand clause for defining a new symbol table.

This implementation uses the ion 1.0 symbol table syntax.

An example would be a document like,
```
(ion_1_1 (symtab "a" "b") (text "$2") (produces b))
```
where the `(symtab "a" "b")` expands to `(toplevel $ion_symbol_table::{symbols: ["a", "b"]})`.

It might be worth checking the ion version of the context at render time, and expand this to a 1.1 module-based symbols definition.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
