### PR TITLE
Promote experimental-read-writer and experimental-ion-1-1 features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,30 +22,21 @@ rust-version = "1.82"
 
 [features]
 default = []
-experimental-ion-hash = ["digest", "experimental-reader-writer"]
+experimental-ion-hash = ["digest"]
 
 # Feature for indicating particularly bleeding edge APIs or functionality in the library.
 # These are not guaranteed any sort of API stability and may also have non-standard
-# Ion behavior (e.g., draft Ion 1.1 capabilities).
+# Ion behavior.
 experimental = [
-    "experimental-reader-writer",
     "experimental-tooling-apis",
     "experimental-serde",
-    "experimental-ion-1-1",
 ]
-
-# Feature for indicating explicit opt-in to Ion 1.1
-experimental-ion-1-1 = ["experimental-reader-writer"]
-
-# Access to the streaming Reader and Writer types.
-# These APIs are functional and well-tested, but are not yet stable.
-experimental-reader-writer = []
 
 # Access to low-level encoding information. These APIs are not near stabilization.
 experimental-tooling-apis = []
 
 # Experimental serde API to serialize and deserialize Ion data into Rust objects using serde crate
-experimental-serde = ["experimental-reader-writer", "dep:serde_with", "dep:serde"]
+experimental-serde = ["dep:serde_with", "dep:serde"]
 
 bigdecimal = ["dep:bigdecimal"]
 

--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -1904,13 +1904,6 @@ mod tests {
 
         expect_int(&mut reader, IonEncoding::Text_1_0, 2)?;
 
-        if cfg!(not(feature = "experimental-ion-1-1")) {
-            reader
-                .next()
-                .expect_err("Ion 1.1 IVM should return an error.");
-            return Ok(());
-        }
-
         // This IVM changes the encoding from 1.0 text to 1.1 text
         expect_version_change(&mut reader, IonEncoding::Text_1_0, IonEncoding::Text_1_1)?;
 
@@ -1955,13 +1948,6 @@ mod tests {
         )?;
 
         expect_int(&mut reader, IonEncoding::Binary_1_0, 2)?;
-
-        if cfg!(not(feature = "experimental-ion-1-1")) {
-            reader
-                .next()
-                .expect_err("Ion 1.1 IVM should return an error.");
-            return Ok(());
-        }
 
         // This IVM changes the encoding from 1.0 binary to 1.1 binary
         expect_version_change(

--- a/src/lazy/binary/raw/v1_1/binary_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/binary_buffer.rs
@@ -1154,7 +1154,6 @@ pub struct EncodedAnnotations {
     pub sequence_length: u16,
 }
 
-#[cfg(feature = "experimental-ion-1-1")]
 #[cfg(test)]
 mod tests {
     use rstest::rstest;

--- a/src/lazy/binary/raw/v1_1/struct.rs
+++ b/src/lazy/binary/raw/v1_1/struct.rs
@@ -322,7 +322,6 @@ impl<'top> Iterator for RawBinaryStructIterator_1_1<'top> {
     }
 }
 
-#[cfg(feature = "experimental-ion-1-1")]
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -136,7 +136,6 @@ pub trait RawVersionMarker<'top>: Debug + Copy + Clone + HasSpan<'top> {
     fn stream_version_after_marker(&self) -> IonResult<IonVersion> {
         match self.major_minor() {
             (1, 0) => Ok(IonVersion::v1_0),
-            #[cfg(feature = "experimental-ion-1-1")]
             (1, 1) => Ok(IonVersion::v1_1),
             (major, minor) => {
                 IonResult::decoding_error(format!("Ion version {major}.{minor} is not supported"))

--- a/src/lazy/encoder/annotate.rs
+++ b/src/lazy/encoder/annotate.rs
@@ -16,7 +16,6 @@ pub trait Annotatable {
     ///
     /// ```
     ///# use ion_rs::IonResult;
-    ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
     /// use ion_rs::{Annotatable, Element, IonData, Writer, v1_0::Text};
     ///
@@ -31,10 +30,7 @@ pub trait Annotatable {
     /// assert!(IonData::eq(&expected, &actual));
     ///# Ok(())
     ///# }
-    ///# #[cfg(not(feature = "experimental-reader-writer"))]
-    ///# fn main() -> IonResult<()> { Ok(()) }
     /// ```
-    #[cfg_attr(not(feature = "experimental-reader-writer"), allow(dead_code))]
     fn annotated_with<'a, A: 'a>(&'a self, annotations: A) -> Annotated<'a, Self, A>
     where
         &'a A: AnnotationSeq<'a>;

--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -1306,7 +1306,6 @@ impl<'top> AnnotatableWriter for BinaryEExpParameterValueWriter_1_1<'_, 'top> {
 }
 
 #[cfg(test)]
-#[cfg(feature = "experimental-ion-1-1")]
 mod tests {
     use num_traits::FloatConst;
     use rstest::rstest;

--- a/src/lazy/encoder/text/v1_1/writer.rs
+++ b/src/lazy/encoder/text/v1_1/writer.rs
@@ -117,7 +117,6 @@ impl<W: Write> LazyRawWriter<W> for LazyRawTextWriter_1_1<W> {
     }
 }
 
-#[cfg(feature = "experimental-ion-1-1")]
 #[cfg(test)]
 mod tests {
     use crate::lazy::any_encoding::IonVersion;

--- a/src/lazy/encoder/value_writer.rs
+++ b/src/lazy/encoder/value_writer.rs
@@ -511,7 +511,7 @@ pub trait SequenceWriter: MakeValueWriter {
     }
 }
 
-#[cfg(all(test, feature = "experimental-reader-writer"))]
+#[cfg(test)]
 mod tests {
     use crate::symbol_ref::AsSymbolRef;
     use crate::{ion_seq, v1_0, Element, IntoAnnotatedElement, SequenceWriter, Writer};

--- a/src/lazy/encoder/write_as_ion.rs
+++ b/src/lazy/encoder/write_as_ion.rs
@@ -43,7 +43,6 @@ pub trait WriteAsIon {
     /// encoded bytes. If the requested encoding is text of any version, returns a `String` instead.
     /// ```
     ///# use ion_rs::IonResult;
-    ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
     ///# use ion_rs::*;
     ///
@@ -53,8 +52,6 @@ pub trait WriteAsIon {
     /// assert_eq!(element.as_string().unwrap(), "foo bar baz");
     ///# Ok(())
     ///# }
-    ///# #[cfg(not(feature = "experimental-reader-writer"))]
-    ///# fn main() -> IonResult<()> { Ok(()) }
     /// ```
     fn encode_as<E: Encoding, C: Into<WriteConfig<E>>>(&self, config: C) -> IonResult<E::Output>
     where

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -128,8 +128,7 @@ impl Deref for WriterMacroTable {
 }
 
 /// An Ion writer that maintains a symbol table and creates new entries as needed.
-#[cfg_attr(feature = "experimental-reader-writer", visibility::make(pub))]
-pub(crate) struct Writer<E: Encoding, Output: Write> {
+pub struct Writer<E: Encoding, Output: Write> {
     symbols: WriterSymbolTable,
     data_writer: E::Writer<Vec<u8>>,
     directive_writer: E::Writer<Vec<u8>>,
@@ -147,7 +146,6 @@ pub type TextWriter_1_1<Output> = Writer<TextEncoding_1_1, Output>;
 #[allow(dead_code)]
 pub type BinaryWriter_1_1<Output> = Writer<BinaryEncoding_1_1, Output>;
 
-#[cfg_attr(not(feature = "experimental-reader-writer"), allow(dead_code))]
 impl<E: Encoding, Output: Write> Writer<E, Output> {
     /// Constructs a writer for the requested encoding using the provided configuration.
     pub fn new(config: impl Into<WriteConfig<E>>, output: Output) -> IonResult<Self> {
@@ -277,15 +275,8 @@ impl<E: Encoding, Output: Write> Writer<E, Output> {
         Ok(self.output)
     }
 
-    #[cfg(feature = "experimental-reader-writer")]
     #[inline]
     pub fn symbol_table(&self) -> &SymbolTable {
-        &self.symbols
-    }
-
-    #[cfg(not(feature = "experimental-reader-writer"))]
-    #[inline]
-    pub(crate) fn symbol_table(&self) -> &SymbolTable {
         &self.symbols
     }
 
@@ -433,21 +424,13 @@ impl<'a, V: ValueWriter> ApplicationValueWriter<'a, V> {
         }
     }
 
-    #[cfg(feature = "experimental-reader-writer")]
     #[inline]
     pub fn symbol_table(&self) -> &SymbolTable {
-        self.symbols
-    }
-
-    #[cfg(not(feature = "experimental-reader-writer"))]
-    #[inline]
-    pub(crate) fn symbol_table(&self) -> &SymbolTable {
         self.symbols
     }
 }
 
 // Generally useful methods, but currently only called in unit tests.
-#[cfg_attr(not(feature = "experimental-reader-writer"), allow(dead_code))]
 impl ApplicationValueWriter<'_, BinaryValueWriter_1_1<'_, '_>> {
     pub fn with_container_encoding(mut self, container_encoding: ContainerEncoding) -> Self {
         self.value_writer_config = self
@@ -752,7 +735,6 @@ impl<'value, V: ValueWriter> ApplicationStructWriter<'value, V> {
     }
 
     // Generally useful, but currently only called in unit tests.
-    #[cfg_attr(not(feature = "experimental-reader-writer"), allow(dead_code))]
     pub fn with_field_name_encoding(mut self, field_name_encoding: FieldNameEncoding) -> Self {
         self.value_writer_config = self
             .value_writer_config
@@ -1053,7 +1035,6 @@ impl<S: SequenceWriter> ElementWriter for S {
     }
 }
 
-#[cfg(feature = "experimental-ion-1-1")]
 #[cfg(test)]
 mod tests {
     use crate::lazy::encoder::value_writer::AnnotatableWriter;

--- a/src/lazy/expanded/compiler.rs
+++ b/src/lazy/expanded/compiler.rs
@@ -1769,7 +1769,6 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "experimental-ion-1-1")]
     #[test]
     fn dependent_macros() -> IonResult<()> {
         use crate::{AnyEncoding, Element, ElementReader, Reader};

--- a/src/lazy/expanded/lazy_element.rs
+++ b/src/lazy/expanded/lazy_element.rs
@@ -172,7 +172,6 @@ mod tests {
     use crate::lazy::reader::IonResultIterExt;
     use crate::{AnyEncoding, Element, IonResult, IonType, Reader, Sequence};
 
-    #[cfg(feature = "experimental-ion-1-1")]
     fn test_data() -> String {
         let test_data = r#"
             $ion_1_1
@@ -197,20 +196,6 @@ mod tests {
 
              // === Produces a value backed by an `ExpandedValueSource::Constructed` ===
              (:greet "Alice")
-         "#;
-        test_data.to_owned()
-    }
-
-    #[cfg(not(feature = "experimental-ion-1-1"))]
-    fn test_data() -> String {
-        let test_data = r#"
-            // === Values backed by `ExpandedValueSource::ValueLiteral` ===
-            foo
-            true
-            baz::5
-            [(), {}, ()]
-            2025T
-            "Hello"
          "#;
         test_data.to_owned()
     }
@@ -283,7 +268,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "experimental-ion-1-1")]
     fn demonstrate_try_filter_map_1_1() -> IonResult<()> {
         let log = r#"
             $ion_1_1

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -917,7 +917,7 @@ impl MacroTable {
     }
 }
 
-#[cfg(all(test, feature = "experimental-ion-1-1"))]
+#[cfg(test)]
 mod tests {
     use crate::lazy::expanded::template::TemplateMacroRef;
     use crate::{

--- a/src/lazy/reader.rs
+++ b/src/lazy/reader.rs
@@ -25,7 +25,6 @@ use crate::{try_or_some_err, IonError, IonResult, MacroTable, SymbolTable};
 /// re-read as long as the reader remains on the same top-level value.
 /// ```
 ///# use ion_rs::IonResult;
-///# #[cfg(feature = "experimental-reader-writer")]
 ///# fn main() -> IonResult<()> {
 ///
 /// // Construct an Element and serialize it as binary Ion.
@@ -57,8 +56,6 @@ use crate::{try_or_some_err, IonError, IonResult, MacroTable, SymbolTable};
 ///
 ///# Ok(())
 ///# }
-///# #[cfg(not(feature = "experimental-reader-writer"))]
-///# fn main() -> IonResult<()> { Ok(()) }
 /// ```
 pub struct Reader<Encoding: Decoder, Input: IonInput> {
     system_reader: SystemReader<Encoding, Input>,
@@ -395,7 +392,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "experimental-ion-1-1"))]
+#[cfg(test)]
 mod tests_1_1 {
     use crate::lazy::text::raw::v1_1::reader::MacroAddress;
     use crate::{v1_1, IonResult, MacroTable, Reader};

--- a/src/lazy/sequence.rs
+++ b/src/lazy/sequence.rs
@@ -18,7 +18,6 @@ use crate::{IonError, IonResult};
 ///
 /// ```
 ///# use ion_rs::IonResult;
-///# #[cfg(feature = "experimental-reader-writer")]
 ///# fn main() -> IonResult<()> {
 ///
 /// // Construct an Element and serialize it as binary Ion.
@@ -50,8 +49,6 @@ use crate::{IonError, IonResult};
 ///
 ///# Ok(())
 ///# }
-///# #[cfg(not(feature = "experimental-reader-writer"))]
-///# fn main() -> IonResult<()> { Ok(()) }
 /// ```
 #[derive(Copy, Clone)]
 pub struct LazyList<'top, D: Decoder> {
@@ -92,7 +89,6 @@ impl<'top, D: Decoder> LazyList<'top, D> {
     ///
     /// ```
     ///# use ion_rs::IonResult;
-    ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
     ///
     /// // Construct an Element and serialize it as binary Ion.
@@ -115,8 +111,6 @@ impl<'top, D: Decoder> LazyList<'top, D> {
     ///
     ///# Ok(())
     ///# }
-    ///# #[cfg(not(feature = "experimental-reader-writer"))]
-    ///# fn main() -> IonResult<()> { Ok(()) }
     /// ```
     pub fn annotations(&self) -> AnnotationsIterator<'top, D> {
         AnnotationsIterator {
@@ -253,7 +247,6 @@ impl<'top, D: Decoder> LazySExp<'top, D> {
     ///
     /// ```
     ///# use ion_rs::IonResult;
-    ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
     ///
     /// // Construct an Element and serialize it as binary Ion.
@@ -276,8 +269,6 @@ impl<'top, D: Decoder> LazySExp<'top, D> {
     ///
     ///# Ok(())
     ///# }
-    ///# #[cfg(not(feature = "experimental-reader-writer"))]
-    ///# fn main() -> IonResult<()> { Ok(()) }
     /// ```
     pub fn annotations(&self) -> AnnotationsIterator<'top, D> {
         AnnotationsIterator {

--- a/src/lazy/struct.rs
+++ b/src/lazy/struct.rs
@@ -18,7 +18,6 @@ use std::fmt::{Debug, Formatter};
 ///
 /// ```
 ///# use ion_rs::IonResult;
-///# #[cfg(feature = "experimental-reader-writer")]
 ///# fn main() -> IonResult<()> {
 /// use ion_rs::{Element, Reader};
 /// use ion_rs::v1_0::Binary;
@@ -42,8 +41,6 @@ use std::fmt::{Debug, Formatter};
 /// assert_eq!(foo_sum, 4);
 ///# Ok(())
 ///# }
-///# #[cfg(not(feature = "experimental-reader-writer"))]
-///# fn main() -> IonResult<()> { Ok(()) }
 /// ```
 #[derive(Copy, Clone)]
 pub struct LazyStruct<'top, D: Decoder> {
@@ -110,7 +107,6 @@ impl<'top, D: Decoder> LazyStruct<'top, D> {
     /// complexity.
     /// ```
     ///# use ion_rs::IonResult;
-    ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
     /// use ion_rs::{Element, ValueRef, Reader};
     /// use ion_rs::v1_0::Binary;
@@ -132,8 +128,6 @@ impl<'top, D: Decoder> LazyStruct<'top, D> {
     ///
     ///# Ok(())
     ///# }
-    ///# #[cfg(not(feature = "experimental-reader-writer"))]
-    ///# fn main() -> IonResult<()> { Ok(()) }
     /// ```
     pub fn find(&self, name: &str) -> IonResult<Option<LazyValue<'top, D>>> {
         let Some(expanded_value) = self.expanded_struct.find(name)? else {
@@ -147,7 +141,6 @@ impl<'top, D: Decoder> LazyStruct<'top, D> {
     /// specified name is found.
     /// ```
     ///# use ion_rs::IonResult;
-    ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
     /// use ion_rs::{Element, Reader};
     /// use ion_rs::v1_0::Binary;
@@ -163,8 +156,6 @@ impl<'top, D: Decoder> LazyStruct<'top, D> {
     ///
     ///# Ok(())
     ///# }
-    ///# #[cfg(not(feature = "experimental-reader-writer"))]
-    ///# fn main() -> IonResult<()> { Ok(()) }
     /// ```
     pub fn find_expected(&self, name: &str) -> IonResult<LazyValue<'top, D>> {
         self.find(name)?
@@ -175,7 +166,6 @@ impl<'top, D: Decoder> LazyStruct<'top, D> {
     /// matching name.
     /// ```
     ///# use ion_rs::IonResult;
-    ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
     /// use ion_rs::{Element, IonType, ValueRef, Reader};
     /// use ion_rs::v1_0::Binary;
@@ -191,8 +181,6 @@ impl<'top, D: Decoder> LazyStruct<'top, D> {
     /// assert_eq!(lazy_struct.get("bar")?, Some(ValueRef::Null(IonType::List)));
     ///# Ok(())
     ///# }
-    ///# #[cfg(not(feature = "experimental-reader-writer"))]
-    ///# fn main() -> IonResult<()> { Ok(()) }
     /// ```
     pub fn get(&self, name: &str) -> IonResult<Option<ValueRef<'top, D>>> {
         self.find(name)?.map(|f| f.read()).transpose()
@@ -202,7 +190,6 @@ impl<'top, D: Decoder> LazyStruct<'top, D> {
     /// specified name is found.
     /// ```
     ///# use ion_rs::IonResult;
-    ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
     /// use ion_rs::{Element, ValueRef, Reader};
     /// use ion_rs::v1_0::Binary;
@@ -217,8 +204,6 @@ impl<'top, D: Decoder> LazyStruct<'top, D> {
     /// assert!(lazy_struct.get_expected("Ontario").is_err());
     ///# Ok(())
     ///# }
-    ///# #[cfg(not(feature = "experimental-reader-writer"))]
-    ///# fn main() -> IonResult<()> { Ok(()) }
     /// ```
     pub fn get_expected(&self, name: &str) -> IonResult<ValueRef<'top, D>> {
         self.get(name)?.ok_or_else(move || {
@@ -231,7 +216,6 @@ impl<'top, D: Decoder> LazyStruct<'top, D> {
     ///
     /// ```
     ///# use ion_rs::IonResult;
-    ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
     ///
     /// // Construct an Element and serialize it as binary Ion.
@@ -255,8 +239,6 @@ impl<'top, D: Decoder> LazyStruct<'top, D> {
     ///
     ///# Ok(())
     ///# }
-    ///# #[cfg(not(feature = "experimental-reader-writer"))]
-    ///# fn main() -> IonResult<()> { Ok(()) }
     /// ```
     pub fn annotations(&self) -> AnnotationsIterator<'top, D> {
         AnnotationsIterator {

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -41,7 +41,6 @@ use std::sync::Arc;
 /// long as the reader remains on the same top-level value.
 /// ```
 ///# use ion_rs::IonResult;
-///# #[cfg(feature="experimental-reader-writer")]
 ///# fn main() -> IonResult<()> {
 ///
 /// // Construct an Element and serialize it as binary Ion.
@@ -73,8 +72,6 @@ use std::sync::Arc;
 ///
 ///# Ok(())
 ///# }
-///# #[cfg(not(feature = "experimental-reader-writer"))]
-///# fn main() -> IonResult<()> { Ok(()) }
 /// ```
 #[cfg_attr(feature = "experimental-tooling-apis", visibility::make(pub))]
 pub(crate) struct SystemReader<Encoding: Decoder, Input: IonInput> {
@@ -998,7 +995,6 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "experimental-ion-1-1")]
     #[test]
     fn detect_encoding_directive_text() -> IonResult<()> {
         let text = r#"
@@ -1014,7 +1010,6 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "experimental-ion-1-1")]
     #[test]
     fn detect_encoding_directive_binary() -> IonResult<()> {
         use crate::lazy::encoder::binary::v1_1::writer::LazyRawBinaryWriter_1_1;
@@ -1081,7 +1076,6 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "experimental-ion-1-1")]
     #[test]
     fn read_encoding_directive_new_active_module() -> IonResult<()> {
         let ion = r#"

--- a/src/lazy/value.rs
+++ b/src/lazy/value.rs
@@ -20,7 +20,6 @@ use crate::{
 ///
 /// ```
 ///# use ion_rs::IonResult;
-///# #[cfg(feature = "experimental-reader-writer")]
 ///# fn main() -> IonResult<()> {
 ///
 /// // Construct an Element and serialize it as binary Ion.
@@ -52,8 +51,6 @@ use crate::{
 ///
 ///# Ok(())
 ///# }
-///# #[cfg(not(feature = "experimental-reader-writer"))]
-///# fn main() -> IonResult<()> { Ok(()) }
 /// ```
 #[derive(Debug, Copy, Clone)]
 pub struct LazyValue<'top, D: Decoder> {
@@ -72,7 +69,6 @@ impl<'top, D: Decoder> LazyValue<'top, D> {
     /// Returns the [`IonType`] of this value.
     /// ```
     ///# use ion_rs::IonResult;
-    ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
     ///
     /// // Construct an Element and serialize it as binary Ion.
@@ -92,8 +88,6 @@ impl<'top, D: Decoder> LazyValue<'top, D> {
     ///
     ///# Ok(())
     ///# }
-    ///# #[cfg(not(feature = "experimental-reader-writer"))]
-    ///# fn main() -> IonResult<()> { Ok(()) }
     /// ```
     pub fn ion_type(&self) -> IonType {
         self.expanded_value.ion_type()
@@ -133,7 +127,6 @@ impl<'top, D: Decoder> LazyValue<'top, D> {
     ///
     /// ```
     ///# use ion_rs::IonResult;
-    ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
     ///
     /// // Construct an Element and serialize it as binary Ion.
@@ -154,8 +147,6 @@ impl<'top, D: Decoder> LazyValue<'top, D> {
     ///
     ///# Ok(())
     ///# }
-    ///# #[cfg(not(feature = "experimental-reader-writer"))]
-    ///# fn main() -> IonResult<()> { Ok(()) }
     /// ```
     pub fn is_null(&self) -> bool {
         self.expanded_value.is_null()
@@ -166,7 +157,6 @@ impl<'top, D: Decoder> LazyValue<'top, D> {
     ///
     /// ```
     ///# use ion_rs::IonResult;
-    ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
     ///
     /// // Construct an Element and serialize it as binary Ion.
@@ -189,8 +179,6 @@ impl<'top, D: Decoder> LazyValue<'top, D> {
     ///
     ///# Ok(())
     ///# }
-    ///# #[cfg(not(feature = "experimental-reader-writer"))]
-    ///# fn main() -> IonResult<()> { Ok(()) }
     /// ```
     pub fn annotations(&self) -> AnnotationsIterator<'top, D> {
         AnnotationsIterator {
@@ -206,7 +194,6 @@ impl<'top, D: Decoder> LazyValue<'top, D> {
     /// Reads the body of this value (that is: its data) and returns it as a [`ValueRef`].
     /// ```
     ///# use ion_rs::IonResult;
-    ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
     ///
     /// // Construct an Element and serialize it as binary Ion.
@@ -230,8 +217,6 @@ impl<'top, D: Decoder> LazyValue<'top, D> {
     ///
     ///# Ok(())
     ///# }
-    ///# #[cfg(not(feature = "experimental-reader-writer"))]
-    ///# fn main() -> IonResult<()> { Ok(()) }
     /// ```
     pub fn read(&self) -> IonResult<ValueRef<'top, D>> {
         self.expanded_value.read_resolved()
@@ -329,7 +314,6 @@ impl<D: Decoder> AnnotationsIterator<'_, D> {
     /// returns an `Err(IonError)`.
     /// ```
     ///# use ion_rs::IonResult;
-    ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
     ///
     /// // Construct an Element and serialize it as binary Ion.
@@ -352,8 +336,6 @@ impl<D: Decoder> AnnotationsIterator<'_, D> {
     ///
     ///# Ok(())
     ///# }
-    ///# #[cfg(not(feature = "experimental-reader-writer"))]
-    ///# fn main() -> IonResult<()> { Ok(()) }
     /// ```
     pub fn are<A: AsSymbolRef, I: IntoIterator<Item = A>>(
         mut self,
@@ -368,7 +350,6 @@ impl<D: Decoder> AnnotationsIterator<'_, D> {
     /// returns an `Err(IonError)`.
     /// ```
     ///# use ion_rs::IonResult;
-    ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
     ///
     /// // Construct an Element and serialize it as binary Ion.
@@ -393,8 +374,6 @@ impl<D: Decoder> AnnotationsIterator<'_, D> {
     ///
     ///# Ok(())
     ///# }
-    ///# #[cfg(not(feature = "experimental-reader-writer"))]
-    ///# fn main() -> IonResult<()> { Ok(()) }
     /// ```
     pub fn starts_with<A: AsSymbolRef, I: IntoIterator<Item = A>>(
         &mut self,
@@ -414,7 +393,6 @@ impl<D: Decoder> AnnotationsIterator<'_, D> {
     /// don't match the provided sequence exactly.
     /// ```
     ///# use ion_rs::IonResult;
-    ///# #[cfg(feature = "experimental-reader-writer")]
     ///# fn main() -> IonResult<()> {
     ///
     /// // Construct an Element and serialize it as binary Ion.
@@ -437,8 +415,6 @@ impl<D: Decoder> AnnotationsIterator<'_, D> {
     ///
     ///# Ok(())
     ///# }
-    ///# #[cfg(not(feature = "experimental-reader-writer"))]
-    ///# fn main() -> IonResult<()> { Ok(()) }
     /// ```
     pub fn expect<A: AsSymbolRef, I: IntoIterator<Item = A>>(
         self,
@@ -649,13 +625,10 @@ mod tests {
         [(1, 1), (1, 6), (1, 12), (2, 1), (3, 7), (4, 7), (4, 8), (4, 10), (4, 12),
         (6, 1), (6, 6), (6, 12), (7, 1), (8, 7), (9, 7), (9, 8), (9, 10), (9, 12)],
     )]
-    #[cfg_attr(
-        feature = "experimental-ion-1-1",
-        case::multiple_top_level_containers_ion_1_1(
+    #[case::multiple_top_level_containers_ion_1_1(
             "$ion_1_1\n{foo:1,bar:2}\n{\n  foo:1,\n  bar:[a,b,c],\n}\n{foo:1,bar:2}\n{\n  foo:1,\n  bar:[a,b,c],\n}",
             [(2, 1), (2, 6), (2, 12), (3, 1), (4, 7), (5, 7), (5, 8), (5, 10), (5, 12),
             (7, 1), (7, 6), (7, 12), (8, 1), (9, 7), (10, 7), (10, 8), (10, 10), (10, 12)],
-        )
     )]
     #[case::binary_1_0_data(
         [
@@ -665,16 +638,13 @@ mod tests {
         ],
         [/* no locations */],
     )]
-    #[cfg_attr(
-        feature = "experimental-ion-1-1",
-        case::binary_1_1_data(
+    #[case::binary_1_1_data(
             [
                 0xE0u8, 0x01, 0x01, 0xEA, // IVM
                 0x95, 65, 10, 66, 10, 67, // String: "A\nB\nC"
                 0x95, 68, 10, 69, 10, 70, // String: "D\nE\nF"
             ],
             [/* no locations */],
-        )
     )]
     fn location_test_slice_input<const N: usize, I: AsRef<[u8]>>(
         #[case] ion_input: I,
@@ -745,13 +715,10 @@ mod tests {
         [(1, 1), (1, 6), (1, 12), (2, 1), (3, 7), (4, 7), (4, 8), (4, 10), (4, 12),
         (6, 1), (6, 6), (6, 12), (7, 1), (8, 7), (9, 7), (9, 8), (9, 10), (9, 12)],
     )]
-    #[cfg_attr(
-        feature = "experimental-ion-1-1",
-        case::multiple_top_level_containers_ion_1_1(
+    #[case::multiple_top_level_containers_ion_1_1(
             "$ion_1_1\n{foo:1,bar:2}\n{\n  foo:1,\n  bar:[a,b,c],\n}\n{foo:1,bar:2}\n{\n  foo:1,\n  bar:[a,b,c],\n}",
             [(2, 1), (2, 6), (2, 12), (3, 1), (4, 7), (5, 7), (5, 8), (5, 10), (5, 12),
             (7, 1), (7, 6), (7, 12), (8, 1), (9, 7), (10, 7), (10, 8), (10, 10), (10, 12)],
-        )
     )]
     // FIXME: Currently failing because of https://github.com/amazon-ion/ion-rust/issues/954
     // #[case::binary_1_0_data(
@@ -762,16 +729,13 @@ mod tests {
     //     ],
     //     [/* no locations */],
     // )]
-    // #[cfg_attr(
-    //     feature = "experimental-ion-1-1",
-    //     case::binary_1_1_data(
+    // #[case::binary_1_1_data(
     //         [
     //             0xE0u8, 0x01, 0x01, 0xEA, // IVM
     //             0x95, 65, 10, 66, 10, 67, // String: "A\nB\nC"
     //             0x95, 68, 10, 69, 10, 70, // String: "D\nE\nF"
     //         ],
     //         [/* no locations */],
-    //     )
     // )]
     fn location_test_stream_input<const N: usize, I: AsRef<[u8]>>(
         #[case] ion_input: I,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,11 +357,7 @@ macro_rules! v1_1_tooling_apis {
     };
 }
 
-#[cfg(feature = "experimental-reader-writer")]
 v1_x_reader_writer!(pub);
-
-#[cfg(not(feature = "experimental-reader-writer"))]
-v1_x_reader_writer!(pub(crate));
 
 #[cfg(feature = "experimental-tooling-apis")]
 v1_x_tooling_apis!(pub);
@@ -376,16 +372,11 @@ pub mod v1_0 {
     #[cfg(not(feature = "experimental-tooling-apis"))]
     v1_0_tooling_apis!(pub(crate));
 
-    #[cfg(feature = "experimental-reader-writer")]
     v1_0_reader_writer!(pub);
-
-    #[cfg(not(feature = "experimental-reader-writer"))]
-    v1_0_reader_writer!(pub(crate));
 
     pub use crate::lazy::encoding::{BinaryEncoding_1_0 as Binary, TextEncoding_1_0 as Text};
 }
 
-#[cfg(feature = "experimental-ion-1-1")]
 pub mod v1_1 {
     pub use crate::constants::v1_1::constants;
     pub use crate::constants::v1_1::system_symbols;
@@ -396,26 +387,7 @@ pub mod v1_1 {
     #[cfg(not(feature = "experimental-tooling-apis"))]
     v1_1_tooling_apis!(pub(crate));
 
-    #[cfg(feature = "experimental-reader-writer")]
     v1_1_reader_writer!(pub);
-
-    #[cfg(not(feature = "experimental-reader-writer"))]
-    v1_1_reader_writer!(pub(crate));
-}
-
-#[cfg(not(feature = "experimental-ion-1-1"))]
-pub(crate) mod v1_1 {
-    #[cfg(feature = "experimental-tooling-apis")]
-    v1_1_tooling_apis!(pub);
-
-    #[cfg(not(feature = "experimental-tooling-apis"))]
-    v1_1_tooling_apis!(pub(crate));
-
-    #[cfg(feature = "experimental-reader-writer")]
-    v1_1_reader_writer!(pub);
-
-    #[cfg(not(feature = "experimental-reader-writer"))]
-    v1_1_reader_writer!(pub(crate));
 }
 
 pub use lazy::reader::IonResultIterExt;

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "experimental-ion-1-1")]
-
 use std::collections::HashMap;
 
 use ion_rs::serde::to_string;
@@ -7,7 +5,6 @@ use serde::Serialize;
 
 use crate::conformance_dsl::prelude::*;
 
-#[cfg(feature = "experimental-reader-writer")]
 mod conformance_dsl;
 
 #[derive(PartialEq, Serialize)]
@@ -122,7 +119,6 @@ impl TestReporter for IonReporter {
     }
 }
 
-#[cfg(feature = "experimental-reader-writer")]
 pub fn main() {
     let options = std::env::args()
         .skip(1)
@@ -189,9 +185,4 @@ pub fn main() {
         }
     }
     reporter.finalize();
-}
-
-#[cfg(not(feature = "experimental-reader-writer"))]
-pub fn main() {
-    println!("Needs feature experimental-reader-writer");
 }

--- a/tests/conformance_dsl/mod.rs
+++ b/tests/conformance_dsl/mod.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "experimental-ion-1-1")]
 #![allow(dead_code)]
 
 mod clause;

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "experimental-ion-1-1")]
-#![cfg(feature = "experimental-reader-writer")]
 #![cfg(feature = "experimental-tooling-apis")]
 mod conformance_dsl;
 use conformance_dsl::prelude::*;

--- a/tests/detect_incomplete_text.rs
+++ b/tests/detect_incomplete_text.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "experimental-reader-writer")]
-
 use crate::ion_tests::{DataStraw, ELEMENT_GLOBAL_SKIP_LIST};
 use ion_rs::{
     AnyEncoding, Element, ElementReader, IonData, IonError, IonResult, IonStream, Reader,
@@ -32,7 +30,6 @@ static CANONICAL_FILE_NAMES: LazyLock<Vec<String>> = LazyLock::new(|| {
 static SKIP_LIST_1_0: LazyLock<HashSet<String>> =
     LazyLock::new(|| CANONICAL_FILE_NAMES.iter().cloned().collect());
 
-#[cfg(feature = "experimental-ion-1-1")]
 static SKIP_LIST_1_1: LazyLock<HashSet<String>> = LazyLock::new(|| {
     CANONICAL_FILE_NAMES
         .iter()
@@ -45,7 +42,6 @@ fn detect_incomplete_input_1_0(file_name: &str) {
     incomplete_text_detection_test(&SKIP_LIST_1_0, file_name).unwrap()
 }
 
-#[cfg(feature = "experimental-ion-1-1")]
 #[test_resources("ion-tests/iontestdata_1_1/good/**/*.ion")]
 fn detect_incomplete_input_1_1(file_name: &str) {
     incomplete_text_detection_test(&SKIP_LIST_1_1, file_name).unwrap()

--- a/tests/element_display.rs
+++ b/tests/element_display.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "experimental-reader-writer")]
 use crate::ion_tests::contains_path;
 use ion_rs::IonData;
 use ion_rs::{Element, IonResult, Sequence};

--- a/tests/ion_tests/lazy_element_ion_tests.rs
+++ b/tests/ion_tests/lazy_element_ion_tests.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "experimental-reader-writer")]
-
 use crate::good_round_trip;
 use crate::ion_tests::{
     bad, equivs, non_equivs, ElementApi, SkipList, ELEMENT_EQUIVS_SKIP_LIST,

--- a/tests/ion_tests/mod.rs
+++ b/tests/ion_tests/mod.rs
@@ -1,5 +1,4 @@
 // Copyright Amazon.com, Inc. or its affiliates.
-#![cfg(feature = "experimental-reader-writer")]
 #![allow(dead_code)]
 
 use std::fs::read;

--- a/tests/ion_tests_1_1.rs
+++ b/tests/ion_tests_1_1.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "experimental-ion-1-1")]
-#![cfg(feature = "experimental-reader-writer")]
 /// TODO: When the Ion 1.1 binary reader is complete, update this module to include binary tests
 mod ion_tests;
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
This PR drops the opt-ins that were `experimental-reader-writer` and `experimental-ion-1-1` in preparation for amazon-ion/ion-docs#397.

This effectively simplifies the features and promotes the previously mentioned sets of functionality into the default feature set. The goal is to simplify the features needed in preparation for ion 1.1 release.

These changes are targeting the ion11 branch, where further ion 1.1 work will take place.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
