### PR TITLE
Address rustfmt differences for re-enabled rustfmt CI/CD check

### DIFF
--- a/benches/byod.rs
+++ b/benches/byod.rs
@@ -40,9 +40,9 @@ mod benchmark {
 
 #[cfg(feature = "experimental")]
 mod benchmark {
+    use criterion::{BenchmarkId, Criterion};
+    use ion_rs::{v1_1::BinaryWriter, Element, *};
     use std::{env, fs, hint::black_box};
-    use criterion::{Criterion, BenchmarkId};
-    use ion_rs::{v1_1::BinaryWriter, *, Element};
 
     pub fn bench_byod_full(c: &mut Criterion) {
         let Some(file) = env::var("ION_BENCH").ok() else {
@@ -56,15 +56,12 @@ mod benchmark {
         read_group.measurement_time(std::time::Duration::from_secs(30));
 
         // Read the provided data as-is with an encoding-agnostic reader.
-        read_group.bench_with_input(
-            BenchmarkId::new("full-read", &file),
-            &data,
-            |b, data| b.iter(|| {
-                let reader = Reader::new(AnyEncoding, data)
-                    .expect("Unable to create reader");
+        read_group.bench_with_input(BenchmarkId::new("full-read", &file), &data, |b, data| {
+            b.iter(|| {
+                let reader = Reader::new(AnyEncoding, data).expect("Unable to create reader");
                 full_read(reader);
             })
-        );
+        });
 
         // Convert the provided data into an ion 1.0 stream, and then measure the performance of
         // reading the stream-equivalent data using a 1.0 reader.
@@ -75,11 +72,10 @@ mod benchmark {
             |b, data| {
                 // Benchmark Read of known 1.0 data.
                 b.iter(|| {
-                    let reader = Reader::new(AnyEncoding, data)
-                        .expect("Unable to create reader");
+                    let reader = Reader::new(AnyEncoding, data).expect("Unable to create reader");
                     full_read(reader);
                 });
-            }
+            },
         );
         drop(one_oh_data);
 
@@ -91,11 +87,10 @@ mod benchmark {
             &delimited_data,
             |b, data| {
                 b.iter(|| {
-                    let reader = Reader::new(AnyEncoding, data)
-                        .expect("unable to create reader");
+                    let reader = Reader::new(AnyEncoding, data).expect("unable to create reader");
                     full_read(reader);
                 });
-            }
+            },
         );
         drop(delimited_data);
 
@@ -107,11 +102,10 @@ mod benchmark {
             &prefixed_data,
             |b, data| {
                 b.iter(|| {
-                    let reader = Reader::new(AnyEncoding, data)
-                        .expect("unable to create reader");
+                    let reader = Reader::new(AnyEncoding, data).expect("unable to create reader");
                     full_read(reader);
                 });
-            }
+            },
         );
         drop(prefixed_data);
 
@@ -123,11 +117,10 @@ mod benchmark {
             &inlined_data,
             |b, data| {
                 b.iter(|| {
-                    let reader = Reader::new(AnyEncoding, data)
-                        .expect("unable to create reader");
+                    let reader = Reader::new(AnyEncoding, data).expect("unable to create reader");
                     full_read(reader);
                 });
-            }
+            },
         );
         drop(inlined_data);
 
@@ -139,11 +132,10 @@ mod benchmark {
             &referenced_data,
             |b, data| {
                 b.iter(|| {
-                    let reader = Reader::new(AnyEncoding, data)
-                        .expect("unable to create reader");
+                    let reader = Reader::new(AnyEncoding, data).expect("unable to create reader");
                     full_read(reader);
                 });
-            }
+            },
         );
         drop(referenced_data);
 
@@ -162,14 +154,13 @@ mod benchmark {
                 let elems = Element::read_all(data).expect("unable to read elements");
                 b.iter(|| {
                     let buffer = Vec::<u8>::with_capacity(size);
-                    let mut writer = BinaryWriter::new(v1_1::Binary, buffer).expect("unable to create writer");
+                    let mut writer =
+                        BinaryWriter::new(v1_1::Binary, buffer).expect("unable to create writer");
                     for elem in &elems {
-                        writer
-                            .write(elem)
-                            .expect("unable to write value");
+                        writer.write(elem).expect("unable to write value");
                     }
                 });
-            }
+            },
         );
 
         // Read the original data using the Element API, and re-write it to an ion 1.1 stream using
@@ -182,7 +173,8 @@ mod benchmark {
                 let elems = Element::read_all(data).expect("unable to read elements");
                 b.iter(|| {
                     let buffer = Vec::<u8>::with_capacity(size);
-                    let mut writer = BinaryWriter::new(v1_1::Binary, buffer).expect("unable to create writer");
+                    let mut writer =
+                        BinaryWriter::new(v1_1::Binary, buffer).expect("unable to create writer");
                     for elem in &elems {
                         writer
                             .value_writer()
@@ -191,7 +183,7 @@ mod benchmark {
                             .expect("unable to write value");
                     }
                 });
-            }
+            },
         );
 
         // Read the original data using the Element API, and re-write it to an ion 1.1 stream using
@@ -204,7 +196,8 @@ mod benchmark {
                 let elems = Element::read_all(data).expect("unable to read elements");
                 b.iter(|| {
                     let buffer = Vec::<u8>::with_capacity(size);
-                    let mut writer = BinaryWriter::new(v1_1::Binary, buffer).expect("unable to create writer");
+                    let mut writer =
+                        BinaryWriter::new(v1_1::Binary, buffer).expect("unable to create writer");
                     for elem in &elems {
                         writer
                             .value_writer()
@@ -213,7 +206,7 @@ mod benchmark {
                             .expect("unable to write value");
                     }
                 });
-            }
+            },
         );
 
         // Read the original data using the Element API, and re-write it to an ion 1.1 stream using
@@ -226,7 +219,8 @@ mod benchmark {
                 let elems = Element::read_all(data).expect("unable to read elements");
                 b.iter(|| {
                     let buffer = Vec::<u8>::with_capacity(size);
-                    let mut writer = Writer::new(v1_1::Binary, buffer).expect("unable to create writer");
+                    let mut writer =
+                        Writer::new(v1_1::Binary, buffer).expect("unable to create writer");
                     for elem in &elems {
                         writer
                             .value_writer()
@@ -235,7 +229,7 @@ mod benchmark {
                             .expect("unable to write value");
                     }
                 });
-            }
+            },
         );
 
         // Read the original data using the Element API, and re-write it to an ion 1.0 stream using
@@ -248,15 +242,14 @@ mod benchmark {
                 let elems = Element::read_all(data).expect("unable to read elements");
                 b.iter(|| {
                     let buffer = Vec::<u8>::with_capacity(size);
-                    let mut writer = Writer::new(v1_0::Binary, buffer).expect("unable to create writer");
+                    let mut writer =
+                        Writer::new(v1_0::Binary, buffer).expect("unable to create writer");
                     for elem in &elems {
-                        writer
-                            .write(elem)
-                            .expect("unable to write value");
+                        writer.write(elem).expect("unable to write value");
                     }
                     let _ = writer.close();
                 });
-            }
+            },
         );
 
         write_group.finish();
@@ -274,9 +267,7 @@ mod benchmark {
                 .write(elem)
                 .expect("unable to write value");
         }
-        writer
-            .close()
-            .expect("unable to close writer")
+        writer.close().expect("unable to close writer")
     }
 
     fn rewrite_delimited_containers(data: &Vec<u8>) -> Vec<u8> {
@@ -291,9 +282,7 @@ mod benchmark {
                 .write(elem)
                 .expect("unable to write value");
         }
-        writer
-            .close()
-            .expect("unable to close writer")
+        writer.close().expect("unable to close writer")
     }
 
     fn rewrite_inline_symbols(data: &Vec<u8>) -> Vec<u8> {
@@ -310,9 +299,7 @@ mod benchmark {
                 .write(elem)
                 .expect("unable to write value");
         }
-        writer
-            .close()
-            .expect("unable to close writer")
+        writer.close().expect("unable to close writer")
     }
 
     fn rewrite_referenced_symbols(data: &Vec<u8>) -> Vec<u8> {
@@ -329,9 +316,7 @@ mod benchmark {
                 .write(elem)
                 .expect("unable to write value");
         }
-        writer
-            .close()
-            .expect("unable to close writer")
+        writer.close().expect("unable to close writer")
     }
 
     fn rewrite_inline_annotations(data: &Vec<u8>) -> Vec<u8> {
@@ -346,9 +331,7 @@ mod benchmark {
                 .write(elem)
                 .expect("unable to write value");
         }
-        writer
-            .close()
-            .expect("unable to close writer")
+        writer.close().expect("unable to close writer")
     }
 
     fn rewrite_as_1_0(data: &Vec<u8>) -> Vec<u8> {
@@ -357,7 +340,9 @@ mod benchmark {
         let elems = Element::read_all(data).expect("unable to read elements");
         // Write data as 1.0
         let buffer = Vec::<u8>::with_capacity(size);
-        elems.encode_to(buffer, v1_0::Binary).expect("unable to re-encode elements")
+        elems
+            .encode_to(buffer, v1_0::Binary)
+            .expect("unable to re-encode elements")
     }
 
     fn rewrite_as_1_1(data: &Vec<u8>) -> Vec<u8> {
@@ -366,7 +351,9 @@ mod benchmark {
         let elems = Element::read_all(data).expect("unable to read elements");
         // Write data as 1.1
         let buffer = Vec::<u8>::with_capacity(size);
-        elems.encode_to(buffer, v1_1::Binary).expect("unable to re-encode elements")
+        elems
+            .encode_to(buffer, v1_1::Binary)
+            .expect("unable to re-encode elements")
     }
 
     #[inline]

--- a/benches/encoding_primitives.rs
+++ b/benches/encoding_primitives.rs
@@ -11,7 +11,7 @@ mod benchmark {
 #[cfg(feature = "experimental")]
 mod benchmark {
     use criterion::{black_box, Criterion};
-    use ion_rs::{IonResult, EncodingContext};
+    use ion_rs::{EncodingContext, IonResult};
     use rand::prelude::StdRng;
     use rand::{distributions::Uniform, Rng, SeedableRng};
     use std::io;
@@ -73,7 +73,8 @@ mod benchmark {
             b.iter(|| {
                 let encoding_context = EncodingContext::empty();
                 let mut decoded_length: usize = 0;
-                let mut input = BinaryBuffer::new(encoding_context.get_ref(), encoded_var_uints.as_slice());
+                let mut input =
+                    BinaryBuffer::new(encoding_context.get_ref(), encoded_var_uints.as_slice());
                 for _ in 0..unsigned_values.len() {
                     let (var_uint, remaining) = input.read_var_uint().unwrap();
                     input = remaining;
@@ -96,7 +97,8 @@ mod benchmark {
             b.iter(|| {
                 let encoding_context = EncodingContext::empty();
                 let mut decoded_length: usize = 0;
-                let mut input = BinaryBuffer::new(encoding_context.get_ref(), encoded_var_ints.as_slice());
+                let mut input =
+                    BinaryBuffer::new(encoding_context.get_ref(), encoded_var_ints.as_slice());
                 for _ in 0..unsigned_values.len() {
                     let (var_int, remaining) = input.read_var_int().unwrap();
                     input = remaining;
@@ -122,7 +124,8 @@ mod benchmark {
             b.iter(|| {
                 let encoding_context = EncodingContext::empty();
                 let mut decoded_length: usize = 0;
-                let mut input = BinaryBuffer::new(encoding_context.get_ref(), encoded_flex_uints.as_slice());
+                let mut input =
+                    BinaryBuffer::new(encoding_context.get_ref(), encoded_flex_uints.as_slice());
                 for _ in 0..unsigned_values.len() {
                     let (flex_uint, remaining) = input.read_flex_uint().unwrap();
                     input = remaining;
@@ -145,7 +148,8 @@ mod benchmark {
             b.iter(|| {
                 let encoding_context = EncodingContext::empty();
                 let mut decoded_length: usize = 0;
-                let mut input = BinaryBuffer::new(encoding_context.get_ref(), encoded_flex_ints.as_slice());
+                let mut input =
+                    BinaryBuffer::new(encoding_context.get_ref(), encoded_flex_ints.as_slice());
                 for _ in 0..unsigned_values.len() {
                     let (flex_int, remaining) = input.read_flex_int().unwrap();
                     input = remaining;
@@ -164,7 +168,8 @@ mod benchmark {
             VarUInt::write_u64(&mut encoded_values_buffer, *value)?;
         }
         let mut decoded_values = Vec::new();
-        let mut input = BinaryBuffer::new(encoding_context.get_ref(), encoded_values_buffer.as_slice());
+        let mut input =
+            BinaryBuffer::new(encoding_context.get_ref(), encoded_values_buffer.as_slice());
         for _ in 0..unsigned_values.len() {
             let (var_uint, remaining) = input.read_var_uint()?;
             input = remaining;
@@ -181,7 +186,8 @@ mod benchmark {
             VarInt::write_i64(&mut encoded_values_buffer, *value)?;
         }
         let mut decoded_values = Vec::new();
-        let mut input = BinaryBuffer::new(encoding_context.get_ref(), encoded_values_buffer.as_slice());
+        let mut input =
+            BinaryBuffer::new(encoding_context.get_ref(), encoded_values_buffer.as_slice());
         for _ in 0..signed_values.len() {
             let (var_int, remaining) = input.read_var_int()?;
             input = remaining;
@@ -198,7 +204,8 @@ mod benchmark {
             FlexUInt::write(&mut encoded_values_buffer, *value)?;
         }
         let mut decoded_values = Vec::new();
-        let mut input = BinaryBuffer::new(encoding_context.get_ref(), encoded_values_buffer.as_slice());
+        let mut input =
+            BinaryBuffer::new(encoding_context.get_ref(), encoded_values_buffer.as_slice());
         for _ in 0..unsigned_values.len() {
             let (flex_uint, remaining) = input.read_flex_uint()?;
             input = remaining;
@@ -215,7 +222,8 @@ mod benchmark {
             FlexInt::write_i64(&mut encoded_values_buffer, *value)?;
         }
         let mut decoded_values = Vec::new();
-        let mut input = BinaryBuffer::new(encoding_context.get_ref(), encoded_values_buffer.as_slice());
+        let mut input =
+            BinaryBuffer::new(encoding_context.get_ref(), encoded_values_buffer.as_slice());
         for _ in 0..signed_values.len() {
             let (flex_int, remaining) = input.read_flex_int()?;
             input = remaining;

--- a/benches/write_many_structs.rs
+++ b/benches/write_many_structs.rs
@@ -10,9 +10,9 @@ mod benchmark {
 
 #[cfg(feature = "experimental")]
 mod benchmark {
-    use std::hint::black_box;
     use criterion::Criterion;
     use ion_rs::{v1_0, v1_1, IonResult, RawSymbolRef, SequenceWriter, StructWriter, ValueWriter};
+    use std::hint::black_box;
 
     fn write_struct_with_string_values(value_writer: impl ValueWriter) -> IonResult<()> {
         let mut struct_ = value_writer.struct_writer()?;

--- a/src/lazy/binary/raw/v1_1/binary_buffer.rs
+++ b/src/lazy/binary/raw/v1_1/binary_buffer.rs
@@ -258,13 +258,20 @@ impl<'a> BinaryBuffer<'a> {
         Ok((value, remaining_input))
     }
 
-    pub fn read_fixed_uint_as_lazy_value(self, encoding: BinaryValueEncoding) -> ParseResult<'a, LazyRawBinaryValue_1_1<'a>> {
+    pub fn read_fixed_uint_as_lazy_value(
+        self,
+        encoding: BinaryValueEncoding,
+    ) -> ParseResult<'a, LazyRawBinaryValue_1_1<'a>> {
         let size_in_bytes = match encoding {
             BinaryValueEncoding::UInt8 => 1,
             BinaryValueEncoding::UInt16 => 2,
             BinaryValueEncoding::UInt32 => 4,
             BinaryValueEncoding::UInt64 => 8,
-            _ => return IonResult::illegal_operation(format!("invalid binary encoding for fixed uint: {encoding:?}")),
+            _ => {
+                return IonResult::illegal_operation(format!(
+                    "invalid binary encoding for fixed uint: {encoding:?}"
+                ))
+            }
         };
 
         if self.len() < size_in_bytes {

--- a/src/lazy/binary/raw/v1_1/e_expression.rs
+++ b/src/lazy/binary/raw/v1_1/e_expression.rs
@@ -328,11 +328,10 @@ impl<'top> Iterator for BinaryEExpArgsInputIter<'top> {
                         remaining,
                     )
                 }
-                enc@ ParameterEncoding::UInt8 |
-                enc@ ParameterEncoding::UInt16 |
-                enc@ ParameterEncoding::UInt32 |
-                enc@ ParameterEncoding::UInt64
-                    => {
+                enc @ ParameterEncoding::UInt8
+                | enc @ ParameterEncoding::UInt16
+                | enc @ ParameterEncoding::UInt32
+                | enc @ ParameterEncoding::UInt64 => {
                     let binary_enc = try_or_some_err!(enc.try_into());
                     let (fixed_uint_lazy_value, remaining) = try_or_some_err! {
                         self.remaining_args_buffer.read_fixed_uint_as_lazy_value(binary_enc)

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -555,8 +555,8 @@ impl<'top> LazyRawBinaryValue_1_0<'top> {
             1 => true,
             invalid => {
                 return IonResult::decoding_error(format!(
-                    "found a boolean value with an illegal representation (must be 0 or 1): {invalid}",
-                ))
+                "found a boolean value with an illegal representation (must be 0 or 1): {invalid}",
+            ))
             }
         };
         Ok(RawValueRef::Bool(value))

--- a/src/lazy/encoder/binary/v1_1/container_writers.rs
+++ b/src/lazy/encoder/binary/v1_1/container_writers.rs
@@ -1,7 +1,9 @@
 use bumpalo::collections::Vec as BumpVec;
 use bumpalo::Bump as BumpAllocator;
 
-use crate::lazy::encoder::binary::v1_1::value_writer::{BinaryEExpParameterValueWriter_1_1, BinaryValueWriter_1_1};
+use crate::lazy::encoder::binary::v1_1::value_writer::{
+    BinaryEExpParameterValueWriter_1_1, BinaryValueWriter_1_1,
+};
 use crate::lazy::encoder::binary::v1_1::{flex_sym::FlexSym, flex_uint::FlexUInt};
 use crate::lazy::encoder::value_writer::internal::{
     EExpWriterInternal, FieldEncoder, MakeValueWriter,
@@ -520,7 +522,9 @@ impl<'top> EExpWriter for BinaryEExpWriter_1_1<'_, 'top> {
     }
 
     fn expr_group_writer(&mut self) -> IonResult<Self::ExprGroupWriter<'_>> {
-        let param = self.signature_iter.expect_next_parameter()
+        let param = self
+            .signature_iter
+            .expect_next_parameter()
             .and_then(|p| p.expect_variadic())?;
 
         let writer = BinaryExprGroupWriter::new(

--- a/src/lazy/encoder/binary/v1_1/fixed_uint.rs
+++ b/src/lazy/encoder/binary/v1_1/fixed_uint.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
-use num_traits::{PrimInt, Unsigned};
 use ice_code::ice as cold_path;
+use num_traits::{PrimInt, Unsigned};
 
 use crate::decimal::coefficient::Coefficient;
 use crate::lazy::encoder::binary::v1_1::fixed_int::{
@@ -68,15 +68,21 @@ impl FixedUInt {
     }
 
     #[inline]
-    pub(crate) fn write_as_uint<I: PrimInt + Unsigned>(output: &mut impl Write, value: impl Into<UInt>) -> IonResult<()> {
+    pub(crate) fn write_as_uint<I: PrimInt + Unsigned>(
+        output: &mut impl Write,
+        value: impl Into<UInt>,
+    ) -> IonResult<()> {
         let size_in_bytes = std::mem::size_of::<I>();
         let value: u128 = value.into().data;
         let encoded_bytes = value.to_le_bytes();
-        let max_value: u128 = num_traits::cast::cast(I::max_value())
-            .ok_or(IonError::encoding_error("Unable to represent bounds for value as 128bit value"))?;
+        let max_value: u128 = num_traits::cast::cast(I::max_value()).ok_or(
+            IonError::encoding_error("Unable to represent bounds for value as 128bit value"),
+        )?;
 
         if !(0..=max_value).contains(&value) {
-            return IonResult::encoding_error(format!("provided unsigned integer value does not fit within {size_in_bytes} byte(s)"));
+            return IonResult::encoding_error(format!(
+                "provided unsigned integer value does not fit within {size_in_bytes} byte(s)"
+            ));
         }
 
         output.write_all(&encoded_bytes[..size_in_bytes])?;

--- a/src/lazy/encoder/binary/v1_1/value_writer.rs
+++ b/src/lazy/encoder/binary/v1_1/value_writer.rs
@@ -1011,7 +1011,7 @@ impl<'value, 'top> BinaryEExpParameterValueWriter_1_1<'value, 'top> {
         macros: &'a MacroTable,
         parameter: Option<&'a Parameter>,
     ) -> BinaryEExpParameterValueWriter_1_1<'a, 'b> {
-        BinaryEExpParameterValueWriter_1_1{
+        BinaryEExpParameterValueWriter_1_1 {
             allocator,
             buffer,
             value_writer_config,
@@ -1041,8 +1041,8 @@ impl<'value, 'top> ValueWriter for BinaryEExpParameterValueWriter_1_1<'value, 't
     // parameter if the parameter is tagless.
 
     fn write_symbol(self, value: impl AsRawSymbolRef) -> IonResult<()> {
-        use crate::IonError;
         use crate::lazy::expanded::template::ParameterEncoding;
+        use crate::IonError;
 
         // TODO: Support tagless types.
         let _param = self
@@ -1061,9 +1061,9 @@ impl<'value, 'top> ValueWriter for BinaryEExpParameterValueWriter_1_1<'value, 't
     }
 
     fn write_i64(self, value: i64) -> IonResult<()> {
+        use crate::lazy::expanded::template::ParameterEncoding as PE;
         use crate::IonError;
         use crate::UInt;
-        use crate::lazy::expanded::template::ParameterEncoding as PE;
 
         #[inline(never)]
         fn error_context(name: &str, err: impl std::error::Error) -> IonError {
@@ -1101,9 +1101,9 @@ impl<'value, 'top> ValueWriter for BinaryEExpParameterValueWriter_1_1<'value, 't
                 );
                 value_writer.write_i64(value)
             }
-            encoding => IonResult::encoding_error(
-                format!("value does not satisfy encoding type {encoding}")
-            ),
+            encoding => IonResult::encoding_error(format!(
+                "value does not satisfy encoding type {encoding}"
+            )),
         };
 
         result.map_err(|err| error_context(param.name(), err))
@@ -1111,8 +1111,8 @@ impl<'value, 'top> ValueWriter for BinaryEExpParameterValueWriter_1_1<'value, 't
 
     fn write_int(self, value: &Int) -> IonResult<()> {
         use crate::lazy::expanded::template::ParameterEncoding as PE;
-        use crate::UInt;
         use crate::IonError;
+        use crate::UInt;
 
         #[inline(never)]
         fn error_context(name: &str, err: impl std::error::Error) -> IonError {
@@ -1150,17 +1150,17 @@ impl<'value, 'top> ValueWriter for BinaryEExpParameterValueWriter_1_1<'value, 't
                 );
                 value_writer.write_int(value)
             }
-            encoding => IonResult::encoding_error(
-                format!("value does not satisfy encoding type {encoding}")
-            ),
+            encoding => IonResult::encoding_error(format!(
+                "value does not satisfy encoding type {encoding}"
+            )),
         };
 
         result.map_err(|err| error_context(param.name(), err))
     }
 
     fn write_f32(self, value: f32) -> IonResult<()> {
-        use crate::IonError;
         use crate::lazy::expanded::template::ParameterEncoding;
+        use crate::IonError;
 
         // TODO: Support tagless types.
         let _param = self
@@ -1179,8 +1179,8 @@ impl<'value, 'top> ValueWriter for BinaryEExpParameterValueWriter_1_1<'value, 't
     }
 
     fn write_f64(self, value: f64) -> IonResult<()> {
-        use crate::IonError;
         use crate::lazy::expanded::template::ParameterEncoding;
+        use crate::IonError;
 
         // TODO: Support tagless types.
         let _param = self
@@ -1199,8 +1199,8 @@ impl<'value, 'top> ValueWriter for BinaryEExpParameterValueWriter_1_1<'value, 't
     }
 
     fn list_writer(self) -> IonResult<Self::ListWriter> {
-        use crate::IonError;
         use crate::lazy::expanded::template::ParameterEncoding;
+        use crate::IonError;
 
         let _param = self
             .parameter
@@ -1219,8 +1219,8 @@ impl<'value, 'top> ValueWriter for BinaryEExpParameterValueWriter_1_1<'value, 't
     }
 
     fn sexp_writer(self) -> IonResult<Self::SExpWriter> {
-        use crate::IonError;
         use crate::lazy::expanded::template::ParameterEncoding;
+        use crate::IonError;
 
         let _param = self
             .parameter
@@ -1239,8 +1239,8 @@ impl<'value, 'top> ValueWriter for BinaryEExpParameterValueWriter_1_1<'value, 't
     }
 
     fn struct_writer(self) -> IonResult<Self::StructWriter> {
-        use crate::IonError;
         use crate::lazy::expanded::template::ParameterEncoding;
+        use crate::IonError;
 
         let _param = self
             .parameter
@@ -1259,11 +1259,11 @@ impl<'value, 'top> ValueWriter for BinaryEExpParameterValueWriter_1_1<'value, 't
     }
 
     fn eexp_writer<'a>(self, macro_id: impl MacroIdLike<'a>) -> IonResult<Self::EExpWriter>
-        where
-            Self: 'a
+    where
+        Self: 'a,
     {
-        use crate::IonError;
         use crate::lazy::expanded::template::ParameterEncoding;
+        use crate::IonError;
 
         let _param = self
             .parameter
@@ -1296,11 +1296,11 @@ impl<'top> AnnotatableWriter for BinaryEExpParameterValueWriter_1_1<'_, 'top> {
         Self: 'a,
     {
         Ok(BinaryAnnotatedValueWriter_1_1::new(
-                self.allocator,
-                self.buffer,
-                annotations.into_annotations_vec(),
-                self.value_writer_config,
-                self.macros,
+            self.allocator,
+            self.buffer,
+            annotations.into_annotations_vec(),
+            self.value_writer_config,
+            self.macros,
         ))
     }
 }
@@ -3266,9 +3266,7 @@ mod tests {
         encoding_test(
             |writer: &mut LazyRawBinaryWriter_1_1<&mut Vec<u8>>| {
                 let mut args = writer.eexp_writer(7)?; // sum
-                args
-                    .write_i64(5)?
-                    .write_i64(6)?;
+                args.write_i64(5)?.write_i64(6)?;
                 args.close()
             },
             &[
@@ -3284,11 +3282,8 @@ mod tests {
     fn write_system_macro_invocation() -> IonResult<()> {
         encoding_test(
             |writer: &mut LazyRawBinaryWriter_1_1<&mut Vec<u8>>| {
-                let mut args =
-                    writer.eexp_writer(MacroIdRef::SystemAddress(system_macros::SUM))?;
-                args
-                    .write_i64(5)?
-                    .write_i64(6)?;
+                let mut args = writer.eexp_writer(MacroIdRef::SystemAddress(system_macros::SUM))?;
+                args.write_i64(5)?.write_i64(6)?;
                 args.close()
             },
             &[

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -473,10 +473,7 @@ impl ApplicationValueWriter<'_, BinaryValueWriter_1_1<'_, '_>> {
         self
     }
 
-    pub fn with_field_name_encoding(
-        mut self,
-        field_name_encoding: FieldNameEncoding,
-    ) -> Self {
+    pub fn with_field_name_encoding(mut self, field_name_encoding: FieldNameEncoding) -> Self {
         self.value_writer_config = self
             .value_writer_config
             .with_field_name_encoding(field_name_encoding);
@@ -1034,7 +1031,8 @@ impl<V: ValueWriter> EExpWriter for ApplicationEExpWriter<'_, V> {
     }
 
     fn expr_group_writer(&mut self) -> IonResult<Self::ExprGroupWriter<'_>> {
-        let _param = self.expect_next_parameter()
+        let _param = self
+            .expect_next_parameter()
             .and_then(|p| p.expect_variadic())?;
         // TODO: Pass `Parameter` to group writer so it can do its own validation
         self.raw_eexp_writer.expr_group_writer()
@@ -1452,6 +1450,7 @@ mod tests {
         #[test]
         fn tagless_uint8_encoding() -> IonResult<()> {
             let macro_source = "(macro foo (uint8::x) (%x))";
+            #[rustfmt::skip]
             let expected: &[u8] = &[
                 0xE0, 0x01, 0x01, 0xEA,                       // IVM
                 0xE7, 0xF9, 0x24, 0x69, 0x6F, 0x6E,           // $ion::
@@ -1518,8 +1517,12 @@ mod tests {
         #[case::uint16("(macro foo (uint16::x) (%x))", 5, "5")]
         #[case::uint32("(macro foo (uint32::x) (%x))", 5, "5")]
         #[case::uint64("(macro foo (uint64::x) (%x))", 5, "5")]
-        fn tagless_uint_encoding(#[case] macro_source: &str, #[case] input: i64, #[case] expected: &str) -> IonResult<()> {
-            use crate::{Int, Element};
+        fn tagless_uint_encoding(
+            #[case] macro_source: &str,
+            #[case] input: i64,
+            #[case] expected: &str,
+        ) -> IonResult<()> {
+            use crate::{Element, Int};
 
             // write_int
 
@@ -1556,7 +1559,10 @@ mod tests {
         #[case::uint16("(macro foo (uint16::x) (%x))", 5u16)]
         #[case::uint32("(macro foo (uint32::x) (%x))", 5u32)]
         #[case::uint64("(macro foo (uint64::x) (%x))", 5u64)]
-        fn tagless_uint_encoding_write_int_fails<T: PrimInt + Unsigned>(#[case] macro_source: &str, #[case] input: T) -> IonResult<()> {
+        fn tagless_uint_encoding_write_int_fails<T: PrimInt + Unsigned>(
+            #[case] macro_source: &str,
+            #[case] input: T,
+        ) -> IonResult<()> {
             let max_int = T::max_value();
             let max_int_plus_one = num_traits::cast::cast::<_, i128>(max_int).unwrap() + 1i128;
             let neg_input = -num_traits::cast::cast::<_, i128>(input).unwrap();
@@ -1581,7 +1587,10 @@ mod tests {
         #[case::uint8("(macro foo (uint8::x) (%x))", 5u8)]
         #[case::uint16("(macro foo (uint16::x) (%x))", 5u16)]
         #[case::uint32("(macro foo (uint32::x) (%x))", 5u32)]
-        fn tagless_uint_encoding_write_i64_fails<T: PrimInt + Unsigned>(#[case] macro_source: &str, #[case] input: T) -> IonResult<()> {
+        fn tagless_uint_encoding_write_i64_fails<T: PrimInt + Unsigned>(
+            #[case] macro_source: &str,
+            #[case] input: T,
+        ) -> IonResult<()> {
             let max_int = T::max_value();
             let max_int_plus_one = num_traits::cast::cast::<_, i128>(max_int).unwrap() + 1i128;
             let neg_input = -num_traits::cast::cast::<_, i128>(input).unwrap();

--- a/src/lazy/expanded/e_expression.rs
+++ b/src/lazy/expanded/e_expression.rs
@@ -8,11 +8,11 @@ use crate::element::iterators::SymbolsIterator;
 use crate::lazy::decoder::{Decoder, RawValueExpr};
 use crate::lazy::expanded::compiler::{ExpansionAnalysis, ExpansionSingleton};
 use crate::lazy::expanded::macro_evaluator::{
-    AnnotateExpansion, ConditionalExpansion, DeltaExpansion, EExpressionArgGroup, ExprGroupExpansion,
-    FlattenExpansion, IsExhaustedIterator, MacroExpansion, MacroExpansionKind, MacroExpr,
-    MacroExprArgsIterator, MakeDecimalExpansion, MakeFieldExpansion, MakeStructExpansion,
-    MakeTextExpansion, MakeTimestampExpansion, RawEExpression, RepeatExpansion, SumExpansion, TemplateExpansion,
-    ValueExpr,
+    AnnotateExpansion, ConditionalExpansion, DeltaExpansion, EExpressionArgGroup,
+    ExprGroupExpansion, FlattenExpansion, IsExhaustedIterator, MacroExpansion, MacroExpansionKind,
+    MacroExpr, MacroExprArgsIterator, MakeDecimalExpansion, MakeFieldExpansion,
+    MakeStructExpansion, MakeTextExpansion, MakeTimestampExpansion, RawEExpression,
+    RepeatExpansion, SumExpansion, TemplateExpansion, ValueExpr,
 };
 use crate::lazy::expanded::macro_table::{MacroKind, MacroRef};
 use crate::lazy::expanded::template::TemplateMacroRef;
@@ -162,14 +162,10 @@ impl<'top, D: Decoder> EExpression<'top, D> {
             MacroKind::Delta => MacroExpansionKind::Delta(DeltaExpansion::new(
                 self.context(),
                 environment,
-                arguments
+                arguments,
             )),
-            MacroKind::Repeat => {
-                MacroExpansionKind::Repeat(RepeatExpansion::new(arguments))
-            }
-            MacroKind::Sum => {
-                MacroExpansionKind::Sum(SumExpansion::new(arguments))
-            }
+            MacroKind::Repeat => MacroExpansionKind::Repeat(RepeatExpansion::new(arguments)),
+            MacroKind::Sum => MacroExpansionKind::Sum(SumExpansion::new(arguments)),
         };
         Ok(MacroExpansion::new(
             self.context(),

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -1,18 +1,23 @@
-use crate::lazy::binary::raw::v1_1::{value::BinaryValueEncoding, binary_buffer::ArgGroupingBitmap};
+use crate::lazy::binary::raw::v1_1::{
+    binary_buffer::ArgGroupingBitmap, value::BinaryValueEncoding,
+};
 use crate::lazy::decoder::Decoder;
 use crate::lazy::expanded::compiler::ExpansionAnalysis;
 use crate::lazy::expanded::macro_evaluator::{
     AnnotateExpansion, ConditionalExpansion, DeltaExpansion, ExprGroupExpansion, FlattenExpansion,
-    MakeDecimalExpansion, MacroEvaluator, MacroExpansion, MacroExpansionKind, MacroExpr,
-    MacroExprArgsIterator, MakeFieldExpansion, MakeStructExpansion, MakeTextExpansion, MakeTimestampExpansion,
-    RepeatExpansion, SumExpansion, TemplateExpansion, ValueExpr,
+    MacroEvaluator, MacroExpansion, MacroExpansionKind, MacroExpr, MacroExprArgsIterator,
+    MakeDecimalExpansion, MakeFieldExpansion, MakeStructExpansion, MakeTextExpansion,
+    MakeTimestampExpansion, RepeatExpansion, SumExpansion, TemplateExpansion, ValueExpr,
 };
 use crate::lazy::expanded::macro_table::{MacroDef, MacroKind, MacroRef};
 use crate::lazy::expanded::r#struct::FieldExpr;
 use crate::lazy::expanded::sequence::Environment;
 use crate::lazy::expanded::{EncodingContextRef, LazyExpandedValue, TemplateVariableReference};
 use crate::result::IonFailure;
-use crate::{try_or_some_err, Bytes, Decimal, Int, IonError, IonResult, IonType, LazyExpandedFieldName, Str, Symbol, SymbolRef, Timestamp, Value};
+use crate::{
+    try_or_some_err, Bytes, Decimal, Int, IonError, IonResult, IonType, LazyExpandedFieldName, Str,
+    Symbol, SymbolRef, Timestamp, Value,
+};
 use bumpalo::collections::Vec as BumpVec;
 use compact_str::CompactString;
 use rustc_hash::FxHashMap;
@@ -235,8 +240,9 @@ impl TryFrom<&ParameterEncoding> for BinaryValueEncoding {
 
     fn try_from(value: &ParameterEncoding) -> Result<Self, Self::Error> {
         match value {
-            ParameterEncoding::MacroShaped(_) =>
-                Err(IonError::illegal_operation("attempt to convert macro-shape parameter encoding to binary value encoding")),
+            ParameterEncoding::MacroShaped(_) => Err(IonError::illegal_operation(
+                "attempt to convert macro-shape parameter encoding to binary value encoding",
+            )),
             ParameterEncoding::FlexUInt => Ok(BinaryValueEncoding::FlexUInt),
             ParameterEncoding::Tagged => Ok(BinaryValueEncoding::Tagged),
             ParameterEncoding::UInt8 => Ok(BinaryValueEncoding::UInt8),
@@ -338,14 +344,17 @@ impl MacroSignature {
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct SignatureIterator<'a> {
     index: usize,
-    macro_def: MacroRef<'a>
+    macro_def: MacroRef<'a>,
 }
 
 impl<'a> SignatureIterator<'a> {
     pub fn new(macro_def: MacroRef<'a>) -> Self {
-        Self { index: 0, macro_def }
+        Self {
+            index: 0,
+            macro_def,
+        }
     }
-    
+
     pub fn parent_macro(&self) -> MacroRef<'_> {
         self.macro_def
     }
@@ -355,9 +364,7 @@ impl<'a> SignatureIterator<'a> {
     }
 
     pub fn current_parameter(&self) -> Option<&'a Parameter> {
-        self.signature()
-            .parameters()
-            .get(self.index)
+        self.signature().parameters().get(self.index)
     }
 
     pub fn expect_next_parameter(&mut self) -> IonResult<&Parameter> {
@@ -662,8 +669,7 @@ impl<'top, D: Decoder> Iterator for TemplateSequenceIterator<'top, D> {
                     // If the macro is guaranteed to expand to exactly one value, we can evaluate it
                     // in place.
                     let new_expansion = try_or_some_err!(invocation.expand());
-                    if invocation.is_singleton()
-                    {
+                    if invocation.is_singleton() {
                         Some(new_expansion.expand_singleton())
                     } else {
                         // Otherwise, add it to the evaluator's stack and return to the top of the loop.
@@ -1273,7 +1279,11 @@ impl<'top, D: Decoder> TemplateExprGroup<'top, D> {
 
 impl<D: Decoder> Debug for TemplateExprGroup<'_, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "(.. /*expr group for param={}*/", self.parameter().name())?;
+        write!(
+            f,
+            "(.. /*expr group for param={}*/",
+            self.parameter().name()
+        )?;
         for expr in self.arg_expressions() {
             write!(f, "\n {expr:?}")?;
         }
@@ -1435,12 +1445,8 @@ impl<'top, D: Decoder> TemplateMacroInvocation<'top, D> {
                 self.environment,
                 arguments,
             )),
-            MacroKind::Repeat => {
-                MacroExpansionKind::Repeat(RepeatExpansion::new(arguments))
-            }
-            MacroKind::Sum => {
-                MacroExpansionKind::Sum(SumExpansion::new(arguments))
-            }
+            MacroKind::Repeat => MacroExpansionKind::Repeat(RepeatExpansion::new(arguments)),
+            MacroKind::Sum => MacroExpansionKind::Sum(SumExpansion::new(arguments)),
         };
         Ok(MacroExpansion::new(
             self.context(),

--- a/src/lazy/reader.rs
+++ b/src/lazy/reader.rs
@@ -107,7 +107,7 @@ impl<Encoding: Decoder, Input: IonInput> Reader<Encoding, Input> {
         self.next()?
             .ok_or_else(|| IonError::decoding_error("expected another top-level value"))
     }
-    
+
     #[allow(dead_code)]
     pub fn symbol_table(&self) -> &SymbolTable {
         self.system_reader.symbol_table()

--- a/src/lazy/struct.rs
+++ b/src/lazy/struct.rs
@@ -221,9 +221,8 @@ impl<'top, D: Decoder> LazyStruct<'top, D> {
     ///# fn main() -> IonResult<()> { Ok(()) }
     /// ```
     pub fn get_expected(&self, name: &str) -> IonResult<ValueRef<'top, D>> {
-        self.get(name)?.ok_or_else(move || {
-            IonError::decoding_error(format!("missing required field {name}"))
-        })
+        self.get(name)?
+            .ok_or_else(move || IonError::decoding_error(format!("missing required field {name}")))
     }
 
     /// Returns an iterator over the annotations on this value. If this value has no annotations,

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -50,9 +50,9 @@ where
 pub struct ValueDeserializer<'a, 'de> {
     pub(crate) value: &'a LazyValue<'de, AnyEncoding>,
     is_human_readable: bool,
-    variant_nesting_depth: usize,  // Holds the number of nested variants we are for tracking
-                                   // variant names in annotations. 0 indicates we're not in a
-                                   // variant.
+    variant_nesting_depth: usize, // Holds the number of nested variants we are for tracking
+                                  // variant names in annotations. 0 indicates we're not in a
+                                  // variant.
 }
 
 impl<'a, 'de> ValueDeserializer<'a, 'de> {
@@ -433,11 +433,15 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer<'_, 'de> {
     {
         // Make sure we've started reading an enum.
         if self.variant_nesting_depth == 0 {
-            return IonResult::decoding_error("unexpected serde state; was not expecting to read an identifier");
+            return IonResult::decoding_error(
+                "unexpected serde state; was not expecting to read an identifier",
+            );
         }
 
         let mut annotations = self.value.annotations();
-        let our_annotation = annotations.nth(self.variant_nesting_depth - 1).transpose()?;
+        let our_annotation = annotations
+            .nth(self.variant_nesting_depth - 1)
+            .transpose()?;
         match our_annotation {
             None => {
                 let symbol = self.value.read()?.expect_symbol()?;
@@ -544,7 +548,10 @@ struct VariantAccess<'a, 'de> {
 
 impl<'a, 'de> VariantAccess<'a, 'de> {
     fn new(de: ValueDeserializer<'a, 'de>) -> Self {
-        let de = ValueDeserializer { variant_nesting_depth: de.variant_nesting_depth + 1, ..de };
+        let de = ValueDeserializer {
+            variant_nesting_depth: de.variant_nesting_depth + 1,
+            ..de
+        };
 
         VariantAccess { de }
     }

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -209,9 +209,9 @@ mod tests {
 
     use crate::{Decimal, Element, Timestamp};
     use chrono::{DateTime, FixedOffset, Utc};
+    use rstest::*;
     use serde::{Deserialize, Serialize};
     use serde_with::serde_as;
-    use rstest::*;
 
     #[rstest]
     #[case::i8(to_binary(&-1_i8).unwrap(),     &[0xE0, 0x01, 0x00, 0xEA, 0x31, 0x01])]
@@ -256,6 +256,7 @@ mod tests {
             #[serde(with = "serde_bytes")]
             binary: Vec<u8>,
         }
+        #[rustfmt::skip]
         let expected = &[
             0xE0, 0x01, 0x00, 0xEA,                               // IVM
             0xEE, 0x8F, 0x81, 0x83, 0xDC,                         // $ion_symbol_table:: {
@@ -264,7 +265,9 @@ mod tests {
             0xD7, 0x8A, 0xA5, 0x68, 0x65, 0x6C, 0x6C, 0x6F,       // {binary: {{ aGVsbG8= }}
         ];
 
-        let test = Test { binary: b"hello".to_vec() }; // aGVsbG8=
+        let test = Test {
+            binary: b"hello".to_vec(),
+        }; // aGVsbG8=
         let ion_data = to_binary(&test).unwrap();
         assert_eq!(&ion_data[..], expected);
         let de: Test = from_ion(ion_data).expect("unable to parse test");
@@ -420,6 +423,7 @@ mod tests {
             Second(u32),
         }
 
+        #[rustfmt::skip]
         let expected_binary = [
             0xE0, 0x01, 0x00, 0xEA,                          // IVM
             0xEE, 0x96, 0x81, 0x83,                          // $ion_symbol_table::

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -77,7 +77,7 @@ impl<V: ValueWriter> ValueSerializer<'_, V> {
         Self {
             value_writer,
             is_human_readable,
-            annotations: vec!(),
+            annotations: vec![],
             lifetime: PhantomData,
         }
     }
@@ -108,42 +108,58 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.with_annotations(self.annotations)?.write(v as i64)
+        self.value_writer
+            .with_annotations(self.annotations)?
+            .write(v as i64)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.with_annotations(self.annotations)?.write(v as i64)
+        self.value_writer
+            .with_annotations(self.annotations)?
+            .write(v as i64)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.with_annotations(self.annotations)?.write(v)
+        self.value_writer
+            .with_annotations(self.annotations)?
+            .write(v)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.with_annotations(self.annotations)?.write(v)
+        self.value_writer
+            .with_annotations(self.annotations)?
+            .write(v)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.with_annotations(self.annotations)?.write(v)
+        self.value_writer
+            .with_annotations(self.annotations)?
+            .write(v)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.with_annotations(self.annotations)?.write(v)
+        self.value_writer
+            .with_annotations(self.annotations)?
+            .write(v)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.with_annotations(self.annotations)?.write(v)
+        self.value_writer
+            .with_annotations(self.annotations)?
+            .write(v)
     }
 
     /// Serialize all integer types using the `Integer` intermediary type.
     fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.with_annotations(self.annotations)?.write(v)
+        self.value_writer
+            .with_annotations(self.annotations)?
+            .write(v)
     }
 
     fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
@@ -151,24 +167,34 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
     }
 
     fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.with_annotations(self.annotations)?.write(v)
+        self.value_writer
+            .with_annotations(self.annotations)?
+            .write(v)
     }
 
     fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
         // TODO: This could be optimized.
-        self.value_writer.with_annotations(self.annotations)?.write(v.to_string())
+        self.value_writer
+            .with_annotations(self.annotations)?
+            .write(v.to_string())
     }
 
     fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.with_annotations(self.annotations)?.write(v)
+        self.value_writer
+            .with_annotations(self.annotations)?
+            .write(v)
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.with_annotations(self.annotations)?.write(v)
+        self.value_writer
+            .with_annotations(self.annotations)?
+            .write(v)
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.with_annotations(self.annotations)?.write(Null(IonType::Null))
+        self.value_writer
+            .with_annotations(self.annotations)?
+            .write(Null(IonType::Null))
     }
 
     fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
@@ -183,7 +209,9 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
     }
 
     fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.with_annotations(self.annotations)?.write(name.as_symbol_ref())
+        self.value_writer
+            .with_annotations(self.annotations)?
+            .write(name.as_symbol_ref())
     }
 
     fn serialize_unit_variant(
@@ -192,7 +220,9 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
         _variant_index: u32,
         variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
-        self.value_writer.with_annotations(self.annotations)?.write(variant.as_symbol_ref())
+        self.value_writer
+            .with_annotations(self.annotations)?
+            .write(variant.as_symbol_ref())
     }
 
     fn serialize_newtype_struct<T>(
@@ -213,7 +243,9 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
             // we are using TUNNELED_TIMESTAMP_TYPE_NAME flag here which indicates a timestamp value
             // The assert statement above that compares the sizes of the Timestamp and value types
             let timestamp = unsafe { std::mem::transmute_copy::<&T, &Timestamp>(&value) };
-            self.value_writer.with_annotations(self.annotations)?.write_timestamp(timestamp)
+            self.value_writer
+                .with_annotations(self.annotations)?
+                .write_timestamp(timestamp)
         } else if name == TUNNELED_DECIMAL_TYPE_NAME {
             // # Safety
             // compiler doesn't understand that the generic T here is actually Decimal here since
@@ -249,7 +281,7 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
     }
 
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        let writer= self.value_writer.with_annotations(self.annotations)?;
+        let writer = self.value_writer.with_annotations(self.annotations)?;
         Ok(SeqWriter {
             seq_writer: writer.list_writer()?,
             is_human_readable: self.is_human_readable,
@@ -261,12 +293,15 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
         name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        let ValueSerializer { value_writer, is_human_readable, mut annotations, .. } = self;
+        let ValueSerializer {
+            value_writer,
+            is_human_readable,
+            mut annotations,
+            ..
+        } = self;
         annotations.push(name);
         Ok(SeqWriter {
-            seq_writer: value_writer
-                .with_annotations(annotations)?
-                .list_writer()?,
+            seq_writer: value_writer.with_annotations(annotations)?.list_writer()?,
             is_human_readable,
         })
     }
@@ -278,12 +313,15 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
         variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        let ValueSerializer { value_writer, is_human_readable, mut annotations, .. } = self;
+        let ValueSerializer {
+            value_writer,
+            is_human_readable,
+            mut annotations,
+            ..
+        } = self;
         annotations.push(variant);
         Ok(SeqWriter {
-            seq_writer: value_writer
-                .with_annotations(annotations)?
-                .list_writer()?,
+            seq_writer: value_writer.with_annotations(annotations)?.list_writer()?,
             is_human_readable,
         })
     }
@@ -313,7 +351,12 @@ impl<'a, V: ValueWriter + 'a> ser::Serializer for ValueSerializer<'a, V> {
         variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        let ValueSerializer { value_writer, is_human_readable, mut annotations, .. } = self;
+        let ValueSerializer {
+            value_writer,
+            is_human_readable,
+            mut annotations,
+            ..
+        } = self;
         annotations.push(variant);
         Ok(MapWriter {
             map_writer: value_writer

--- a/src/types/decimal/mod.rs
+++ b/src/types/decimal/mod.rs
@@ -256,7 +256,10 @@ impl Decimal {
             // end.
             let mut coeff = self.coefficient().as_int().unwrap_or(Int::ZERO);
             coeff.data /= 10i128.pow(self.exponent.unsigned_abs() as u32);
-            Decimal::new(Coefficient::from_sign_and_value(self.coefficient_sign, coeff), 0)
+            Decimal::new(
+                Coefficient::from_sign_and_value(self.coefficient_sign, coeff),
+                0,
+            )
         }
     }
 
@@ -264,11 +267,17 @@ impl Decimal {
     /// zero maintaining the sign of the original coefficient.
     pub fn fract(&self) -> Decimal {
         if self.exponent >= 0 {
-            Decimal::new(Coefficient::from_sign_and_value(self.coefficient_sign, 0), 0)
+            Decimal::new(
+                Coefficient::from_sign_and_value(self.coefficient_sign, 0),
+                0,
+            )
         } else {
             let mut coeff = self.coefficient().as_int().unwrap_or(Int::ZERO);
             coeff.data %= 10i128.pow(self.exponent.unsigned_abs() as u32);
-            Decimal::new(Coefficient::from_sign_and_value(self.coefficient_sign, coeff), self.exponent)
+            Decimal::new(
+                Coefficient::from_sign_and_value(self.coefficient_sign, coeff),
+                self.exponent,
+            )
         }
     }
 }
@@ -358,7 +367,7 @@ impl Sub for Decimal {
             // and we can do integer arithmetic.
             let mut lhs_int = self.coefficient().as_int().unwrap_or(Int::ZERO);
             let mut rhs_int = rhs.coefficient().as_int().unwrap_or(Int::ZERO);
-            let exp = if self.exponent >  rhs.exponent {
+            let exp = if self.exponent > rhs.exponent {
                 lhs_int.data *= 10i128.pow((self.exponent - rhs.exponent) as u32);
                 rhs.exponent
             } else {
@@ -962,7 +971,7 @@ mod decimal_tests {
     #[case(Decimal::NEGATIVE_ZERO, Decimal::ZERO, Sign::Negative)]
     #[case(Decimal::ZERO, Decimal::ZERO, Sign::Positive)]
     #[case(Decimal::ZERO, Decimal::NEGATIVE_ZERO, Sign::Positive)]
-    fn decimal_sub_signzero(#[case] lhs: Decimal, #[case] rhs: Decimal, #[case]sign: Sign) {
+    fn decimal_sub_signzero(#[case] lhs: Decimal, #[case] rhs: Decimal, #[case] sign: Sign) {
         let val = lhs - rhs;
         assert_eq!(val.coefficient().sign(), sign);
     }
@@ -987,5 +996,4 @@ mod decimal_tests {
     fn decimal_fract(#[case] value: Decimal, #[case] expected: Decimal) {
         assert_eq!(value.fract(), expected);
     }
-
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -29,7 +29,10 @@ pub use r#struct::Struct;
 pub use sexp::SExp;
 pub use string::Str;
 pub use symbol::Symbol;
-pub use timestamp::{HasDay, HasFractionalSeconds, HasHour, HasMinute, HasMonth, HasOffset, HasSeconds, HasYear, Mantissa, Timestamp, TimestampBuilder, TimestampPrecision};
+pub use timestamp::{
+    HasDay, HasFractionalSeconds, HasHour, HasMinute, HasMonth, HasOffset, HasSeconds, HasYear,
+    Mantissa, Timestamp, TimestampBuilder, TimestampPrecision,
+};
 
 use crate::ion_data::{IonDataHash, IonDataOrd};
 use std::cmp::Ordering;

--- a/tests/conformance_tests.rs
+++ b/tests/conformance_tests.rs
@@ -176,8 +176,6 @@ mod ion_tests {
             test.run().expect("test failed");
         }
 
-        println!(
-            "SUMMARY: {file_name} : Total Tests {total_tests} :  Skipped {total_skipped}",
-        );
+        println!("SUMMARY: {file_name} : Total Tests {total_tests} :  Skipped {total_skipped}",);
     }
 }

--- a/tests/ion_hash_tests.rs
+++ b/tests/ion_hash_tests.rs
@@ -226,9 +226,7 @@ fn test_case(
     if expected_string != actual_string {
         Err(IonHashTestError::TestFailed {
             test_case_name,
-            message: Some(format!(
-                "expected: {expected_string}\nwas: {actual_string}",
-            )),
+            message: Some(format!("expected: {expected_string}\nwas: {actual_string}",)),
         })
     } else {
         Ok(())


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
This PR is just the result of running rustfmt. With the changes made in #1006, the rustfmt check was re-enabled after some period of not being run in the workflow resulting in failures due to rustfmt diffs being detected.

In a few cases I added in `#[rustfmt::skip]` in order to maintain spacing in comments for multi-line byte slices that contained ion text equivalent comments. Otherwise, the changes are all rustfmt provided.


### Before PR
```
% cargo fmt --check --message-format 'short'
/Users/glitch/Code/sandbox/ion-rust/benches/byod.rs
/Users/glitch/Code/sandbox/ion-rust/benches/encoding_primitives.rs
/Users/glitch/Code/sandbox/ion-rust/benches/write_many_structs.rs
/Users/glitch/Code/sandbox/ion-rust/src/lazy/binary/raw/v1_1/binary_buffer.rs
/Users/glitch/Code/sandbox/ion-rust/src/lazy/binary/raw/v1_1/e_expression.rs
/Users/glitch/Code/sandbox/ion-rust/src/lazy/binary/raw/value.rs
/Users/glitch/Code/sandbox/ion-rust/src/lazy/encoder/binary/v1_1/container_writers.rs
/Users/glitch/Code/sandbox/ion-rust/src/lazy/encoder/binary/v1_1/fixed_uint.rs
/Users/glitch/Code/sandbox/ion-rust/src/lazy/encoder/binary/v1_1/value_writer.rs
/Users/glitch/Code/sandbox/ion-rust/src/lazy/encoder/writer.rs
/Users/glitch/Code/sandbox/ion-rust/src/lazy/expanded/e_expression.rs
/Users/glitch/Code/sandbox/ion-rust/src/lazy/expanded/macro_evaluator.rs
/Users/glitch/Code/sandbox/ion-rust/src/lazy/expanded/template.rs
/Users/glitch/Code/sandbox/ion-rust/src/lazy/reader.rs
/Users/glitch/Code/sandbox/ion-rust/src/lazy/struct.rs
/Users/glitch/Code/sandbox/ion-rust/src/serde/de.rs
/Users/glitch/Code/sandbox/ion-rust/src/serde/mod.rs
/Users/glitch/Code/sandbox/ion-rust/src/serde/ser.rs
/Users/glitch/Code/sandbox/ion-rust/src/types/decimal/mod.rs
/Users/glitch/Code/sandbox/ion-rust/src/types/mod.rs
/Users/glitch/Code/sandbox/ion-rust/tests/conformance_dsl/model.rs
/Users/glitch/Code/sandbox/ion-rust/tests/conformance_dsl/model.rs
/Users/glitch/Code/sandbox/ion-rust/tests/conformance_tests.rs
/Users/glitch/Code/sandbox/ion-rust/tests/ion_hash_tests.rs
% cargo fmt --check --message-format 'short' | wc -l
      24
```

### After PR
```
% cargo fmt --check --message-format 'short'
%
```
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
