### PR TITLE
Both `Element` and `&Element` implement `WriteAsIon` now

### DIFF
--- a/src/lazy/encoder/write_as_ion.rs
+++ b/src/lazy/encoder/write_as_ion.rs
@@ -77,7 +77,7 @@ pub trait WriteAsIon {
     }
 }
 
-impl WriteAsIon for &Element {
+impl WriteAsIon for Element {
     fn write_as_ion<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
         if self.annotations().is_empty() {
             self.value().write_as_ion(writer)

--- a/src/lazy/encoder/write_as_ion.rs
+++ b/src/lazy/encoder/write_as_ion.rs
@@ -547,36 +547,21 @@ impl<T: WriteAsIon> WriteAsIon for Option<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ion_list, v1_0, Writer, IntoAnnotatedElement};
+    use crate::v1_0;
 
     #[test]
-    fn write_element_owned_and_borrowed() -> IonResult<()> {
-        let mut writer = Writer::new(v1_0::Text, Vec::new())?;
+    fn test_element_write_as_ion_without_annotations() -> IonResult<()> {
+        let element = Element::read_one("42")?;
+        let encoded: String = element.encode_as(v1_0::Text)?;
+        assert_eq!(encoded.trim(), "42");
+        Ok(())
+    }
 
-        // Test owned Element with annotations (else branch)
-        let annotated_element: Element = ion_list![].with_annotations(["valid"]);
-        writer.write(annotated_element)?;
-
-        // Test owned Element without annotations (if branch)
-        let plain_element: Element = ion_list![1, 2, 3].into();
-        writer.write(plain_element)?;
-
-        // Test borrowed Element with annotations
-        let element2: Element = "ion!".with_annotations(["amazon"]);
-        writer.write(&element2)?;
-
-        // Test borrowed Element without annotations
-        let element3: Element = 10.into();
-        writer.write(&element3)?;
-
-        let output = writer.close()?;
-        let output_str = String::from_utf8_lossy(&output);
-
-        assert!(output_str.contains("valid::[]"));
-        assert!(output_str.contains("[1, 2, 3"));
-        assert!(output_str.contains("amazon::\"ion!\""));
-        assert!(output_str.contains("10"));
-
+    #[test]
+    fn test_element_write_as_ion_with_annotations() -> IonResult<()> {
+        let element = Element::read_one("foo::42")?;
+        let encoded: String = element.encode_as(v1_0::Text)?;
+        assert_eq!(encoded.trim(), "foo::42");
         Ok(())
     }
 }

--- a/src/lazy/encoder/write_as_ion.rs
+++ b/src/lazy/encoder/write_as_ion.rs
@@ -553,23 +553,29 @@ mod tests {
     fn write_element_owned_and_borrowed() -> IonResult<()> {
         let mut writer = Writer::new(v1_0::Text, Vec::new())?;
 
-        // Test owned Element
-        let element: Element = ion_list![].with_annotations(["valid"]);
-        writer.write(element)?;
+        // Test owned Element with annotations (else branch)
+        let annotated_element: Element = ion_list![].with_annotations(["valid"]);
+        writer.write(annotated_element)?;
 
-        // Test borrowed Element
-        let element2: Element = ion_list![1, 2, 3].with_annotations(["numbers"]);
+        // Test owned Element without annotations (if branch)
+        let plain_element: Element = ion_list![1, 2, 3].into();
+        writer.write(plain_element)?;
+
+        // Test borrowed Element with annotations
+        let element2: Element = "ion!".with_annotations(["amazon"]);
         writer.write(&element2)?;
 
-        // Test Element types as owned values
-        writer.write("hello, world".with_annotations(["greeting"]))?;
+        // Test borrowed Element without annotations
+        let element3: Element = 10.into();
+        writer.write(&element3)?;
 
         let output = writer.close()?;
         let output_str = String::from_utf8_lossy(&output);
 
         assert!(output_str.contains("valid::[]"));
-        assert!(output_str.contains("numbers::[1, 2, 3"));
-        assert!(output_str.contains("greeting::\"hello, world\""));
+        assert!(output_str.contains("[1, 2, 3"));
+        assert!(output_str.contains("amazon::\"ion!\""));
+        assert!(output_str.contains("10"));
 
         Ok(())
     }

--- a/src/lazy/encoder/write_as_ion.rs
+++ b/src/lazy/encoder/write_as_ion.rs
@@ -543,3 +543,34 @@ impl<T: WriteAsIon> WriteAsIon for Option<T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ion_list, v1_0, Writer, IntoAnnotatedElement};
+
+    #[test]
+    fn write_element_owned_and_borrowed() -> IonResult<()> {
+        let mut writer = Writer::new(v1_0::Text, Vec::new())?;
+
+        // Test owned Element
+        let element: Element = ion_list![].with_annotations(["valid"]);
+        writer.write(element)?;
+
+        // Test borrowed Element
+        let element2: Element = ion_list![1, 2, 3].with_annotations(["numbers"]);
+        writer.write(&element2)?;
+
+        // Test Element types as owned values
+        writer.write("hello, world".with_annotations(["greeting"]))?;
+
+        let output = writer.close()?;
+        let output_str = String::from_utf8_lossy(&output);
+
+        assert!(output_str.contains("valid::[]"));
+        assert!(output_str.contains("numbers::[1, 2, 3"));
+        assert!(output_str.contains("greeting::\"hello, world\""));
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
#844 

*Description of changes:*
Both `Element` and `&Element` implement `WriteAsIon` now
- `Element` implements it directly
- `&Element` gets it via the implementation `impl<T: WriteAsIon> WriteAsIon for &T` in `write_as_ion.rs`

This fixes the issue of `Element` not being able to implement the trait, new users can now use the API without needing to remember to add `&`.

*Example:*
```
// using this to invoke the api
// this creates an empty List using the macro and adds the annotation "valid" to the List
// then writes the annotated element to the ion stream
writer.write(ion_list![].with_annotations(["valid"]))?;
```

Before
```
// gave this error because Element did not implement WriteAsIon
error[E0277]: the trait bound `ion_rs::Element: WriteAsIon` is not satisfied
```

After
```
// works with or without the '&' because both implement WriteAsIon now
// produces an empty List, annotated with 'valid::'
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
