### PR TITLE
Add feature for bigdecimal integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ experimental-tooling-apis = []
 # Experimental serde API to serialize and deserialize Ion data into Rust objects using serde crate
 experimental-serde = ["experimental-reader-writer", "dep:serde_with", "dep:serde"]
 
+bigdecimal = ["dep:bigdecimal"]
+
 [dependencies]
 base64 = "0.12"
 


### PR DESCRIPTION
A feature to turn on the optional `bigdecimal` dependency is needed for other crates to use #989 , else it results in 

```
error: failed to load source for dependency `ion-rs`
Caused by:
  Unable to update .../ion-rust
Caused by:
  failed to parse manifest at `.../ion-rust/Cargo.toml`
Caused by:
  optional dependency `bigdecimal` is not included in any feature
  Make sure that `dep:bigdecimal` is included in one of features in the [features] table.
Process finished with exit code 101
```

---


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
