### PR TITLE
Add support for nested variant types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ memchr = "2.7.4"
 [dev-dependencies]
 rstest = "0.19.0"
 rstest_reuse = "0.6.0"
+serde_bytes = "0.11.17"
 # Used by ion-tests integration
 walkdir = "2.5.0"
 test-generator = "0.3"

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -50,6 +50,8 @@ where
 pub struct ValueDeserializer<'a, 'de> {
     pub(crate) value: &'a LazyValue<'de, AnyEncoding>,
     is_human_readable: bool,
+    variant_nesting_depth: usize,  // Holds the number of nested variants we are for tracking
+                                   // variant names in annotations. 1-based.
 }
 
 impl<'a, 'de> ValueDeserializer<'a, 'de> {
@@ -57,6 +59,7 @@ impl<'a, 'de> ValueDeserializer<'a, 'de> {
         Self {
             value,
             is_human_readable,
+            variant_nesting_depth: 0,
         }
     }
 
@@ -428,8 +431,8 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer<'_, 'de> {
         V: Visitor<'de>,
     {
         let mut annotations = self.value.annotations();
-        let first_annotation = annotations.next().transpose()?;
-        match first_annotation {
+        let our_annotation = annotations.nth(self.variant_nesting_depth - 1).transpose()?;
+        match our_annotation {
             None => {
                 let symbol = self.value.read()?.expect_symbol()?;
                 let symbol_text = symbol.text().ok_or_else(|| {
@@ -535,6 +538,8 @@ struct VariantAccess<'a, 'de> {
 
 impl<'a, 'de> VariantAccess<'a, 'de> {
     fn new(de: ValueDeserializer<'a, 'de>) -> Self {
+        let de = ValueDeserializer { variant_nesting_depth: de.variant_nesting_depth + 1, ..de };
+
         VariantAccess { de }
     }
 }

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -211,6 +211,39 @@ mod tests {
     use chrono::{DateTime, FixedOffset, Utc};
     use serde::{Deserialize, Serialize};
     use serde_with::serde_as;
+    use rstest::*;
+
+    #[rstest]
+    #[case::i8(to_binary(&-1_i8).unwrap(),     &[0xE0, 0x01, 0x00, 0xEA, 0x31, 0x01])]
+    #[case::i16(to_binary(&-1_i16).unwrap(),   &[0xE0, 0x01, 0x00, 0xEA, 0x31, 0x01])]
+    #[case::i32(to_binary(&-1_i32).unwrap(),   &[0xE0, 0x01, 0x00, 0xEA, 0x31, 0x01])]
+    #[case::i64(to_binary(&-1_i64).unwrap(),   &[0xE0, 0x01, 0x00, 0xEA, 0x31, 0x01])]
+    #[case::u8(to_binary(&1_u8).unwrap(),      &[0xE0, 0x01, 0x00, 0xEA, 0x21, 0x01])]
+    #[case::u16(to_binary(&1_u16).unwrap(),    &[0xE0, 0x01, 0x00, 0xEA, 0x21, 0x01])]
+    #[case::u32(to_binary(&1_u32).unwrap(),    &[0xE0, 0x01, 0x00, 0xEA, 0x21, 0x01])]
+    #[case::u64(to_binary(&1_u64).unwrap(),    &[0xE0, 0x01, 0x00, 0xEA, 0x21, 0x01])]
+    #[case::char(to_binary(&'a').unwrap(),     &[0xE0, 0x01, 0x00, 0xEA, 0x81, 0x61])]
+    #[case::str(to_binary(&"a").unwrap(),      &[0xE0, 0x01, 0x00, 0xEA, 0x81, 0x61])]
+    #[case::some(to_binary(&Some(1)).unwrap(), &[0xE0, 0x01, 0x00, 0xEA, 0x21, 0x01])]
+    fn test_primitives_binary(#[case] ion_data: Vec<u8>, #[case] expected: &[u8]) {
+        assert_eq!(&ion_data[..], expected);
+    }
+
+    #[rstest]
+    #[case::i8(to_string(&-1_i8).unwrap(),     "-1")]
+    #[case::i16(to_string(&-1_i16).unwrap(),   "-1")]
+    #[case::i32(to_string(&-1_i32).unwrap(),   "-1")]
+    #[case::i64(to_string(&-1_i64).unwrap(),   "-1")]
+    #[case::u8(to_string(&1_u8).unwrap(),      "1")]
+    #[case::u16(to_string(&1_u16).unwrap(),    "1")]
+    #[case::u32(to_string(&1_u32).unwrap(),    "1")]
+    #[case::u64(to_string(&1_u64).unwrap(),    "1")]
+    #[case::char(to_string(&'a').unwrap(),     "\"a\"")]
+    #[case::str(to_string(&"a").unwrap(),      "\"a\"")]
+    #[case::some(to_string(&Some(1)).unwrap(), "1" )]
+    fn test_primitives_text(#[case] ion_data: String, #[case] expected: &str) {
+        assert_eq!(ion_data.trim(), expected);
+    }
 
     #[test]
     fn test_struct() {

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -249,10 +249,10 @@ mod tests {
 
     #[test]
     fn test_blob() {
-        #[derive(Serialize, Deserialize)]
+        #[derive(Serialize, Deserialize, Debug, PartialEq)]
         struct Test {
             #[serde(with = "serde_bytes")]
-            binary: &'static [u8],
+            binary: Vec<u8>,
         }
         let expected = &[
             0xE0, 0x01, 0x00, 0xEA,                               // IVM
@@ -262,12 +262,16 @@ mod tests {
             0xD7, 0x8A, 0xA5, 0x68, 0x65, 0x6C, 0x6C, 0x6F,       // {binary: {{ aGVsbG8= }}
         ];
 
-        let test = Test { binary: b"hello" }; // aGVsbG8=
+        let test = Test { binary: b"hello".to_vec() }; // aGVsbG8=
         let ion_data = to_binary(&test).unwrap();
         assert_eq!(&ion_data[..], expected);
+        let de: Test = from_ion(ion_data).expect("unable to parse test");
+        assert_eq!(de, test);
 
         let ion_data_str = to_string(&test).unwrap();
         assert_eq!(ion_data_str.trim(), "{binary: {{aGVsbG8=}}, }");
+        let de: Test = from_ion(ion_data_str).expect("unable to parse test");
+        assert_eq!(de, test);
     }
 
     #[test]

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -227,6 +227,7 @@ mod tests {
     #[case::char(to_binary(&'a').unwrap(),     &[0xE0, 0x01, 0x00, 0xEA, 0x81, 0x61])]
     #[case::str(to_binary(&"a").unwrap(),      &[0xE0, 0x01, 0x00, 0xEA, 0x81, 0x61])]
     #[case::some(to_binary(&Some(1)).unwrap(), &[0xE0, 0x01, 0x00, 0xEA, 0x21, 0x01])]
+    #[case::unit(to_binary(&()).unwrap(),      &[0xE0, 0x01, 0x00, 0xEA, 0x0F])]
     fn test_primitives_binary(#[case] ion_data: Vec<u8>, #[case] expected: &[u8]) {
         assert_eq!(&ion_data[..], expected);
     }
@@ -243,13 +244,14 @@ mod tests {
     #[case::char(to_string(&'a').unwrap(),     "\"a\"")]
     #[case::str(to_string(&"a").unwrap(),      "\"a\"")]
     #[case::some(to_string(&Some(1)).unwrap(), "1" )]
+    #[case::unit(to_string(&()).unwrap(),      "null")]
     fn test_primitives_text(#[case] ion_data: String, #[case] expected: &str) {
         assert_eq!(ion_data.trim(), expected);
     }
 
     #[test]
     fn test_blob() {
-        #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        #[derive(Serialize, Deserialize)]
         struct Test {
             #[serde(with = "serde_bytes")]
             binary: Vec<u8>,
@@ -266,12 +268,12 @@ mod tests {
         let ion_data = to_binary(&test).unwrap();
         assert_eq!(&ion_data[..], expected);
         let de: Test = from_ion(ion_data).expect("unable to parse test");
-        assert_eq!(de, test);
+        assert_eq!(de.binary, test.binary);
 
         let ion_data_str = to_string(&test).unwrap();
         assert_eq!(ion_data_str.trim(), "{binary: {{aGVsbG8=}}, }");
         let de: Test = from_ion(ion_data_str).expect("unable to parse test");
-        assert_eq!(de, test);
+        assert_eq!(de.binary, test.binary);
     }
 
     #[test]

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -235,7 +235,7 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
     }
 
     fn serialize_newtype_variant<T>(
-        self,
+        mut self,
         _name: &'static str,
         _variant_index: u32,
         variant: &'static str,
@@ -244,13 +244,8 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
     where
         T: ?Sized + Serialize,
     {
-        let mut annotations = self.annotations.clone();
-        annotations.push(variant);
-        value.serialize(ValueSerializer::new_with_annotations(
-            self.value_writer,
-            self.is_human_readable,
-            annotations,
-        ))
+        self.annotations.push(variant);
+        value.serialize(self)
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -68,6 +68,7 @@ where
 pub struct ValueSerializer<'a, V: ValueWriter> {
     pub(crate) value_writer: V,
     pub(crate) is_human_readable: bool,
+    pub(crate) annotations: Vec<&'static str>,
     lifetime: PhantomData<&'a ()>,
 }
 
@@ -76,7 +77,15 @@ impl<V: ValueWriter> ValueSerializer<'_, V> {
         Self {
             value_writer,
             is_human_readable,
+            annotations: vec!(),
             lifetime: PhantomData,
+        }
+    }
+
+    pub fn new_with_annotations(value_writer: V, is_human_readable: bool, annotations: Vec<&'static str>) -> Self {
+        Self {
+            annotations,
+            ..Self::new(value_writer, is_human_readable)
         }
     }
 }
@@ -86,8 +95,8 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
     type Error = IonError;
 
     type SerializeSeq = SeqWriter<V>;
-    type SerializeTuple = SeqWriter<V>;
-    type SerializeTupleStruct = SeqWriter<V>;
+    type SerializeTuple = SeqWriter<V::AnnotatedValueWriter<'a>>;
+    type SerializeTupleStruct = SeqWriter<V::AnnotatedValueWriter<'a>>;
     type SerializeTupleVariant = SeqWriter<V::AnnotatedValueWriter<'a>>;
     type SerializeMap = MapWriter<V>;
     type SerializeStruct = MapWriter<V>;
@@ -106,42 +115,42 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.write(v as i64)
+        self.value_writer.with_annotations(self.annotations)?.write(v as i64)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.write(v as i64)
+        self.value_writer.with_annotations(self.annotations)?.write(v as i64)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.write(v)
+        self.value_writer.with_annotations(self.annotations)?.write(v)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.write(v)
+        self.value_writer.with_annotations(self.annotations)?.write(v)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.write(v)
+        self.value_writer.with_annotations(self.annotations)?.write(v)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.write(v)
+        self.value_writer.with_annotations(self.annotations)?.write(v)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.write(v)
+        self.value_writer.with_annotations(self.annotations)?.write(v)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.write(v)
+        self.value_writer.with_annotations(self.annotations)?.write(v)
     }
 
     fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
@@ -149,24 +158,24 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
     }
 
     fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.write(v)
+        self.value_writer.with_annotations(self.annotations)?.write(v)
     }
 
     fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
         // TODO: This could be optimized.
-        self.value_writer.write(v.to_string())
+        self.value_writer.with_annotations(self.annotations)?.write(v.to_string())
     }
 
     fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.write(v)
+        self.value_writer.with_annotations(self.annotations)?.write(v)
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.write(v)
+        self.value_writer.with_annotations(self.annotations)?.write(v)
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.write(Null(IonType::Null))
+        self.value_writer.with_annotations(self.annotations)?.write(Null(IonType::Null))
     }
 
     fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
@@ -181,7 +190,7 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
     }
 
     fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.write(name.as_symbol_ref())
+        self.value_writer.with_annotations(self.annotations)?.write(name.as_symbol_ref())
     }
 
     fn serialize_unit_variant(
@@ -190,7 +199,7 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
         _variant_index: u32,
         variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.write(variant.as_symbol_ref())
+        self.value_writer.with_annotations(self.annotations)?.write(variant.as_symbol_ref())
     }
 
     fn serialize_newtype_struct<T>(
@@ -211,7 +220,7 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
             // we are using TUNNELED_TIMESTAMP_TYPE_NAME flag here which indicates a timestamp value
             // The assert statement above that compares the sizes of the Timestamp and value types
             let timestamp = unsafe { std::mem::transmute_copy::<&T, &Timestamp>(&value) };
-            self.value_writer.write_timestamp(timestamp)
+            self.value_writer.with_annotations(self.annotations)?.write_timestamp(timestamp)
         } else if name == TUNNELED_DECIMAL_TYPE_NAME {
             // # Safety
             // compiler doesn't understand that the generic T here is actually Decimal here since
@@ -235,9 +244,12 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
     where
         T: ?Sized + Serialize,
     {
-        value.serialize(ValueSerializer::new(
-            self.value_writer.with_annotations([variant])?,
+        let mut annotations = self.annotations.clone();
+        annotations.push(variant);
+        value.serialize(ValueSerializer::new_with_annotations(
+            self.value_writer,
             self.is_human_readable,
+            annotations,
         ))
     }
 
@@ -249,19 +261,25 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
     }
 
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        let writer= self.value_writer.with_annotations(self.annotations)?;
         Ok(SeqWriter {
-            seq_writer: self.value_writer.list_writer()?,
+            seq_writer: writer.list_writer()?,
             is_human_readable: self.is_human_readable,
         })
     }
 
     fn serialize_tuple_struct(
         self,
-        _name: &'static str,
+        name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        let mut annotations = self.annotations.clone();
+        annotations.push(name);
         Ok(SeqWriter {
-            seq_writer: self.value_writer.list_writer()?,
+            seq_writer: self
+                .value_writer
+                .with_annotations(annotations)?
+                .list_writer()?,
             is_human_readable: self.is_human_readable,
         })
     }
@@ -273,10 +291,12 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
         variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        let mut annotations = self.annotations.clone();
+        annotations.push(variant);
         Ok(SeqWriter {
             seq_writer: self
                 .value_writer
-                .with_annotations([variant])?
+                .with_annotations(annotations)?
                 .list_writer()?,
             is_human_readable: self.is_human_readable,
         })
@@ -307,10 +327,12 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
         variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        let mut annotations = self.annotations.clone();
+        annotations.push(variant);
         Ok(MapWriter {
             map_writer: self
                 .value_writer
-                .with_annotations([variant])?
+                .with_annotations(annotations)?
                 .struct_writer()?,
             is_human_readable: self.is_human_readable,
         })

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -81,13 +81,6 @@ impl<V: ValueWriter> ValueSerializer<'_, V> {
             lifetime: PhantomData,
         }
     }
-
-    pub fn new_with_annotations(value_writer: V, is_human_readable: bool, annotations: Vec<&'static str>) -> Self {
-        Self {
-            annotations,
-            ..Self::new(value_writer, is_human_readable)
-        }
-    }
 }
 
 impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
@@ -268,14 +261,13 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
         name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        let mut annotations = self.annotations.clone();
+        let ValueSerializer { value_writer, is_human_readable, mut annotations, .. } = self;
         annotations.push(name);
         Ok(SeqWriter {
-            seq_writer: self
-                .value_writer
+            seq_writer: value_writer
                 .with_annotations(annotations)?
                 .list_writer()?,
-            is_human_readable: self.is_human_readable,
+            is_human_readable,
         })
     }
 
@@ -286,14 +278,13 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
         variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        let mut annotations = self.annotations.clone();
+        let ValueSerializer { value_writer, is_human_readable, mut annotations, .. } = self;
         annotations.push(variant);
         Ok(SeqWriter {
-            seq_writer: self
-                .value_writer
+            seq_writer: value_writer
                 .with_annotations(annotations)?
                 .list_writer()?,
-            is_human_readable: self.is_human_readable,
+            is_human_readable,
         })
     }
 
@@ -322,14 +313,13 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
         variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        let mut annotations = self.annotations.clone();
+        let ValueSerializer { value_writer, is_human_readable, mut annotations, .. } = self;
         annotations.push(variant);
         Ok(MapWriter {
-            map_writer: self
-                .value_writer
+            map_writer: value_writer
                 .with_annotations(annotations)?
                 .struct_writer()?,
-            is_human_readable: self.is_human_readable,
+            is_human_readable,
         })
     }
 }


### PR DESCRIPTION
*Issue #, if available:* #978

*Description of changes:*
This PR adds support for nested variant types, allowing something like:
```rust
#[derive(Serialize, Deserialize, PartialEq, Debug)]
enum Outter {
    First(Inner),
}

#[derive(Serialize, Deserialize, PartialEq, Debug)]
enum Inner {
    Second(u32),
}

// 
let value = Outter::First(Inner::Second(3));
let value_str = to_string(&value).unwrap();

println!("{}", value_str); // prints: "First::Second::3"
```

On the serialization side this PR adds a new vector of `&'static str` to hold the list of variant names that will be used for annotations.  Once a serializable type is reached the annotations are given to the writer and the type is serialized.

On the deserialization side, we need to keep track of how deep the nesting goes so that we can pull the right annotation for determining the variant. The field `variant_nesting_depth` was added to `ValueDeserializer` so that the depth of nesting can be tracked. When we access a variant via `VariantAccess`, a new `ValueDeserializer` is created with an incremented `variant_nesting_depth`. When we need to determine the variant via annotations, the `variant_nesting_depth` is used to get the appropriate annotation. 

Prior to this PR if a nested variant type was serialized, it would only serialize the name of the most inner variant as the annotation list. Details about this can be seen in the attached issue #978.


### Additional
Some more unit tests for primitive values were also added in response to the codecov report.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
