### PR TITLE
Implement uint8 tagless encoding

### DIFF
--- a/src/lazy/binary/raw/v1_1/binary_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/binary_buffer.rs
@@ -258,6 +258,21 @@ impl<'a> BinaryBuffer<'a> {
         Ok((value, remaining_input))
     }
 
+    pub fn read_fixed_uint_as_lazy_value(self, size_in_bytes: usize) -> ParseResult<'a, LazyRawBinaryValue_1_1<'a>> {
+        let Some(first_byte) = self.peek_next_byte() else {
+            return IonResult::incomplete("a uint8", self.offset());
+        };
+
+        if self.len() < size_in_bytes {
+            return IonResult::incomplete("a uint8", self.offset());
+        }
+
+        let matched_input = self.slice(0, size_in_bytes);
+        let remaining_input = self.slice_to_end(size_in_bytes);
+        let value = LazyRawBinaryValue_1_1::for_fixed_uint(matched_input);
+        Ok((value, remaining_input))
+    }
+
     pub fn slice_to_end(&self, offset: usize) -> BinaryBuffer<'a> {
         BinaryBuffer {
             data: &self.data[offset..],

--- a/src/lazy/binary/raw/v1_1/binary_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/binary_buffer.rs
@@ -259,17 +259,13 @@ impl<'a> BinaryBuffer<'a> {
     }
 
     pub fn read_fixed_uint_as_lazy_value(self, size_in_bytes: usize) -> ParseResult<'a, LazyRawBinaryValue_1_1<'a>> {
-        let Some(first_byte) = self.peek_next_byte() else {
-            return IonResult::incomplete("a uint8", self.offset());
-        };
-
         if self.len() < size_in_bytes {
             return IonResult::incomplete("a uint8", self.offset());
         }
 
         let matched_input = self.slice(0, size_in_bytes);
         let remaining_input = self.slice_to_end(size_in_bytes);
-        let value = LazyRawBinaryValue_1_1::for_fixed_uint(matched_input);
+        let value = LazyRawBinaryValue_1_1::for_fixed_uint8(matched_input);
         Ok((value, remaining_input))
     }
 

--- a/src/lazy/binary/raw/v1_1/e_expression.rs
+++ b/src/lazy/binary/raw/v1_1/e_expression.rs
@@ -328,6 +328,20 @@ impl<'top> Iterator for BinaryEExpArgsInputIter<'top> {
                         remaining,
                     )
                 }
+                ParameterEncoding::UInt8 => {
+                    let (fixed_uint_lazy_value, remaining) = try_or_some_err! {
+                        self.remaining_args_buffer.read_fixed_uint_as_lazy_value(1)
+                    };
+                    let value_ref = &*self
+                        .remaining_args_buffer
+                        .context()
+                        .allocator()
+                        .alloc_with(|| fixed_uint_lazy_value);
+                    (
+                        EExpArg::new(parameter, EExpArgExpr::ValueLiteral(value_ref)),
+                        remaining,
+                    )
+                }
                 ParameterEncoding::MacroShaped(_macro_ref) => {
                     todo!("macro-shaped parameter encoding")
                 } // TODO: The other tagless encodings

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -361,7 +361,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
         }
     }
 
-    pub(crate) fn for_fixed_uint(input: BinaryBuffer<'top>) -> Self {
+    pub(crate) fn for_fixed_uint8(input: BinaryBuffer<'top>) -> Self {
         let encoded_value = EncodedBinaryValue {
             encoding: BinaryValueEncoding::UInt8,
             header: Header {

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -111,6 +111,7 @@ impl<'top> RawVersionMarker<'top> for LazyRawBinaryVersionMarker_1_1<'top> {
 pub enum BinaryValueEncoding {
     Tagged,
     FlexUInt,
+    UInt8,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -343,6 +344,33 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
             },
 
             // FlexUInts cannot have any annotations
+            annotations_header_length: 0,
+            annotations_sequence_length: 0,
+            annotations_encoding: AnnotationsEncoding::SymbolAddress,
+
+            header_offset: input.offset(),
+            length_length: 0,
+            value_body_length: input.len(),
+            total_length: input.len(),
+        };
+
+        LazyRawBinaryValue_1_1 {
+            encoded_value,
+            input,
+            delimited_contents: DelimitedContents::None,
+        }
+    }
+
+    pub(crate) fn for_fixed_uint(input: BinaryBuffer<'top>) -> Self {
+        let encoded_value = EncodedBinaryValue {
+            encoding: BinaryValueEncoding::UInt8,
+            header: Header {
+                ion_type: IonType::Int,
+                ion_type_code: OpcodeType::Nop,
+                length_type: LengthType::Unknown,
+                byte: 0,
+            },
+
             annotations_header_length: 0,
             annotations_sequence_length: 0,
             annotations_encoding: AnnotationsEncoding::SymbolAddress,

--- a/src/lazy/encoder/binary/v1_1/container_writers.rs
+++ b/src/lazy/encoder/binary/v1_1/container_writers.rs
@@ -512,6 +512,11 @@ impl<'top> EExpWriter for BinaryEExpWriter_1_1<'_, 'top> {
         Ok(())
     }
 
+    fn write_fixed_uint8(&mut self, value: impl Into<u8>) -> IonResult<()> {
+        self.buffer.push(value.into());
+        Ok(())
+    }
+
     fn expr_group_writer(&mut self) -> IonResult<Self::ExprGroupWriter<'_>> {
         todo!("safe binary expression group serialization")
     }

--- a/src/lazy/encoder/value_writer.rs
+++ b/src/lazy/encoder/value_writer.rs
@@ -64,7 +64,11 @@ pub trait EExpWriter: SequenceWriter + EExpWriterInternal {
     fn current_parameter(&self) -> Option<&Parameter>;
 
     fn write_flex_uint(&mut self, _value: impl Into<UInt>) -> IonResult<()> {
-        todo!("current only implemented for binary 1.1 to enable unit testing for the reader")
+        todo!("currently only implemented for binary 1.1 to enable unit testing for the reader")
+    }
+
+    fn write_fixed_uint8(&mut self, _value: impl Into<u8>) -> IonResult<()> {
+        todo!("currently only implemented for binary 1.1 to enable unit testing for the reader")
     }
 
     fn expr_group_writer(&mut self) -> IonResult<Self::ExprGroupWriter<'_>>;

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -1464,7 +1464,7 @@ mod tests {
             let foo = writer.compile_macro("(macro foo (uint8::x) (%x))")?;
             let mut eexp_writer = writer.eexp_writer(&foo)?;
             eexp_writer.write_fixed_uint8(5)?;
-            eexp_writer.close();
+            let _ = eexp_writer.close();
             let output = writer.close()?;
             assert_eq!(output.as_slice(), expected);
             Ok(())

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -1022,6 +1022,12 @@ impl<V: ValueWriter> EExpWriter for ApplicationEExpWriter<'_, V> {
         self.raw_eexp_writer.write_flex_uint(value)
     }
 
+    fn write_fixed_uint8(&mut self, value: impl Into<u8>) -> IonResult<()> {
+        self.expect_next_parameter()
+            .and_then(|p| p.expect_encoding(&ParameterEncoding::UInt8))?;
+        self.raw_eexp_writer.write_fixed_uint8(value)
+    }
+
     fn expr_group_writer(&mut self) -> IonResult<Self::ExprGroupWriter<'_>> {
         self.expect_next_parameter()
             .and_then(|p| p.expect_variadic())?;
@@ -1433,6 +1439,34 @@ mod tests {
             // Attempt to write a tagged value for parameter `a`, which has a cardinality of
             // zero-or-more, and therefore requires an expression group.
             assert!(eexp_writer.write("hello").is_err());
+            Ok(())
+        }
+
+        #[test]
+        fn tagless_uint8_encoding() -> IonResult<()> {
+            let expected: &[u8] = &[
+                0xE0, 0x01, 0x01, 0xEA,                       // IVM
+                0xE7, 0xF9, 0x24, 0x69, 0x6F, 0x6E,           // $ion::
+                0xFC, 0x55, 0xEE, 0x10, 0xA1, 0x5F,           // (module _
+                0xC4, 0xEE, 0x0F, 0xA1, 0x5F,                 //   (symbol_table _ )
+                0xFC, 0x3F, 0xEE, 0x0E, 0xA1, 0x5F,           //   (macro_table _
+                0xFC, 0x33,                                   //      (
+                0xA5, 0x6d, 0x61, 0x63, 0x72, 0x6F,           //        macro
+                0xA3, 0x66, 0x6F, 0x6F,                       //        foo
+                0xC9,                                         //        (
+                0xE7, 0xF7, 0x75, 0x69, 0x6E, 0x74, 0x38,     //          uint8::
+                0xA1, 0x78,                                   //          x )
+                0xC4, 0xA1, 0x25, 0xA1, 0x78,                 //        ('%' x))))
+                0x18, 0x05,                                   //  (:foo 5)
+
+            ];
+            let mut writer = Writer::new(v1_1::Binary, Vec::new())?;
+            let foo = writer.compile_macro("(macro foo (uint8::x) (%x))")?;
+            let mut eexp_writer = writer.eexp_writer(&foo)?;
+            eexp_writer.write_fixed_uint8(5)?;
+            eexp_writer.close();
+            let output = writer.close()?;
+            assert_eq!(output.as_slice(), expected);
             Ok(())
         }
     }

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -378,6 +378,7 @@ impl TemplateCompiler {
             // If it's not in the local scope, see if it's a built-in.
             return match encoding_name {
                 "flex_uint" => Ok(ParameterEncoding::FlexUInt),
+                "uint8" => Ok(ParameterEncoding::UInt8),
                 _ => IonResult::decoding_error(format!(
                     "unrecognized encoding '{encoding_name}' specified for parameter"
                 )),
@@ -1687,6 +1688,29 @@ mod tests {
                 .unwrap()
                 .encoding(),
             &ParameterEncoding::FlexUInt
+        );
+        expect_variable(&template, 0, 0)?;
+        Ok(())
+    }
+
+    #[test]
+    fn identity_with_uint8() -> IonResult<()> {
+        let resources = TestResources::new();
+        let context = resources.context();
+
+        let expression = "(macro identity (uint8::x) (%x))";
+
+        let template = TemplateCompiler::compile_from_source(context.macro_table(), expression)?;
+        assert_eq!(template.name(), "identity");
+        assert_eq!(template.signature().len(), 1);
+        assert_eq!(
+            template
+                .signature()
+                .parameters()
+                .first()
+                .unwrap()
+                .encoding(),
+            &ParameterEncoding::UInt8,
         );
         expect_variable(&template, 0, 0)?;
         Ok(())

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -2779,6 +2779,30 @@ mod tests {
     }
 
     #[test]
+    fn uint8_parameters() -> IonResult<()> {
+        let template_definition =
+            "(macro int_pair (uint8::x uint8::y) (.values (%x) (%y)))";
+        let macro_id = MacroTable::FIRST_USER_MACRO_ID as u8;
+        let tests: &[(&[u8], (u64, u64))] = &[
+            (&[macro_id, 0x00, 0x00], (0, 0)),
+        ];
+
+        for (stream, (num1, num2)) in tests.iter().copied() {
+            let mut reader = Reader::new(v1_1::Binary, stream)?;
+            reader.register_template_src(template_definition)?;
+            assert_eq!(
+                reader.next()?.unwrap().read()?.expect_int()?,
+                Int::from(num1)
+            );
+            assert_eq!(
+                reader.next()?.unwrap().read()?.expect_int()?,
+                Int::from(num2)
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
     fn it_takes_all_kinds() -> IonResult<()> {
         eval_template_invocation(
             r#"(macro foo () 

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -163,6 +163,9 @@ fn write_macro_signature_as_ion<V: ValueWriter>(
             ParameterEncoding::FlexUInt => value_writer
                 .with_annotations("flex_uint")?
                 .write_symbol(param.name())?,
+            ParameterEncoding::UInt8 => value_writer
+                .with_annotations("uint8")?
+                .write_symbol(param.name())?,
             ParameterEncoding::MacroShaped(_) => todo!(),
         };
         let cardinality_modifier = match param.cardinality() {

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -207,6 +207,7 @@ pub enum ParameterEncoding {
     /// A 'tagged' type is one whose binary encoding begins with an opcode (sometimes called a 'tag'.)
     Tagged,
     FlexUInt,
+    UInt8,
     // TODO: tagless types, including fixed-width types and macros
     MacroShaped(Arc<MacroDef>),
 }
@@ -217,6 +218,7 @@ impl Display for ParameterEncoding {
         match self {
             Tagged => write!(f, "tagged"),
             FlexUInt => write!(f, "flex_uint"),
+            UInt8 => write!(f, "uint8"),
             MacroShaped(m) => write!(f, "{}", m.name().unwrap_or("<anonymous>")),
         }
     }


### PR DESCRIPTION
*Issue #, if available:* #943

*Description of changes:*
This PR implements the "backend" support for tagless encoding of uint8s.

By "backend" I mean that the ability to read tagless uint8s is provided, however writing them leans on a function exposed by the EExpr writer for writing `uint8`s specifically. This mirrors the support for `FlexUInt` and will require adding some functionality to existing writers to allow plumbing parameter info down so that we can verify values being written to ensure they fit the range of numeric primitives, etc., as well as handle expression groups.

## Testing
### CLI Reading
```
 % ./target/release/ion inspect ~/Code/sandbox/tagless_output/output.10n
┌──────────────┬──────────────┬─────────────────────────┬──────────────────────┐
│    Offset    │    Length    │       Binary Ion        │       Text Ion       │
├──────────────┼──────────────┼─────────────────────────┼──────────────────────┘
│            0 │            4 │ e0 01 01 ea             │ $ion_1_1 // Version marker
├──────────────┼──────────────┼─────────────────────────┤
│            4 │            6 │ e7 f9 24 69 6f 6e       │ $ion:: // <text>
│           10 │           44 │ fc 55                   │ (
│           12 │            2 │ ee 10                   │ · module
│           14 │            2 │ a1 5f                   │ · _
│           16 │            5 │ c4                      │ · (
│           17 │            2 │ ee 0f                   │ · · symbol_table
│           19 │            2 │ a1 5f                   │ · · _
│              │              │                         │ · )
│           21 │           33 │ fc 3f                   │ · (
│           23 │            2 │ ee 0e                   │ · · macro_table
│           25 │            2 │ a1 5f                   │ · · _
│           27 │           27 │ fc 33                   │ · · (
│           29 │            6 │ a5 6d 61 63 72 6f       │ · · · macro
│           35 │            4 │ a3 66 6f 6f             │ · · · foo
│           39 │           10 │ c9                      │ · · · (
│           40 │            7 │ e7 f7 75 69 6e 74 38    │ · · · · uint8:: // <text>
│           47 │            2 │ a1 78                   │ · · · · x
│              │              │                         │ · · · )
│           49 │            5 │ c4                      │ · · · (
│           50 │            2 │ a1 25                   │ · · · · '%'
│           52 │            2 │ a1 78                   │ · · · · x
│              │              │                         │ · · · )
│              │              │                         │ · · )
│              │              │                         │ · )
│              │              │                         │ )
├──────────────┼──────────────┼─────────────────────────┤
│           54 │            2 │ 18                      │ (:foo
│           55 │            1 │ 05                      │ · 5 // x
│              │              │                         │ )
├──────────────┼──────────────┼─────────────────────────┤
│           55 │            1 │ 05                      │ 5
├──────────────┼──────────────┼─────────────────────────┤
│           56 │              │                         │  // End of stream
└──────────────┴──────────────┴─────────────────────────┘
```

```shell
% ./target/release/ion dump ~/Code/sandbox/tagless_output/output.10n
5
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
