### PR TITLE
Swapped to write scale then coefficient for long timestamps

### DIFF
--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -2424,8 +2424,8 @@ mod tests {
                     0b1000_0000, // oooo_oomm
                     0b0001_0110, // ssoo_oooo
                     0b0000_0000, // ...._ssss
-                    0b0000_0001, // FlexUInt: 0 subseconds
-                    0b0000_0011, // FixedUInt: scale of 3 (exp: -3)
+                    0b0000_0111, // FlexUInt: scale of 3 (exp: -3)
+                    0b0000_0000, // FixedUInt: 0 subseconds
                 ],
             ),
             (
@@ -2440,8 +2440,8 @@ mod tests {
                     0b1000_0001, // oooo_oomm
                     0b1001_0110, // ssoo_oooo
                     0b0000_0111, // ...._ssss
-                    0b0011_1101, // FlexUInt: 30 subseconds
-                    0b0000_0110, // FixedUInt: scale of 6 (exp: -6)
+                    0b0000_1101, // FlexUInt: scale of 6 (exp: -6)
+                    0b0001_1110, // FixedUInt: 30 subseconds
                 ],
             ),
             (
@@ -2456,8 +2456,8 @@ mod tests {
                     0b1000_0010, // oooo_oomm
                     0b0101_0110, // ssoo_oooo
                     0b0000_1011, // ...._ssss
-                    0b0101_1011, // FlexUInt: 45 subseconds
-                    0b0000_1001, // FixedUInt: scale of 9 (exp: -9)
+                    0b0001_0011, // FlexUInt: scale of 9 (exp: -9)
+                    0b0010_1101, // FixedUInt: 45 subseconds
                 ],
             ),
             (
@@ -2472,8 +2472,8 @@ mod tests {
                     0b1111_1110, // oooo_oomm
                     0b0111_1111, // ssoo_oooo
                     0b0000_1011, // ...._ssss
-                    0b0101_1011, // FlexUInt: 45 subseconds
-                    0b0000_1001, // FixedUInt: scale of 9 (exp: -9)
+                    0b0001_0011, // FlexUInt: scale of 9 (exp: -9)
+                    0b0010_1101, // FixedUInt: 45 subseconds
                 ],
             ),
         ];


### PR DESCRIPTION
*Issue #, if available:*
#1000

*Description of changes:*
Long-form timestamps were being encoded incorrectly. The encoder was encoding the timestamp as: *coefficient first, then scale*; however, it should have been *scale first, then coefficient* - as that is what the decoder is expecting. Because of the mismatch the decoder was reading the wrong bytes causing the *thousands of zeros* issue.

Example:
```
// Before fix - decoder reading wrong bytes:
Scale: 1000 (should be 9)
Coefficient: 9 (should be 1000)
Result: 0001-01-01T00:00:00.000...000009-00:00

// After fix - correct decoding:
Scale: 9
Coefficient: 1000
Result: 0001-01-01T00:00:00.000001-00:00
```
```
Original broken encoding: f8 15 01 40 04 00 fc 3f 00 a2 0f 09
                                                    ^^^^^^ ^^
                                              coefficient scale
                                              (1000)     (9)
```
```
Fixed encoding: f8 13 01 40 04 00 fc 3f 00 0d 01
                                           ^^ ^^
                                        scale coeff
                                        (9)   (1000)
```
When timestamps before the year 1970 are created, they are created as long form timestamps "[Long-form timestamps](https://amazon-ion.github.io/ion-docs/books/ion-1-1/binary/values/timestamp.html#long-form-timestamps), a less compact representation capable of representing any timestamp in the Ion data model."



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
