### PR TITLE
Re-add `build_raw_writer` to `WriteConfig`

### DIFF
--- a/src/write_config.rs
+++ b/src/write_config.rs
@@ -57,12 +57,6 @@ impl<E: Encoding> WriteConfig<E> {
     pub fn build_raw_writer<W: io::Write>(self, output: W) -> IonResult<E::Writer<W>> {
         E::Writer::build(self, output)
     }
-
-    #[cfg(not(feature = "experimental-tooling-apis"))]
-    pub(crate) fn build_raw_writer<W: io::Write>(self, output: W) -> IonResult<E::Writer<W>> {
-        E::Writer::build(self, output)
-    }
-
 }
 
 impl WriteConfig<TextEncoding_1_0> {


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
This PR adds the `build_raw_writer` method back to `WriteConfig`, which had previously been removed based on dead-code warnings, but is in [use by](https://github.com/amazon-ion/ion-cli/blob/9ef10583cdf70dc81f41cb24441504032b3e1989/src/bin/ion/commands/inspect.rs#L269) ion-cli.



---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
