### PR TITLE
Implement tagless ints

### DIFF
--- a/src/lazy/binary/raw/v1_1/binary_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/binary_buffer.rs
@@ -258,36 +258,18 @@ impl<'a> BinaryBuffer<'a> {
         Ok((value, remaining_input))
     }
 
-    pub fn read_fixed_uint_as_lazy_value(self, encoding: BinaryValueEncoding) -> ParseResult<'a, LazyRawBinaryValue_1_1<'a>> {
+    pub fn read_fixed_int_type_as_lazy_value(self, encoding: BinaryValueEncoding) -> ParseResult<'a, LazyRawBinaryValue_1_1<'a>> {
+        use BinaryValueEncoding::*;
         let size_in_bytes = match encoding {
-            BinaryValueEncoding::UInt8 => 1,
-            BinaryValueEncoding::UInt16 => 2,
-            BinaryValueEncoding::UInt32 => 4,
-            BinaryValueEncoding::UInt64 => 8,
-            _ => return IonResult::illegal_operation(format!("invalid binary encoding for fixed uint: {encoding:?}")),
+            UInt8 | Int8 => 1,
+            UInt16 | Int16 => 2,
+            UInt32 | Int32 => 4,
+            UInt64 | Int64 => 8,
+            _ => return IonResult::illegal_operation(format!("invalid binary encoding for fixed int or uint: {encoding:?}")),
         };
 
         if self.len() < size_in_bytes {
-            return IonResult::incomplete("a uint", self.offset());
-        }
-
-        let matched_input = self.slice(0, size_in_bytes);
-        let remaining_input = self.slice_to_end(size_in_bytes);
-        let value = LazyRawBinaryValue_1_1::for_fixed_int_type(matched_input, encoding);
-        Ok((value, remaining_input))
-    }
-
-    pub fn read_fixed_int_as_lazy_value(self, encoding: BinaryValueEncoding) -> ParseResult<'a, LazyRawBinaryValue_1_1<'a>> {
-        let size_in_bytes = match encoding {
-            BinaryValueEncoding::Int8 => 1,
-            BinaryValueEncoding::Int16 => 2,
-            BinaryValueEncoding::Int32 => 4,
-            BinaryValueEncoding::Int64 => 8,
-            _ => return IonResult::illegal_operation(format!("invalid binary encoding for fixed int: {encoding:?}")),
-        };
-
-        if self.len() < size_in_bytes {
-            return IonResult::incomplete("an int", self.offset());
+            return IonResult::incomplete("a(n) uint/int", self.offset());
         }
 
         let matched_input = self.slice(0, size_in_bytes);

--- a/src/lazy/binary/raw/v1_1/binary_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/binary_buffer.rs
@@ -273,7 +273,26 @@ impl<'a> BinaryBuffer<'a> {
 
         let matched_input = self.slice(0, size_in_bytes);
         let remaining_input = self.slice_to_end(size_in_bytes);
-        let value = LazyRawBinaryValue_1_1::for_fixed_uint(matched_input, encoding);
+        let value = LazyRawBinaryValue_1_1::for_fixed_int_type(matched_input, encoding);
+        Ok((value, remaining_input))
+    }
+
+    pub fn read_fixed_int_as_lazy_value(self, encoding: BinaryValueEncoding) -> ParseResult<'a, LazyRawBinaryValue_1_1<'a>> {
+        let size_in_bytes = match encoding {
+            BinaryValueEncoding::Int8 => 1,
+            BinaryValueEncoding::Int16 => 2,
+            BinaryValueEncoding::Int32 => 4,
+            BinaryValueEncoding::Int64 => 8,
+            _ => return IonResult::illegal_operation(format!("invalid binary encoding for fixed int: {encoding:?}")),
+        };
+
+        if self.len() < size_in_bytes {
+            return IonResult::incomplete("an int", self.offset());
+        }
+
+        let matched_input = self.slice(0, size_in_bytes);
+        let remaining_input = self.slice_to_end(size_in_bytes);
+        let value = LazyRawBinaryValue_1_1::for_fixed_int_type(matched_input, encoding);
         Ok((value, remaining_input))
     }
 

--- a/src/lazy/binary/raw/v1_1/e_expression.rs
+++ b/src/lazy/binary/raw/v1_1/e_expression.rs
@@ -331,36 +331,21 @@ impl<'top> Iterator for BinaryEExpArgsInputIter<'top> {
                 enc@ ParameterEncoding::UInt8 |
                 enc@ ParameterEncoding::UInt16 |
                 enc@ ParameterEncoding::UInt32 |
-                enc@ ParameterEncoding::UInt64
+                enc@ ParameterEncoding::UInt64 |
+                enc@ ParameterEncoding::Int8 |
+                enc@ ParameterEncoding::Int16 |
+                enc@ ParameterEncoding::Int32 |
+                enc@ ParameterEncoding::Int64
                     => {
                     let binary_enc = try_or_some_err!(enc.try_into());
                     let (fixed_uint_lazy_value, remaining) = try_or_some_err! {
-                        self.remaining_args_buffer.read_fixed_uint_as_lazy_value(binary_enc)
+                        self.remaining_args_buffer.read_fixed_int_type_as_lazy_value(binary_enc)
                     };
                     let value_ref = &*self
                         .remaining_args_buffer
                         .context()
                         .allocator()
                         .alloc_with(|| fixed_uint_lazy_value);
-                    (
-                        EExpArg::new(parameter, EExpArgExpr::ValueLiteral(value_ref)),
-                        remaining,
-                    )
-                }
-                enc @ ParameterEncoding::Int8 |
-                enc @ ParameterEncoding::Int16 |
-                enc @ ParameterEncoding::Int32 |
-                enc @ ParameterEncoding::Int64
-                    => {
-                    let binary_enc = try_or_some_err!(enc.try_into());
-                    let (fixed_int_lazy_value, remaining) = try_or_some_err! {
-                        self.remaining_args_buffer.read_fixed_int_as_lazy_value(binary_enc)
-                    };
-                    let value_ref = &*self
-                        .remaining_args_buffer
-                        .context()
-                        .allocator()
-                        .alloc_with(|| fixed_int_lazy_value);
                     (
                         EExpArg::new(parameter, EExpArgExpr::ValueLiteral(value_ref)),
                         remaining,

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -115,6 +115,10 @@ pub enum BinaryValueEncoding {
     UInt16,
     UInt32,
     UInt64,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -364,7 +368,7 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
         }
     }
 
-    pub(crate) fn for_fixed_uint(input: BinaryBuffer<'top>, encoding: BinaryValueEncoding) -> Self {
+    pub(crate) fn for_fixed_int_type(input: BinaryBuffer<'top>, encoding: BinaryValueEncoding) -> Self {
         let encoded_value = EncodedBinaryValue {
             encoding,
             header: Header {

--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -1086,6 +1086,10 @@ impl<'value, 'top> ValueWriter for BinaryEExpParameterValueWriter_1_1<'value, 't
             PE::UInt64 => value
                 .try_into()
                 .and_then(|uint: UInt| FixedUInt::write_as_uint::<u64>(self.buffer, uint)),
+            PE::Int8 => FixedInt::write_as_int::<i8>(self.buffer, value),
+            PE::Int16 => FixedInt::write_as_int::<i16>(self.buffer, value),
+            PE::Int32 => FixedInt::write_as_int::<i32>(self.buffer, value),
+            PE::Int64 => FixedInt::write_as_int::<i64>(self.buffer, value),
             PE::FlexUInt => value
                 .try_into()
                 .and_then(|uint: UInt| FlexUInt::write(self.buffer, uint))
@@ -1135,6 +1139,10 @@ impl<'value, 'top> ValueWriter for BinaryEExpParameterValueWriter_1_1<'value, 't
             PE::UInt64 => value
                 .try_into()
                 .and_then(|uint: UInt| FixedUInt::write_as_uint::<u64>(self.buffer, uint)),
+            PE::Int8 => FixedInt::write_as_int::<i8>(self.buffer, value),
+            PE::Int16 => FixedInt::write_as_int::<i16>(self.buffer, value),
+            PE::Int32 => FixedInt::write_as_int::<i32>(self.buffer, value),
+            PE::Int64 => FixedInt::write_as_int::<i64>(self.buffer, value),
             PE::FlexUInt => value
                 .try_into()
                 .and_then(|uint: UInt| FlexUInt::write(self.buffer, uint))

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -1375,7 +1375,7 @@ mod tests {
 
     mod eexp_parameter_validation {
         use super::*;
-        use num_traits::{PrimInt, Unsigned};
+        use num_traits::{PrimInt, Signed, Unsigned};
         use rstest::*;
 
         #[test]
@@ -1516,7 +1516,7 @@ mod tests {
         #[case::int32_pos("(macro foo (int32::x) (%x))", 5, "5")]
         #[case::int64_neg("(macro foo (int64::x) (%x))", -5, "-5")]
         #[case::int64_pos("(macro foo (int64::x) (%x))", 5, "5")]
-        fn tagless_uint_encoding(#[case] macro_source: &str, #[case] input: i64, #[case] expected: &str) -> IonResult<()> {
+        fn tagless_int_type_encoding(#[case] macro_source: &str, #[case] input: i64, #[case] expected: &str) -> IonResult<()> {
             use crate::{Int, Element};
 
             // write_int
@@ -1549,6 +1549,10 @@ mod tests {
             Ok(())
         }
 
+        /// Ensure that writing fixed int values outside the range of the tagless type's size is
+        /// caught as an error. This test uses the '_input' field to get the type of the primitive
+        /// we want to write in order to retrieve the maximum values for the primitive via
+        /// num_traits.
         #[rstest]
         #[case::uint8("(macro foo (uint8::x) (%x))", 5u8)]
         #[case::uint16("(macro foo (uint16::x) (%x))", 5u16)]
@@ -1575,6 +1579,11 @@ mod tests {
             Ok(())
         }
 
+        /// Ensure that writing fixed int values outside the range of the tagless type's size is
+        /// caught as an error. This test uses the '_input' field to get the type of the primitive
+        /// we want to write in order to retrieve the maximum values for the primitive via
+        /// num_traits. This test differs from the above test in that it uses `write_i64` and
+        /// cannot handle 64bit values.
         #[rstest]
         #[case::uint8("(macro foo (uint8::x) (%x))", 5u8)]
         #[case::uint16("(macro foo (uint16::x) (%x))", 5u16)]
@@ -1597,6 +1606,66 @@ mod tests {
             let foo = writer.compile_macro(macro_source)?;
             let mut eexp_writer = writer.eexp_writer(&foo)?;
             let result = eexp_writer.write_i64(neg_input.try_into().unwrap());
+            assert!(result.is_err(), "unexpected success");
+
+            Ok(())
+        }
+
+        /// Ensure that writing fixed int values outside the range of the tagless type's size is
+        /// caught as an error. This test uses the '_input' field to get the type of the primitive
+        /// we want to write in order to retrieve the minimum and maximum values for the primitive
+        /// via num_traits.
+        #[rstest]
+        #[case::int8("(macro foo (int8::x) (%x))", 5i8)]
+        #[case::uint16("(macro foo (int16::x) (%x))", 5i16)]
+        #[case::uint32("(macro foo (int32::x) (%x))", 5i32)]
+        #[case::uint64("(macro foo (int64::x) (%x))", 5i64)]
+        fn tagless_int_encoding_write_int_fails<T: PrimInt + Signed>(#[case] macro_source: &str, #[case] _input: T) -> IonResult<()> {
+            let max_int = T::max_value();
+            let max_int_plus_one = num_traits::cast::cast::<_, i128>(max_int).unwrap() + 1i128;
+            let min_int = T::min_value();
+            let min_int_minus_one = num_traits::cast::cast::<_, i128>(min_int).unwrap() - 1i128;
+
+            let mut writer = Writer::new(v1_1::Binary, Vec::new())?;
+            let foo = writer.compile_macro(macro_source)?;
+            let mut eexp_writer = writer.eexp_writer(&foo)?;
+            let result = eexp_writer.write_int(&max_int_plus_one.into());
+            assert!(result.is_err(), "unexpected success");
+
+            let mut writer = Writer::new(v1_1::Binary, Vec::new())?;
+            let foo = writer.compile_macro(macro_source)?;
+            let mut eexp_writer = writer.eexp_writer(&foo)?;
+            let result = eexp_writer.write_int(&min_int_minus_one.into());
+            assert!(result.is_err(), "unexpected success");
+
+            Ok(())
+        }
+
+        /// Ensure that writing fixed int values outside the range of the tagless type's size is
+        /// caught as an error. This test uses the '_input' field to get the type of the primitive
+        /// we want to write in order to retrieve the minimum and maximum values for the primitive
+        /// via num_traits. This test differs from the above test in that it uses `write_i64` and
+        /// cannot handle 64bit values.
+        #[rstest]
+        #[case::int8("(macro foo (int8::x) (%x))", 5i8)]
+        #[case::uint16("(macro foo (int16::x) (%x))", 5i16)]
+        #[case::uint32("(macro foo (int32::x) (%x))", 5i32)]
+        fn tagless_int_encoding_write_i64_fails<T: PrimInt + Signed>(#[case] macro_source: &str, #[case] _input: T) -> IonResult<()> {
+            let max_int = T::max_value();
+            let max_int_plus_one = num_traits::cast::cast::<_, i128>(max_int).unwrap() + 1i128;
+            let min_int = T::min_value();
+            let min_int_minus_one = num_traits::cast::cast::<_, i128>(min_int).unwrap() - 1i128;
+
+            let mut writer = Writer::new(v1_1::Binary, Vec::new())?;
+            let foo = writer.compile_macro(macro_source)?;
+            let mut eexp_writer = writer.eexp_writer(&foo)?;
+            let result = eexp_writer.write_i64(max_int_plus_one.try_into().unwrap());
+            assert!(result.is_err(), "unexpected success");
+
+            let mut writer = Writer::new(v1_1::Binary, Vec::new())?;
+            let foo = writer.compile_macro(macro_source)?;
+            let mut eexp_writer = writer.eexp_writer(&foo)?;
+            let result = eexp_writer.write_i64(min_int_minus_one.try_into().unwrap());
             assert!(result.is_err(), "unexpected success");
 
             Ok(())

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -1508,6 +1508,14 @@ mod tests {
         #[case::uint16("(macro foo (uint16::x) (%x))", 5, "5")]
         #[case::uint32("(macro foo (uint32::x) (%x))", 5, "5")]
         #[case::uint64("(macro foo (uint64::x) (%x))", 5, "5")]
+        #[case::int8_neg("(macro foo (int8::x) (%x))", -5, "-5")]
+        #[case::int8_pos("(macro foo (int8::x) (%x))", 5, "5")]
+        #[case::int16_neg("(macro foo (int16::x) (%x))", -5, "-5")]
+        #[case::int16_pos("(macro foo (int16::x) (%x))", 5, "5")]
+        #[case::int32_neg("(macro foo (int32::x) (%x))", -5, "-5")]
+        #[case::int32_pos("(macro foo (int32::x) (%x))", 5, "5")]
+        #[case::int64_neg("(macro foo (int64::x) (%x))", -5, "-5")]
+        #[case::int64_pos("(macro foo (int64::x) (%x))", 5, "5")]
         fn tagless_uint_encoding(#[case] macro_source: &str, #[case] input: i64, #[case] expected: &str) -> IonResult<()> {
             use crate::{Int, Element};
 
@@ -1593,5 +1601,6 @@ mod tests {
 
             Ok(())
         }
+
     }
 }

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -382,6 +382,10 @@ impl TemplateCompiler {
                 "uint16" => Ok(ParameterEncoding::UInt16),
                 "uint32" => Ok(ParameterEncoding::UInt32),
                 "uint64" => Ok(ParameterEncoding::UInt64),
+                "int8" => Ok(ParameterEncoding::Int8),
+                "int16" => Ok(ParameterEncoding::Int16),
+                "int32" => Ok(ParameterEncoding::Int32),
+                "int64" => Ok(ParameterEncoding::Int64),
                 _ => IonResult::decoding_error(format!(
                     "unrecognized encoding '{encoding_name}' specified for parameter"
                 )),

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -175,6 +175,18 @@ fn write_macro_signature_as_ion<V: ValueWriter>(
             ParameterEncoding::UInt64 => value_writer
                 .with_annotations("uint64")?
                 .write_symbol(param.name())?,
+            ParameterEncoding::Int8 => value_writer
+                .with_annotations("int8")?
+                .write_symbol(param.name())?,
+            ParameterEncoding::Int16 => value_writer
+                .with_annotations("int16")?
+                .write_symbol(param.name())?,
+            ParameterEncoding::Int32 => value_writer
+                .with_annotations("int32")?
+                .write_symbol(param.name())?,
+            ParameterEncoding::Int64 => value_writer
+                .with_annotations("int64")?
+                .write_symbol(param.name())?,
             ParameterEncoding::MacroShaped(_) => todo!(),
         };
         let cardinality_modifier = match param.cardinality() {

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -211,6 +211,10 @@ pub enum ParameterEncoding {
     UInt16,
     UInt32,
     UInt64,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
     // TODO: tagless types, including fixed-width types and macros
     MacroShaped(Arc<MacroDef>),
 }
@@ -225,6 +229,10 @@ impl Display for ParameterEncoding {
             UInt16 => write!(f, "uint16"),
             UInt32 => write!(f, "uint32"),
             UInt64 => write!(f, "uint64"),
+            Int8 => write!(f, "int8"),
+            Int16 => write!(f, "int16"),
+            Int32 => write!(f, "int32"),
+            Int64 => write!(f, "int64"),
             MacroShaped(m) => write!(f, "{}", m.name().unwrap_or("<anonymous>")),
         }
     }
@@ -243,6 +251,10 @@ impl TryFrom<&ParameterEncoding> for BinaryValueEncoding {
             ParameterEncoding::UInt16 => Ok(BinaryValueEncoding::UInt16),
             ParameterEncoding::UInt32 => Ok(BinaryValueEncoding::UInt32),
             ParameterEncoding::UInt64 => Ok(BinaryValueEncoding::UInt64),
+            ParameterEncoding::Int8 => Ok(BinaryValueEncoding::Int8),
+            ParameterEncoding::Int16 => Ok(BinaryValueEncoding::Int16),
+            ParameterEncoding::Int32 => Ok(BinaryValueEncoding::Int32),
+            ParameterEncoding::Int64 => Ok(BinaryValueEncoding::Int64),
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:* #943

*Description of changes:*
Prior to this PR supported tagless encoding was limited to unsigned int types. This PR extends the types to include signed integers (`int8`, `int16`, `int32`, and `int64`).

### CLI Testing

Below is an inspect of an encoding and usage of the following macro:
```lisp
(macro foo (int8::a int16::b int32::c int64::d)
   (.sum (.sum (%a) (%b)) (.sum (%c) (%d)))
)
```

```
 ./target/release/ion inspect ../sandbox/tagless_output/output-ints.10n
┌──────────────┬──────────────┬─────────────────────────┬──────────────────────┐
│    Offset    │    Length    │       Binary Ion        │       Text Ion       │
├──────────────┼──────────────┼─────────────────────────┼──────────────────────┘
│            0 │            4 │ e0 01 01 ea             │ $ion_1_1 // Version marker
├──────────────┼──────────────┼─────────────────────────┤
│            4 │            6 │ e7 f9 24 69 6f 6e       │ $ion:: // <text>
│           10 │          110 │ fc d9                   │ (
│           12 │            2 │ ee 10                   │ · module
│           14 │            2 │ a1 5f                   │ · _
│           16 │            5 │ c4                      │ · (
│           17 │            2 │ ee 0f                   │ · · symbol_table
│           19 │            2 │ a1 5f                   │ · · _
│              │              │                         │ · )
│           21 │           99 │ fc c3                   │ · (
│           23 │            2 │ ee 0e                   │ · · macro_table
│           25 │            2 │ a1 5f                   │ · · _
│           27 │           93 │ fc b7                   │ · · (
│           29 │            6 │ a5 6d 61 63 72 6f       │ · · · macro
│           35 │            4 │ a3 66 6f 6f             │ · · · foo
│           39 │           37 │ fc 47                   │ · · · (
│           41 │            6 │ e7 f9 69 6e 74 38       │ · · · · int8:: // <text>
│           47 │            2 │ a1 61                   │ · · · · a
│           49 │            7 │ e7 f7 69 6e 74 31 36    │ · · · · int16:: // <text>
│           56 │            2 │ a1 62                   │ · · · · b
│           58 │            7 │ e7 f7 69 6e 74 33 32    │ · · · · int32:: // <text>
│           65 │            2 │ a1 63                   │ · · · · c
│           67 │            7 │ e7 f7 69 6e 74 36 34    │ · · · · int64:: // <text>
│           74 │            2 │ a1 64                   │ · · · · d
│              │              │                         │ · · · )
│           76 │           44 │ fc 55                   │ · · · (
│           78 │            2 │ a1 2e                   │ · · · · '.'
│           80 │            4 │ a3 73 75 6d             │ · · · · sum
│           84 │           18 │ fc 21                   │ · · · · (
│           86 │            2 │ a1 2e                   │ · · · · · '.'
│           88 │            4 │ a3 73 75 6d             │ · · · · · sum
│           92 │            5 │ c4                      │ · · · · · (
│           93 │            2 │ a1 25                   │ · · · · · · '%'
│           95 │            2 │ a1 61                   │ · · · · · · a
│              │              │                         │ · · · · · )
│           97 │            5 │ c4                      │ · · · · · (
│           98 │            2 │ a1 25                   │ · · · · · · '%'
│          100 │            2 │ a1 62                   │ · · · · · · b
│              │              │                         │ · · · · · )
│              │              │                         │ · · · · )
│          102 │           18 │ fc 21                   │ · · · · (
│          104 │            2 │ a1 2e                   │ · · · · · '.'
│          106 │            4 │ a3 73 75 6d             │ · · · · · sum
│          110 │            5 │ c4                      │ · · · · · (
│          111 │            2 │ a1 25                   │ · · · · · · '%'
│          113 │            2 │ a1 63                   │ · · · · · · c
│              │              │                         │ · · · · · )
│          115 │            5 │ c4                      │ · · · · · (
│          116 │            2 │ a1 25                   │ · · · · · · '%'
│          118 │            2 │ a1 64                   │ · · · · · · d
│              │              │                         │ · · · · · )
│              │              │                         │ · · · · )
│              │              │                         │ · · · )
│              │              │                         │ · · )
│              │              │                         │ · )
│              │              │                         │ )
├──────────────┼──────────────┼─────────────────────────┤
│          120 │           16 │ 18                      │ (:foo
│          121 │            1 │ ff                      │ · -1 // a
│          122 │            2 │ fe ff                   │ · -2 // b
│          124 │            4 │ fd ff ff ff             │ · -3 // c
│          128 │            8 │ 1e 00 00 00 00 00 00 00 │ · 30 // d
│              │              │                         │ )
│              │              │                         │ 24
├──────────────┼──────────────┼─────────────────────────┤
│          136 │              │                         │  // End of stream
└──────────────┴──────────────┴─────────────────────────┘
```


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
