### PR TITLE
Implement system macro make_decimal

### DIFF
--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -10,8 +10,9 @@ use crate::lazy::expanded::compiler::{ExpansionAnalysis, ExpansionSingleton};
 use crate::lazy::expanded::macro_evaluator::{
     AnnotateExpansion, ConditionalExpansion, EExpressionArgGroup, ExprGroupExpansion,
     FlattenExpansion, IsExhaustedIterator, MacroExpansion, MacroExpansionKind, MacroExpr,
-    MacroExprArgsIterator, MakeFieldExpansion, MakeStructExpansion, MakeTextExpansion,
-    RawEExpression, RepeatExpansion, SumExpansion, TemplateExpansion, ValueExpr,
+    MacroExprArgsIterator, MakeDecimalExpansion, MakeFieldExpansion, MakeStructExpansion,
+    MakeTextExpansion, RawEExpression, RepeatExpansion, SumExpansion, TemplateExpansion,
+    ValueExpr,
 };
 use crate::lazy::expanded::macro_table::{MacroKind, MacroRef};
 use crate::lazy::expanded::template::TemplateMacroRef;
@@ -115,6 +116,9 @@ impl<'top, D: Decoder> EExpression<'top, D> {
             MacroKind::None => MacroExpansionKind::None,
             MacroKind::ExprGroup => {
                 MacroExpansionKind::ExprGroup(ExprGroupExpansion::new(arguments))
+            }
+            MacroKind::MakeDecimal => {
+                MacroExpansionKind::MakeDecimal(MakeDecimalExpansion::new(arguments))
             }
             MacroKind::MakeString => {
                 MacroExpansionKind::MakeString(MakeTextExpansion::string_maker(arguments))

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -355,6 +355,7 @@ fn write_template_struct_element<V: ValueWriter>(
 pub enum MacroKind {
     None, // `(.none)` returns the empty stream
     ExprGroup,
+    MakeDecimal,
     MakeString,
     MakeSymbol,
     MakeField,
@@ -625,7 +626,7 @@ impl MacroTable {
             builtin(
                 "make_decimal",
                 "(coefficient exponent)",
-                MacroKind::ToDo,
+                MacroKind::MakeDecimal,
                 ExpansionAnalysis::single_application_value(IonType::Decimal),
             ),
             builtin(

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -3,8 +3,9 @@ use crate::lazy::decoder::Decoder;
 use crate::lazy::expanded::compiler::ExpansionAnalysis;
 use crate::lazy::expanded::macro_evaluator::{
     AnnotateExpansion, ConditionalExpansion, ExprGroupExpansion, FlattenExpansion, MacroEvaluator,
-    MacroExpansion, MacroExpansionKind, MacroExpr, MacroExprArgsIterator, MakeFieldExpansion,
-    MakeStructExpansion, MakeTextExpansion, RepeatExpansion, SumExpansion, TemplateExpansion, ValueExpr,
+    MacroExpansion, MacroExpansionKind, MacroExpr, MacroExprArgsIterator, MakeDecimalExpansion,
+    MakeFieldExpansion, MakeStructExpansion, MakeTextExpansion, RepeatExpansion, SumExpansion,
+    TemplateExpansion, ValueExpr,
 };
 use crate::lazy::expanded::macro_table::{MacroDef, MacroKind, MacroRef};
 use crate::lazy::expanded::r#struct::FieldExpr;
@@ -1359,6 +1360,9 @@ impl<'top, D: Decoder> TemplateMacroInvocation<'top, D> {
             MacroKind::None => MacroExpansionKind::None,
             MacroKind::ExprGroup => {
                 unreachable!("cannot invoke ExprGroup from a TemplateMacroInvocation")
+            }
+            MacroKind::MakeDecimal => {
+                MacroExpansionKind::MakeDecimal(MakeDecimalExpansion::new(arguments))
             }
             MacroKind::MakeString => {
                 MacroExpansionKind::MakeString(MakeTextExpansion::string_maker(arguments))


### PR DESCRIPTION
*Issue #, if available:* #942

*Description of changes:*
This PR implements the `make_decimal` system macro.

```
Running tests: ion-tests/conformance/system_macros/make_decimal.ion
  make_decimal can be invoked                              ...  [Ok]
  the first argument must be a single, non-null integer    ...  [Ok]
  the second argument must be a single, non-null integer   ...  [Ok]
  in binary both arguments are encoded as tagged values    ...  [Ok]
  make_decimal creates a single unannotated decimal        ...  [Ok]
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
