### PR TITLE
Remove all but one test from skiplist for data_model/decimal.ion

### DIFF
--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -50,8 +50,11 @@ mod ion_tests {
             "ion-tests/conformance/data_model/float.ion",
             "Ion 1.1 binary" // PANIC: not yet implemented: implement half-precision floats
         ),
-        // Issue parsing the comments left in decimal.ion, see ion-rust#972
-        skip!("ion-tests/conformance/data_model/decimal.ion"),
+        skip!(
+            "ion-tests/conformance/data_model/decimal.ion",
+            // Error: Found a 13-byte VarInt. Max supported size is 9 bytes.
+            "the decimal positive zero"
+        ),
         // Mismatched produces due to symbol id transcription.
         skip!("ion-tests/conformance/core/toplevel_produces.ion"),
         // Unrecognized encoding 'int8' (only flex_uint appears to be supported)


### PR DESCRIPTION
*Issue #, if available:* #972

*Description of changes:*

Prior to this PR the conformance test `data_model/decimal.ion` was in the skip-list due to the parsing error identified in #972. With that issue addressed, we can now remove most of that set of tests from the skip-list.

This PR does just that. There is only 1 failing test in `data_model/decimal.ion` now, due to a VarInt size that ion-rust does not currently support.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
