### PR TITLE
Implement remaining tagless uints

### DIFF
--- a/src/lazy/binary/raw/v1_1/binary_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/binary_buffer.rs
@@ -260,12 +260,20 @@ impl<'a> BinaryBuffer<'a> {
 
     pub fn read_fixed_uint_as_lazy_value(self, size_in_bytes: usize) -> ParseResult<'a, LazyRawBinaryValue_1_1<'a>> {
         if self.len() < size_in_bytes {
-            return IonResult::incomplete("a uint8", self.offset());
+            return IonResult::incomplete("a uint", self.offset());
         }
+
+        let encoding = match size_in_bytes {
+            1 => BinaryValueEncoding::UInt8,
+            2 => BinaryValueEncoding::UInt16,
+            4 => BinaryValueEncoding::UInt32,
+            8 => BinaryValueEncoding::UInt64,
+            _ => return IonResult::decoding_error(format!("Invalid byte size for fixed uint: {size_in_bytes}")),
+        };
 
         let matched_input = self.slice(0, size_in_bytes);
         let remaining_input = self.slice_to_end(size_in_bytes);
-        let value = LazyRawBinaryValue_1_1::for_fixed_uint8(matched_input);
+        let value = LazyRawBinaryValue_1_1::for_fixed_uint(matched_input, encoding);
         Ok((value, remaining_input))
     }
 

--- a/src/lazy/binary/raw/v1_1/binary_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/binary_buffer.rs
@@ -258,6 +258,21 @@ impl<'a> BinaryBuffer<'a> {
         Ok((value, remaining_input))
     }
 
+    pub fn read_fixed_uint_as_lazy_value(self, size_in_bytes: usize) -> ParseResult<'a, LazyRawBinaryValue_1_1<'a>> {
+        let Some(first_byte) = self.peek_next_byte() else {
+            return IonResult::incomplete("a uint8", self.offset());
+        };
+
+        if self.len() < size_in_bytes {
+            return IonResult::incomplete("a uint8", self.offset());
+        }
+
+        let matched_input = self.slice(0, size_in_bytes);
+        let remaining_input = self.slice_to_end(size_in_bytes);
+        let value = LazyRawBinaryValue_1_1::for_fixed_uint(matched_input);
+        Ok((value, remaining_input))
+    }
+
     pub fn slice_to_end(&self, offset: usize) -> BinaryBuffer<'a> {
         BinaryBuffer {
             data: &self.data[offset..],

--- a/src/lazy/binary/raw/v1_1/binary_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/binary_buffer.rs
@@ -259,17 +259,13 @@ impl<'a> BinaryBuffer<'a> {
     }
 
     pub fn read_fixed_uint_as_lazy_value(self, size_in_bytes: usize) -> ParseResult<'a, LazyRawBinaryValue_1_1<'a>> {
-        let Some(first_byte) = self.peek_next_byte() else {
-            return IonResult::incomplete("a uint8", self.offset());
-        };
-
         if self.len() < size_in_bytes {
             return IonResult::incomplete("a uint8", self.offset());
         }
 
         let matched_input = self.slice(0, size_in_bytes);
         let remaining_input = self.slice_to_end(size_in_bytes);
-        let value = LazyRawBinaryValue_1_1::for_fixed_uint(matched_input);
+        let value = LazyRawBinaryValue_1_1::for_fixed_uint8(matched_input);
         Ok((value, remaining_input))
     }
 

--- a/src/lazy/binary/raw/v1_1/e_expression.rs
+++ b/src/lazy/binary/raw/v1_1/e_expression.rs
@@ -342,6 +342,48 @@ impl<'top> Iterator for BinaryEExpArgsInputIter<'top> {
                         remaining,
                     )
                 }
+                ParameterEncoding::UInt16 => {
+                    let (fixed_uint_lazy_value, remaining) = try_or_some_err! {
+                        self.remaining_args_buffer.read_fixed_uint_as_lazy_value(2)
+                    };
+                    let value_ref = &*self
+                        .remaining_args_buffer
+                        .context()
+                        .allocator()
+                        .alloc_with(|| fixed_uint_lazy_value);
+                    (
+                        EExpArg::new(parameter, EExpArgExpr::ValueLiteral(value_ref)),
+                        remaining,
+                    )
+                }
+                ParameterEncoding::UInt32 => {
+                    let (fixed_uint_lazy_value, remaining) = try_or_some_err! {
+                        self.remaining_args_buffer.read_fixed_uint_as_lazy_value(4)
+                    };
+                    let value_ref = &*self
+                        .remaining_args_buffer
+                        .context()
+                        .allocator()
+                        .alloc_with(|| fixed_uint_lazy_value);
+                    (
+                        EExpArg::new(parameter, EExpArgExpr::ValueLiteral(value_ref)),
+                        remaining,
+                    )
+                }
+                ParameterEncoding::UInt64 => {
+                    let (fixed_uint_lazy_value, remaining) = try_or_some_err! {
+                        self.remaining_args_buffer.read_fixed_uint_as_lazy_value(8)
+                    };
+                    let value_ref = &*self
+                        .remaining_args_buffer
+                        .context()
+                        .allocator()
+                        .alloc_with(|| fixed_uint_lazy_value);
+                    (
+                        EExpArg::new(parameter, EExpArgExpr::ValueLiteral(value_ref)),
+                        remaining,
+                    )
+                }
                 ParameterEncoding::MacroShaped(_macro_ref) => {
                     todo!("macro-shaped parameter encoding")
                 } // TODO: The other tagless encodings

--- a/src/lazy/binary/raw/v1_1/e_expression.rs
+++ b/src/lazy/binary/raw/v1_1/e_expression.rs
@@ -328,6 +328,20 @@ impl<'top> Iterator for BinaryEExpArgsInputIter<'top> {
                         remaining,
                     )
                 }
+                ParameterEncoding::UInt8 => {
+                    let (fixed_uint_lazy_value, remaining) = try_or_some_err! {
+                        self.remaining_args_buffer.read_fixed_uint_as_lazy_value(1)
+                    };
+                    let value_ref = &*self
+                        .remaining_args_buffer
+                        .context()
+                        .allocator()
+                        .alloc_with(|| fixed_uint_lazy_value);
+                    (
+                        EExpArg::new(parameter, EExpArgExpr::ValueLiteral(value_ref)),
+                        remaining,
+                    )
+                }
                 ParameterEncoding::MacroShaped(_macro_ref) => {
                     todo!("macro-shaped parameter encoding")
                 } // TODO: The other tagless encodings

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -361,7 +361,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
         }
     }
 
-    pub(crate) fn for_fixed_uint(input: BinaryBuffer<'top>) -> Self {
+    pub(crate) fn for_fixed_uint8(input: BinaryBuffer<'top>) -> Self {
         let encoded_value = EncodedBinaryValue {
             encoding: BinaryValueEncoding::UInt8,
             header: Header {

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -111,6 +111,7 @@ impl<'top> RawVersionMarker<'top> for LazyRawBinaryVersionMarker_1_1<'top> {
 pub enum BinaryValueEncoding {
     Tagged,
     FlexUInt,
+    UInt8,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -343,6 +344,33 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
             },
 
             // FlexUInts cannot have any annotations
+            annotations_header_length: 0,
+            annotations_sequence_length: 0,
+            annotations_encoding: AnnotationsEncoding::SymbolAddress,
+
+            header_offset: input.offset(),
+            length_length: 0,
+            value_body_length: input.len(),
+            total_length: input.len(),
+        };
+
+        LazyRawBinaryValue_1_1 {
+            encoded_value,
+            input,
+            delimited_contents: DelimitedContents::None,
+        }
+    }
+
+    pub(crate) fn for_fixed_uint(input: BinaryBuffer<'top>) -> Self {
+        let encoded_value = EncodedBinaryValue {
+            encoding: BinaryValueEncoding::UInt8,
+            header: Header {
+                ion_type: IonType::Int,
+                ion_type_code: OpcodeType::Nop,
+                length_type: LengthType::Unknown,
+                byte: 0,
+            },
+
             annotations_header_length: 0,
             annotations_sequence_length: 0,
             annotations_encoding: AnnotationsEncoding::SymbolAddress,

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -112,6 +112,9 @@ pub enum BinaryValueEncoding {
     Tagged,
     FlexUInt,
     UInt8,
+    UInt16,
+    UInt32,
+    UInt64,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -361,9 +364,9 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
         }
     }
 
-    pub(crate) fn for_fixed_uint8(input: BinaryBuffer<'top>) -> Self {
+    pub(crate) fn for_fixed_uint(input: BinaryBuffer<'top>, encoding: BinaryValueEncoding) -> Self {
         let encoded_value = EncodedBinaryValue {
-            encoding: BinaryValueEncoding::UInt8,
+            encoding,
             header: Header {
                 ion_type: IonType::Int,
                 ion_type_code: OpcodeType::Nop,

--- a/src/lazy/encoder/binary/v1_1/container_writers.rs
+++ b/src/lazy/encoder/binary/v1_1/container_writers.rs
@@ -512,6 +512,11 @@ impl<'top> EExpWriter for BinaryEExpWriter_1_1<'_, 'top> {
         Ok(())
     }
 
+    fn write_fixed_uint8(&mut self, value: impl Into<u8>) -> IonResult<()> {
+        self.buffer.push(value.into());
+        Ok(())
+    }
+
     fn expr_group_writer(&mut self) -> IonResult<Self::ExprGroupWriter<'_>> {
         todo!("safe binary expression group serialization")
     }

--- a/src/lazy/encoder/binary/v1_1/fixed_uint.rs
+++ b/src/lazy/encoder/binary/v1_1/fixed_uint.rs
@@ -73,7 +73,7 @@ impl FixedUInt {
         let encoded_bytes = value.to_le_bytes();
 
         if !(0..256u128).contains(&value) {
-            return IonResult::encoding_error("provided unsigned intger value does not fit within 1 byte");
+            return IonResult::encoding_error("provided unsigned integer value does not fit within 1 byte");
         }
 
         output.write_all(&encoded_bytes[..1])?;

--- a/src/lazy/encoder/binary/v1_1/fixed_uint.rs
+++ b/src/lazy/encoder/binary/v1_1/fixed_uint.rs
@@ -65,6 +65,20 @@ impl FixedUInt {
     pub fn size_in_bytes(&self) -> usize {
         self.size_in_bytes
     }
+
+    /// Write the provided UInt-like as a uint8 ensuring that the value fits in 8bits.
+    #[inline]
+    pub(crate) fn write_as_uint8<W: Write>(output: &mut W, value: impl Into<UInt>) -> IonResult<()> {
+        let value = value.into().data;
+        let encoded_bytes = value.to_le_bytes();
+
+        if !(0..256u128).contains(&value) {
+            return IonResult::encoding_error("provided unsigned intger value does not fit within 1 byte");
+        }
+
+        output.write_all(&encoded_bytes[..1])?;
+        Ok(())
+    }
 }
 
 impl TryFrom<FixedUInt> for Coefficient {

--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -1075,18 +1075,13 @@ impl<'value, 'top> ValueWriter for BinaryEExpParameterValueWriter_1_1<'value, 't
             .and_then(|p| p.expect_single_expression())?;
 
         let result = match param.encoding() {
-            PE::UInt8 => {
-                value
-                    .try_into()
-                    .and_then(|uint: UInt| FixedUInt::write_as_uint8(self.buffer, uint))
-                    .map(|_| ())
-            }
-            PE::FlexUInt => {
-                value
-                    .try_into()
-                    .and_then(|uint: UInt| FlexUInt::write(self.buffer, uint))
-                    .map(|_| ())
-            }
+            PE::UInt8 => value
+                .try_into()
+                .and_then(|uint: UInt| FixedUInt::write_as_uint8(self.buffer, uint)),
+            PE::FlexUInt => value
+                .try_into()
+                .and_then(|uint: UInt| FlexUInt::write(self.buffer, uint))
+                .map(|_| ()),
             PE::Tagged => {
                 let value_writer = BinaryValueWriter_1_1::new(
                     self.allocator,
@@ -1096,8 +1091,9 @@ impl<'value, 'top> ValueWriter for BinaryEExpParameterValueWriter_1_1<'value, 't
                 );
                 value_writer.write_i64(value)
             }
-            encoding => return IonResult::encoding_error(format!("value does not satisfy encoding type {encoding}")),
-
+            encoding => IonResult::encoding_error(
+                format!("value does not satisfy encoding type {encoding}")
+            ),
         };
 
         result.map_err(|err| error_context(param.name(), err))
@@ -1119,17 +1115,13 @@ impl<'value, 'top> ValueWriter for BinaryEExpParameterValueWriter_1_1<'value, 't
             .and_then(|p| p.expect_single_expression())?;
 
         let result = match param.encoding() {
-            PE::UInt8 => {
-                value
-                    .try_into()
-                    .and_then(|uint: UInt| FixedUInt::write_as_uint8(self.buffer, uint))
-            }
-            PE::FlexUInt => {
-                value
-                    .try_into()
-                    .and_then(|uint: UInt| FlexUInt::write(self.buffer, uint))
-                    .map(|_| ())
-            }
+            PE::UInt8 => value
+                .try_into()
+                .and_then(|uint: UInt| FixedUInt::write_as_uint8(self.buffer, uint)),
+            PE::FlexUInt => value
+                .try_into()
+                .and_then(|uint: UInt| FlexUInt::write(self.buffer, uint))
+                .map(|_| ()),
             PE::Tagged => {
                 let value_writer = BinaryValueWriter_1_1::new(
                     self.allocator,
@@ -1139,7 +1131,9 @@ impl<'value, 'top> ValueWriter for BinaryEExpParameterValueWriter_1_1<'value, 't
                 );
                 value_writer.write_int(value)
             }
-            encoding => return IonResult::encoding_error(format!("value provided for '{}' does not satisfy encoding type {encoding}", param.name())),
+            encoding => IonResult::encoding_error(
+                format!("value does not satisfy encoding type {encoding}")
+            ),
         };
 
         result.map_err(|err| error_context(param.name(), err))

--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -1076,7 +1076,16 @@ impl<'value, 'top> ValueWriter for BinaryEExpParameterValueWriter_1_1<'value, 't
         let result = match param.encoding() {
             PE::UInt8 => value
                 .try_into()
-                .and_then(|uint: UInt| FixedUInt::write_as_uint8(self.buffer, uint)),
+                .and_then(|uint: UInt| FixedUInt::write_as_uint::<u8>(self.buffer, uint)),
+            PE::UInt16 => value
+                .try_into()
+                .and_then(|uint: UInt| FixedUInt::write_as_uint::<u16>(self.buffer, uint)),
+            PE::UInt32 => value
+                .try_into()
+                .and_then(|uint: UInt| FixedUInt::write_as_uint::<u32>(self.buffer, uint)),
+            PE::UInt64 => value
+                .try_into()
+                .and_then(|uint: UInt| FixedUInt::write_as_uint::<u64>(self.buffer, uint)),
             PE::FlexUInt => value
                 .try_into()
                 .and_then(|uint: UInt| FlexUInt::write(self.buffer, uint))
@@ -1116,7 +1125,16 @@ impl<'value, 'top> ValueWriter for BinaryEExpParameterValueWriter_1_1<'value, 't
         let result = match param.encoding() {
             PE::UInt8 => value
                 .try_into()
-                .and_then(|uint: UInt| FixedUInt::write_as_uint8(self.buffer, uint)),
+                .and_then(|uint: UInt| FixedUInt::write_as_uint::<u8>(self.buffer, uint)),
+            PE::UInt16 => value
+                .try_into()
+                .and_then(|uint: UInt| FixedUInt::write_as_uint::<u16>(self.buffer, uint)),
+            PE::UInt32 => value
+                .try_into()
+                .and_then(|uint: UInt| FixedUInt::write_as_uint::<u32>(self.buffer, uint)),
+            PE::UInt64 => value
+                .try_into()
+                .and_then(|uint: UInt| FixedUInt::write_as_uint::<u64>(self.buffer, uint)),
             PE::FlexUInt => value
                 .try_into()
                 .and_then(|uint: UInt| FlexUInt::write(self.buffer, uint))

--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -18,6 +18,7 @@ use crate::lazy::encoder::value_writer_config::{
     AnnotationsEncoding, ContainerEncoding, FieldNameEncoding, SymbolValueEncoding,
     ValueWriterConfig,
 };
+use crate::lazy::expanded::template::Parameter;
 use crate::lazy::text::raw::v1_1::reader::{MacroIdLike, ModuleKind};
 use crate::raw_symbol_ref::AsRawSymbolRef;
 use crate::result::IonFailure;
@@ -964,6 +965,330 @@ impl<'value, 'top> BinaryAnnotatedValueWriter_1_1<'value, 'top> {
             self.macros,
         );
         writer
+    }
+}
+
+macro_rules! validate_parameter_and_delegate {
+    () => {};
+    ($value_type:ty => $method:ident, $($rest:tt)*) => {
+        fn $method(self, value: $value_type) -> IonResult<()> {
+            use $crate::IonError;
+            use $crate::lazy::expanded::template::ParameterEncoding;
+            println!("Param: {:?}", self.parameter);
+            let _param = self
+                .parameter
+                .ok_or(IonError::encoding_error("unexpected parameter provided"))
+                .and_then(|p| p.expect_encoding(&ParameterEncoding::Tagged))
+                .and_then(|p| p.expect_single_expression())?;
+
+            let value_writer = $crate::lazy::encoder::binary::v1_1::value_writer::BinaryValueWriter_1_1::new(
+                self.allocator,
+                self.buffer,
+                self.value_writer_config,
+                self.macros,
+            );
+            value_writer.$method(value)?;
+            Ok(())
+        }
+        validate_parameter_and_delegate!($($rest)*);
+    };
+}
+
+pub struct BinaryEExpParameterValueWriter_1_1<'value, 'top> {
+    allocator: &'top BumpAllocator,
+    buffer: &'value mut BumpVec<'top, u8>,
+    value_writer_config: ValueWriterConfig,
+    macros: &'value MacroTable,
+    parameter: Option<&'value Parameter>,
+}
+
+impl<'value, 'top> BinaryEExpParameterValueWriter_1_1<'value, 'top> {
+    pub(crate) fn new<'a, 'b: 'a>(
+        allocator: &'b BumpAllocator,
+        buffer: &'a mut BumpVec<'b, u8>,
+        value_writer_config: ValueWriterConfig,
+        macros: &'a MacroTable,
+        parameter: Option<&'a Parameter>,
+    ) -> BinaryEExpParameterValueWriter_1_1<'a, 'b> {
+        BinaryEExpParameterValueWriter_1_1{
+            allocator,
+            buffer,
+            value_writer_config,
+            macros,
+            parameter,
+        }
+    }
+}
+
+impl<'value, 'top> ValueWriter for BinaryEExpParameterValueWriter_1_1<'value, 'top> {
+    type ListWriter = BinaryListWriter_1_1<'value, 'top>;
+    type SExpWriter = BinarySExpWriter_1_1<'value, 'top>;
+    type StructWriter = BinaryStructWriter_1_1<'value, 'top>;
+    type EExpWriter = BinaryEExpWriter_1_1<'value, 'top>;
+
+    validate_parameter_and_delegate!(
+        IonType => write_null,
+        bool => write_bool,
+        &Decimal => write_decimal,
+        &Timestamp => write_timestamp,
+        impl AsRef<str> => write_string,
+        impl AsRef<[u8]> => write_clob,
+        impl AsRef<[u8]> => write_blob,
+    );
+
+    // These types need to have ranges validated to ensure we can write the value to a tagless
+    // parameter if the parameter is tagless.
+
+    fn write_symbol(self, value: impl AsRawSymbolRef) -> IonResult<()> {
+        use crate::IonError;
+        use crate::lazy::expanded::template::ParameterEncoding;
+
+        // TODO: Support tagless types.
+        let _param = self
+            .parameter
+            .ok_or(IonError::encoding_error("unexpected parameter provided"))
+            .and_then(|p| p.expect_encoding(&ParameterEncoding::Tagged))
+            .and_then(|p| p.expect_single_expression())?;
+
+        let value_writer = BinaryValueWriter_1_1::new(
+            self.allocator,
+            self.buffer,
+            self.value_writer_config,
+            self.macros,
+        );
+        value_writer.write_symbol(value)
+    }
+
+    fn write_i64(self, value: i64) -> IonResult<()> {
+        use crate::IonError;
+        use crate::UInt;
+        use crate::lazy::expanded::template::ParameterEncoding as PE;
+
+        #[inline(never)]
+        fn error_context(name: &str, err: impl std::error::Error) -> IonError {
+            IonError::encoding_error(format!("error with value provided for '{name}': {err}"))
+        }
+
+        let param = self
+            .parameter
+            .ok_or(IonError::encoding_error("unexpected parameter provided"))
+            .and_then(|p| p.expect_single_expression())?;
+
+        let result = match param.encoding() {
+            PE::UInt8 => {
+                value
+                    .try_into()
+                    .and_then(|uint: UInt| FixedUInt::write_as_uint8(self.buffer, uint))
+                    .map(|_| ())
+            }
+            PE::FlexUInt => {
+                value
+                    .try_into()
+                    .and_then(|uint: UInt| FlexUInt::write(self.buffer, uint))
+                    .map(|_| ())
+            }
+            PE::Tagged => {
+                let value_writer = BinaryValueWriter_1_1::new(
+                    self.allocator,
+                    self.buffer,
+                    self.value_writer_config,
+                    self.macros,
+                );
+                value_writer.write_i64(value)
+            }
+            encoding => return IonResult::encoding_error(format!("value does not satisfy encoding type {encoding}")),
+
+        };
+
+        result.map_err(|err| error_context(param.name(), err))
+    }
+
+    fn write_int(self, value: &Int) -> IonResult<()> {
+        use crate::lazy::expanded::template::ParameterEncoding as PE;
+        use crate::UInt;
+        use crate::IonError;
+
+        #[inline(never)]
+        fn error_context(name: &str, err: impl std::error::Error) -> IonError {
+            IonError::encoding_error(format!("error with value provided for '{name}': {err}"))
+        }
+
+        let param = self
+            .parameter
+            .ok_or(IonError::encoding_error("unexpected parameter provided"))
+            .and_then(|p| p.expect_single_expression())?;
+
+        let result = match param.encoding() {
+            PE::UInt8 => {
+                value
+                    .try_into()
+                    .and_then(|uint: UInt| FixedUInt::write_as_uint8(self.buffer, uint))
+            }
+            PE::FlexUInt => {
+                value
+                    .try_into()
+                    .and_then(|uint: UInt| FlexUInt::write(self.buffer, uint))
+                    .map(|_| ())
+            }
+            PE::Tagged => {
+                let value_writer = BinaryValueWriter_1_1::new(
+                    self.allocator,
+                    self.buffer,
+                    self.value_writer_config,
+                    self.macros,
+                );
+                value_writer.write_int(value)
+            }
+            encoding => return IonResult::encoding_error(format!("value provided for '{}' does not satisfy encoding type {encoding}", param.name())),
+        };
+
+        result.map_err(|err| error_context(param.name(), err))
+    }
+
+    fn write_f32(self, value: f32) -> IonResult<()> {
+        use crate::IonError;
+        use crate::lazy::expanded::template::ParameterEncoding;
+
+        // TODO: Support tagless types.
+        let _param = self
+            .parameter
+            .ok_or(IonError::encoding_error("unexpected parameter provided"))
+            .and_then(|p| p.expect_encoding(&ParameterEncoding::Tagged))
+            .and_then(|p| p.expect_single_expression())?;
+
+        let value_writer = BinaryValueWriter_1_1::new(
+            self.allocator,
+            self.buffer,
+            self.value_writer_config,
+            self.macros,
+        );
+        value_writer.write_f32(value)
+    }
+
+    fn write_f64(self, value: f64) -> IonResult<()> {
+        use crate::IonError;
+        use crate::lazy::expanded::template::ParameterEncoding;
+
+        // TODO: Support tagless types.
+        let _param = self
+            .parameter
+            .ok_or(IonError::encoding_error("unexpected parameter provided"))
+            .and_then(|p| p.expect_encoding(&ParameterEncoding::Tagged))
+            .and_then(|p| p.expect_single_expression())?;
+
+        let value_writer = BinaryValueWriter_1_1::new(
+            self.allocator,
+            self.buffer,
+            self.value_writer_config,
+            self.macros,
+        );
+        value_writer.write_f64(value)
+    }
+
+    fn list_writer(self) -> IonResult<Self::ListWriter> {
+        use crate::IonError;
+        use crate::lazy::expanded::template::ParameterEncoding;
+
+        let _param = self
+            .parameter
+            .ok_or(IonError::encoding_error("unexpected parameter provided"))
+            .and_then(|p| p.expect_encoding(&ParameterEncoding::Tagged))
+            .and_then(|p| p.expect_single_expression())?;
+
+        let value_writer = BinaryValueWriter_1_1::new(
+            self.allocator,
+            self.buffer,
+            self.value_writer_config,
+            self.macros,
+        );
+
+        value_writer.list_writer()
+    }
+
+    fn sexp_writer(self) -> IonResult<Self::SExpWriter> {
+        use crate::IonError;
+        use crate::lazy::expanded::template::ParameterEncoding;
+
+        let _param = self
+            .parameter
+            .ok_or(IonError::encoding_error("unexpected parameter provided"))
+            .and_then(|p| p.expect_encoding(&ParameterEncoding::Tagged))
+            .and_then(|p| p.expect_single_expression())?;
+
+        let value_writer = BinaryValueWriter_1_1::new(
+            self.allocator,
+            self.buffer,
+            self.value_writer_config,
+            self.macros,
+        );
+
+        value_writer.sexp_writer()
+    }
+
+    fn struct_writer(self) -> IonResult<Self::StructWriter> {
+        use crate::IonError;
+        use crate::lazy::expanded::template::ParameterEncoding;
+
+        let _param = self
+            .parameter
+            .ok_or(IonError::encoding_error("unexpected parameter provided"))
+            .and_then(|p| p.expect_encoding(&ParameterEncoding::Tagged))
+            .and_then(|p| p.expect_single_expression())?;
+
+        let value_writer = BinaryValueWriter_1_1::new(
+            self.allocator,
+            self.buffer,
+            self.value_writer_config,
+            self.macros,
+        );
+
+        value_writer.struct_writer()
+    }
+
+    fn eexp_writer<'a>(self, macro_id: impl MacroIdLike<'a>) -> IonResult<Self::EExpWriter>
+        where
+            Self: 'a
+    {
+        use crate::IonError;
+        use crate::lazy::expanded::template::ParameterEncoding;
+
+        let _param = self
+            .parameter
+            .ok_or(IonError::encoding_error("unexpected parameter provided"))
+            .and_then(|p| p.expect_encoding(&ParameterEncoding::Tagged))
+            .and_then(|p| p.expect_single_expression())?;
+
+        let value_writer = BinaryValueWriter_1_1::new(
+            self.allocator,
+            self.buffer,
+            self.value_writer_config,
+            self.macros,
+        );
+
+        value_writer.eexp_writer(macro_id)
+    }
+}
+
+impl<'top> AnnotatableWriter for BinaryEExpParameterValueWriter_1_1<'_, 'top> {
+    type AnnotatedValueWriter<'a>
+        = BinaryAnnotatedValueWriter_1_1<'a, 'top>
+    where
+        Self: 'a;
+
+    fn with_annotations<'a>(
+        self,
+        annotations: impl AnnotationSeq<'a>,
+    ) -> IonResult<Self::AnnotatedValueWriter<'a>>
+    where
+        Self: 'a,
+    {
+        Ok(BinaryAnnotatedValueWriter_1_1::new(
+                self.allocator,
+                self.buffer,
+                annotations.into_annotations_vec(),
+                self.value_writer_config,
+                self.macros,
+        ))
     }
 }
 
@@ -2920,21 +3245,23 @@ mod tests {
         Ok(())
     }
 
+    // TODO: Revisit this unit test, we need to change the system macro being called.. originally
+    // it was calling (:none), but with the parameter tracking it will fail since :none does not
+    // take arguments.
     #[test]
     fn write_macro_invocations() -> IonResult<()> {
         encoding_test(
             |writer: &mut LazyRawBinaryWriter_1_1<&mut Vec<u8>>| {
-                let mut args = writer.eexp_writer(0)?;
-                args.write_symbol("foo")?
-                    .write_symbol("bar")?
-                    .write_symbol("baz")?;
+                let mut args = writer.eexp_writer(7)?; // sum
+                args
+                    .write_i64(5)?
+                    .write_i64(6)?;
                 args.close()
             },
             &[
-                0x00, // Invoke macro address 0
-                0xA3, 0x66, 0x6f, 0x6f, // foo
-                0xA3, 0x62, 0x61, 0x72, // bar
-                0xA3, 0x62, 0x61, 0x7a, // baz
+                0x07, // Invoke macro address 7
+                0x61, 0x05, // 5
+                0x61, 0x06, // 6
             ],
         )?;
         Ok(())
@@ -2945,17 +3272,16 @@ mod tests {
         encoding_test(
             |writer: &mut LazyRawBinaryWriter_1_1<&mut Vec<u8>>| {
                 let mut args =
-                    writer.eexp_writer(MacroIdRef::SystemAddress(system_macros::MAKE_STRING))?;
-                args.write_symbol("foo")?
-                    .write_symbol("bar")?
-                    .write_symbol("baz")?;
+                    writer.eexp_writer(MacroIdRef::SystemAddress(system_macros::SUM))?;
+                args
+                    .write_i64(5)?
+                    .write_i64(6)?;
                 args.close()
             },
             &[
-                0xEF, 0x09, // Invoke system macro address 3
-                0xA3, 0x66, 0x6f, 0x6f, // foo
-                0xA3, 0x62, 0x61, 0x72, // bar
-                0xA3, 0x62, 0x61, 0x7a, // baz
+                0xEF, 0x07, // Invoke system macro address 7 (sum)
+                0x61, 0x05, // 5
+                0x61, 0x06, // 6
             ],
         )?;
         Ok(())

--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -974,7 +974,6 @@ macro_rules! validate_parameter_and_delegate {
         fn $method(self, value: $value_type) -> IonResult<()> {
             use $crate::IonError;
             use $crate::lazy::expanded::template::ParameterEncoding;
-            println!("Param: {:?}", self.parameter);
             let _param = self
                 .parameter
                 .ok_or(IonError::encoding_error("unexpected parameter provided"))

--- a/src/lazy/encoder/value_writer.rs
+++ b/src/lazy/encoder/value_writer.rs
@@ -64,7 +64,11 @@ pub trait EExpWriter: SequenceWriter + EExpWriterInternal {
     fn current_parameter(&self) -> Option<&Parameter>;
 
     fn write_flex_uint(&mut self, _value: impl Into<UInt>) -> IonResult<()> {
-        todo!("current only implemented for binary 1.1 to enable unit testing for the reader")
+        todo!("currently only implemented for binary 1.1 to enable unit testing for the reader")
+    }
+
+    fn write_fixed_uint8(&mut self, _value: impl Into<u8>) -> IonResult<()> {
+        todo!("currently only implemented for binary 1.1 to enable unit testing for the reader")
     }
 
     fn expr_group_writer(&mut self) -> IonResult<Self::ExprGroupWriter<'_>>;

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -962,11 +962,11 @@ impl<V: ValueWriter> SequenceWriter for ApplicationEExpWriter<'_, V> {
     /// Writes a value in the current context (list, s-expression, or stream) and upon success
     /// returns another reference to `self` to enable method chaining.
     fn write<Value: WriteAsIon>(&mut self, value: Value) -> IonResult<&mut Self> {
-        self.expect_next_parameter()
-            // Make sure this parameter accepts an ungrouped value expression
-            .and_then(|p| p.expect_single_expression())
-            // Make sure this parameter supports the tagged encoding
-            .and_then(|p| p.expect_encoding(&ParameterEncoding::Tagged))?;
+        // self.expect_next_parameter()
+        //     // Make sure this parameter accepts an ungrouped value expression
+        //     .and_then(|p| p.expect_single_expression())
+        //     // Make sure this parameter supports the tagged encoding
+        //     .and_then(|p| p.expect_encoding(&ParameterEncoding::Tagged))?;
         value.write_as_ion(self.make_value_writer())?;
         Ok(self)
     }
@@ -1029,7 +1029,7 @@ impl<V: ValueWriter> EExpWriter for ApplicationEExpWriter<'_, V> {
     }
 
     fn expr_group_writer(&mut self) -> IonResult<Self::ExprGroupWriter<'_>> {
-        self.expect_next_parameter()
+        let _param = self.expect_next_parameter()
             .and_then(|p| p.expect_variadic())?;
         // TODO: Pass `Parameter` to group writer so it can do its own validation
         self.raw_eexp_writer.expr_group_writer()
@@ -1444,6 +1444,7 @@ mod tests {
 
         #[test]
         fn tagless_uint8_encoding() -> IonResult<()> {
+            let macro_source = "(macro foo (uint8::x) (%x))";
             let expected: &[u8] = &[
                 0xE0, 0x01, 0x01, 0xEA,                       // IVM
                 0xE7, 0xF9, 0x24, 0x69, 0x6F, 0x6E,           // $ion::
@@ -1460,13 +1461,48 @@ mod tests {
                 0x18, 0x05,                                   //  (:foo 5)
 
             ];
+
             let mut writer = Writer::new(v1_1::Binary, Vec::new())?;
-            let foo = writer.compile_macro("(macro foo (uint8::x) (%x))")?;
+            let foo = writer.compile_macro(macro_source)?;
             let mut eexp_writer = writer.eexp_writer(&foo)?;
-            eexp_writer.write_fixed_uint8(5)?;
+            // eexp_writer should do the "right thing" given the parameter's encoding.
+            eexp_writer.write_int(&5.into())?;
             let _ = eexp_writer.close();
             let output = writer.close()?;
             assert_eq!(output.as_slice(), expected);
+
+            let mut writer = Writer::new(v1_1::Binary, Vec::new())?;
+            let foo = writer.compile_macro(macro_source)?;
+            let mut eexp_writer = writer.eexp_writer(&foo)?;
+            // eexp_writer should do the "right thing" given the parameter's encoding.
+            eexp_writer.write_i64(5i64)?;
+            let _ = eexp_writer.close();
+            let output = writer.close()?;
+            assert_eq!(output.as_slice(), expected);
+
+            Ok(())
+        }
+
+        #[test]
+        fn tagless_uint8_encoding_fails() -> IonResult<()> {
+            let macro_source = "(macro foo (uint8::x) (%x))";
+
+            let mut writer = Writer::new(v1_1::Binary, Vec::new())?;
+            let foo = writer.compile_macro(macro_source)?;
+            let mut eexp_writer = writer.eexp_writer(&foo)?;
+            // eexp_writer should do the "right thing" given the parameter's encoding.
+            let result = eexp_writer.write_int(&1024.into());
+            // the "right thing" should be to error, since `x` can only be an 8bit unsigned int.
+            assert!(result.is_err(), "unexpected success");
+
+            let mut writer = Writer::new(v1_1::Binary, Vec::new())?;
+            let foo = writer.compile_macro(macro_source)?;
+            let mut eexp_writer = writer.eexp_writer(&foo)?;
+            // eexp_writer should do the "right thing" given the parameter's encoding.
+            let result = eexp_writer.write_i64(1024.into());
+            // the "right thing" should be to error, since `x` can only be an 8bit unsigned int.
+            assert!(result.is_err(), "unexpected success");
+
             Ok(())
         }
     }

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -1380,6 +1380,8 @@ mod tests {
 
     mod eexp_parameter_validation {
         use super::*;
+        use num_traits::{PrimInt, Unsigned};
+        use rstest::*;
 
         #[test]
         fn accept_valid_parameter_encoding() -> IonResult<()> {
@@ -1501,6 +1503,97 @@ mod tests {
             // eexp_writer should do the "right thing" given the parameter's encoding.
             let result = eexp_writer.write_i64(1024.into());
             // the "right thing" should be to error, since `x` can only be an 8bit unsigned int.
+            assert!(result.is_err(), "unexpected success");
+
+            Ok(())
+        }
+
+        #[rstest]
+        #[case::uint8("(macro foo (uint8::x) (%x))", 5, "5")]
+        #[case::uint16("(macro foo (uint16::x) (%x))", 5, "5")]
+        #[case::uint32("(macro foo (uint32::x) (%x))", 5, "5")]
+        #[case::uint64("(macro foo (uint64::x) (%x))", 5, "5")]
+        fn tagless_uint_encoding(#[case] macro_source: &str, #[case] input: i64, #[case] expected: &str) -> IonResult<()> {
+            use crate::{Int, Element};
+
+            // write_int
+
+            let mut writer = Writer::new(v1_1::Binary, Vec::new())?;
+            let foo = writer.compile_macro(macro_source)?;
+            let mut eexp_writer = writer.eexp_writer(&foo)?;
+            let int: Int = input.into();
+            eexp_writer.write_int(&int)?;
+            eexp_writer.close()?;
+
+            let output = writer.close()?;
+            let actual = Element::read_all(&output)?;
+            let exp_elem = Element::read_all(expected)?;
+            assert_eq!(actual, exp_elem);
+
+            // write_i64
+
+            let mut writer = Writer::new(v1_1::Binary, Vec::new())?;
+            let foo = writer.compile_macro(macro_source)?;
+            let mut eexp_writer = writer.eexp_writer(&foo)?;
+            eexp_writer.write_i64(input)?;
+            eexp_writer.close()?;
+
+            let output = writer.close()?;
+            let actual = Element::read_all(&output)?;
+            let exp_elem = Element::read_all(expected)?;
+            assert_eq!(actual, exp_elem);
+
+            Ok(())
+        }
+
+        #[rstest]
+        #[case::uint8("(macro foo (uint8::x) (%x))", 5u8)]
+        #[case::uint16("(macro foo (uint16::x) (%x))", 5u16)]
+        #[case::uint32("(macro foo (uint32::x) (%x))", 5u32)]
+        #[case::uint64("(macro foo (uint64::x) (%x))", 5u64)]
+        fn tagless_uint_encoding_write_int_fails<T: PrimInt + Unsigned>(#[case] macro_source: &str, #[case] input: T) -> IonResult<()> {
+            let max_int = T::max_value();
+            let max_int_plus_one = num_traits::cast::cast::<_, i128>(max_int).unwrap() + 1i128;
+            let neg_input = -num_traits::cast::cast::<_, i128>(input).unwrap();
+
+            let mut writer = Writer::new(v1_1::Binary, Vec::new())?;
+            let foo = writer.compile_macro(macro_source)?;
+            let mut eexp_writer = writer.eexp_writer(&foo)?;
+            let result = eexp_writer.write_int(&max_int_plus_one.into());
+            assert!(result.is_err(), "unexpected success");
+
+            // Ensure we cannot write a negative value..
+            let mut writer = Writer::new(v1_1::Binary, Vec::new())?;
+            let foo = writer.compile_macro(macro_source)?;
+            let mut eexp_writer = writer.eexp_writer(&foo)?;
+            let result = eexp_writer.write_int(&neg_input.into());
+            assert!(result.is_err(), "unexpected success");
+
+            Ok(())
+        }
+
+        #[rstest]
+        #[case::uint8("(macro foo (uint8::x) (%x))", 5u8)]
+        #[case::uint16("(macro foo (uint16::x) (%x))", 5u16)]
+        #[case::uint32("(macro foo (uint32::x) (%x))", 5u32)]
+        fn tagless_uint_encoding_write_i64_fails<T: PrimInt + Unsigned>(#[case] macro_source: &str, #[case] input: T) -> IonResult<()> {
+            let max_int = T::max_value();
+            let max_int_plus_one = num_traits::cast::cast::<_, i128>(max_int).unwrap() + 1i128;
+            let neg_input = -num_traits::cast::cast::<_, i128>(input).unwrap();
+
+            let mut writer = Writer::new(v1_1::Binary, Vec::new())?;
+            let foo = writer.compile_macro(macro_source)?;
+            let mut eexp_writer = writer.eexp_writer(&foo)?;
+            // eexp_writer should do the "right thing" given the parameter's encoding.
+            let result = eexp_writer.write_i64(max_int_plus_one.try_into().unwrap());
+            // the "right thing" should be to error, since `x` can only be an 8bit unsigned int.
+            assert!(result.is_err(), "unexpected success");
+
+            // Ensure we cannot write a negative value..
+            let mut writer = Writer::new(v1_1::Binary, Vec::new())?;
+            let foo = writer.compile_macro(macro_source)?;
+            let mut eexp_writer = writer.eexp_writer(&foo)?;
+            let result = eexp_writer.write_i64(neg_input.try_into().unwrap());
             assert!(result.is_err(), "unexpected success");
 
             Ok(())

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -1464,7 +1464,7 @@ mod tests {
             let foo = writer.compile_macro("(macro foo (uint8::x) (%x))")?;
             let mut eexp_writer = writer.eexp_writer(&foo)?;
             eexp_writer.write_fixed_uint8(5)?;
-            eexp_writer.close();
+            let _ = eexp_writer.close();
             let output = writer.close()?;
             assert_eq!(output.as_slice(), expected);
             Ok(())

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -1022,6 +1022,12 @@ impl<V: ValueWriter> EExpWriter for ApplicationEExpWriter<'_, V> {
         self.raw_eexp_writer.write_flex_uint(value)
     }
 
+    fn write_fixed_uint8(&mut self, value: impl Into<u8>) -> IonResult<()> {
+        self.expect_next_parameter()
+            .and_then(|p| p.expect_encoding(&ParameterEncoding::UInt8))?;
+        self.raw_eexp_writer.write_fixed_uint8(value)
+    }
+
     fn expr_group_writer(&mut self) -> IonResult<Self::ExprGroupWriter<'_>> {
         self.expect_next_parameter()
             .and_then(|p| p.expect_variadic())?;
@@ -1433,6 +1439,34 @@ mod tests {
             // Attempt to write a tagged value for parameter `a`, which has a cardinality of
             // zero-or-more, and therefore requires an expression group.
             assert!(eexp_writer.write("hello").is_err());
+            Ok(())
+        }
+
+        #[test]
+        fn tagless_uint8_encoding() -> IonResult<()> {
+            let expected: &[u8] = &[
+                0xE0, 0x01, 0x01, 0xEA,                       // IVM
+                0xE7, 0xF9, 0x24, 0x69, 0x6F, 0x6E,           // $ion::
+                0xFC, 0x55, 0xEE, 0x10, 0xA1, 0x5F,           // (module _
+                0xC4, 0xEE, 0x0F, 0xA1, 0x5F,                 //   (symbol_table _ )
+                0xFC, 0x3F, 0xEE, 0x0E, 0xA1, 0x5F,           //   (macro_table _
+                0xFC, 0x33,                                   //      (
+                0xA5, 0x6d, 0x61, 0x63, 0x72, 0x6F,           //        macro
+                0xA3, 0x66, 0x6F, 0x6F,                       //        foo
+                0xC9,                                         //        (
+                0xE7, 0xF7, 0x75, 0x69, 0x6E, 0x74, 0x38,     //          uint8::
+                0xA1, 0x78,                                   //          x )
+                0xC4, 0xA1, 0x25, 0xA1, 0x78,                 //        ('%' x))))
+                0x18, 0x05,                                   //  (:foo 5)
+
+            ];
+            let mut writer = Writer::new(v1_1::Binary, Vec::new())?;
+            let foo = writer.compile_macro("(macro foo (uint8::x) (%x))")?;
+            let mut eexp_writer = writer.eexp_writer(&foo)?;
+            eexp_writer.write_fixed_uint8(5)?;
+            eexp_writer.close();
+            let output = writer.close()?;
+            assert_eq!(output.as_slice(), expected);
             Ok(())
         }
     }

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -378,6 +378,7 @@ impl TemplateCompiler {
             // If it's not in the local scope, see if it's a built-in.
             return match encoding_name {
                 "flex_uint" => Ok(ParameterEncoding::FlexUInt),
+                "uint8" => Ok(ParameterEncoding::UInt8),
                 _ => IonResult::decoding_error(format!(
                     "unrecognized encoding '{encoding_name}' specified for parameter"
                 )),
@@ -1687,6 +1688,29 @@ mod tests {
                 .unwrap()
                 .encoding(),
             &ParameterEncoding::FlexUInt
+        );
+        expect_variable(&template, 0, 0)?;
+        Ok(())
+    }
+
+    #[test]
+    fn identity_with_uint8() -> IonResult<()> {
+        let resources = TestResources::new();
+        let context = resources.context();
+
+        let expression = "(macro identity (uint8::x) (%x))";
+
+        let template = TemplateCompiler::compile_from_source(context.macro_table(), expression)?;
+        assert_eq!(template.name(), "identity");
+        assert_eq!(template.signature().len(), 1);
+        assert_eq!(
+            template
+                .signature()
+                .parameters()
+                .first()
+                .unwrap()
+                .encoding(),
+            &ParameterEncoding::UInt8,
         );
         expect_variable(&template, 0, 0)?;
         Ok(())

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -379,6 +379,9 @@ impl TemplateCompiler {
             return match encoding_name {
                 "flex_uint" => Ok(ParameterEncoding::FlexUInt),
                 "uint8" => Ok(ParameterEncoding::UInt8),
+                "uint16" => Ok(ParameterEncoding::UInt16),
+                "uint32" => Ok(ParameterEncoding::UInt32),
+                "uint64" => Ok(ParameterEncoding::UInt64),
                 _ => IonResult::decoding_error(format!(
                     "unrecognized encoding '{encoding_name}' specified for parameter"
                 )),

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -2779,6 +2779,30 @@ mod tests {
     }
 
     #[test]
+    fn uint8_parameters() -> IonResult<()> {
+        let template_definition =
+            "(macro int_pair (uint8::x uint8::y) (.values (%x) (%y)))";
+        let macro_id = MacroTable::FIRST_USER_MACRO_ID as u8;
+        let tests: &[(&[u8], (u64, u64))] = &[
+            (&[macro_id, 0x00, 0x00], (0, 0)),
+        ];
+
+        for (stream, (num1, num2)) in tests.iter().copied() {
+            let mut reader = Reader::new(v1_1::Binary, stream)?;
+            reader.register_template_src(template_definition)?;
+            assert_eq!(
+                reader.next()?.unwrap().read()?.expect_int()?,
+                Int::from(num1)
+            );
+            assert_eq!(
+                reader.next()?.unwrap().read()?.expect_int()?,
+                Int::from(num2)
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
     fn it_takes_all_kinds() -> IonResult<()> {
         eval_template_invocation(
             r#"(macro foo () 

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -166,6 +166,15 @@ fn write_macro_signature_as_ion<V: ValueWriter>(
             ParameterEncoding::UInt8 => value_writer
                 .with_annotations("uint8")?
                 .write_symbol(param.name())?,
+            ParameterEncoding::UInt16 => value_writer
+                .with_annotations("uint16")?
+                .write_symbol(param.name())?,
+            ParameterEncoding::UInt32 => value_writer
+                .with_annotations("uint32")?
+                .write_symbol(param.name())?,
+            ParameterEncoding::UInt64 => value_writer
+                .with_annotations("uint64")?
+                .write_symbol(param.name())?,
             ParameterEncoding::MacroShaped(_) => todo!(),
         };
         let cardinality_modifier = match param.cardinality() {

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -163,6 +163,9 @@ fn write_macro_signature_as_ion<V: ValueWriter>(
             ParameterEncoding::FlexUInt => value_writer
                 .with_annotations("flex_uint")?
                 .write_symbol(param.name())?,
+            ParameterEncoding::UInt8 => value_writer
+                .with_annotations("uint8")?
+                .write_symbol(param.name())?,
             ParameterEncoding::MacroShaped(_) => todo!(),
         };
         let cardinality_modifier = match param.cardinality() {

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -207,6 +207,7 @@ pub enum ParameterEncoding {
     /// A 'tagged' type is one whose binary encoding begins with an opcode (sometimes called a 'tag'.)
     Tagged,
     FlexUInt,
+    UInt8,
     // TODO: tagless types, including fixed-width types and macros
     MacroShaped(Arc<MacroDef>),
 }
@@ -217,6 +218,7 @@ impl Display for ParameterEncoding {
         match self {
             Tagged => write!(f, "tagged"),
             FlexUInt => write!(f, "flex_uint"),
+            UInt8 => write!(f, "uint8"),
             MacroShaped(m) => write!(f, "{}", m.name().unwrap_or("<anonymous>")),
         }
     }

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -208,6 +208,9 @@ pub enum ParameterEncoding {
     Tagged,
     FlexUInt,
     UInt8,
+    UInt16,
+    UInt32,
+    UInt64,
     // TODO: tagless types, including fixed-width types and macros
     MacroShaped(Arc<MacroDef>),
 }
@@ -219,6 +222,9 @@ impl Display for ParameterEncoding {
             Tagged => write!(f, "tagged"),
             FlexUInt => write!(f, "flex_uint"),
             UInt8 => write!(f, "uint8"),
+            UInt16 => write!(f, "uint16"),
+            UInt32 => write!(f, "uint32"),
+            UInt64 => write!(f, "uint64"),
             MacroShaped(m) => write!(f, "{}", m.name().unwrap_or("<anonymous>")),
         }
     }


### PR DESCRIPTION
> Note: This PR includes #991 & #992.

*Issue #, if available:* #943

*Description of changes:*
Prior to this PR (as of #991) supported tagless encoding was limited to `uint8`. This PR extends the unsigned int support to the remaining `uint` types by implementing `uint16`, `uint32` and `uint64`.

### CLI Testing
Below is an inspect of an encoding and usage of the following macro:
```lisp
(macro foo (uint8::a uint16::b uint32::c uint64::d)
   (.sum (.sum (%a) (%b)) (.sum (%c) (%d)))
)
```
```
$ ./target/release/ion inspect ~/Code/sandbox/tagless_output/output.10n
┌──────────────┬──────────────┬─────────────────────────┬──────────────────────┐
│    Offset    │    Length    │       Binary Ion        │       Text Ion       │
├──────────────┼──────────────┼─────────────────────────┼──────────────────────┘
│            0 │            4 │ e0 01 01 ea             │ $ion_1_1 // Version marker
├──────────────┼──────────────┼─────────────────────────┤
│            4 │            6 │ e7 f9 24 69 6f 6e       │ $ion:: // <text>
│           10 │          114 │ fc e1                   │ (
│           12 │            2 │ ee 10                   │ · module
│           14 │            2 │ a1 5f                   │ · _
│           16 │            5 │ c4                      │ · (
│           17 │            2 │ ee 0f                   │ · · symbol_table
│           19 │            2 │ a1 5f                   │ · · _
│              │              │                         │ · )
│           21 │          103 │ fc cb                   │ · (
│           23 │            2 │ ee 0e                   │ · · macro_table
│           25 │            2 │ a1 5f                   │ · · _
│           27 │           97 │ fc bf                   │ · · (
│           29 │            6 │ a5 6d 61 63 72 6f       │ · · · macro
│           35 │            4 │ a3 66 6f 6f             │ · · · foo
│           39 │           41 │ fc 4f                   │ · · · (
│           41 │            7 │ e7 f7 75 69 6e 74 38    │ · · · · uint8:: // <text>
│           48 │            2 │ a1 61                   │ · · · · a
│           50 │            8 │ e7 f5 75 69 6e 74 31 36 │ · · · · uint16:: // <text>
│           58 │            2 │ a1 62                   │ · · · · b
│           60 │            8 │ e7 f5 75 69 6e 74 33 32 │ · · · · uint32:: // <text>
│           68 │            2 │ a1 63                   │ · · · · c
│           70 │            8 │ e7 f5 75 69 6e 74 36 34 │ · · · · uint64:: // <text>
│           78 │            2 │ a1 64                   │ · · · · d
│              │              │                         │ · · · )
│           80 │           44 │ fc 55                   │ · · · (
│           82 │            2 │ a1 2e                   │ · · · · '.'
│           84 │            4 │ a3 73 75 6d             │ · · · · sum
│           88 │           18 │ fc 21                   │ · · · · (
│           90 │            2 │ a1 2e                   │ · · · · · '.'
│           92 │            4 │ a3 73 75 6d             │ · · · · · sum
│           96 │            5 │ c4                      │ · · · · · (
│           97 │            2 │ a1 25                   │ · · · · · · '%'
│           99 │            2 │ a1 61                   │ · · · · · · a
│              │              │                         │ · · · · · )
│          101 │            5 │ c4                      │ · · · · · (
│          102 │            2 │ a1 25                   │ · · · · · · '%'
│          104 │            2 │ a1 62                   │ · · · · · · b
│              │              │                         │ · · · · · )
│              │              │                         │ · · · · )
│          106 │           18 │ fc 21                   │ · · · · (
│          108 │            2 │ a1 2e                   │ · · · · · '.'
│          110 │            4 │ a3 73 75 6d             │ · · · · · sum
│          114 │            5 │ c4                      │ · · · · · (
│          115 │            2 │ a1 25                   │ · · · · · · '%'
│          117 │            2 │ a1 63                   │ · · · · · · c
│              │              │                         │ · · · · · )
│          119 │            5 │ c4                      │ · · · · · (
│          120 │            2 │ a1 25                   │ · · · · · · '%'
│          122 │            2 │ a1 64                   │ · · · · · · d
│              │              │                         │ · · · · · )
│              │              │                         │ · · · · )
│              │              │                         │ · · · )
│              │              │                         │ · · )
│              │              │                         │ · )
│              │              │                         │ )
├──────────────┼──────────────┼─────────────────────────┤
│          124 │           16 │ 18                      │ (:foo
│          125 │            1 │ 01                      │ · 1 // a
│          126 │            2 │ 02 00                   │ · 2 // b
│          128 │            4 │ 03 00 00 00             │ · 3 // c
│          132 │            8 │ 04 00 00 00 00 00 00 00 │ · 4 // d
│              │              │                         │ )
│              │              │                         │ 10
├──────────────┼──────────────┼─────────────────────────┤
│          140 │              │                         │  // End of stream
└──────────────┴──────────────┴─────────────────────────┘
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
