### PR TITLE
Address new clippy lints for inline format

### DIFF
--- a/examples/read_all_values.rs
+++ b/examples/read_all_values.rs
@@ -37,7 +37,7 @@ mod lazy_reader_example {
         while let Some(lazy_value) = reader.next()? {
             count += count_value_and_children(&lazy_value)?;
         }
-        println!("Read {} values.", count);
+        println!("Read {count} values.");
         Ok(())
     }
 

--- a/src/element/reader.rs
+++ b/src/element/reader.rs
@@ -48,12 +48,11 @@ pub trait ElementReader {
         match iter.next() {
             Some(Ok(element)) => {
                 return IonResult::decoding_error(format!(
-                    "found more than one value; second value: {}",
-                    element
+                    "found more than one value; second value: {element}",
                 ))
             }
             Some(Err(e)) => {
-                return IonResult::decoding_error(format!("error after expected value: {}", e))
+                return IonResult::decoding_error(format!("error after expected value: {e}"))
             }
             None => {}
         };

--- a/src/element/sequence.rs
+++ b/src/element/sequence.rs
@@ -244,7 +244,7 @@ mod tests {
         let mut it = seq.into_iter();
 
         assert_eq!(
-            format!("{:?}", it),
+            format!("{it:?}"),
             "OwnedSequenceIterator([true, false, \"hello\"])"
         );
 

--- a/src/lazy/binary/raw/reader.rs
+++ b/src/lazy/binary/raw/reader.rs
@@ -290,7 +290,7 @@ mod tests {
         let _symbol_table = reader.next()?.expect_value()?;
         let lazy_list = reader.next()?.expect_value()?.read()?.expect_list()?;
         // Exercise the `Debug` impl
-        println!("Lazy Raw Sequence: {:?}", lazy_list);
+        println!("Lazy Raw Sequence: {lazy_list:?}");
         let mut list_values = lazy_list.sequence.iter();
         assert_eq!(
             list_values

--- a/src/lazy/binary/raw/struct.rs
+++ b/src/lazy/binary/raw/struct.rs
@@ -42,7 +42,7 @@ impl Debug for LazyRawBinaryStruct_1_0<'_> {
         for field in self {
             let (name, lazy_value) = field?.expect_name_value()?;
             let value = lazy_value.read()?;
-            write!(f, "{:?}:{:?},", name, value)?;
+            write!(f, "{name:?}:{value:?},")?;
         }
         write!(f, "}}")?;
         Ok(())

--- a/src/lazy/binary/raw/v1_1/reader.rs
+++ b/src/lazy/binary/raw/v1_1/reader.rs
@@ -1003,7 +1003,7 @@ mod tests {
                         assert_eq!(name.read()?, *expected_name);
                         assert_eq!(value.ion_type(), *expected_value_type);
                     }
-                    other => panic!("unexpected value for field: {:?}", other),
+                    other => panic!("unexpected value for field: {other:?}"),
                 }
             }
         }

--- a/src/lazy/binary/raw/v1_1/struct.rs
+++ b/src/lazy/binary/raw/v1_1/struct.rs
@@ -77,7 +77,7 @@ impl Debug for LazyRawBinaryStruct_1_1<'_> {
         for field in self {
             let (name, lazy_value) = field?.expect_name_value()?;
             let value = lazy_value.read()?;
-            write!(f, "{:?}:{:?},", name, value)?;
+            write!(f, "{name:?}:{value:?},")?;
         }
         write!(f, "}}")?;
         Ok(())

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -555,8 +555,7 @@ impl<'top> LazyRawBinaryValue_1_0<'top> {
             1 => true,
             invalid => {
                 return IonResult::decoding_error(format!(
-                    "found a boolean value with an illegal representation (must be 0 or 1): {}",
-                    invalid
+                    "found a boolean value with an illegal representation (must be 0 or 1): {invalid}",
                 ))
             }
         };

--- a/src/lazy/bytes_ref.rs
+++ b/src/lazy/bytes_ref.rs
@@ -96,7 +96,7 @@ impl Debug for BytesRef<'_> {
         // Shows up to the first 32 bytes in hex
         write!(f, "BytesRef: [")?;
         for byte in data.iter().copied().take(NUM_BYTES_TO_SHOW) {
-            write!(f, "{:x} ", byte)?;
+            write!(f, "{byte:x} ")?;
         }
         if data.len() > NUM_BYTES_TO_SHOW {
             write!(f, "...{} more", (data.len() - NUM_BYTES_TO_SHOW))?;

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -202,8 +202,7 @@ impl<V: Debug, M: Debug> RawValueExpr<V, M> {
     pub fn expect_macro(self) -> IonResult<M> {
         match self {
             RawValueExpr::ValueLiteral(v) => IonResult::decoding_error(format!(
-                "expected a macro invocation but found a value literal ({:?})",
-                v
+                "expected a macro invocation but found a value literal ({v:?})",
             )),
             RawValueExpr::EExp(m) => Ok(m),
         }
@@ -280,8 +279,7 @@ impl<'top, D: Decoder> LazyRawFieldExpr<'top, D> {
     pub fn expect_name_value(self) -> IonResult<(D::FieldName<'top>, D::Value<'top>)> {
         let LazyRawFieldExpr::NameValue(name, value) = self else {
             return IonResult::decoding_error(format!(
-                "expected a name/value pair but found {:?}",
-                self
+                "expected a name/value pair but found {self:?}",
             ));
         };
         Ok((name, value))
@@ -290,8 +288,7 @@ impl<'top, D: Decoder> LazyRawFieldExpr<'top, D> {
     pub fn expect_name_eexp(self) -> IonResult<(D::FieldName<'top>, D::EExp<'top>)> {
         let LazyRawFieldExpr::NameEExp(name, eexp) = self else {
             return IonResult::decoding_error(format!(
-                "expected a name/e-expression pair but found {:?}",
-                self
+                "expected a name/e-expression pair but found {self:?}",
             ));
         };
         Ok((name, eexp))
@@ -300,8 +297,7 @@ impl<'top, D: Decoder> LazyRawFieldExpr<'top, D> {
     pub fn expect_eexp(self) -> IonResult<D::EExp<'top>> {
         let LazyRawFieldExpr::EExp(eexp) = self else {
             return IonResult::decoding_error(format!(
-                "expected an e-expression but found {:?}",
-                self
+                "expected an e-expression but found {self:?}",
             ));
         };
         Ok(eexp)

--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -3119,7 +3119,7 @@ mod tests {
                     use std::fmt::Write;
                     let is_eq = before.ion_eq(after);
                     let flag = if is_eq { "" } else { "<- not IonEq" };
-                    writeln!(&mut text, "({}, {}) {}", before, after, flag).unwrap();
+                    writeln!(&mut text, "({before}, {after}) {flag}").unwrap();
                     text
                 }
             )

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -1073,8 +1073,7 @@ mod tests {
             let actual_bytes = raw_value.span().bytes();
             assert_eq!(
                 actual_bytes, *expected_bytes,
-                "actual {:02X?} != expected {:02X?}",
-                actual_bytes, expected_bytes
+                "actual {actual_bytes:02X?} != expected {expected_bytes:02X?}",
             );
             println!(
                 "{:?} {:02X?} == {:02X?}",
@@ -1247,7 +1246,7 @@ mod tests {
         struct_writer.close()?;
         let bytes = writer.close()?;
 
-        println!("encoded bytes: {:02X?}", bytes);
+        println!("encoded bytes: {bytes:02X?}");
 
         let mut reader = SystemReader::new(v1_1::Binary, bytes.as_slice());
         let struct_ = reader.expect_next_value()?.read()?.expect_struct()?;

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -362,8 +362,7 @@ impl TemplateCompiler {
             Some(Err(e)) => return Err(e),
             Some(Ok(annotation)) => {
                 return IonResult::decoding_error(format!(
-                    "found unexpected third annotation ('{:?}') on parameter",
-                    annotation
+                    "found unexpected third annotation ('{annotation:?}') on parameter",
                 ))
             }
         };

--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -75,7 +75,7 @@ impl<D: Decoder> Debug for EExpArgGroup<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "(: {:?}", self.raw_arg_group)?;
         for expr in self.expressions() {
-            write!(f, " {:?}", expr)?;
+            write!(f, " {expr:?}")?;
         }
         write!(f, ")")
     }

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -199,10 +199,10 @@ pub enum MacroExprKind<'top, D: Decoder> {
 impl<D: Decoder> Debug for MacroExprKind<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            MacroExprKind::TemplateMacro(t) => write!(f, "{:?}", t),
-            MacroExprKind::TemplateArgGroup(g) => write!(f, "{:?}", g),
-            MacroExprKind::EExp(e) => write!(f, "{:?}", e),
-            MacroExprKind::EExpArgGroup(g) => write!(f, "{:?}", g),
+            MacroExprKind::TemplateMacro(t) => write!(f, "{t:?}"),
+            MacroExprKind::TemplateArgGroup(g) => write!(f, "{g:?}"),
+            MacroExprKind::EExp(e) => write!(f, "{e:?}"),
+            MacroExprKind::EExpArgGroup(g) => write!(f, "{g:?}"),
         }
     }
 }
@@ -376,8 +376,8 @@ pub enum ValueExpr<'top, D: Decoder> {
 impl<D: Decoder> Debug for ValueExpr<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            ValueExpr::ValueLiteral(v) => write!(f, "value={:?}", v),
-            ValueExpr::MacroInvocation(i) => write!(f, "invocation={:?}", i),
+            ValueExpr::ValueLiteral(v) => write!(f, "value={v:?}"),
+            ValueExpr::MacroInvocation(i) => write!(f, "invocation={i:?}"),
         }
     }
 }
@@ -616,7 +616,7 @@ impl<D: Decoder> Debug for MacroExpansion<'_, D> {
             MacroExpansionKind::Conditional(test) => test.name(),
             MacroExpansionKind::Template(t) => {
                 return if let Some(name) = t.template.name() {
-                    write!(f, "<expansion of template '{}'>", name)
+                    write!(f, "<expansion of template '{name}'>")
                 } else {
                     write!(f, "<expansion of anonymous template>")
                 }
@@ -1744,8 +1744,7 @@ mod tests {
         let expected = expected_reader.read_all_elements()?;
         assert_eq!(
             actual, &expected,
-            "actual\n{:?}\nwas not equal to expected\n{:?}\n",
-            actual, expected
+            "actual\n{actual:?}\nwas not equal to expected\n{expected:?}\n",
         );
         Ok(())
     }

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -1225,8 +1225,7 @@ impl<Encoding: Decoder> PartialEq for ExpandedValueRef<'_, Encoding> {
 impl<'top, Encoding: Decoder> ExpandedValueRef<'top, Encoding> {
     fn expected<T>(self, expected_name: &str) -> IonResult<T> {
         IonResult::decoding_error(format!(
-            "expected a(n) {} but found a {:?}",
-            expected_name, self
+            "expected a(n) {expected_name} but found a {self:?}",
         ))
     }
 
@@ -1366,14 +1365,14 @@ impl<D: Decoder> Debug for ExpandedValueRef<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use ExpandedValueRef::*;
         match self {
-            Null(ion_type) => write!(f, "null.{}", ion_type),
-            Bool(b) => write!(f, "{}", b),
-            Int(i) => write!(f, "{}", i),
-            Float(float) => write!(f, "{}", float),
-            Decimal(d) => write!(f, "{}", d),
-            Timestamp(t) => write!(f, "{}", t),
-            String(s) => write!(f, "{}", s),
-            Symbol(s) => write!(f, "{:?}", s),
+            Null(ion_type) => write!(f, "null.{ion_type}"),
+            Bool(b) => write!(f, "{b}"),
+            Int(i) => write!(f, "{i}"),
+            Float(float) => write!(f, "{float}"),
+            Decimal(d) => write!(f, "{d}"),
+            Timestamp(t) => write!(f, "{t}"),
+            String(s) => write!(f, "{s}"),
+            Symbol(s) => write!(f, "{s:?}"),
             Blob(b) => write!(f, "blob ({} bytes)", b.len()),
             Clob(c) => write!(f, "clob ({} bytes)", c.len()),
             // TODO: Debug impls for LazyExpandedRaw[ContainerType]

--- a/src/lazy/expanded/sequence.rs
+++ b/src/lazy/expanded/sequence.rs
@@ -32,7 +32,7 @@ impl<D: Decoder> Debug for Environment<'_, D> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Environment::[")?;
         for expr in self.expressions {
-            writeln!(f, "{:?}", expr)?;
+            writeln!(f, "{expr:?}")?;
         }
         write!(f, "]")
     }

--- a/src/lazy/expanded/struct.rs
+++ b/src/lazy/expanded/struct.rs
@@ -335,7 +335,7 @@ impl<'top, D: Decoder> LazyExpandedStruct<'top, D> {
         if let Some(value) = self.get(name)? {
             Ok(value)
         } else {
-            IonResult::decoding_error(format!("did not find expected struct field '{}'", name))
+            IonResult::decoding_error(format!("did not find expected struct field '{name}'"))
         }
     }
 }
@@ -644,8 +644,7 @@ fn next_struct_from_macro<'top, D: Decoder>(
     let value_ref = expanded_value.read()?;
     let ExpandedValueRef::Struct(struct_) = value_ref else {
         return IonResult::decoding_error(format!(
-            "macros in field name position must produce structs; found: {:?}",
-            value_ref
+            "macros in field name position must produce structs; found: {value_ref:?}",
         ));
     };
     Ok(Some(struct_))

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -1249,7 +1249,7 @@ impl<D: Decoder> Debug for TemplateExprGroup<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "(.. /*expr group for param={}*/", self.parameter().name())?;
         for expr in self.arg_expressions() {
-            write!(f, "\n {:?}", expr)?;
+            write!(f, "\n {expr:?}")?;
         }
         write!(f, "\n)",)
     }
@@ -1276,7 +1276,7 @@ impl<D: Decoder> Debug for TemplateMacroInvocation<'_, D> {
             self.invoked_macro().name().unwrap_or("<anonymous>")
         )?;
         for expr in self.arg_expressions() {
-            write!(f, " {:?}", expr)?;
+            write!(f, " {expr:?}")?;
         }
         write!(f, ")")
     }

--- a/src/lazy/raw_stream_item.rs
+++ b/src/lazy/raw_stream_item.rs
@@ -88,7 +88,7 @@ impl<M: Copy + Debug, V: Copy + Debug, E: Copy + Debug> RawStreamItem<M, V, E> {
     /// is not an IVM.
     pub fn expect_ivm(self) -> IonResult<M> {
         self.version_marker()
-            .ok_or_else(|| IonError::decoding_error(format!("expected IVM, found {:?}", self)))
+            .ok_or_else(|| IonError::decoding_error(format!("expected IVM, found {self:?}")))
     }
 
     /// If this item is a value, returns `Some(&LazyValue)`. Otherwise, returns `None`.
@@ -106,7 +106,7 @@ impl<M: Copy + Debug, V: Copy + Debug, E: Copy + Debug> RawStreamItem<M, V, E> {
         if let Self::Value(value) = self {
             Ok(value)
         } else {
-            IonResult::decoding_error(format!("expected value, found {:?}", self))
+            IonResult::decoding_error(format!("expected value, found {self:?}"))
         }
     }
 
@@ -122,7 +122,7 @@ impl<M: Copy + Debug, V: Copy + Debug, E: Copy + Debug> RawStreamItem<M, V, E> {
         if let Self::EExp(m) = self {
             Ok(m)
         } else {
-            IonResult::decoding_error(format!("expected a macro invocation, found {:?}", self))
+            IonResult::decoding_error(format!("expected a macro invocation, found {self:?}"))
         }
     }
 }

--- a/src/lazy/raw_value_ref.rs
+++ b/src/lazy/raw_value_ref.rs
@@ -57,19 +57,19 @@ impl<D: Decoder> PartialEq for RawValueRef<'_, D> {
 impl<D: Decoder> Debug for RawValueRef<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            RawValueRef::Null(ion_type) => write!(f, "null.{}", ion_type),
-            RawValueRef::Bool(b) => write!(f, "{}", b),
-            RawValueRef::Int(i) => write!(f, "{}", i),
-            RawValueRef::Float(float) => write!(f, "{}", float),
-            RawValueRef::Decimal(d) => write!(f, "{}", d),
-            RawValueRef::Timestamp(t) => write!(f, "{}", t),
-            RawValueRef::String(s) => write!(f, "{}", s),
-            RawValueRef::Symbol(s) => write!(f, "{:?}", s),
+            RawValueRef::Null(ion_type) => write!(f, "null.{ion_type}"),
+            RawValueRef::Bool(b) => write!(f, "{b}"),
+            RawValueRef::Int(i) => write!(f, "{i}"),
+            RawValueRef::Float(float) => write!(f, "{float}"),
+            RawValueRef::Decimal(d) => write!(f, "{d}"),
+            RawValueRef::Timestamp(t) => write!(f, "{t}"),
+            RawValueRef::String(s) => write!(f, "{s}"),
+            RawValueRef::Symbol(s) => write!(f, "{s:?}"),
             RawValueRef::Blob(b) => write!(f, "blob ({} bytes)", b.len()),
             RawValueRef::Clob(c) => write!(f, "clob ({} bytes)", c.len()),
-            RawValueRef::SExp(s) => write!(f, "sexp={:?}", s),
-            RawValueRef::List(l) => write!(f, "{:?}", l),
-            RawValueRef::Struct(s) => write!(f, "{:?}", s),
+            RawValueRef::SExp(s) => write!(f, "sexp={s:?}"),
+            RawValueRef::List(l) => write!(f, "{l:?}"),
+            RawValueRef::Struct(s) => write!(f, "{s:?}"),
         }
     }
 }
@@ -128,7 +128,7 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         if let RawValueRef::Int(i) = self {
             i.expect_i64()
         } else {
-            IonResult::decoding_error(format!("expected an i64 (int), found: {:?}", self))
+            IonResult::decoding_error(format!("expected an i64 (int), found: {self:?}"))
         }
     }
 
@@ -208,7 +208,7 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         if let RawValueRef::Struct(s) = self {
             Ok(s)
         } else {
-            IonResult::decoding_error(format!("expected a struct, found: {:?}", self))
+            IonResult::decoding_error(format!("expected a struct, found: {self:?}"))
         }
     }
 }

--- a/src/lazy/streaming_raw_reader.rs
+++ b/src/lazy/streaming_raw_reader.rs
@@ -797,7 +797,7 @@ mod tests {
         let result = reader.next(context);
         // Because the input stream is exhausted, the incomplete value is illegal data and raises
         // a decoding error.
-        assert!(matches!(result, Err(IonError::Decoding(_))), "{:?}", result);
+        assert!(matches!(result, Err(IonError::Decoding(_))), "{result:?}");
         Ok(())
     }
 

--- a/src/lazy/struct.rs
+++ b/src/lazy/struct.rs
@@ -168,7 +168,7 @@ impl<'top, D: Decoder> LazyStruct<'top, D> {
     /// ```
     pub fn find_expected(&self, name: &str) -> IonResult<LazyValue<'top, D>> {
         self.find(name)?
-            .ok_or_else(|| IonError::decoding_error(format!("missing required field {}", name)))
+            .ok_or_else(|| IonError::decoding_error(format!("missing required field {name}")))
     }
 
     /// Like [`LazyStruct::find`], but eagerly calls [`LazyValue::read`] on the first field with a
@@ -222,7 +222,7 @@ impl<'top, D: Decoder> LazyStruct<'top, D> {
     /// ```
     pub fn get_expected(&self, name: &str) -> IonResult<ValueRef<'top, D>> {
         self.get(name)?.ok_or_else(move || {
-            IonError::decoding_error(format!("missing required field {}", name))
+            IonError::decoding_error(format!("missing required field {name}"))
         })
     }
 

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -678,9 +678,9 @@ mod tests {
                 SystemStreamItem::VersionMarker(marker) => {
                     println!("ivm => v{}.{}", marker.major(), marker.minor())
                 }
-                SystemStreamItem::SymbolTable(ref s) => println!("symtab => {:?}", s),
+                SystemStreamItem::SymbolTable(ref s) => println!("symtab => {s:?}"),
                 SystemStreamItem::EncodingDirective(ref s) => {
-                    println!("encoding directive => {:?}", s)
+                    println!("encoding directive => {s:?}")
                 }
                 SystemStreamItem::Value(ref v) => println!("value => {:?}", v.read()?),
                 SystemStreamItem::EndOfStream(_) => break,

--- a/src/lazy/system_stream_item.rs
+++ b/src/lazy/system_stream_item.rs
@@ -57,7 +57,7 @@ impl<'top, D: Decoder> SystemStreamItem<'top, D> {
     /// is not an IVM.
     pub fn expect_ivm(self) -> IonResult<D::VersionMarker<'top>> {
         self.as_version_marker()
-            .ok_or_else(|| IonError::decoding_error(format!("expected IVM, found {:?}", self)))
+            .ok_or_else(|| IonError::decoding_error(format!("expected IVM, found {self:?}")))
     }
 
     /// If this item is a application-level value, returns `Some(&LazyValue)`. Otherwise,
@@ -76,7 +76,7 @@ impl<'top, D: Decoder> SystemStreamItem<'top, D> {
         if let Self::Value(value) = self {
             Ok(value)
         } else {
-            IonResult::decoding_error(format!("expected value, found {:?}", self))
+            IonResult::decoding_error(format!("expected value, found {self:?}"))
         }
     }
 
@@ -95,7 +95,7 @@ impl<'top, D: Decoder> SystemStreamItem<'top, D> {
         if let Self::SymbolTable(value) = self {
             Ok(value)
         } else {
-            IonResult::decoding_error(format!("expected symbol table, found {:?}", self))
+            IonResult::decoding_error(format!("expected symbol table, found {self:?}"))
         }
     }
 
@@ -114,7 +114,7 @@ impl<'top, D: Decoder> SystemStreamItem<'top, D> {
         if let Self::EncodingDirective(sexp) = self {
             Ok(sexp)
         } else {
-            IonResult::decoding_error(format!("expected encoding directive, found {:?}", self))
+            IonResult::decoding_error(format!("expected encoding directive, found {self:?}"))
         }
     }
 

--- a/src/lazy/text/buffer.rs
+++ b/src/lazy/text/buffer.rs
@@ -627,7 +627,7 @@ impl<'top> TextBuffer<'top> {
             MacroIdRef::LocalName(name) => {
                 let Some(macro_address) = ION_1_1_SYSTEM_MACROS.address_for_name(name) else {
                     return self
-                        .invalid(format!("found unrecognized system macro name: '{}'", name))
+                        .invalid(format!("found unrecognized system macro name: '{name}'"))
                         .context("reading an e-expression's macro ID as a local name")
                         .cut();
                 };
@@ -638,8 +638,7 @@ impl<'top> TextBuffer<'top> {
                 let Some(system_address) = SystemMacroAddress::new(address) else {
                     return self
                         .invalid(format!(
-                            "found out-of-bounds system macro address {}",
-                            address
+                            "found out-of-bounds system macro address {address}",
                         ))
                         .context("reading an e-expression's macro ID as a system address")
                         .cut();
@@ -676,7 +675,7 @@ impl<'top> TextBuffer<'top> {
 
             let macro_ref = id.resolve(input.context().macro_table()).map_err(|_| {
                 (*input)
-                    .invalid(format!("could not find macro with id {:?}", id))
+                    .invalid(format!("could not find macro with id {id:?}"))
                     .context("reading an e-expression")
                     .cut_err()
             })?;
@@ -1905,7 +1904,7 @@ impl<'top> TextBuffer<'top> {
     fn validate_clob_text(&self) -> IonParseResult<'top, ()> {
         for byte in self.bytes().iter().copied() {
             if !Self::byte_is_legal_clob_ascii(byte) {
-                let message = format!("found an illegal byte '{:0x}' in clob", byte);
+                let message = format!("found an illegal byte '{byte:0x}' in clob");
                 return self.invalid(message).context("reading a clob").cut();
             }
         }

--- a/src/lazy/text/matched.rs
+++ b/src/lazy/text/matched.rs
@@ -245,7 +245,7 @@ impl MatchedFloat {
         let text = sanitized.as_utf8(matched_input.offset())?;
         let float = f64::from_str(text).map_err(|e| {
             matched_input
-                .invalid(format!("encountered an unexpected error ({:?})", e))
+                .invalid(format!("encountered an unexpected error ({e:?})"))
                 .context("reading a float")
         })?;
         Ok(float)
@@ -640,7 +640,7 @@ fn decode_escape_into_bytes<'data>(
         }
         _ => {
             return Err(IonError::Decoding(
-                DecodingError::new(format!("invalid escape sequence '\\{}", escape_id))
+                DecodingError::new(format!("invalid escape sequence '\\{escape_id}"))
                     .with_position(input.offset()),
             ))
         }
@@ -688,8 +688,7 @@ fn decode_hex_digits_escape<'data>(
     if !all_are_hex_digits {
         return Err(IonError::Decoding(
             DecodingError::new(format!(
-                "found a {}-hex-digit escape sequence that contained an invalid hex digit",
-                num_digits,
+                "found a {num_digits}-hex-digit escape sequence that contained an invalid hex digit",
             ))
             .with_position(input.offset()),
         ));
@@ -1234,8 +1233,7 @@ mod tests {
             let actual = matched.read(buffer).unwrap();
             assert_eq!(
                 actual, expected,
-                "Actual didn't match expected for input '{}'.\n{:?}\n!=\n{:?}",
-                data, actual, expected
+                "Actual didn't match expected for input '{data}'.\n{actual:?}\n!=\n{expected:?}",
             );
         }
 
@@ -1270,8 +1268,7 @@ mod tests {
             let actual = matched.read(buffer).unwrap();
             assert_eq!(
                 actual, expected,
-                "Actual didn't match expected for input '{}'.\n{:?}\n!=\n{:?}",
-                data, actual, expected
+                "Actual didn't match expected for input '{data}'.\n{actual:?}\n!=\n{expected:?}",
             );
         }
 
@@ -1372,34 +1369,27 @@ mod tests {
             let result = peek(TextBuffer::match_decimal).parse_next(&mut buffer);
             assert!(
                 result.is_ok(),
-                "Unexpected match error for input: '{data}': {:?}",
-                result
+                "Unexpected match error for input: '{data}': {result:?}",
             );
             let result = result.unwrap().read(buffer);
             assert!(
                 result.is_ok(),
-                "Unexpected read error for input '{data}': {:?}",
-                result
+                "Unexpected read error for input '{data}': {result:?}",
             );
             let actual = result.unwrap();
             assert_eq!(
                 actual, expected,
-                "Actual didn't match expected for input '{}'.\n{:?}\n!=\n{:?}",
-                data, actual, expected
+                "Actual didn't match expected for input '{data}'.\n{actual:?}\n!=\n{expected:?}",
             );
             assert_eq!(
                 actual.coefficient(),
                 expected.coefficient(),
-                "Actual coefficient didn't match expected coefficient for input '{}' .\n{:?}\n!=\n{:?}",
-                data, actual, expected
+                "Actual coefficient didn't match expected coefficient for input '{data}' .\n{actual:?}\n!=\n{expected:?}",
             );
             assert_eq!(
                 actual.exponent(),
                 expected.exponent(),
-                "Actual exponent didn't match expected exponent for input '{}' .\n{:?}\n!=\n{:?}",
-                data,
-                actual,
-                expected
+                "Actual exponent didn't match expected exponent for input '{data}' .\n{actual:?}\n!=\n{expected:?}",
             );
         }
 
@@ -1457,10 +1447,7 @@ mod tests {
             assert_eq!(
                 actual,
                 expected.as_ref(),
-                "Actual didn't match expected for input '{}'.\n{:?}\n!=\n{:?}",
-                data,
-                actual,
-                expected
+                "Actual didn't match expected for input '{data}'.\n{actual:?}\n!=\n{expected:?}",
             );
         }
 
@@ -1496,8 +1483,7 @@ mod tests {
             let actual = matched.read(context.allocator(), buffer).unwrap();
             assert_eq!(
                 actual, expected,
-                "Actual didn't match expected for input '{}'.\n{:?}\n!=\n{:?}",
-                data, actual, expected
+                "Actual didn't match expected for input '{data}'.\n{actual:?}\n!=\n{expected:?}",
             );
         }
 
@@ -1551,8 +1537,7 @@ mod tests {
             let result = read_clob(context, data);
             assert!(
                 result.is_ok(),
-                "Unexpected read failure for input '{data}': {:?}",
-                result
+                "Unexpected read failure for input '{data}': {result:?}",
             );
             let actual = result.unwrap();
             assert_eq!(

--- a/src/lazy/text/raw/reader.rs
+++ b/src/lazy/text/raw/reader.rs
@@ -138,7 +138,7 @@ mod tests {
                 lazy_value.is_null()
             );
             let value_ref = lazy_value.read().expect("reading failed");
-            assert_eq!(value_ref, expected, "{:?} != {:?}", value_ref, expected);
+            assert_eq!(value_ref, expected, "{value_ref:?} != {expected:?}");
         }
     }
 

--- a/src/lazy/text/raw/sequence.rs
+++ b/src/lazy/text/raw/sequence.rs
@@ -278,8 +278,7 @@ mod tests {
         let actual_range = value.data_range();
         assert_eq!(
             actual_range, expected,
-            "Sequence range ({:?}) did not match expected range ({:?})",
-            actual_range, expected
+            "Sequence range ({actual_range:?}) did not match expected range ({expected:?})",
         );
         Ok(())
     }

--- a/src/lazy/text/raw/struct.rs
+++ b/src/lazy/text/raw/struct.rs
@@ -125,10 +125,9 @@ mod tests {
         let actual_range = value.data_range();
         assert_eq!(
             actual_range, expected,
-            "Struct range ({:?}) did not match expected range ({:?})",
-            actual_range, expected
+            "Struct range ({actual_range:?}) did not match expected range ({expected:?})",
         );
-        println!("input ok: {}", ion_data);
+        println!("input ok: {ion_data}");
         Ok(())
     }
 

--- a/src/lazy/text/raw/v1_1/reader.rs
+++ b/src/lazy/text/raw/v1_1/reader.rs
@@ -328,8 +328,8 @@ impl MacroIdRef<'_> {
 impl Display for MacroIdRef<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            MacroIdRef::LocalName(name) => write!(f, "{}", name),
-            MacroIdRef::LocalAddress(address) => write!(f, "{}", address),
+            MacroIdRef::LocalName(name) => write!(f, "{name}"),
+            MacroIdRef::LocalAddress(address) => write!(f, "{address}"),
             MacroIdRef::SystemAddress(address) => {
                 write!(f, "$ion::{}", address.as_usize())
             }
@@ -601,7 +601,7 @@ mod tests {
             lazy_value.is_null()
         );
         let value_ref = lazy_value.read().expect("reading failed");
-        assert_eq!(value_ref, expected, "{:?} != {:?}", value_ref, expected);
+        assert_eq!(value_ref, expected, "{value_ref:?} != {expected:?}");
     }
 
     #[test]

--- a/src/lazy/value_ref.rs
+++ b/src/lazy/value_ref.rs
@@ -64,19 +64,19 @@ impl<D: Decoder> Debug for ValueRef<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use ValueRef::*;
         match self {
-            Null(ion_type) => write!(f, "null.{}", ion_type),
-            Bool(b) => write!(f, "{}", b),
-            Int(i) => write!(f, "{}", i),
-            Float(float) => write!(f, "{}", float),
-            Decimal(d) => write!(f, "{}", d),
-            Timestamp(t) => write!(f, "{}", t),
-            String(s) => write!(f, "{}", s),
+            Null(ion_type) => write!(f, "null.{ion_type}"),
+            Bool(b) => write!(f, "{b}"),
+            Int(i) => write!(f, "{i}"),
+            Float(float) => write!(f, "{float}"),
+            Decimal(d) => write!(f, "{d}"),
+            Timestamp(t) => write!(f, "{t}"),
+            String(s) => write!(f, "{s}"),
             Symbol(s) => write!(f, "{}", s.text().unwrap_or("$0")),
             Blob(b) => write!(f, "blob ({} bytes)", b.len()),
             Clob(c) => write!(f, "clob ({} bytes)", c.len()),
-            SExp(s) => write!(f, "sexp={:?}", s),
-            List(l) => write!(f, "{:?}", l),
-            Struct(s) => write!(f, "{:?}", s),
+            SExp(s) => write!(f, "sexp={s:?}"),
+            List(l) => write!(f, "{l:?}"),
+            Struct(s) => write!(f, "{s:?}"),
         }
     }
 }
@@ -183,7 +183,7 @@ impl<'top, D: Decoder> ValueRef<'top, D> {
         if let ValueRef::Symbol(s) = self {
             Ok(s)
         } else {
-            IonResult::decoding_error(format!("expected a symbol, found {:?}", self))
+            IonResult::decoding_error(format!("expected a symbol, found {self:?}"))
         }
     }
 

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -278,7 +278,7 @@ mod tests {
         };
 
         let result = to_pretty(&test).expect("failed to serialize");
-        println!("result: {}", result);
+        println!("result: {result}");
         let back_result: Test = from_ion(result.as_str()).expect("failed to deserialize");
 
         assert_eq!(back_result.int, 1);

--- a/src/shared_symbol_table.rs
+++ b/src/shared_symbol_table.rs
@@ -83,8 +83,7 @@ impl TryFrom<Element> for SharedSymbolTable {
             .ok_or_else(|| IonError::decoding_error("missing a 'name' field"))?;
         let name = name_field.as_string().ok_or_else(|| {
             IonError::decoding_error(format!(
-                "expected the 'name' field to be a string, but found a(n) {}",
-                name_field
+                "expected the 'name' field to be a string, but found a(n) {name_field}",
             ))
         })?;
         let mut version = sst_struct

--- a/src/text/text_formatter.rs
+++ b/src/text/text_formatter.rs
@@ -496,7 +496,7 @@ impl<W: fmt::Write> FmtValueFormatter<'_, W> {
             let list_value = peekable_itr.next().unwrap();
             write!(self.output, "{list_value}")?;
             if peekable_itr.peek().is_some() {
-                write!(self.output, "{}", delimiter)?;
+                write!(self.output, "{delimiter}")?;
             }
         }
         Ok(())

--- a/src/types/decimal/mod.rs
+++ b/src/types/decimal/mod.rs
@@ -485,7 +485,7 @@ impl Display for Decimal {
                 write!(f, "{}.{}", &digits[0..dot_index], &digits[dot_index..len])
             } else if dot_index > -(WIDE_NUMBER as i64) { // e.g. 0.ABC or 0.000ABC
                 let width = dot_index.unsigned_abs() as usize + len;
-                write!(f, "0.{digits:0>width$}", width = width, digits = digits)
+                write!(f, "0.{digits:0>width$}")
             } else { // e.g. A.BCd-12
                 write!(f, "{}.{}d{}", &digits[0..1], &digits[1..len], (dot_index - 1))
             }

--- a/src/write_config.rs
+++ b/src/write_config.rs
@@ -4,7 +4,6 @@ use std::marker::PhantomData;
 use crate::lazy::encoder::value_writer::SequenceWriter;
 use crate::lazy::encoder::write_as_ion::WriteAsIon;
 use crate::lazy::encoder::writer::Writer;
-use crate::lazy::encoder::LazyRawWriter;
 use crate::lazy::encoding::{
     BinaryEncoding_1_0, BinaryEncoding_1_1, Encoding, OutputFromBytes, TextEncoding_1_0,
     TextEncoding_1_1,
@@ -51,11 +50,6 @@ impl<E: Encoding> WriteConfig<E> {
         let mut writer = Writer::new(self.clone(), output)?;
         writer.write_all(values)?;
         writer.close()
-    }
-
-    #[cfg(feature = "experimental-tooling-apis")]
-    pub fn build_raw_writer<W: io::Write>(self, output: W) -> IonResult<E::Writer<W>> {
-        E::Writer::build(self, output)
     }
 }
 

--- a/src/write_config.rs
+++ b/src/write_config.rs
@@ -4,6 +4,7 @@ use std::marker::PhantomData;
 use crate::lazy::encoder::value_writer::SequenceWriter;
 use crate::lazy::encoder::write_as_ion::WriteAsIon;
 use crate::lazy::encoder::writer::Writer;
+use crate::lazy::encoder::LazyRawWriter;
 use crate::lazy::encoding::{
     BinaryEncoding_1_0, BinaryEncoding_1_1, Encoding, OutputFromBytes, TextEncoding_1_0,
     TextEncoding_1_1,
@@ -50,6 +51,11 @@ impl<E: Encoding> WriteConfig<E> {
         let mut writer = Writer::new(self.clone(), output)?;
         writer.write_all(values)?;
         writer.close()
+    }
+
+    #[cfg(feature = "experimental-tooling-apis")]
+    pub fn build_raw_writer<W: io::Write>(self, output: W) -> IonResult<E::Writer<W>> {
+        E::Writer::build(self, output)
     }
 }
 

--- a/tests/conformance_dsl/fragment.rs
+++ b/tests/conformance_dsl/fragment.rs
@@ -88,7 +88,7 @@ impl Fragment {
                     writer.flush()?;
                     let _ = writer
                         .output_mut()
-                        .write(format!("$ion_{}_{} ", maj, min).as_bytes())?;
+                        .write(format!("$ion_{maj}_{min} ").as_bytes())?;
                     Ok(())
                 }
             },

--- a/tests/conformance_dsl/mod.rs
+++ b/tests/conformance_dsl/mod.rs
@@ -471,9 +471,9 @@ mod tests {
 
         for test in tests {
             Document::from_str(test)
-                .unwrap_or_else(|e| panic!("Failed to load document: <<{}>>\n{:?}", test, e))
+                .unwrap_or_else(|e| panic!("Failed to load document: <<{test}>>\n{e:?}"))
                 .run()
-                .unwrap_or_else(|e| panic!("Test failed for simple doc: <<{}>>\n{:?}", test, e));
+                .unwrap_or_else(|e| panic!("Test failed for simple doc: <<{test}>>\n{e:?}"));
         }
     }
 
@@ -486,9 +486,9 @@ mod tests {
                  (produces 1)
              )"#;
         Document::from_str(test)
-            .unwrap_or_else(|e| panic!("Failed to load document:\n{:?}", e))
+            .unwrap_or_else(|e| panic!("Failed to load document:\n{e:?}"))
             .run()
-            .unwrap_or_else(|e| panic!("Test failed: {:?}", e));
+            .unwrap_or_else(|e| panic!("Test failed: {e:?}"));
     }
 
     #[test]
@@ -514,11 +514,11 @@ mod tests {
             r#"(ion_1_1 (text "2.3") (denotes (Decimal 23 -1)))"#,
         ];
         for test in tests {
-            println!("Testing: {}", test);
+            println!("Testing: {test}");
             Document::from_str(test)
-                .unwrap_or_else(|e| panic!("Failed to load document: <<{}>>\n{:?}", test, e))
+                .unwrap_or_else(|e| panic!("Failed to load document: <<{test}>>\n{e:?}"))
                 .run()
-                .unwrap_or_else(|e| panic!("Test failed for simple doc: <<{}>>\n{:?}", test, e));
+                .unwrap_or_else(|e| panic!("Test failed for simple doc: <<{test}>>\n{e:?}"));
         }
     }
 
@@ -533,11 +533,11 @@ mod tests {
         ];
 
         for test in tests {
-            println!("Testing: {}", test);
+            println!("Testing: {test}");
             Document::from_str(test)
-                .unwrap_or_else(|e| panic!("Failed to load document: <<{}>>\n{:?}", test, e))
+                .unwrap_or_else(|e| panic!("Failed to load document: <<{test}>>\n{e:?}"))
                 .run()
-                .unwrap_or_else(|e| panic!("Test failed for simple doc: <<{}>>\n{:?}", test, e));
+                .unwrap_or_else(|e| panic!("Test failed for simple doc: <<{test}>>\n{e:?}"));
         }
     }
 
@@ -550,10 +550,10 @@ mod tests {
                        (produces halb))
                )
             "#;
-        println!("Testing: {}", test);
+        println!("Testing: {test}");
         let doc = Document::from_str(test)
-            .unwrap_or_else(|e| panic!("Failed to load document: <<{}>>\n{:?}", test, e));
-        println!("Document: {:?}", doc);
+            .unwrap_or_else(|e| panic!("Failed to load document: <<{test}>>\n{e:?}"));
+        println!("Document: {doc:?}");
         match doc.run() {
             Err(_) => (),
             Ok(_) => panic!("Unexpected successful test evaluation"),
@@ -570,11 +570,11 @@ mod tests {
         ];
 
         for test in tests {
-            println!("Testing: {}", test);
+            println!("Testing: {test}");
             Document::from_str(test)
-                .unwrap_or_else(|e| panic!("Failed to load document: <<{}>>\n{:?}", test, e))
+                .unwrap_or_else(|e| panic!("Failed to load document: <<{test}>>\n{e:?}"))
                 .run()
-                .unwrap_or_else(|e| panic!("Test failed for simple doc: <<{}>>\n{:?}", test, e));
+                .unwrap_or_else(|e| panic!("Test failed for simple doc: <<{test}>>\n{e:?}"));
         }
     }
 
@@ -582,8 +582,8 @@ mod tests {
     fn test_symtab() {
         let source = r#"(ion_1_1 (symtab "a" "b") (text "$2") (produces b))"#;
         let doc = Document::from_str(source)
-            .unwrap_or_else(|e| panic!("Failed to load document: <<{}>>\n{:?}", source, e));
-        println!("Document: {:?}", doc);
+            .unwrap_or_else(|e| panic!("Failed to load document: <<{source}>>\n{e:?}"));
+        println!("Document: {doc:?}");
         doc.run().expect("test document failed");
     }
 }

--- a/tests/conformance_dsl/model.rs
+++ b/tests/conformance_dsl/model.rs
@@ -34,9 +34,9 @@ impl SymbolToken {
 impl std::fmt::Display for SymbolToken {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            SymbolToken::Text(txt) => write!(f, "{}", txt),
-            SymbolToken::Address(id) => write!(f, "#${}", id),
-            SymbolToken::Absent(txt, id) => write!(f, "#${}#{}", txt, id),
+            SymbolToken::Text(txt) => write!(f, "{txt}"),
+            SymbolToken::Address(id) => write!(f, "#${id}"),
+            SymbolToken::Absent(txt, id) => write!(f, "#${txt}#{id}"),
         }
     }
 }

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -143,7 +143,7 @@ mod ion_tests {
                 .is_some_and(|source| *source == file_name)
         });
         if skip_item.is_some_and(|item| item.tests.is_empty()) {
-            println!("SKIPPING: {}", file_name);
+            println!("SKIPPING: {file_name}");
             return;
         }
 
@@ -155,7 +155,7 @@ mod ion_tests {
             total_tests += 1;
             let name = if let Some(name) = &test.name {
                 if skip_tests.contains(&name.as_str()) {
-                    println!("Skipping: {} => \"{}\"", file_name, name);
+                    println!("Skipping: {file_name} => \"{name}\"");
                     total_skipped += 1;
                     continue;
                 }
@@ -164,13 +164,12 @@ mod ion_tests {
                 ""
             };
 
-            println!("TESTING: {} => {}", file_name, name);
+            println!("TESTING: {file_name} => {name}");
             test.run().expect("test failed");
         }
 
         println!(
-            "SUMMARY: {} : Total Tests {} :  Skipped {}",
-            file_name, total_tests, total_skipped
+            "SUMMARY: {file_name} : Total Tests {total_tests} :  Skipped {total_skipped}",
         );
     }
 }

--- a/tests/ion_hash_tests.rs
+++ b/tests/ion_hash_tests.rs
@@ -130,7 +130,7 @@ fn test_file(file_name: &str) -> IonHashTestResult<()> {
                 .text()
                 .expect("test name without text");
             if should_ignore(test_case_name) {
-                println!("skipping: {}", test_case_name);
+                println!("skipping: {test_case_name}");
                 continue;
             }
         }
@@ -205,7 +205,7 @@ fn test_case(
     };
 
     if should_ignore(&test_case_name) {
-        println!("skipping: {}", test_case_name);
+        println!("skipping: {test_case_name}");
         return Ok(());
     }
 
@@ -227,8 +227,7 @@ fn test_case(
         Err(IonHashTestError::TestFailed {
             test_case_name,
             message: Some(format!(
-                "expected: {}\nwas: {}",
-                expected_string, actual_string
+                "expected: {expected_string}\nwas: {actual_string}",
             )),
         })
     } else {
@@ -256,7 +255,7 @@ fn expected_hash(struct_: &Struct) -> IonResult<Vec<u8>> {
 
         match method {
             "digest" | "final_digest" => Ok(bytes),
-            _ => panic!("unknown expectation `{}`", method),
+            _ => panic!("unknown expectation `{method}`"),
         }
     } else {
         panic!("expected at least expectation!")


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Rust 1.88 was released yesterday and with it came new clippy lints. One of the new linting rules checks for places where variables can be used inline with `format!`.

So, in order to keep our build checks working, and not create a precedence for disabling lints, this PR updates all of the format call sites that clippy identified. The format inlining does not currently support field access (eg. `format!("{foo.bar}")`) so there are some untouched formats that might come up in the future. 

Inlined format was added in 1.66. We do not have an MSRV policy defined yet, but our Cargo.toml specifies the use of 1.82, so we are clear there.

Every change in this PR should be a simple move of one or more variable args to be included in the format string.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
