### PR TITLE
Implement `repeat` system macro.

### DIFF
--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -11,7 +11,7 @@ use crate::lazy::expanded::macro_evaluator::{
     AnnotateExpansion, ConditionalExpansion, EExpressionArgGroup, ExprGroupExpansion,
     FlattenExpansion, IsExhaustedIterator, MacroExpansion, MacroExpansionKind, MacroExpr,
     MacroExprArgsIterator, MakeFieldExpansion, MakeStructExpansion, MakeTextExpansion,
-    RawEExpression, TemplateExpansion, ValueExpr,
+    RawEExpression, RepeatExpansion, TemplateExpansion, ValueExpr,
 };
 use crate::lazy::expanded::macro_table::{MacroKind, MacroRef};
 use crate::lazy::expanded::template::TemplateMacroRef;
@@ -151,6 +151,9 @@ impl<'top, D: Decoder> EExpression<'top, D> {
             }
             MacroKind::IfMulti => {
                 MacroExpansionKind::Conditional(ConditionalExpansion::if_multi(arguments))
+            }
+            MacroKind::Repeat => {
+                MacroExpansionKind::Repeat(RepeatExpansion::new(arguments))
             }
         };
         Ok(MacroExpansion::new(

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -1413,7 +1413,7 @@ impl<'top, D: Decoder> RepeatExpansion<'top, D> {
         (0..self.current_offset).for_each(|_| { arguments.next(); }); // Skip to the next argument
 
         let value_arg_expr = match arguments.next() {
-            None => { println!("Empty value arg expr"); todo!(); }, // How do we handle empty values?
+            None => todo!(), // How do we handle empty values?
             Some(Err(e)) => return Err(e),
             Some(Ok(expr)) => expr,
         };
@@ -1426,12 +1426,10 @@ impl<'top, D: Decoder> RepeatExpansion<'top, D> {
         }
 
         if self.current_iteration == max_repeat {
-            println!("Emitting final step at iteration {} max {}", self.current_iteration, max_repeat);
             Ok(MacroExpansionStep::FinalStep(Some(
                 value_arg_expr,
             )))
         } else {
-            println!("Emitting step at iteration {} max {}", self.current_iteration, max_repeat);
             Ok(MacroExpansionStep::Step(
                 value_arg_expr,
             ))

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -1409,7 +1409,7 @@ impl<'top, D: Decoder> RepeatExpansion<'top, D> {
         (0..self.current_offset).for_each(|_| { arguments.next(); }); // Skip to the next argument
 
         let value_arg_expr = match arguments.next() {
-            None => todo!(), // How do we handle empty values?
+            None => return Ok(MacroExpansionStep::FinalStep(None)),
             Some(Err(e)) => return Err(e),
             Some(Ok(expr)) => expr,
         };
@@ -3113,12 +3113,14 @@ mod tests {
     fn repeat_eexp() -> IonResult<()> {
         stream_eq(
             r#"
+            (:repeat 1 )
             (:repeat 0 a)
             (:repeat 2 a)
             (:repeat 3 {foo: bar})
             (:repeat 2 (:repeat 2 a))
             "#,
             r#"
+
             a a
             {foo: bar} {foo: bar} {foo: bar}
             a a a a
@@ -3141,6 +3143,7 @@ mod tests {
             panic!("unexpected success");
         }
     }
+
 
     #[test]
     fn e_expressions_inside_a_list() -> IonResult<()> {

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -366,6 +366,7 @@ pub enum MacroKind {
     IfSome,
     IfSingle,
     IfMulti,
+    Repeat,
     // A placeholder for not-yet-implemented macros
     ToDo,
 }
@@ -581,7 +582,7 @@ impl MacroTable {
             builtin(
                 "repeat",
                 "(n expr*)",
-                MacroKind::ToDo,
+                MacroKind::Repeat,
                 ExpansionAnalysis::no_assertions_made(),
             ),
             builtin(

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -4,7 +4,7 @@ use crate::lazy::expanded::compiler::ExpansionAnalysis;
 use crate::lazy::expanded::macro_evaluator::{
     AnnotateExpansion, ConditionalExpansion, ExprGroupExpansion, FlattenExpansion, MacroEvaluator,
     MacroExpansion, MacroExpansionKind, MacroExpr, MacroExprArgsIterator, MakeFieldExpansion,
-    MakeStructExpansion, MakeTextExpansion, TemplateExpansion, ValueExpr,
+    MakeStructExpansion, MakeTextExpansion, RepeatExpansion, TemplateExpansion, ValueExpr,
 };
 use crate::lazy::expanded::macro_table::{MacroDef, MacroKind, MacroRef};
 use crate::lazy::expanded::r#struct::FieldExpr;
@@ -1397,6 +1397,9 @@ impl<'top, D: Decoder> TemplateMacroInvocation<'top, D> {
             }
             MacroKind::IfMulti => {
                 MacroExpansionKind::Conditional(ConditionalExpansion::if_multi(arguments))
+            }
+            MacroKind::Repeat => {
+                MacroExpansionKind::Repeat(RepeatExpansion::new(arguments))
             }
         };
         Ok(MacroExpansion::new(

--- a/tests/conformance_dsl/continuation.rs
+++ b/tests/conformance_dsl/continuation.rs
@@ -238,7 +238,7 @@ impl Produces {
             match (actual_value, expected_elem) {
                 (None, None) => break,
                 (Some(actual_value), Some(expected_elem)) => {
-                    is_equal &= dbg!(dbg!(expected_elem).eq(dbg!(&actual_value)));
+                    is_equal &= expected_elem.eq(&actual_value);
                 }
                 _ => is_equal = false,
             }

--- a/tests/conformance_dsl/continuation.rs
+++ b/tests/conformance_dsl/continuation.rs
@@ -226,7 +226,7 @@ impl Produces {
     /// Creates a reader using the provided context, and compares the read values from the input
     /// document with the elements specified in the associated Produces clause for equality.
     pub fn evaluate(&self, ctx: &Context) -> InnerResult<()> {
-        use ion_rs::{AnyEncoding, Decoder};
+        use ion_rs::{AnyEncoding, Decoder, IonData};
         let (input, _encoding) = ctx.input(ctx.encoding())?;
         let mut reader = ion_rs::Reader::new(AnyEncoding.with_catalog(ctx.build_catalog()), input)?;
 
@@ -238,7 +238,7 @@ impl Produces {
             match (actual_value, expected_elem) {
                 (None, None) => break,
                 (Some(actual_value), Some(expected_elem)) => {
-                    is_equal &= expected_elem.eq(&actual_value);
+                    is_equal &= IonData::eq(expected_elem, &actual_value);
                 }
                 _ => is_equal = false,
             }

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -72,15 +72,15 @@ mod ion_tests {
         skip!("ion-tests/conformance/system_macros/add_symbols.ion"),
         skip!("ion-tests/conformance/system_macros/set_macros.ion"),
         skip!("ion-tests/conformance/system_macros/set_symbols.ion"),
-        // Error: Decoding Error: macro none signature has 0 parameters(s), e-expression had an
-        // extra argument.
-        skip!("ion-tests/conformance/system_macros/default.ion"),
+        skip!(
+            "ion-tests/conformance/system_macros/default.ion",
+            // Error: Decoding Error: macro none signature has 0 parameters(s)
+            "when the first argument is non-empty, the second argument is not expanded"
+        ),
         // System macro delta not yet implemented
         skip!("ion-tests/conformance/system_macros/delta.ion"),
         // System macro make_decimal not yet implemented
         skip!("ion-tests/conformance/system_macros/make_decimal.ion"),
-        // System macro repeat not yet implemented
-        skip!("ion-tests/conformance/system_macros/repeat.ion"),
         // System macro parse_ion not yet implemented
         skip!("ion-tests/conformance/system_macros/parse_ion.ion"),
         // System macro sum not yet implemented


### PR DESCRIPTION
*Issue #, if available:* #942

*Description of changes:*
This PR adds an implementation for the builtin system macro `repeat`.

In addition to the builtin implementation, I've also updated the conformance test skip-list to skip the only test in `system_macros/default.ion` that fails, and to remove `system_macros/repeat.ion` which now passes.

```
Running tests: ion-tests/conformance/system_macros/repeat.ion
  repeat can be invoked                                             ...  [Ok]
  repeat can produce                                                ...  [Ok]
  repeat will ignore any annotations on the number of repetitions   ...  [Ok]
  repeat signals an error when                                      ...  [Ok]
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
