### PR TITLE
Implement tagless float types

### DIFF
--- a/src/lazy/binary/raw/v1_1/binary_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/binary_buffer.rs
@@ -278,6 +278,24 @@ impl<'a> BinaryBuffer<'a> {
         Ok((value, remaining_input))
     }
 
+    pub fn read_float_as_lazy_value(self, encoding: BinaryValueEncoding) -> ParseResult<'a, LazyRawBinaryValue_1_1<'a>> {
+        use BinaryValueEncoding::{Float32, Float64};
+        let size_in_bytes = match encoding {
+            Float32 => 4,
+            Float64 => 8,
+            _ => return IonResult::illegal_operation(format!("invalid binary encoding for taggless float value: {encoding:?}")),
+        };
+
+        if self.len() < size_in_bytes {
+            return IonResult::incomplete("a float", self.offset());
+        }
+
+        let matched_input = self.slice(0, size_in_bytes);
+        let remaining_input = self.slice_to_end(size_in_bytes);
+        let value = LazyRawBinaryValue_1_1::for_float_type(matched_input, encoding);
+        Ok((value, remaining_input))
+    }
+
     pub fn slice_to_end(&self, offset: usize) -> BinaryBuffer<'a> {
         BinaryBuffer {
             data: &self.data[offset..],

--- a/src/lazy/binary/raw/v1_1/e_expression.rs
+++ b/src/lazy/binary/raw/v1_1/e_expression.rs
@@ -351,6 +351,23 @@ impl<'top> Iterator for BinaryEExpArgsInputIter<'top> {
                         remaining,
                     )
                 }
+                enc@ ParameterEncoding::Float32 |
+                enc@ ParameterEncoding::Float64
+                    => {
+                        let binary_enc = try_or_some_err!(enc.try_into());
+                        let (float_lazy_value, remaining) = try_or_some_err! {
+                            self.remaining_args_buffer.read_float_as_lazy_value(binary_enc)
+                        };
+                        let value_ref = &*self
+                            .remaining_args_buffer
+                            .context()
+                            .allocator()
+                            .alloc_with(|| float_lazy_value);
+                        (
+                            EExpArg::new(parameter, EExpArgExpr::ValueLiteral(value_ref)),
+                            remaining,
+                        )
+                }
                 ParameterEncoding::MacroShaped(_macro_ref) => {
                     todo!("macro-shaped parameter encoding")
                 } // TODO: The other tagless encodings

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -119,6 +119,8 @@ pub enum BinaryValueEncoding {
     Int16,
     Int32,
     Int64,
+    Float32,
+    Float64,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -373,6 +375,33 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
             encoding,
             header: Header {
                 ion_type: IonType::Int,
+                ion_type_code: OpcodeType::Nop,
+                length_type: LengthType::Unknown,
+                byte: 0,
+            },
+
+            annotations_header_length: 0,
+            annotations_sequence_length: 0,
+            annotations_encoding: AnnotationsEncoding::SymbolAddress,
+
+            header_offset: input.offset(),
+            length_length: 0,
+            value_body_length: input.len(),
+            total_length: input.len(),
+        };
+
+        LazyRawBinaryValue_1_1 {
+            encoded_value,
+            input,
+            delimited_contents: DelimitedContents::None,
+        }
+    }
+
+    pub(crate) fn for_float_type(input: BinaryBuffer<'top>, encoding: BinaryValueEncoding) -> Self {
+        let encoded_value = EncodedBinaryValue {
+            encoding,
+            header: Header {
+                ion_type: IonType::Float,
                 ion_type_code: OpcodeType::Nop,
                 length_type: LengthType::Unknown,
                 byte: 0,

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -386,6 +386,8 @@ impl TemplateCompiler {
                 "int16" => Ok(ParameterEncoding::Int16),
                 "int32" => Ok(ParameterEncoding::Int32),
                 "int64" => Ok(ParameterEncoding::Int64),
+                "float32" => Ok(ParameterEncoding::Float32),
+                "float64" => Ok(ParameterEncoding::Float64),
                 _ => IonResult::decoding_error(format!(
                     "unrecognized encoding '{encoding_name}' specified for parameter"
                 )),

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -187,6 +187,12 @@ fn write_macro_signature_as_ion<V: ValueWriter>(
             ParameterEncoding::Int64 => value_writer
                 .with_annotations("int64")?
                 .write_symbol(param.name())?,
+            ParameterEncoding::Float32 => value_writer
+                .with_annotations("float32")?
+                .write_symbol(param.name())?,
+            ParameterEncoding::Float64 => value_writer
+                .with_annotations("float64")?
+                .write_symbol(param.name())?,
             ParameterEncoding::MacroShaped(_) => todo!(),
         };
         let cardinality_modifier = match param.cardinality() {

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -215,6 +215,8 @@ pub enum ParameterEncoding {
     Int16,
     Int32,
     Int64,
+    Float32,
+    Float64,
     // TODO: tagless types, including fixed-width types and macros
     MacroShaped(Arc<MacroDef>),
 }
@@ -233,6 +235,8 @@ impl Display for ParameterEncoding {
             Int16 => write!(f, "int16"),
             Int32 => write!(f, "int32"),
             Int64 => write!(f, "int64"),
+            Float32 => write!(f, "float32"),
+            Float64 => write!(f, "float64"),
             MacroShaped(m) => write!(f, "{}", m.name().unwrap_or("<anonymous>")),
         }
     }
@@ -255,6 +259,8 @@ impl TryFrom<&ParameterEncoding> for BinaryValueEncoding {
             ParameterEncoding::Int16 => Ok(BinaryValueEncoding::Int16),
             ParameterEncoding::Int32 => Ok(BinaryValueEncoding::Int32),
             ParameterEncoding::Int64 => Ok(BinaryValueEncoding::Int64),
+            ParameterEncoding::Float32 => Ok(BinaryValueEncoding::Float32),
+            ParameterEncoding::Float64 => Ok(BinaryValueEncoding::Float64),
         }
     }
 }


### PR DESCRIPTION
> This PR is based off of the changes in #996 

*Issue #, if available:* #943

*Description of changes:*
This PR implements tagless floats, both float32, and float64.


### CLI Testing
Below is the output of `ion inspect` of the definition and evocation of the following macro:
```lisp
(macro foo (float32::a float64::b) 
     [(%a), (%b)]
)
```

```
┌──────────────┬──────────────┬─────────────────────────┬──────────────────────┐
│    Offset    │    Length    │       Binary Ion        │       Text Ion       │
├──────────────┼──────────────┼─────────────────────────┼──────────────────────┘
│            0 │            4 │ e0 01 01 ea             │ $ion_1_1 // Version marker
├──────────────┼──────────────┼─────────────────────────┤
│            4 │            6 │ e7 f9 24 69 6f 6e       │ $ion:: // <text>
│           10 │           64 │ fc 7d                   │ (
│           12 │            2 │ ee 10                   │ · module
│           14 │            2 │ a1 5f                   │ · _
│           16 │            5 │ c4                      │ · (
│           17 │            2 │ ee 0f                   │ · · symbol_table
│           19 │            2 │ a1 5f                   │ · · _
│              │              │                         │ · )
│           21 │           53 │ fc 67                   │ · (
│           23 │            2 │ ee 0e                   │ · · macro_table
│           25 │            2 │ a1 5f                   │ · · _
│           27 │           47 │ fc 5b                   │ · · (
│           29 │            6 │ a5 6d 61 63 72 6f       │ · · · macro
│           35 │            4 │ a3 66 6f 6f             │ · · · foo
│           39 │           24 │ fc 2d                   │ · · · (
│           41 │            9 │ e7 f3 66 6c 6f 61 74 33 │ · · · · float32:: // <text>
│           50 │            2 │ a1 61                   │ · · · · a
│           52 │            9 │ e7 f3 66 6c 6f 61 74 36 │ · · · · float64:: // <text>
│           61 │            2 │ a1 62                   │ · · · · b
│              │              │                         │ · · · )
│           63 │           11 │ ba                      │ · · · [
│           64 │            5 │ c4                      │ · · · · (
│           65 │            2 │ a1 25                   │ · · · · · '%'
│           67 │            2 │ a1 61                   │ · · · · · a
│              │              │                         │ · · · · ),
│           69 │            5 │ c4                      │ · · · · (
│           70 │            2 │ a1 25                   │ · · · · · '%'
│           72 │            2 │ a1 62                   │ · · · · · b
│              │              │                         │ · · · · ),
│              │              │                         │ · · · ]
│              │              │                         │ · · )
│              │              │                         │ · )
│              │              │                         │ )
├──────────────┼──────────────┼─────────────────────────┤
│           74 │           13 │ 18                      │ (:foo
│           75 │            4 │ 1f 85 ab 3f             │ · 1.340000033378601e0 // a
│           79 │            8 │ b8 1e 85 eb 51 b8 16 40 │ · 5.68e0 // b
│              │              │                         │ )
│              │              │                         │ [
│              │              │                    (%a) │ · 1.340000033378601e0,
│              │              │                    (%b) │ · 5.68e0,
│              │              │                         │ ]
├──────────────┼──────────────┼─────────────────────────┤
│           87 │              │                         │  // End of stream
└──────────────┴──────────────┴─────────────────────────┘
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
