### PR TITLE
Move typed null handling from ion_type() to read_null() methods

### DIFF
--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -141,7 +141,12 @@ impl<'top> HasRange for &'top LazyRawBinaryValue_1_1<'top> {
 
 impl<'top> LazyRawValue<'top, BinaryEncoding_1_1> for &'top LazyRawBinaryValue_1_1<'top> {
     fn ion_type(&self) -> IonType {
-        self.encoded_value.ion_type()
+        if self.encoded_value.header.type_code() == OpcodeType::TypedNull {
+            let body = self.value_body();
+            ION_1_1_TYPED_NULL_TYPES[body[0] as usize]
+        } else {
+            self.encoded_value.ion_type()
+        }
     }
 
     fn is_null(&self) -> bool {

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -429,11 +429,13 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
     }
 
     fn read_null(&self) -> IonResult<IonType> {
-        Ok(if self.encoded_value.header.type_code() == OpcodeType::TypedNull {
-            ION_1_1_TYPED_NULL_TYPES[self.value_body()[0] as usize]
+        let ion_type = if self.encoded_value.header.type_code() == OpcodeType::TypedNull {
+            let body = self.value_body();
+            ION_1_1_TYPED_NULL_TYPES[body[0] as usize]
         } else {
             self.encoded_value.ion_type()
-        })
+        };
+        Ok(ion_type)
     }
 
     pub fn is_delimited(&self) -> bool {

--- a/src/lazy/binary/raw/v1_1/value.rs
+++ b/src/lazy/binary/raw/v1_1/value.rs
@@ -429,13 +429,11 @@ impl<'top> LazyRawBinaryValue_1_1<'top> {
     }
 
     fn read_null(&self) -> IonResult<IonType> {
-        let ion_type = if self.encoded_value.header.type_code() == OpcodeType::TypedNull {
-            let body = self.value_body();
-            ION_1_1_TYPED_NULL_TYPES[body[0] as usize]
+        Ok(if self.encoded_value.header.type_code() == OpcodeType::TypedNull {
+            ION_1_1_TYPED_NULL_TYPES[self.value_body()[0] as usize]
         } else {
             self.encoded_value.ion_type()
-        };
-        Ok(ion_type)
+        })
     }
 
     pub fn is_delimited(&self) -> bool {

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -501,10 +501,13 @@ impl<'top> LazyRawBinaryValue_1_0<'top> {
     /// calling this method will not read additional data; the `RawValueRef` will provide a
     /// [`LazyRawBinaryList_1_0`], [`LazyRawBinarySExp_1_0`], or [`LazyRawBinaryStruct_1_0`]
     /// that can be traversed to access the container's contents.
+    fn read_null(&self) -> IonResult<IonType> {
+        Ok(self.encoded_value.ion_type())
+    }
+
     pub fn read(&self) -> ValueParseResult<'top, BinaryEncoding_1_0> {
         if self.is_null() {
-            let raw_value_ref = RawValueRef::Null(self.ion_type());
-            return Ok(raw_value_ref);
+            return Ok(RawValueRef::Null(self.read_null()?));
         }
 
         match self.ion_type() {

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -501,13 +501,10 @@ impl<'top> LazyRawBinaryValue_1_0<'top> {
     /// calling this method will not read additional data; the `RawValueRef` will provide a
     /// [`LazyRawBinaryList_1_0`], [`LazyRawBinarySExp_1_0`], or [`LazyRawBinaryStruct_1_0`]
     /// that can be traversed to access the container's contents.
-    fn read_null(&self) -> IonResult<IonType> {
-        Ok(self.encoded_value.ion_type())
-    }
-
     pub fn read(&self) -> ValueParseResult<'top, BinaryEncoding_1_0> {
         if self.is_null() {
-            return Ok(RawValueRef::Null(self.read_null()?));
+            let raw_value_ref = RawValueRef::Null(self.ion_type());
+            return Ok(raw_value_ref);
         }
 
         match self.ion_type() {


### PR DESCRIPTION
*Issue #, if available:*
#828 

*Description of changes:*

Typed nulls in Ion 1.1 use `OpcodeType::TypedNull` encoding where the actual type information is stored in the value body. The `ion_type()` method was  only reading the header type while missing the logic to decode the actual type from the body.

Applying the typed null handling logic from `read_null()` to `ion_type()` determines if this is a typed null or regular value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
