### PR TITLE
Implement system macro make_timestamp

### DIFF
--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -11,7 +11,7 @@ use crate::lazy::expanded::macro_evaluator::{
     AnnotateExpansion, ConditionalExpansion, DeltaExpansion, EExpressionArgGroup, ExprGroupExpansion,
     FlattenExpansion, IsExhaustedIterator, MacroExpansion, MacroExpansionKind, MacroExpr,
     MacroExprArgsIterator, MakeDecimalExpansion, MakeFieldExpansion, MakeStructExpansion,
-    MakeTextExpansion, RawEExpression, RepeatExpansion, SumExpansion, TemplateExpansion,
+    MakeTextExpansion, MakeTimestampExpansion, RawEExpression, RepeatExpansion, SumExpansion, TemplateExpansion,
     ValueExpr,
 };
 use crate::lazy::expanded::macro_table::{MacroKind, MacroRef};
@@ -128,6 +128,9 @@ impl<'top, D: Decoder> EExpression<'top, D> {
             }
             MacroKind::MakeStruct => {
                 MacroExpansionKind::MakeStruct(MakeStructExpansion::new(arguments))
+            }
+            MacroKind::MakeTimestamp => {
+                MacroExpansionKind::MakeTimestamp(MakeTimestampExpansion::new(arguments))
             }
             MacroKind::MakeField => {
                 MacroExpansionKind::MakeField(MakeFieldExpansion::new(arguments))

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -1511,9 +1511,7 @@ impl TimestampBuilderWrapper {
         Ok(builder_wrapper)
     }
 
-    /// Process the provided ValueRef as the offset parameter for the timestamp. The caller is
-    /// responsible for setting the offset on the timestamp, since there are multiple
-    /// TimestampBuilder types that can do that.
+    /// Process the provided ValueRef as the offset parameter for the timestamp.
     fn process_offset<'top, D: Decoder>(&self, value: ValueRef<'top, D>) -> IonResult<TimestampBuilderWrapper> {
         let offset = value
             .expect_int()?
@@ -1525,7 +1523,7 @@ impl TimestampBuilderWrapper {
             Self::WithMinute(builder) => builder.clone().with_offset(offset as i32),
             Self::WithSecond(builder) => builder.clone().with_offset(offset as i32),
             Self::WithFractionalSeconds(builder) => builder.clone().with_offset(offset as i32),
-            _ => unimplemented!(),
+            _ => return IonResult::decoding_error("Invalid state while building timestamp; tried to set field 'Offset' without setting time"),
         };
 
         Ok(TimestampBuilderWrapper::WithOffset(new_builder))

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -360,6 +360,7 @@ pub enum MacroKind {
     MakeSymbol,
     MakeField,
     MakeStruct,
+    MakeTimestamp,
     Annotate,
     Flatten,
     Template(TemplateBody),
@@ -633,7 +634,7 @@ impl MacroTable {
             builtin(
                 "make_timestamp",
                 "(year month? day? hour? minute? second? offset_minutes?)",
-                MacroKind::ToDo,
+                MacroKind::MakeTimestamp,
                 ExpansionAnalysis::single_application_value(IonType::Timestamp),
             ),
             builtin(

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -4,8 +4,8 @@ use crate::lazy::expanded::compiler::ExpansionAnalysis;
 use crate::lazy::expanded::macro_evaluator::{
     AnnotateExpansion, ConditionalExpansion, DeltaExpansion, ExprGroupExpansion, FlattenExpansion,
     MakeDecimalExpansion, MacroEvaluator, MacroExpansion, MacroExpansionKind, MacroExpr,
-    MacroExprArgsIterator, MakeFieldExpansion, MakeStructExpansion, MakeTextExpansion, RepeatExpansion,
-    SumExpansion, TemplateExpansion, ValueExpr,
+    MacroExprArgsIterator, MakeFieldExpansion, MakeStructExpansion, MakeTextExpansion, MakeTimestampExpansion,
+    RepeatExpansion, SumExpansion, TemplateExpansion, ValueExpr,
 };
 use crate::lazy::expanded::macro_table::{MacroDef, MacroKind, MacroRef};
 use crate::lazy::expanded::r#struct::FieldExpr;
@@ -1363,6 +1363,9 @@ impl<'top, D: Decoder> TemplateMacroInvocation<'top, D> {
             }
             MacroKind::MakeDecimal => {
                 MacroExpansionKind::MakeDecimal(MakeDecimalExpansion::new(arguments))
+            }
+            MacroKind::MakeTimestamp => {
+                MacroExpansionKind::MakeTimestamp(MakeTimestampExpansion::new(arguments))
             }
             MacroKind::MakeString => {
                 MacroExpansionKind::MakeString(MakeTextExpansion::string_maker(arguments))

--- a/src/types/decimal/mod.rs
+++ b/src/types/decimal/mod.rs
@@ -258,6 +258,8 @@ impl Decimal {
         }
     }
 
+    /// Returns the fractional part of `self`. Values with no fractional component will return
+    /// zero.
     pub fn fract(&self) -> Decimal {
         if self.exponent >= 0 {
             Decimal::ZERO

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -29,7 +29,7 @@ pub use r#struct::Struct;
 pub use sexp::SExp;
 pub use string::Str;
 pub use symbol::Symbol;
-pub use timestamp::{HasMinute, Mantissa, Timestamp, TimestampBuilder, TimestampPrecision};
+pub use timestamp::{HasDay, HasFractionalSeconds, HasHour, HasMinute, HasMonth, HasOffset, HasSeconds, HasYear, Mantissa, Timestamp, TimestampBuilder, TimestampPrecision};
 
 use crate::ion_data::{IonDataHash, IonDataOrd};
 use std::cmp::Ordering;


### PR DESCRIPTION
*Issue #, if available:* #942 (and a little of #970)

*Description of changes:*
This PR implements the `make_timestamp` system macro. It's a bigger PR than I really wanted, but I also wanted something to handle the timestamp builder a little better.

There are a few changes in here that are not directly related to `make_timestamp`, but do get used in the implementation:

- Added an implementation of `Sub` for `Decimal`. I originally added this thinking some arithmetic operations on Decimals would make handling the fractional second Decimal nicer. Ultimately I didn't use it.
-  I added `fract` and `trunc` to Decimal to handle extracting the whole and fractional values from the decimal. This mirrors the floating point types in Rust.
- I extended the `SystemMacroArguments` type to be a little more generic. It takes a generic argument that is `AsRef<str>`, which lets you provide a type that can be used to return a `&str` for the parameter name. In the `make_timestamp` implementation this is used to provide an enum that can be used to provide both the argument's position, as well as the name. Right now the only 2 implementations that are using it are `make_decimal` and `make_timestamp`, so it seems a bit overkill, but I'll circle back around and revisit the other system macros where it could be used.

The `TimestampBuilderWrapper` type that I'm using to handle the changing `TimestampBuilder` types adds a lot of bulk to the diff.


### Conformance Test
```
Running tests: ion-tests/conformance/system_macros/make_timestamp.ion
  make_timestamp can be invoked                                          ...  [Ok]
  make_timestamp produces a single, unannotated timestamp                ...  [Ok]
  the arguments may have annotations, which are silently dropped         ...  [Ok]
  the year argument                                                      ...  [Ok]
  the month argument                                                     ...  [Ok]
  the day argument                                                       ...  [Ok]
  the hour argument                                                      ...  [Ok]
  the minute argument                                                    ...  [Ok]
  the hour and minute arguments are encoded in binary as tagged values   ...  [Ok]
  the seconds argument                                                   ...  [Ok]
  the offset argument                                                    ...  [Ok]
```

### CLI
```
echo '$ion_1_1 (:make_timestamp 1 2 3 4 5 6.05 272)' | target/release/ion dump
0001-02-03T04:05:06.05+04:32
```
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
