### PR TITLE
Added u64 integer methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,3 +242,4 @@ bb.out.*
 .history
 
 # End of https://www.toptal.com/developers/gitignore/api/c,c++,rust,cmake,clion,visualstudiocode,valgrind
+.vscode/launch.json

--- a/src/types/integer.rs
+++ b/src/types/integer.rs
@@ -261,6 +261,19 @@ impl Int {
     }
 
     #[inline(always)]
+    pub fn as_u64(&self) -> Option<u64> {
+        u64::try_from(self.data).ok()
+    }
+
+    #[inline]
+    pub fn expect_u64(&self) -> IonResult<u64> {
+        self.as_u64().ok_or_else(
+            #[inline(never)]
+            || IonError::decoding_error(format!("Int {self} was not in the range of a u64.")),
+        )
+    }
+
+    #[inline(always)]
     pub fn as_usize(&self) -> Option<usize> {
         usize::try_from(self.data).ok()
     }

--- a/src/types/integer.rs
+++ b/src/types/integer.rs
@@ -649,4 +649,20 @@ mod integer_tests {
         assert_eq!(UInt::from(128_000u128).expect_u64(), Ok(128_000u64));
         assert!(UInt::from(u128::MAX).expect_u64().is_err())
     }
+
+    #[test]
+    fn int_as_u64() {
+        assert_eq!(Int::from(128_000i64).as_u64(), Some(128_000u64));
+        assert_eq!(Int::from(0i64).as_u64(), Some(0u64));
+        assert!(Int::from(-1i64).as_u64().is_none());
+        assert!(Int::from(i128::MAX).as_u64().is_none());
+    }
+
+    #[test]
+    fn int_expect_u64() {
+        assert_eq!(Int::from(128_000i64).expect_u64(), Ok(128_000u64));
+        assert_eq!(Int::from(0i64).expect_u64(), Ok(0u64));
+        assert!(Int::from(-1i64).expect_u64().is_err());
+        assert!(Int::from(i128::MAX).expect_u64().is_err());
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
#840 

*Description of changes:*
Added `Int::as_u64()` method to `integer.rs` alongside tests for it. `as_u64` and `expect_u64` were missing from the Ion-rust integer types.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
