### PR TITLE
Add 'bring your own data' benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,11 @@ harness = false
 name = "encoding_primitives"
 harness = false
 
+[[bench]]
+name = "byod"
+harness = false
+bench = false
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/benches/byod.rs
+++ b/benches/byod.rs
@@ -265,8 +265,9 @@ mod benchmark {
         for elem in &elems {
             writer
                 .value_writer()
+                .with_annotations_encoding(AnnotationsEncoding::InlineText)
                 .with_symbol_value_encoding(SymbolValueEncoding::InlineText)
-                // .with_annotations_encoding(AnnotationsEncoding::InlineText)
+                .with_field_name_encoding(FieldNameEncoding::InlineText)
                 .write(elem)
                 .expect("unable to write value");
         }
@@ -284,6 +285,8 @@ mod benchmark {
             writer
                 .value_writer()
                 .with_annotations_encoding(AnnotationsEncoding::SymbolIds)
+                .with_symbol_value_encoding(SymbolValueEncoding::SymbolIds)
+                .with_field_name_encoding(FieldNameEncoding::SymbolIds)
                 .write(elem)
                 .expect("unable to write value");
         }

--- a/benches/byod.rs
+++ b/benches/byod.rs
@@ -1,0 +1,382 @@
+use criterion::{criterion_group, criterion_main};
+
+#[cfg(not(feature = "experimental"))]
+mod benchmark {
+    use criterion::Criterion;
+    pub fn full_read(_c: &mut Criterion) {
+        panic!("This benchmark requires the 'experimental' feature to work; try again with `--features experimental`");
+    }
+}
+
+#[cfg(feature = "experimental")]
+mod benchmark {
+    use std::{env, fs, hint::black_box};
+    use criterion::{Criterion, BenchmarkId};
+    use ion_rs::{v1_1::BinaryWriter, *, Element};
+
+    pub fn bench_byod_full(c: &mut Criterion) {
+        let Some(file) = env::var("ION_BENCH").ok() else {
+            eprintln!("Provide a data file by specifying its path using either the ION_BENCH_1_0, or ION_BENCH_1_1, envoronment variable");
+            return;
+        };
+
+        let data = fs::read(&file).expect("unable to read data");
+
+        let mut read_group = c.benchmark_group("read");
+        read_group.measurement_time(std::time::Duration::from_secs(30));
+
+        // Read the provided data as-is with an encoding-agnostic reader.
+        read_group.bench_with_input(
+            BenchmarkId::new("full-read", &file),
+            &data,
+            |b, data| b.iter(|| {
+                let reader = Reader::new(AnyEncoding, data)
+                    .expect("Unable to create reader");
+                full_read(reader);
+            })
+        );
+
+        // Convert the provided data into an ion 1.0 stream, and then measure the performance of
+        // reading the stream-equivalent data using a 1.0 reader.
+        let one_oh_data = rewrite_as_1_0(&data);
+        read_group.bench_with_input(
+            BenchmarkId::new("convert-1.0-full-read", &file),
+            &one_oh_data,
+            |b, data| {
+                // Benchmark Read of known 1.0 data.
+                b.iter(|| {
+                    let reader = Reader::new(AnyEncoding, data)
+                        .expect("Unable to create reader");
+                    full_read(reader);
+                });
+            }
+        );
+        drop(one_oh_data);
+
+        // Convert the provided data into an ion 1.1 stream that uses delimited containers and then
+        // measure the performance of reading the stream-equivalent data using a 1.1 reader.
+        let delimited_data = rewrite_delimited_containers(&data);
+        read_group.bench_with_input(
+            BenchmarkId::new("convert-delimited-full-read", &file),
+            &delimited_data,
+            |b, data| {
+                b.iter(|| {
+                    let reader = Reader::new(AnyEncoding, data)
+                        .expect("unable to create reader");
+                    full_read(reader);
+                });
+            }
+        );
+        drop(delimited_data);
+
+        let prefixed_data = rewrite_prefixed_containers(&data);
+        read_group.bench_with_input(
+            BenchmarkId::new("convert-prefixed-full-read", &file),
+            &prefixed_data,
+            |b, data| {
+                b.iter(|| {
+                    let reader = Reader::new(AnyEncoding, data)
+                        .expect("unable to create reader");
+                    full_read(reader);
+                });
+            }
+        );
+        drop(prefixed_data);
+
+        // Convert the provided data into an ion 1.1 stream that uses inlined text symbols and then
+        // measure the performance of reading the stream-equivalent data using a 1.1 reader.
+        let inlined_data = rewrite_inline_symbols(&data);
+        read_group.bench_with_input(
+            BenchmarkId::new("convert-inlined-symbols-full-read", &file),
+            &inlined_data,
+            |b, data| {
+                b.iter(|| {
+                    let reader = Reader::new(AnyEncoding, data)
+                        .expect("unable to create reader");
+                    full_read(reader);
+                });
+            }
+        );
+        drop(inlined_data);
+
+        let referenced_data = rewrite_referenced_symbols(&data);
+        read_group.bench_with_input(
+            BenchmarkId::new("convert-referenced-symbols-full-read", &file),
+            &referenced_data,
+            |b, data| {
+                b.iter(|| {
+                    let reader = Reader::new(AnyEncoding, data)
+                        .expect("unable to create reader");
+                    full_read(reader);
+                });
+            }
+        );
+        drop(referenced_data);
+
+        read_group.finish();
+
+        let mut write_group = c.benchmark_group("write");
+        write_group.measurement_time(std::time::Duration::from_secs(30));
+
+        // Re-write the provided data with an ion 1.1 writer using default settings.
+        write_group.bench_with_input(
+            BenchmarkId::new("full-write-binary-1.1-default", &file),
+            &data,
+            |b, data| {
+                let size = data.len();
+                let elems = Element::read_all(data).expect("unable to read elements");
+                b.iter(|| {
+                    let buffer = Vec::<u8>::with_capacity(size);
+                    let mut writer = BinaryWriter::new(v1_1::Binary, buffer).expect("unable to create writer");
+                    for elem in &elems {
+                        writer
+                            .write(elem)
+                            .expect("unable to write value");
+                    }
+                });
+            }
+        );
+
+        // Re-write the provided data using an ion 1.1 writer configured to use delimited containers.
+        write_group.bench_with_input(
+            BenchmarkId::new("full-write-binary-1.1-delimited", &file),
+            &data,
+            |b, data| {
+                let size = data.len();
+                let elems = Element::read_all(data).expect("unable to read elements");
+                b.iter(|| {
+                    let buffer = Vec::<u8>::with_capacity(size);
+                    let mut writer = BinaryWriter::new(v1_1::Binary, buffer).expect("unable to create writer");
+                    for elem in &elems {
+                        writer
+                            .value_writer()
+                            .with_container_encoding(ContainerEncoding::Delimited)
+                            .write(elem)
+                            .expect("unable to write value");
+                    }
+                });
+            }
+        );
+
+        // Re-write the provided data using an ion 1.1 writer configured to use inline symbols
+        write_group.bench_with_input(
+            BenchmarkId::new("full-write-binary-1.1-inline-symbols", &file),
+            &data,
+            |b, data| {
+                let size = data.len();
+                let elems = Element::read_all(data).expect("unable to read elements");
+                b.iter(|| {
+                    let buffer = Vec::<u8>::with_capacity(size);
+                    let mut writer = BinaryWriter::new(v1_1::Binary, buffer).expect("unable to create writer");
+                    for elem in &elems {
+                        writer
+                            .value_writer()
+                            .with_symbol_value_encoding(SymbolValueEncoding::InlineText)
+                            .write(elem)
+                            .expect("unable to write value");
+                    }
+                });
+            }
+        );
+
+        // Re-write the provided data using an ion 1.1 writer configured to use inline annotations.
+        write_group.bench_with_input(
+            BenchmarkId::new("full-write-binary-1.1-inline-annotations", &file),
+            &data,
+            |b, data| {
+                let size = data.len();
+                let elems = Element::read_all(data).expect("unable to read elements");
+                b.iter(|| {
+                    let buffer = Vec::<u8>::with_capacity(size);
+                    let mut writer = Writer::new(v1_1::Binary, buffer).expect("unable to create writer");
+                    for elem in &elems {
+                        writer
+                            .value_writer()
+                            .with_annotations_encoding(AnnotationsEncoding::InlineText)
+                            .write(elem)
+                            .expect("unable to write value");
+                    }
+                });
+            }
+        );
+
+        // Re-write the provided data using an ion 1.0 writer.
+        write_group.bench_with_input(
+            BenchmarkId::new("full-write-binary-1.0", &file),
+            &data,
+            |b, data| {
+                let size = data.len();
+                let elems = Element::read_all(data).expect("unable to read elements");
+                b.iter(|| {
+                    let buffer = Vec::<u8>::with_capacity(size);
+                    let mut writer = Writer::new(v1_0::Binary, buffer).expect("unable to create writer");
+                    for elem in &elems {
+                        writer
+                            .write(elem)
+                            .expect("unable to write value");
+                    }
+                    let _ = writer.close();
+                });
+            }
+        );
+
+        write_group.finish();
+    }
+
+    fn rewrite_prefixed_containers(data: &Vec<u8>) -> Vec<u8> {
+        let size = data.len();
+        let elems = Element::read_all(data).expect("Unable to read elements");
+        let buffer = Vec::<u8>::with_capacity(size);
+        let mut writer = Writer::new(v1_1::Binary, buffer).expect("unable to create writer");
+        for elem in &elems {
+            writer
+                .value_writer()
+                .with_container_encoding(ContainerEncoding::LengthPrefixed)
+                .write(elem)
+                .expect("unable to write value");
+        }
+        writer
+            .close()
+            .expect("unable to close writer")
+    }
+
+    fn rewrite_delimited_containers(data: &Vec<u8>) -> Vec<u8> {
+        let size = data.len();
+        let elems = Element::read_all(data).expect("Unable to read elements");
+        let buffer = Vec::<u8>::with_capacity(size);
+        let mut writer = Writer::new(v1_1::Binary, buffer).expect("unable to create writer");
+        for elem in &elems {
+            writer
+                .value_writer()
+                .with_container_encoding(ContainerEncoding::Delimited)
+                .write(elem)
+                .expect("unable to write value");
+        }
+        writer
+            .close()
+            .expect("unable to close writer")
+    }
+
+    fn rewrite_inline_symbols(data: &Vec<u8>) -> Vec<u8> {
+        let size = data.len();
+        let elems = Element::read_all(data).expect("Unable to read elements");
+        let buffer = Vec::<u8>::with_capacity(size);
+        let mut writer = Writer::new(v1_1::Binary, buffer).expect("unable to create writer");
+        for elem in &elems {
+            writer
+                .value_writer()
+                .with_symbol_value_encoding(SymbolValueEncoding::InlineText)
+                // .with_annotations_encoding(AnnotationsEncoding::InlineText)
+                .write(elem)
+                .expect("unable to write value");
+        }
+        writer
+            .close()
+            .expect("unable to close writer")
+    }
+
+    fn rewrite_referenced_symbols(data: &Vec<u8>) -> Vec<u8> {
+        let size = data.len();
+        let elems = Element::read_all(data).expect("Unable to read elements");
+        let buffer = Vec::<u8>::with_capacity(size);
+        let mut writer = Writer::new(v1_1::Binary, buffer).expect("unable to create writer");
+        for elem in &elems {
+            writer
+                .value_writer()
+                .with_annotations_encoding(AnnotationsEncoding::SymbolIds)
+                .write(elem)
+                .expect("unable to write value");
+        }
+        writer
+            .close()
+            .expect("unable to close writer")
+    }
+
+    fn rewrite_inline_annotations(data: &Vec<u8>) -> Vec<u8> {
+        let size = data.len();
+        let elems = Element::read_all(data).expect("Unable to read elements");
+        let buffer = Vec::<u8>::with_capacity(size);
+        let mut writer = Writer::new(v1_1::Binary, buffer).expect("unable to create writer");
+        for elem in &elems {
+            writer
+                .value_writer()
+                .with_annotations_encoding(AnnotationsEncoding::InlineText)
+                .write(elem)
+                .expect("unable to write value");
+        }
+        writer
+            .close()
+            .expect("unable to close writer")
+    }
+
+    fn rewrite_as_1_0(data: &Vec<u8>) -> Vec<u8> {
+        let size = data.len();
+        // Read initial data.
+        let elems = Element::read_all(data).expect("unable to read elements");
+        // Write data as 1.0
+        let buffer = Vec::<u8>::with_capacity(size);
+        elems.encode_to(buffer, v1_0::Binary).expect("unable to re-encode elements")
+    }
+
+    fn rewrite_as_1_1(data: &Vec<u8>) -> Vec<u8> {
+        let size = data.len();
+        // Read initial data.
+        let elems = Element::read_all(data).expect("unable to read elements");
+        // Write data as 1.1
+        let buffer = Vec::<u8>::with_capacity(size);
+        elems.encode_to(buffer, v1_1::Binary).expect("unable to re-encode elements")
+    }
+
+    #[inline]
+    fn handle_lazy_value<D: Decoder>(value: LazyValue<'_, D>) {
+        match black_box(value.read()).expect("unable to read value") {
+            ValueRef::Null(_tpe) => (),
+            ValueRef::Bool(_val) => (),
+            ValueRef::Int(_val) => (),
+            ValueRef::Float(_val) => (),
+            ValueRef::Decimal(_val) => (),
+            ValueRef::Timestamp(_val) => (),
+            ValueRef::String(_val) => (),
+            ValueRef::Symbol(_val) => (),
+            ValueRef::Blob(_val) => (),
+            ValueRef::Clob(_val) => (),
+            ValueRef::SExp(sexp) => full_read_sexp(sexp),
+            ValueRef::List(list) => full_read_list(list),
+            ValueRef::Struct(strukt) => full_read_struct(strukt),
+        }
+    }
+
+    fn full_read<D: Decoder, I: IonInput>(mut reader: Reader<D, I>) {
+        loop {
+            let Some(val) = reader.next().unwrap() else {
+                break;
+            };
+
+            handle_lazy_value(val);
+        }
+    }
+
+    fn full_read_struct<D: Decoder>(strukt: LazyStruct<'_, D>) {
+        for field in &strukt {
+            let field = field.expect("unable to read field");
+            handle_lazy_value(field.value());
+        }
+    }
+
+    fn full_read_sexp<D: Decoder>(sexp: LazySExp<'_, D>) {
+        for value in &sexp {
+            let value = value.expect("unable to read sexp value");
+            handle_lazy_value(value);
+        }
+    }
+
+    fn full_read_list<D: Decoder>(list: LazyList<'_, D>) {
+        for value in &list {
+            let value = value.expect("unable to read list item");
+            handle_lazy_value(value);
+        }
+    }
+}
+
+criterion_group!(benches, benchmark::bench_byod_full);
+criterion_main!(benches);

--- a/benches/encoding_primitives.rs
+++ b/benches/encoding_primitives.rs
@@ -11,7 +11,7 @@ mod benchmark {
 #[cfg(feature = "experimental")]
 mod benchmark {
     use criterion::{black_box, Criterion};
-    use ion_rs::IonResult;
+    use ion_rs::{IonResult, EncodingContext};
     use rand::prelude::StdRng;
     use rand::{distributions::Uniform, Rng, SeedableRng};
     use std::io;
@@ -71,8 +71,9 @@ mod benchmark {
         });
         binary_1_0_group.bench_function("read VarUInt", |b| {
             b.iter(|| {
+                let encoding_context = EncodingContext::empty();
                 let mut decoded_length: usize = 0;
-                let mut input = BinaryBuffer::new(encoded_var_uints.as_slice());
+                let mut input = BinaryBuffer::new(encoding_context.get_ref(), encoded_var_uints.as_slice());
                 for _ in 0..unsigned_values.len() {
                     let (var_uint, remaining) = input.read_var_uint().unwrap();
                     input = remaining;
@@ -93,8 +94,9 @@ mod benchmark {
         });
         binary_1_0_group.bench_function("read VarInt", |b| {
             b.iter(|| {
+                let encoding_context = EncodingContext::empty();
                 let mut decoded_length: usize = 0;
-                let mut input = BinaryBuffer::new(encoded_var_ints.as_slice());
+                let mut input = BinaryBuffer::new(encoding_context.get_ref(), encoded_var_ints.as_slice());
                 for _ in 0..unsigned_values.len() {
                     let (var_int, remaining) = input.read_var_int().unwrap();
                     input = remaining;
@@ -118,8 +120,9 @@ mod benchmark {
         });
         binary_1_1_group.bench_function("read FlexUInt", |b| {
             b.iter(|| {
+                let encoding_context = EncodingContext::empty();
                 let mut decoded_length: usize = 0;
-                let mut input = BinaryBuffer::new(encoded_flex_uints.as_slice());
+                let mut input = BinaryBuffer::new(encoding_context.get_ref(), encoded_flex_uints.as_slice());
                 for _ in 0..unsigned_values.len() {
                     let (flex_uint, remaining) = input.read_flex_uint().unwrap();
                     input = remaining;
@@ -140,8 +143,9 @@ mod benchmark {
         });
         binary_1_1_group.bench_function("read FlexInt", |b| {
             b.iter(|| {
+                let encoding_context = EncodingContext::empty();
                 let mut decoded_length: usize = 0;
-                let mut input = BinaryBuffer::new(encoded_flex_ints.as_slice());
+                let mut input = BinaryBuffer::new(encoding_context.get_ref(), encoded_flex_ints.as_slice());
                 for _ in 0..unsigned_values.len() {
                     let (flex_int, remaining) = input.read_flex_int().unwrap();
                     input = remaining;
@@ -154,12 +158,13 @@ mod benchmark {
     }
 
     fn roundtrip_var_uint_test(unsigned_values: &[u64]) -> IonResult<Vec<u8>> {
+        let encoding_context = EncodingContext::empty();
         let mut encoded_values_buffer = Vec::new();
         for value in unsigned_values {
             VarUInt::write_u64(&mut encoded_values_buffer, *value)?;
         }
         let mut decoded_values = Vec::new();
-        let mut input = BinaryBuffer::new(encoded_values_buffer.as_slice());
+        let mut input = BinaryBuffer::new(encoding_context.get_ref(), encoded_values_buffer.as_slice());
         for _ in 0..unsigned_values.len() {
             let (var_uint, remaining) = input.read_var_uint()?;
             input = remaining;
@@ -170,12 +175,13 @@ mod benchmark {
     }
 
     fn roundtrip_var_int_test(signed_values: &[i64]) -> IonResult<Vec<u8>> {
+        let encoding_context = EncodingContext::empty();
         let mut encoded_values_buffer = Vec::new();
         for value in signed_values {
             VarInt::write_i64(&mut encoded_values_buffer, *value)?;
         }
         let mut decoded_values = Vec::new();
-        let mut input = BinaryBuffer::new(encoded_values_buffer.as_slice());
+        let mut input = BinaryBuffer::new(encoding_context.get_ref(), encoded_values_buffer.as_slice());
         for _ in 0..signed_values.len() {
             let (var_int, remaining) = input.read_var_int()?;
             input = remaining;
@@ -186,12 +192,13 @@ mod benchmark {
     }
 
     fn roundtrip_flex_uint_test(unsigned_values: &[u64]) -> IonResult<Vec<u8>> {
+        let encoding_context = EncodingContext::empty();
         let mut encoded_values_buffer = Vec::new();
         for value in unsigned_values {
             FlexUInt::write(&mut encoded_values_buffer, *value)?;
         }
         let mut decoded_values = Vec::new();
-        let mut input = BinaryBuffer::new(encoded_values_buffer.as_slice());
+        let mut input = BinaryBuffer::new(encoding_context.get_ref(), encoded_values_buffer.as_slice());
         for _ in 0..unsigned_values.len() {
             let (flex_uint, remaining) = input.read_flex_uint()?;
             input = remaining;
@@ -202,12 +209,13 @@ mod benchmark {
     }
 
     fn roundtrip_flex_int_test(signed_values: &[i64]) -> IonResult<Vec<u8>> {
+        let encoding_context = EncodingContext::empty();
         let mut encoded_values_buffer = Vec::new();
         for value in signed_values {
             FlexInt::write_i64(&mut encoded_values_buffer, *value)?;
         }
         let mut decoded_values = Vec::new();
-        let mut input = BinaryBuffer::new(encoded_values_buffer.as_slice());
+        let mut input = BinaryBuffer::new(encoding_context.get_ref(), encoded_values_buffer.as_slice());
         for _ in 0..signed_values.len() {
             let (flex_int, remaining) = input.read_flex_int()?;
             input = remaining;

--- a/benches/write_many_structs.rs
+++ b/benches/write_many_structs.rs
@@ -10,7 +10,8 @@ mod benchmark {
 
 #[cfg(feature = "experimental")]
 mod benchmark {
-    use criterion::{black_box, Criterion};
+    use std::hint::black_box;
+    use criterion::Criterion;
     use ion_rs::{v1_0, v1_1, IonResult, RawSymbolRef, SequenceWriter, StructWriter, ValueWriter};
 
     fn write_struct_with_string_values(value_writer: impl ValueWriter) -> IonResult<()> {

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -472,6 +472,16 @@ impl ApplicationValueWriter<'_, BinaryValueWriter_1_1<'_, '_>> {
             .with_symbol_value_encoding(symbol_value_encoding);
         self
     }
+
+    pub fn with_field_name_encoding(
+        mut self,
+        field_name_encoding: FieldNameEncoding,
+    ) -> Self {
+        self.value_writer_config = self
+            .value_writer_config
+            .with_field_name_encoding(field_name_encoding);
+        self
+    }
 }
 
 impl<V: ValueWriter> AnnotatableWriter for ApplicationValueWriter<'_, V> {


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
This PR adds a 'Bring Your Own Data' benchmark that can be used to test read and write performance with any ion dataset.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
