### PR TITLE
Do not allow incomplete errors during top-level comment parsing

### DIFF
--- a/src/lazy/text/buffer.rs
+++ b/src/lazy/text/buffer.rs
@@ -11,7 +11,7 @@ use winnow::stream::{
     Accumulate, CompareResult, ContainsToken, FindSlice, Location, SliceLen, Stream,
     StreamIsPartial,
 };
-use winnow::token::{one_of, rest, take_till, take_until, take_while};
+use winnow::token::{one_of, take_till, take_until, take_while};
 use winnow::{dispatch, Parser};
 
 use crate::lazy::decoder::{LazyRawValueExpr, RawValueExpr};
@@ -2098,16 +2098,6 @@ where
     P: Parser<TextBuffer<'data>, Output, IonParseError<'data>>,
 {
     repeat::<_, _, (), _, _>(n, parser).take()
-}
-
-pub fn incomplete_is_ok<'data, P>(
-    parser: P,
-) -> impl Parser<TextBuffer<'data>, TextBuffer<'data>, IonParseError<'data>>
-where
-    P: Parser<TextBuffer<'data>, TextBuffer<'data>, IonParseError<'data>>,
-{
-    // If we run out of input while applying the parser, consider the rest of the input to match.
-    alt((parser.complete_err(), rest))
 }
 
 #[cfg(test)]

--- a/src/lazy/text/raw/reader.rs
+++ b/src/lazy/text/raw/reader.rs
@@ -6,10 +6,9 @@ use crate::lazy::encoding::TextEncoding_1_0;
 use crate::lazy::expanded::EncodingContextRef;
 use crate::lazy::raw_stream_item::{EndPosition, LazyRawStreamItem, RawStreamItem};
 use crate::lazy::streaming_raw_reader::RawReaderState;
-use crate::lazy::text::buffer::{incomplete_is_ok, TextBuffer};
+use crate::lazy::text::buffer::TextBuffer;
 use crate::lazy::text::parse_result::WithContext;
 use crate::{Encoding, IonResult};
-use winnow::Parser;
 
 /// A text Ion 1.0 reader that yields [`LazyRawStreamItem`]s representing the top level values found
 /// in the provided input stream.
@@ -59,8 +58,9 @@ impl<'data> LazyRawTextReader_1_0<'data> {
             .match_top_level_item_1_0()
             .with_context("reading a top-level value", self.input)?;
 
-        let _trailing_ws = incomplete_is_ok(TextBuffer::match_optional_comments_and_whitespace)
-            .parse_next(&mut self.input)
+        let _trailing_ws = self
+            .input
+            .match_optional_comments_and_whitespace()
             .with_context("reading trailing top-level whitespace/comments", self.input)?;
         Ok(matched_item)
     }

--- a/src/lazy/text/raw/v1_1/reader.rs
+++ b/src/lazy/text/raw/v1_1/reader.rs
@@ -13,7 +13,7 @@ use crate::lazy::expanded::EncodingContextRef;
 use crate::lazy::raw_stream_item::{EndPosition, LazyRawStreamItem, RawStreamItem};
 use crate::lazy::span::Span;
 use crate::lazy::streaming_raw_reader::RawReaderState;
-use crate::lazy::text::buffer::{incomplete_is_ok, TextBuffer};
+use crate::lazy::text::buffer::TextBuffer;
 use crate::lazy::text::matched::MatchedValue;
 use crate::lazy::text::parse_result::WithContext;
 use crate::lazy::text::raw::v1_1::arg_group::{EExpArg, TextEExpArgGroup};
@@ -24,7 +24,6 @@ use compact_str::CompactString;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::Range;
-use winnow::Parser;
 
 pub struct LazyRawTextReader_1_1<'data> {
     input: TextBuffer<'data>,
@@ -86,8 +85,9 @@ impl<'data> LazyRawReader<'data, TextEncoding_1_1> for LazyRawTextReader_1_1<'da
             .match_top_level_item_1_1()
             .with_context("reading a v1.1 top-level value", self.input)?;
 
-        let _trailing_ws = incomplete_is_ok(TextBuffer::match_optional_comments_and_whitespace)
-            .parse_next(&mut self.input)
+        let _trailing_ws = self
+            .input
+            .match_optional_comments_and_whitespace()
             .with_context(
                 "reading trailing top-level whitespace/comments in v1.1",
                 self.input,


### PR DESCRIPTION
*Issue #, if available:* #972

*Description of changes:*
Prior to this PR when both text parsers (1.0 and 1.1) encountered an incomplete error in a comment (or whitespace) that followed an ion value, they would return the remaining input as a successful parse. If this occurred in the middle of a comment it would leave the parser mid-comment to continue parsing without the context that it was still in a comment.

In the referenced issue, this occurred in a conformance test, where the comment was in-part valid ion data. The parser reached the end of the buffer in the middle of a decimal value, and after consuming the buffer contents and finally refilling the buffer, the parser continued to parse the commented out decimal as ion data. 

The attached issue where the issue was identified provides some more details.

This PR removes the use of `incomplete_is_ok` allowing the incomplete to bubble up immediately without consuming any of the buffer data. This may not be the most efficient if there is a large amount of whitespace between values; consuming the whitespace right away is probably a better approach, however it does not work for comments. I'm not super familiar with winnow, so I wasn't able to work `incomplete_is_ok` into just the whitespace parsing in a reasonable time, so I'll follow up with that at another time.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
