### PR TITLE
Implement sum system macro

### DIFF
--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -11,7 +11,7 @@ use crate::lazy::expanded::macro_evaluator::{
     AnnotateExpansion, ConditionalExpansion, EExpressionArgGroup, ExprGroupExpansion,
     FlattenExpansion, IsExhaustedIterator, MacroExpansion, MacroExpansionKind, MacroExpr,
     MacroExprArgsIterator, MakeFieldExpansion, MakeStructExpansion, MakeTextExpansion,
-    RawEExpression, TemplateExpansion, ValueExpr,
+    RawEExpression, SumExpansion, TemplateExpansion, ValueExpr,
 };
 use crate::lazy::expanded::macro_table::{MacroKind, MacroRef};
 use crate::lazy::expanded::template::TemplateMacroRef;
@@ -151,6 +151,9 @@ impl<'top, D: Decoder> EExpression<'top, D> {
             }
             MacroKind::IfMulti => {
                 MacroExpansionKind::Conditional(ConditionalExpansion::if_multi(arguments))
+            }
+            MacroKind::Sum => {
+                MacroExpansionKind::Sum(SumExpansion::new(arguments))
             }
         };
         Ok(MacroExpansion::new(

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -366,6 +366,7 @@ pub enum MacroKind {
     IfSome,
     IfSingle,
     IfMulti,
+    Sum,
     // A placeholder for not-yet-implemented macros
     ToDo,
 }
@@ -599,7 +600,7 @@ impl MacroTable {
             builtin(
                 "sum",
                 "(a b)",
-                MacroKind::ToDo,
+                MacroKind::Sum,
                 ExpansionAnalysis::single_application_value(IonType::Int),
             ),
             builtin(

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -4,7 +4,7 @@ use crate::lazy::expanded::compiler::ExpansionAnalysis;
 use crate::lazy::expanded::macro_evaluator::{
     AnnotateExpansion, ConditionalExpansion, ExprGroupExpansion, FlattenExpansion, MacroEvaluator,
     MacroExpansion, MacroExpansionKind, MacroExpr, MacroExprArgsIterator, MakeFieldExpansion,
-    MakeStructExpansion, MakeTextExpansion, TemplateExpansion, ValueExpr,
+    MakeStructExpansion, MakeTextExpansion, SumExpansion, TemplateExpansion, ValueExpr,
 };
 use crate::lazy::expanded::macro_table::{MacroDef, MacroKind, MacroRef};
 use crate::lazy::expanded::r#struct::FieldExpr;
@@ -1397,6 +1397,9 @@ impl<'top, D: Decoder> TemplateMacroInvocation<'top, D> {
             }
             MacroKind::IfMulti => {
                 MacroExpansionKind::Conditional(ConditionalExpansion::if_multi(arguments))
+            }
+            MacroKind::Sum => {
+                MacroExpansionKind::Sum(SumExpansion::new(arguments))
             }
         };
         Ok(MacroExpansion::new(

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -83,8 +83,6 @@ mod ion_tests {
         skip!("ion-tests/conformance/system_macros/repeat.ion"),
         // System macro parse_ion not yet implemented
         skip!("ion-tests/conformance/system_macros/parse_ion.ion"),
-        // System macro sum not yet implemented
-        skip!("ion-tests/conformance/system_macros/sum.ion"),
         // System macro make_timestamp not yet implemented
         skip!("ion-tests/conformance/system_macros/make_timestamp.ion"),
         // $0 is not resolving: "expected text but found a symbol with undefined text"


### PR DESCRIPTION
*Issue #, if available:* #942

*Description of changes:*
This PR adds an implementation for the `sum` system macro.

In addition this PR removes `conformance/system_macros/sum.ion` from the skip-list.

```
Running tests: ion-tests/conformance/system_macros/sum.ion
  sum can be invoked                                              ...  [Ok]
  sum produces a single, unannotated integer that is the sum of   ...  [Ok]
  sum is commutative                                              ...  [Ok]
  sum arguments may not be                                        ...  [Ok]
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
