### PR TITLE
Clean up public API for v1.0.0 release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,7 +76,6 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt, clippy
-          rustflags: "" # Default: '-D warnings', we do not want that for now.
           override: true
       - name: Cargo Test (default/no features)
         if: matrix.features == 'default'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,11 @@ experimental = [
     "experimental-tooling-apis",
     "experimental-serde",
     "experimental-ion-1-1",
+    "experimental-chrono",
 ]
+
+# Access to public conversions between Timestamp and chrono types (NaiveDateTime, DateTime<FixedOffset>).
+experimental-chrono = []
 
 # Feature for indicating explicit opt-in to Ion 1.1
 experimental-ion-1-1 = ["experimental-reader-writer"]
@@ -45,7 +49,7 @@ experimental-reader-writer = []
 experimental-tooling-apis = []
 
 # Experimental serde API to serialize and deserialize Ion data into Rust objects using serde crate
-experimental-serde = ["experimental-reader-writer", "dep:serde_with", "dep:serde"]
+experimental-serde = ["experimental-reader-writer", "experimental-chrono", "dep:serde_with", "dep:serde"]
 
 bigdecimal = ["dep:bigdecimal"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rust-version = "1.82"
 
 [features]
 default = []
-experimental-ion-hash = ["digest", "experimental-reader-writer"]
+experimental-ion-hash = ["dep:digest", "dep:sha2", "experimental-reader-writer"]
 
 # Feature for indicating particularly bleeding edge APIs or functionality in the library.
 # These are not guaranteed any sort of API stability and may also have non-standard

--- a/benches/read_many_structs.rs
+++ b/benches/read_many_structs.rs
@@ -1,5 +1,4 @@
 use criterion::{criterion_group, criterion_main};
-use ion_rs::MacroTable;
 
 #[cfg(not(feature = "experimental"))]
 mod benchmark {
@@ -10,8 +9,12 @@ mod benchmark {
     }
 }
 
+#[cfg(feature = "experimental")]
+use ion_rs::MacroTable;
+
 /// An Ion 1.1 test stream to benchmark. Each instance of this type contains data that was encoded
 /// with different settings; for example, using more or fewer macros, or using length-prefixing.
+#[cfg(feature = "experimental")]
 #[allow(non_camel_case_types)]
 pub struct TestData_1_1 {
     name: String,
@@ -25,6 +28,7 @@ pub struct TestData_1_1 {
 /// makes the stream much more compact, but comes at the expense of evaluation overhead when the
 /// stream is read. If only a subset of the fields are read from each value, this overhead will be
 /// minimal.
+#[cfg(feature = "experimental")]
 fn maximally_compact_1_1_data(num_values: usize) -> TestData_1_1 {
     let template_definition_text: String = r#"
         (macro event (timestamp thread_id thread_name client_num host_id parameters*)
@@ -84,6 +88,7 @@ fn maximally_compact_1_1_data(num_values: usize) -> TestData_1_1 {
 /// a template that does not use additional macros. This makes the stream compact relative to its
 /// Ion 1.0 equivalent, but not as compact as it is in the "maximally compact" configuration above.
 /// The lighter use of macros means that there is less evaluation overhead at read time.
+#[cfg(feature = "experimental")]
 fn moderately_compact_1_1_data(num_values: usize) -> TestData_1_1 {
     let template_definition_text = r#"
         (macro event (timestamp thread_id thread_name client_num host_id parameters*)
@@ -151,6 +156,7 @@ fn moderately_compact_1_1_data(num_values: usize) -> TestData_1_1 {
 /// length-prefixed. This allows the reader to step over e-expressions without fully parsing them,
 /// making top-level skip-scanning highly efficient at the expense of 1-2 extra bytes per
 /// e-expression.
+#[cfg(feature = "experimental")]
 fn length_prefixed_moderately_compact_1_1_data(num_values: usize) -> TestData_1_1 {
     let template_definition_text = r#"
         (macro event (timestamp thread_id thread_name client_num host_id parameters*)

--- a/src/binary/decimal.rs
+++ b/src/binary/decimal.rs
@@ -7,7 +7,7 @@ use arrayvec::ArrayVec;
 use crate::binary::int::DecodedInt;
 use crate::binary::var_int::VarInt;
 use crate::binary::var_uint::VarUInt;
-use crate::decimal::coefficient::Sign;
+use crate::decimal::Sign;
 use crate::ion_data::IonEq;
 use crate::result::{IonFailure, IonResult};
 use crate::{Decimal, Int, IonError};

--- a/src/binary/int.rs
+++ b/src/binary/int.rs
@@ -1,7 +1,6 @@
 use crate::decimal::Coefficient;
 use crate::result::IonResult;
 use crate::Int;
-use num_traits::Zero;
 use std::io::Write;
 
 const INT_NEGATIVE_ZERO: u8 = 0x80;

--- a/src/binary/int.rs
+++ b/src/binary/int.rs
@@ -1,4 +1,4 @@
-use crate::decimal::coefficient::Coefficient;
+use crate::decimal::Coefficient;
 use crate::result::IonResult;
 use crate::Int;
 use num_traits::Zero;

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -16,16 +16,9 @@ pub trait Catalog {
 }
 
 #[derive(Default)]
+#[allow(dead_code)] // Used in some features and in tests without feature flags
 pub struct MapCatalog {
     tables_by_name: HashMap<String, BTreeMap<usize, SharedSymbolTable>>,
-}
-
-impl MapCatalog {
-    pub fn new() -> Self {
-        Self {
-            tables_by_name: HashMap::new(),
-        }
-    }
 }
 
 impl Catalog for MapCatalog {
@@ -50,7 +43,14 @@ impl Catalog for MapCatalog {
     }
 }
 
+#[allow(dead_code)] // Used in some features and in tests without feature flags
 impl MapCatalog {
+    pub fn new() -> Self {
+        Self {
+            tables_by_name: HashMap::new(),
+        }
+    }
+
     /// Adds a Shared Symbol Table with name into the Catalog
     pub fn insert_table(&mut self, table: SharedSymbolTable) {
         match self.tables_by_name.get_mut(table.name()) {

--- a/src/element/element_writer.rs
+++ b/src/element/element_writer.rs
@@ -6,6 +6,7 @@
 use crate::result::IonResult;
 use crate::{Element, Value};
 
+#[allow(unused)] // Used in tests and for multiple feature flags
 /// Serializes [`Element`] instances into some kind of output sink.
 pub trait ElementWriter {
     /// Serializes a single [`Value`] at the current depth of the writer.

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -21,7 +21,7 @@
 //! [serde-json-value]: https://docs.serde.rs/serde_json/value/enum.Value.html
 
 pub use annotations::{Annotations, IntoAnnotations};
-pub use sequence::{OwnedSequenceIterator, Sequence};
+pub use sequence::Sequence;
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 use std::hash::Hasher;

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -1071,7 +1071,8 @@ mod tests {
 
     /// Makes a timestamp from an RFC-3339 string and panics if it can't
     fn make_timestamp<T: AsRef<str>>(text: T) -> Timestamp {
-        DateTime::parse_from_rfc3339(text.as_ref()).unwrap().into()
+        let dt = DateTime::parse_from_rfc3339(text.as_ref()).unwrap();
+        Timestamp::from_fixed_offset_datetime(dt)
     }
 
     struct CaseAnnotations {

--- a/src/element/reader.rs
+++ b/src/element/reader.rs
@@ -63,6 +63,7 @@ pub trait ElementReader {
     /// returning the complete sequence as a `Vec<Element>`.
     ///
     /// If an error occurs while reading, returns `Err(IonError)`.
+    #[allow(unused)] // Used in tests and for multiple feature flags
     fn read_all_elements(&mut self) -> IonResult<Sequence> {
         self.elements().collect()
     }

--- a/src/ion_hash/mod.rs
+++ b/src/ion_hash/mod.rs
@@ -8,14 +8,14 @@
 //! use ion_rs::ion_hash;
 //!
 //! # // XXX this doc test requires an optional feature--so this makes sure we can still run tests
-//! # #[cfg(feature = "sha2")]
+//! # #[cfg(feature = "experimental-ion-hash")]
 //! # fn main() -> IonResult<()> {
 //!   let elem = Element::read_one(b"\"hello world\"")?;
 //!   let digest = ion_hash::sha256(&elem);
 //!   println!("{:?}", digest);
 //! # Ok(())
 //! # }
-//! # #[cfg(not(feature = "sha2"))]
+//! # #[cfg(not(feature = "experimental-ion-hash"))]
 //! # fn main() {}
 //! ```
 
@@ -29,12 +29,12 @@ mod element_hasher;
 mod representation;
 mod type_qualifier;
 
-#[cfg(feature = "sha2")]
+#[cfg(feature = "experimental-ion-hash")]
 use digest::Output;
-#[cfg(feature = "sha2")]
+#[cfg(feature = "experimental-ion-hash")]
 use sha2::Sha256;
 /// Utility to hash an [`Element`] using SHA-256 as the hash function.
-#[cfg(feature = "sha2")]
+#[cfg(feature = "experimental-ion-hash")]
 pub fn sha256(elem: &Element) -> IonResult<Output<Sha256>> {
     Sha256::hash_element(elem)
 }

--- a/src/lazy/binary/binary_buffer.rs
+++ b/src/lazy/binary/binary_buffer.rs
@@ -367,7 +367,7 @@ impl<'a> BinaryBuffer<'a> {
         magnitude_le.reverse();
         magnitude_le.push(0);
         let value = Int::from_le_signed_bytes(&magnitude_le);
-        let value = if is_negative { -value } else { value };
+        let value = if is_negative { value.neg() } else { value };
 
         Ok((
             DecodedInt::new(value, is_negative, length),

--- a/src/lazy/binary/raw/value.rs
+++ b/src/lazy/binary/raw/value.rs
@@ -570,7 +570,6 @@ impl<'top> LazyRawBinaryValue_1_0<'top> {
         let magnitude: Int = DecodedUInt::uint_from_slice(uint_bytes).into();
 
         use crate::binary::type_code::IonTypeCode::*;
-        use num_traits::Zero;
         let value = match (self.encoded_value.header.ion_type_code, magnitude) {
             (PositiveInteger, integer) => integer,
             (NegativeInteger, integer) if integer.is_zero() => {
@@ -578,7 +577,7 @@ impl<'top> LazyRawBinaryValue_1_0<'top> {
                     "found a negative integer (typecode=3) with a value of 0",
                 );
             }
-            (NegativeInteger, integer) => -integer,
+            (NegativeInteger, integer) => integer.neg(),
             _itc => return IonResult::decoding_error("unexpected ion type code"),
         };
         Ok(RawValueRef::Int(value))

--- a/src/lazy/decoder.rs
+++ b/src/lazy/decoder.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 use std::io::Write;
 use std::ops::Range;
 
+use crate::catalog::Catalog;
 use crate::lazy::any_encoding::{IonEncoding, IonVersion};
 use crate::lazy::encoder::text::v1_0::writer::LazyRawTextWriter_1_0;
 use crate::lazy::encoder::text::v1_1::writer::LazyRawTextWriter_1_1;
@@ -18,9 +19,8 @@ use crate::lazy::streaming_raw_reader::RawReaderState;
 use crate::read_config::ReadConfig;
 use crate::result::IonFailure;
 use crate::{
-    v1_0, v1_1, Catalog, Encoding, FieldExpr, IonResult, IonType, LazyExpandedFieldName,
-    LazyExpandedValue, LazyRawAnyFieldName, LazyRawWriter, MacroExpr, RawSymbolRef, ValueExpr,
-    ValueRef,
+    v1_0, v1_1, Encoding, FieldExpr, IonResult, IonType, LazyExpandedFieldName, LazyExpandedValue,
+    LazyRawAnyFieldName, LazyRawWriter, MacroExpr, RawSymbolRef, ValueExpr, ValueRef,
 };
 
 pub trait HasSpan<'top>: HasRange {

--- a/src/lazy/encoder/binary/v1_1/fixed_int.rs
+++ b/src/lazy/encoder/binary/v1_1/fixed_int.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use crate::decimal::coefficient::Coefficient;
+use crate::decimal::Coefficient;
 use crate::result::IonFailure;
 use crate::{Int, IonResult};
 

--- a/src/lazy/encoder/binary/v1_1/fixed_uint.rs
+++ b/src/lazy/encoder/binary/v1_1/fixed_uint.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use ice_code::ice as cold_path;
 use num_traits::{PrimInt, Unsigned};
 
-use crate::decimal::coefficient::Coefficient;
+use crate::decimal::Coefficient;
 use crate::lazy::encoder::binary::v1_1::fixed_int::{
     MAX_INT_SIZE_IN_BYTES, MAX_UINT_SIZE_IN_BYTES,
 };

--- a/src/lazy/encoder/text/v1_0/writer.rs
+++ b/src/lazy/encoder/text/v1_0/writer.rs
@@ -136,8 +136,9 @@ impl<W: Write> LazyRawWriter<W> for LazyRawTextWriter_1_0<W> {
 
 #[cfg(test)]
 mod tests {
+    use crate::element::reader::ElementReader;
     use crate::lazy::encoder::text::v1_0::writer::LazyRawTextWriter_1_0;
-    use crate::{v1_1, Annotatable, ElementReader, IonData, IonResult, Reader, SequenceWriter};
+    use crate::{v1_1, Annotatable, IonData, IonResult, Reader, SequenceWriter};
 
     #[test]
     fn write_annotated_values() -> IonResult<()> {

--- a/src/lazy/encoder/writer.rs
+++ b/src/lazy/encoder/writer.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use crate::constants::v1_0::system_symbol_ids;
 use crate::constants::v1_1;
+use crate::element::element_writer::ElementWriter;
 use crate::lazy::encoder::annotation_seq::{AnnotationSeq, AnnotationsVec};
 use crate::lazy::encoder::binary::v1_1::value_writer::BinaryValueWriter_1_1;
 use crate::lazy::encoder::value_writer::internal::{
@@ -30,9 +31,9 @@ use crate::raw_symbol_ref::AsRawSymbolRef;
 use crate::result::IonFailure;
 use crate::write_config::WriteConfig;
 use crate::{
-    ContextWriter, Decimal, Element, ElementWriter, Int, IonError, IonInput, IonResult, IonType,
-    IonVersion, MacroDef, MacroTable, RawSymbolRef, Symbol, SymbolId, SymbolTable, TemplateMacro,
-    Timestamp, UInt, Value,
+    ContextWriter, Decimal, Element, Int, IonError, IonInput, IonResult, IonType, IonVersion,
+    MacroDef, MacroTable, RawSymbolRef, Symbol, SymbolId, SymbolTable, TemplateMacro, Timestamp,
+    UInt, Value,
 };
 
 /// A thin wrapper around a `SymbolTable` that tracks the number of symbols whose definition has

--- a/src/lazy/expanded/lazy_element.rs
+++ b/src/lazy/expanded/lazy_element.rs
@@ -169,8 +169,7 @@ impl<Encoding: Decoder> TryFrom<&LazyElement<Encoding>> for Element {
 #[cfg(test)]
 mod tests {
     use crate::lazy::expanded::lazy_element::LazyElement;
-    use crate::lazy::reader::IonResultIterExt;
-    use crate::{AnyEncoding, Element, IonResult, IonType, Reader, Sequence};
+    use crate::{AnyEncoding, Element, IonResult, Reader, Sequence};
 
     #[cfg(feature = "experimental-ion-1-1")]
     fn test_data() -> String {
@@ -266,60 +265,6 @@ mod tests {
         drop(reader);
         // The `LazyElement` is still valid/usable.
         assert_eq!(Element::symbol("foo"), Element::try_from(lazy_element)?);
-        Ok(())
-    }
-
-    #[test]
-    fn demonstrate_try_filter_and_try_map() -> IonResult<()> {
-        let mut reader = Reader::new(AnyEncoding, r#"1 2 3 4 5 6 7 8 9 10"#)?;
-        let evens: IonResult<Vec<i64>> = reader
-            .try_filter(|element| Ok(element.ion_type() == IonType::Int))
-            .try_map(|element| element.read()?.clone().expect_i64())
-            .try_filter(|i| Ok(i % 2 == 0))
-            .collect();
-        drop(reader);
-        assert_eq!(vec![2, 4, 6, 8, 10], evens?);
-        Ok(())
-    }
-
-    #[test]
-    #[cfg(feature = "experimental-ion-1-1")]
-    fn demonstrate_try_filter_map_1_1() -> IonResult<()> {
-        let log = r#"
-            $ion_1_1
-            (:add_macros
-                (macro request (requestId server elapsedMs page status)
-                    {
-                        requestId: (%requestId),
-                        server: (%server),
-                        elapsedMs: (%elapsedMs),
-                        page: (%page),
-                        status: (%status),
-                    }))
-            (:request abc100 'server1.example.com' 40 "index.html" 200)
-            (:request def84 'server2.example.com' 3500 "productFoo.html" 200)
-            (:request abc101 'server1.example.com' 31 "index.html" 200)
-            (:request abc102 'server1.example.com' 4000 "productFoo.html" 200)
-            (:request def85 'server2.example.com' 10 "productBar.html" 404)
-        "#;
-
-        let mut reader = Reader::new(AnyEncoding, log)?;
-        let problem_requests = reader
-            .try_filter_map(|element| {
-                let event = element.read()?.clone().expect_struct()?;
-                let status = event.get_expected("status")?.expect_i64()?;
-                let elapsed = event.get_expected("elapsedMs")?.expect_i64()?;
-                if status != 200 || elapsed > 1000 {
-                    Ok(Some(
-                        event.get_expected("requestId")?.expect_text()?.to_owned(),
-                    ))
-                } else {
-                    Ok(None)
-                }
-            })
-            .collect::<IonResult<Vec<String>>>();
-        drop(reader);
-        assert_eq!(problem_requests?, vec!["def84", "abc102", "def85"]);
         Ok(())
     }
 }

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -1903,7 +1903,7 @@ impl<'top, D: Decoder> SumExpansion<'top, D> {
         for value in self.arguments {
             let value = value?;
             let i = self.get_integer(env, value)?;
-            sum = sum + i;
+            sum = sum.add(i);
         }
 
         let value_ref = context.allocator().alloc_with(|| ValueRef::Int(sum));
@@ -2182,7 +2182,7 @@ impl<'top, D: Decoder> DeltaExpansion<'top, D> {
         };
 
         if let Some(ref mut current_base) = self.current_base {
-            *current_base = current_base.clone() + delta;
+            *current_base = current_base.clone().add(delta);
             let value_ref = context
                 .allocator()
                 .alloc_with(|| ValueRef::Int(self.current_base.clone().unwrap()));

--- a/src/lazy/expanded/macro_evaluator.rs
+++ b/src/lazy/expanded/macro_evaluator.rs
@@ -2326,7 +2326,8 @@ impl<'top> TemplateExpansion<'top> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{v1_1, ElementReader, Int, IonResult, MacroTable, Reader, Sequence};
+    use crate::element::reader::ElementReader;
+    use crate::{v1_1, Int, IonResult, MacroTable, Reader, Sequence};
     use rstest::*;
 
     /// Reads `input` and `expected` and asserts that their output is Ion-equivalent.

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -39,6 +39,7 @@ use std::fmt::{Debug, Formatter};
 use std::ops::{Deref, Range};
 use std::rc::Rc;
 
+use crate::catalog::Catalog;
 use crate::element::iterators::SymbolsIterator;
 use crate::lazy::any_encoding::{IonEncoding, IonVersion};
 use crate::lazy::bytes_ref::BytesRef;
@@ -65,7 +66,7 @@ use crate::location::SourceLocation;
 use crate::raw_symbol_ref::AsRawSymbolRef;
 use crate::result::IonFailure;
 use crate::{
-    Catalog, Decimal, HasRange, HasSpan, Int, IonResult, IonType, RawStreamItem, RawSymbolRef,
+    Decimal, HasRange, HasSpan, Int, IonResult, IonType, RawStreamItem, RawSymbolRef,
     RawVersionMarker, Span, SymbolRef, SymbolTable, Timestamp, ValueRef,
 };
 

--- a/src/lazy/expanded/sequence.rs
+++ b/src/lazy/expanded/sequence.rs
@@ -210,11 +210,13 @@ impl<'top, D: Decoder> Iterator for ExpandedListIterator<'top, D> {
 /// Like an [`ExpandedListIterator`], but will yield macro invocations before also yielding
 /// that macro's expansion.
 #[derive(Debug)]
+#[cfg(feature = "experimental-tooling-apis")]
 pub struct ListValueExprIterator<'top, D: Decoder> {
     context: EncodingContextRef<'top>,
     source: ExpandedListIteratorSource<'top, D>,
 }
 
+#[cfg(feature = "experimental-tooling-apis")]
 impl<'top, D: Decoder> Iterator for ListValueExprIterator<'top, D> {
     type Item = IonResult<ValueExpr<'top, D>>;
 
@@ -232,11 +234,13 @@ impl<'top, D: Decoder> Iterator for ListValueExprIterator<'top, D> {
 /// Like an [`ExpandedSExpIterator`], but will yield macro invocations before also yielding
 /// that macro's expansion.
 #[derive(Debug)]
+#[cfg(feature = "experimental-tooling-apis")]
 pub struct SExpValueExprIterator<'top, D: Decoder> {
     context: EncodingContextRef<'top>,
     source: ExpandedSExpIteratorSource<'top, D>,
 }
 
+#[cfg(feature = "experimental-tooling-apis")]
 impl<'top, D: Decoder> Iterator for SExpValueExprIterator<'top, D> {
     type Item = IonResult<ValueExpr<'top, D>>;
 
@@ -374,6 +378,7 @@ impl<'top, D: Decoder> Iterator for ExpandedSExpIterator<'top, D> {
     }
 }
 
+#[cfg(feature = "experimental-tooling-apis")]
 fn expand_next_sequence_value_expr<'top, D: Decoder>(
     context: EncodingContextRef<'top>,
     evaluator: &mut MacroEvaluator<'top, D>,

--- a/src/lazy/expanded/template.rs
+++ b/src/lazy/expanded/template.rs
@@ -623,6 +623,7 @@ impl<'top, D: Decoder> TemplateSequenceIterator<'top, D> {
     /// * The next value produced by continuing the evaluation of a macro in progress (when the evaluator is not empty)
     /// * The next macro invocation from the stream (when the evaluator is empty)
     /// * `None` when the stream and evaluator are both exhausted
+    #[cfg(feature = "experimental-tooling-apis")]
     pub fn next_value_expr(&mut self) -> Option<IonResult<ValueExpr<'top, D>>> {
         // If the evaluator's stack is not empty, give it the opportunity to yield a value.
         if let Some(value) = try_or_some_err!(self.evaluator.next()) {

--- a/src/lazy/reader.rs
+++ b/src/lazy/reader.rs
@@ -8,7 +8,7 @@ use crate::lazy::system_reader::SystemReader;
 use crate::lazy::value::LazyValue;
 use crate::read_config::ReadConfig;
 use crate::result::IonFailure;
-use crate::{try_or_some_err, IonError, IonResult, MacroTable, SymbolTable};
+use crate::{IonError, IonResult, MacroTable, SymbolTable};
 
 /// An Ion reader that only reads each value that it visits upon request (that is: lazily).
 ///
@@ -179,79 +179,6 @@ impl<Encoding: Decoder, Input: IonInput> Iterator for LazyElementIterator<'_, En
             Err(e) => Some(Err(e)),
         }
     }
-}
-
-/// Extension methods for iterators that return an `IonResult`.
-///
-/// These methods are analogous to methods that already exist on `Iterator`,
-/// but automatically handle situations where the input `IonResult` is an `Err`
-/// sparing the user from writing more boilerplate.
-// This code is not used within the library but is intentionally available to tests and applications.
-pub trait IonResultIterExt<Item>: Iterator<Item = IonResult<Item>> {
-    /// Filters a stream of `IonResult` values.
-    ///
-    /// If the current value is an `Err`, it is passed through as that error.
-    /// If the current value is `Ok` but the predicate does not approve its contents,
-    /// the value is discarded.
-    /// Otherwise, passes the value through without modification.
-    fn try_filter<FalliblePredicate>(
-        &mut self,
-        mut predicate: FalliblePredicate,
-    ) -> impl Iterator<Item = IonResult<Item>>
-    where
-        FalliblePredicate: FnMut(&Item) -> IonResult<bool>,
-    {
-        self.filter_map(move |result| {
-            let element = match result {
-                Ok(element) => element,
-                Err(e) => return Some(Err(e)),
-            };
-
-            match predicate(&element) {
-                Ok(true) => Some(Ok(element)),
-                Ok(false) => None,
-                Err(e) => Some(Err(e)),
-            }
-        })
-    }
-
-    /// Maps a stream of `IonResult<Item>` values to `IonResult<Output>` items.
-    ///
-    /// If the current value is an `Err`, it is passed through as that error.
-    /// If the current value is `Ok`, applies the `map_fn` and passes its result through.
-    fn try_map<MapFn, Output>(
-        &mut self,
-        mut map_fn: MapFn,
-    ) -> impl Iterator<Item = IonResult<Output>>
-    where
-        MapFn: FnMut(&Item) -> IonResult<Output>,
-    {
-        self.map(move |result| {
-            let element = result?;
-            map_fn(&element)
-        })
-    }
-
-    /// Similar to [`try_filter`](Self::try_filter) and [`try_map`](Self::try_map) above, but performs both operations in a single step.
-    fn try_filter_map<'a, MappingPredicate, Output>(
-        &'a mut self,
-        mut mapping_predicate: MappingPredicate,
-    ) -> impl Iterator<Item = IonResult<Output>>
-    where
-        MappingPredicate: FnMut(&Item) -> IonResult<Option<Output>> + 'a,
-    {
-        self.filter_map(move |item_result| {
-            let item = try_or_some_err!(item_result);
-            mapping_predicate(&item).transpose()
-        })
-    }
-}
-
-impl<Item, T> IonResultIterExt<Item> for T
-where
-    T: Iterator<Item = IonResult<Item>>,
-{
-    // Uses default implementations
 }
 
 pub struct ElementIterator<'iter, Encoding: Decoder, Input: IonInput> {

--- a/src/lazy/streaming_raw_reader.rs
+++ b/src/lazy/streaming_raw_reader.rs
@@ -612,9 +612,9 @@ impl<R: Read> IonDataSource for IonStream<R> {
 
 /// Types that can be used as a source of Ion data.
 ///
-/// In general, this trait is implemented by mapping `Self` to either:
-///   * [`IonSlice`], if `Self` is an implementation of `AsRef<[u8]>`
-///   * [`IonStream`], if `Self` is an implementation of `io::Read`
+/// This trait is sealed and cannot be implemented outside of this crate.
+/// It is implemented for common input types including `&[u8]`, `&str`,
+/// `String`, `Vec<u8>`, `File`, `BufReader`, and `StdinLock`.
 pub trait IonInput {
     type DataSource: IonDataSource;
 

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -1,5 +1,6 @@
 #![allow(non_camel_case_types)]
 
+use crate::catalog::Catalog;
 use crate::constants::v1_1;
 use crate::lazy::any_encoding::{IonEncoding, IonVersion};
 use crate::lazy::decoder::Decoder;
@@ -16,8 +17,8 @@ use crate::lazy::value::LazyValue;
 use crate::read_config::ReadConfig;
 use crate::result::IonFailure;
 use crate::{
-    AnyEncoding, Catalog, Int, IonError, IonResult, IonType, LazyField, LazySExp, LazyStruct,
-    Symbol, SymbolTable, ValueRef,
+    AnyEncoding, Int, IonError, IonResult, IonType, LazyField, LazySExp, LazyStruct, Symbol,
+    SymbolTable, ValueRef,
 };
 use std::ops::Deref;
 use std::sync::Arc;
@@ -652,9 +653,7 @@ mod tests {
     use crate::lazy::binary::test_utilities::to_binary_ion;
     use crate::lazy::decoder::RawVersionMarker;
     use crate::lazy::system_stream_item::SystemStreamItem;
-    use crate::{
-        v1_0, AnyEncoding, Catalog, IonResult, SequenceWriter, SymbolRef, ValueWriter, Writer,
-    };
+    use crate::{v1_0, AnyEncoding, IonResult, SequenceWriter, SymbolRef, ValueWriter, Writer};
 
     use super::*;
 
@@ -745,8 +744,9 @@ mod tests {
 
     // === Shared Symbol Tables ===
 
+    use crate::catalog::MapCatalog;
     use crate::lazy::encoder::value_writer::AnnotatableWriter;
-    use crate::{MapCatalog, SharedSymbolTable};
+    use crate::shared_symbol_table::SharedSymbolTable;
 
     fn system_reader_with_catalog_for<Input: IonInput>(
         input: Input,

--- a/src/lazy/text/matched.rs
+++ b/src/lazy/text/matched.rs
@@ -37,9 +37,7 @@ use bumpalo::collections::Vec as BumpVec;
 use bumpalo::Bump as BumpAllocator;
 use ice_code::ice as cold_path;
 use num_bigint::BigUint;
-use num_traits::Zero;
 use smallvec::SmallVec;
-use std::ops::Neg;
 use winnow::combinator::alt;
 use winnow::combinator::preceded;
 use winnow::stream::{AsChar, Stream};
@@ -191,7 +189,7 @@ impl MatchedInt {
         let text = sanitized.as_utf8(matched_input.offset())?;
         let magnitude: Int = UInt::from_str_radix(text, self.radix())?.into();
         let signed = if self.is_negative {
-            -magnitude
+            magnitude.neg()
         } else {
             magnitude
         };

--- a/src/lazy/text/matched.rs
+++ b/src/lazy/text/matched.rs
@@ -19,10 +19,10 @@
 //! use the previously recorded information to minimize the amount of information that needs to be
 //! re-discovered.
 
-use std::ops::{Neg, Range};
+use std::ops::Range;
 use std::str::FromStr;
 
-use crate::decimal::coefficient::Coefficient;
+use crate::decimal::Coefficient;
 use crate::lazy::bytes_ref::BytesRef;
 use crate::lazy::decoder::{Decoder, LazyRawFieldExpr, LazyRawValueExpr};
 use crate::lazy::span::Span;
@@ -39,6 +39,7 @@ use ice_code::ice as cold_path;
 use num_bigint::BigUint;
 use num_traits::Zero;
 use smallvec::SmallVec;
+use std::ops::Neg;
 use winnow::combinator::alt;
 use winnow::combinator::preceded;
 use winnow::stream::{AsChar, Stream};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,25 +139,40 @@
 use rstest_reuse;
 
 // Exposed to allow benchmark comparisons between the 1.0 primitives and 1.1 primitives
+#[cfg(feature = "experimental-reader-writer")]
 pub use catalog::{Catalog, EmptyCatalog, MapCatalog};
+#[cfg(not(feature = "experimental-reader-writer"))]
+pub(crate) use catalog::{Catalog, EmptyCatalog, MapCatalog};
 pub use element::builders::{SequenceBuilder, StructBuilder};
-pub use element::{
-    element_writer::ElementWriter, reader::ElementReader, Annotations, Element,
-    IntoAnnotatedElement, IntoAnnotations, OwnedSequenceIterator, Sequence, Value,
-};
+#[cfg(feature = "experimental-reader-writer")]
+pub use element::{element_writer::ElementWriter, reader::ElementReader};
+#[cfg(not(feature = "experimental-reader-writer"))]
+pub(crate) use element::{element_writer::ElementWriter, reader::ElementReader};
+pub use element::{Annotations, Element, IntoAnnotatedElement, IntoAnnotations, Sequence, Value};
 pub use ion_data::IonData;
+pub use lazy::streaming_raw_reader::IonInput;
+pub use location::SourceLocation;
 
 #[doc(inline)]
 pub use result::{ConversionOperationError, ConversionOperationResult, IonError, IonResult};
+#[cfg(feature = "experimental-reader-writer")]
 pub use shared_symbol_table::SharedSymbolTable;
+#[cfg(not(feature = "experimental-reader-writer"))]
+pub(crate) use shared_symbol_table::SharedSymbolTable;
 pub use symbol_ref::SymbolRef;
 #[doc(inline)]
 pub use types::{
     decimal::Decimal, Blob, Bytes, Clob, Int, IonType, List, Null, SExp, Str, Struct, Symbol,
-    SymbolId, Timestamp, TimestampPrecision, UInt,
+    Timestamp, TimestampPrecision, UInt,
 };
-// Allow access to less commonly used types like decimal::coefficient::{Coefficient, Sign}
-pub use types::decimal;
+pub mod decimal {
+    //! Types for working with Ion decimal coefficients.
+    pub use crate::types::decimal::{Coefficient, Sign};
+}
+#[cfg(feature = "experimental-reader-writer")]
+pub use types::SymbolId;
+#[cfg(not(feature = "experimental-reader-writer"))]
+pub(crate) use types::SymbolId;
 
 #[cfg(feature = "experimental-tooling-apis")]
 pub use crate::text::text_formatter::{FmtValueFormatter, IoValueFormatter};
@@ -190,14 +205,25 @@ pub(crate) mod lazy;
 mod location;
 mod write_config;
 
+#[cfg(feature = "experimental-reader-writer")]
 pub use crate::lazy::any_encoding::AnyEncoding;
+#[cfg(not(feature = "experimental-reader-writer"))]
+pub(crate) use crate::lazy::any_encoding::AnyEncoding;
+
+#[cfg(feature = "experimental-tooling-apis")]
 pub use crate::lazy::decoder::{HasRange, HasSpan};
+#[cfg(not(feature = "experimental-tooling-apis"))]
+pub(crate) use crate::lazy::decoder::{HasRange, HasSpan};
+
+#[cfg(feature = "experimental-tooling-apis")]
 pub use crate::lazy::span::Span;
+#[cfg(not(feature = "experimental-tooling-apis"))]
+pub(crate) use crate::lazy::span::Span;
 macro_rules! v1_x_reader_writer {
     ($visibility:vis) => {
        #[allow(unused_imports)]
         $visibility use crate::{
-            lazy::streaming_raw_reader::{IonInput, IonSlice, IonStream},
+            lazy::streaming_raw_reader::{IonSlice, IonStream},
             lazy::decoder::Decoder,
             lazy::encoder::Encoder,
             lazy::encoding::Encoding,
@@ -418,8 +444,6 @@ pub(crate) mod v1_1 {
     v1_1_reader_writer!(pub(crate));
 }
 
-pub use lazy::reader::IonResultIterExt;
-
 /// Whether or not the text spacing is generous/human-friendly or something more compact.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
 #[non_exhaustive]
@@ -428,15 +452,6 @@ pub enum TextFormat {
     Lines,
     #[default]
     Pretty,
-}
-
-/// Supported Ion encodings.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[non_exhaustive]
-pub enum Format {
-    Text(TextFormat),
-    Binary,
-    // TODO: Json(TextKind)
 }
 
 /// Early returns `Some(Err(_))` if the provided expression returns an `Err(_)`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,13 +141,9 @@ use rstest_reuse;
 // Exposed to allow benchmark comparisons between the 1.0 primitives and 1.1 primitives
 #[cfg(feature = "experimental-reader-writer")]
 pub use catalog::{Catalog, EmptyCatalog, MapCatalog};
-#[cfg(not(feature = "experimental-reader-writer"))]
-pub(crate) use catalog::{Catalog, EmptyCatalog, MapCatalog};
 pub use element::builders::{SequenceBuilder, StructBuilder};
 #[cfg(feature = "experimental-reader-writer")]
 pub use element::{element_writer::ElementWriter, reader::ElementReader};
-#[cfg(not(feature = "experimental-reader-writer"))]
-pub(crate) use element::{element_writer::ElementWriter, reader::ElementReader};
 pub use element::{Annotations, Element, IntoAnnotatedElement, IntoAnnotations, Sequence, Value};
 pub use ion_data::IonData;
 pub use lazy::streaming_raw_reader::IonInput;
@@ -157,8 +153,6 @@ pub use location::SourceLocation;
 pub use result::{ConversionOperationError, ConversionOperationResult, IonError, IonResult};
 #[cfg(feature = "experimental-reader-writer")]
 pub use shared_symbol_table::SharedSymbolTable;
-#[cfg(not(feature = "experimental-reader-writer"))]
-pub(crate) use shared_symbol_table::SharedSymbolTable;
 pub use symbol_ref::SymbolRef;
 #[doc(inline)]
 pub use types::{

--- a/src/read_config.rs
+++ b/src/read_config.rs
@@ -1,9 +1,9 @@
-use crate::catalog::EmptyCatalog;
+use crate::catalog::{Catalog, EmptyCatalog};
 use crate::lazy::any_encoding::AnyEncoding;
 use crate::lazy::encoding::{
     BinaryEncoding_1_0, BinaryEncoding_1_1, TextEncoding_1_0, TextEncoding_1_1,
 };
-use crate::{Catalog, Decoder};
+use crate::Decoder;
 
 /// Provides configuration details for reader construction.
 pub struct ReadConfig<D: Decoder> {

--- a/src/result/conversion.rs
+++ b/src/result/conversion.rs
@@ -1,5 +1,6 @@
 use crate::{Bytes, Decimal, Int, IonType, Sequence, Str, Struct, Symbol, Timestamp};
 
+use std::fmt;
 use std::marker::PhantomData;
 use thiserror::Error;
 
@@ -29,23 +30,35 @@ where
 
 /// Represents a mismatch during conversion between the expected type and the actual value's type;
 /// Holds the original value that was not able to be converted.
-#[derive(Clone, Debug, Error, PartialEq)]
-#[error("Type conversion error; expected a(n) {}, found a(n) {}",
-            ToType::expected_type_name(), .input_value.expected_type_name())]
-pub struct ConversionOperationError<FromType, ToType>
-where
-    FromType: ValueTypeExpectation,
-    ToType: TypeExpectation,
-{
+#[derive(Clone, Debug, PartialEq)]
+pub struct ConversionOperationError<FromType, ToType> {
     input_value: FromType,
     output_type: PhantomData<ToType>,
 }
 
-impl<FromType, ToType> ConversionOperationError<FromType, ToType>
+impl<FromType, ToType> fmt::Display for ConversionOperationError<FromType, ToType>
 where
     FromType: ValueTypeExpectation,
     ToType: TypeExpectation,
 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Type conversion error; expected a(n) {}, found a(n) {}",
+            ToType::expected_type_name(),
+            self.input_value.expected_type_name()
+        )
+    }
+}
+
+impl<FromType, ToType> std::error::Error for ConversionOperationError<FromType, ToType>
+where
+    FromType: ValueTypeExpectation + fmt::Debug,
+    ToType: TypeExpectation + fmt::Debug,
+{
+}
+
+impl<FromType, ToType> ConversionOperationError<FromType, ToType> {
     pub fn new(input_value: FromType) -> Self {
         Self {
             input_value,

--- a/src/types/decimal/coefficient.rs
+++ b/src/types/decimal/coefficient.rs
@@ -3,8 +3,6 @@
 use std::convert::TryFrom;
 use std::fmt::{Display, Formatter};
 
-use num_traits::Zero;
-
 use crate::result::{IonError, IonFailure};
 use crate::types::CountDecimalDigits;
 use crate::IonResult;
@@ -196,8 +194,6 @@ impl Display for Coefficient {
 
 #[cfg(test)]
 mod coefficient_tests {
-    use std::ops::Neg;
-
     use crate::ion_data::IonEq;
     use crate::Int;
     use crate::{Decimal, UInt};

--- a/src/types/decimal/mod.rs
+++ b/src/types/decimal/mod.rs
@@ -1,7 +1,6 @@
 //! Types related to [`Decimal`], the in-memory representation of an Ion decimal value.
 
 use std::cmp::Ordering;
-use std::ops::Sub;
 
 use crate::ion_data::{IonDataHash, IonDataOrd, IonEq};
 use crate::result::{IonError, IonFailure};
@@ -353,52 +352,6 @@ impl PartialOrd for Decimal {
 impl Ord for Decimal {
     fn cmp(&self, other: &Self) -> Ordering {
         Decimal::compare(self, other)
-    }
-}
-
-impl Sub for Decimal {
-    type Output = Self;
-
-    /// Calculate the result of self - rhs.
-    ///
-    /// Regarding signed zero: This function will propagate negative zero following
-    /// the rules of IEEE 754 subtraction with signed zero and default rounding.
-    /// Specifically:
-    ///     +0.0 - +0.0 == 0
-    ///     +0.0 - -0.0 == 0
-    ///     -0.0 - +0.0 == -0
-    ///     -0.0 - -0.0 == 0
-    fn sub(self, rhs: Self) -> Self::Output {
-        let lhs_coeff = self.coefficient();
-        let rhs_coeff = rhs.coefficient();
-
-        // Handle propagating signed zeros. Only when LHS is negative, and RHS differs, is the
-        // result negative zero on subtraction.
-        if rhs.is_zero() && self.is_zero() {
-            if lhs_coeff.is_negative() && !rhs_coeff.is_negative() {
-                Decimal::NEGATIVE_ZERO
-            } else {
-                Decimal::ZERO
-            }
-        } else {
-            // Scale the larger value up so that both coefficients are the same scaling factor apart
-            // and we can do integer arithmetic.
-            let mut lhs_int = self.coefficient().as_int().unwrap_or(Int::ZERO).data;
-            let mut rhs_int = rhs.coefficient().as_int().unwrap_or(Int::ZERO).data;
-
-            let scaling_factor = IntData::from_big(
-                BigInt::from(10).pow(self.exponent.abs_diff(rhs.exponent) as u32),
-            );
-            let exp = if self.exponent > rhs.exponent {
-                lhs_int = lhs_int * scaling_factor;
-                rhs.exponent
-            } else {
-                rhs_int = rhs_int * scaling_factor;
-                self.exponent
-            };
-            let new_coeff = lhs_int - rhs_int;
-            Decimal::new(Int::from(new_coeff), exp)
-        }
     }
 }
 
@@ -977,31 +930,6 @@ mod decimal_tests {
     }
 
     #[rstest]
-    #[case(Decimal::new(1, 0), Decimal::new(1, 0), Decimal::new(0, 0))]
-    #[case(Decimal::new(-1, 0), Decimal::new(1, 0), Decimal::new(-2, 0))]
-    #[case(Decimal::new(1, -5), Decimal::new(1, 0), Decimal::new(-99999, -5))]
-    #[case(Decimal::new(1, 0), Decimal::new(1, 0), Decimal::new(0, 0))]
-    #[case(Decimal::new(-1, 0), Decimal::new(-2, 0), Decimal::new(1, 0))]
-    #[case(Decimal::ZERO, Decimal::ZERO, Decimal::ZERO)]
-    #[case(Decimal::ZERO, Decimal::NEGATIVE_ZERO, Decimal::ZERO)]
-    #[case(Decimal::NEGATIVE_ZERO, Decimal::ZERO, Decimal::NEGATIVE_ZERO)]
-    #[case(Decimal::NEGATIVE_ZERO, Decimal::NEGATIVE_ZERO, Decimal::ZERO)]
-    #[case(Decimal::NEGATIVE_ZERO, Decimal::new(1, 0), Decimal::new(-1, 0))]
-    fn decimal_sub(#[case] lhs: Decimal, #[case] rhs: Decimal, #[case] expected: Decimal) {
-        assert_eq!(lhs - rhs, expected);
-    }
-
-    #[rstest]
-    #[case(Decimal::NEGATIVE_ZERO, Decimal::NEGATIVE_ZERO, Sign::Positive)]
-    #[case(Decimal::NEGATIVE_ZERO, Decimal::ZERO, Sign::Negative)]
-    #[case(Decimal::ZERO, Decimal::ZERO, Sign::Positive)]
-    #[case(Decimal::ZERO, Decimal::NEGATIVE_ZERO, Sign::Positive)]
-    fn decimal_sub_signzero(#[case] lhs: Decimal, #[case] rhs: Decimal, #[case] sign: Sign) {
-        let val = lhs - rhs;
-        assert_eq!(val.coefficient().sign(), sign);
-    }
-
-    #[rstest]
     #[case(Decimal::new(1, 0), Decimal::new(1, 0))]
     #[case(Decimal::new(15, -1), Decimal::new(1, 0))]
     #[case(Decimal::new(105, -1), Decimal::new(10, 0))]
@@ -1093,14 +1021,5 @@ mod decimal_tests {
         // since the integer part is zero.
         let d = Decimal::new(1i64, -39i64);
         assert_eq!(d.fract(), Decimal::new(1i64, -39i64));
-    }
-
-    #[test]
-    fn subtract_decimals_with_large_exponent_difference() {
-        // 1e40 - 1e0 is valid Ion decimal arithmetic.
-        let lhs = Decimal::new(1i64, 40i64);
-        let rhs = Decimal::new(1i64, 0i64);
-        let result = lhs - rhs;
-        assert!(result > Decimal::new(0i64, 0i64));
     }
 }

--- a/src/types/decimal/mod.rs
+++ b/src/types/decimal/mod.rs
@@ -3,7 +3,6 @@
 use std::cmp::Ordering;
 use std::ops::Sub;
 
-use crate::decimal::coefficient::{Coefficient, Sign};
 use crate::ion_data::{IonDataHash, IonDataOrd, IonEq};
 use crate::result::{IonError, IonFailure};
 use crate::types::integer::{IntData, UIntData};
@@ -15,7 +14,8 @@ use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::ops::Neg;
 
-pub mod coefficient;
+pub(crate) mod coefficient;
+pub use coefficient::{Coefficient, Sign};
 
 /// An arbitrary-precision Decimal type with a distinct representation of negative zero (`-0`).
 ///
@@ -26,7 +26,7 @@ pub mod coefficient;
 /// # use ion_rs::IonResult;
 /// # fn main() -> IonResult<()> {
 /// use ion_rs::{Int, Decimal, UInt};
-/// use ion_rs::decimal::coefficient::Sign;
+/// use ion_rs::decimal::Sign;
 /// // Equivalent to: 1225 * 10^-2, or 12.25
 /// let decimal = Decimal::new(1225, -2);
 /// // The coefficient can be viewed as a sign/magnitude pair...
@@ -695,7 +695,7 @@ mod bigdecimal {
 
         #[test]
         fn convert_large_coefficient_decimal_to_bigdecimal() {
-            use crate::decimal::coefficient::Coefficient;
+            use crate::decimal::Coefficient;
             use crate::Int;
             // 2^128 + 1 is a valid Ion decimal coefficient that exceeds u128::MAX.
             let mut bytes = vec![1u8];
@@ -711,7 +711,7 @@ mod bigdecimal {
 
 #[cfg(test)]
 mod decimal_tests {
-    use crate::decimal::coefficient::{Coefficient, Sign};
+    use crate::decimal::{Coefficient, Sign};
     use crate::result::IonResult;
     use crate::{Decimal, Int};
 

--- a/src/types/integer/mod.rs
+++ b/src/types/integer/mod.rs
@@ -8,12 +8,11 @@ use crate::{IonError, IonResult};
 use big_small::AsBigOrSmallValue;
 pub(crate) use int_data::{IntData, UIntData};
 use num_bigint::BigInt;
-use num_traits::Zero;
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::mem;
-use std::ops::{Add, Neg, Sub};
+use std::ops::{Add, Neg};
 
 /// Represents an unsigned integer of any size.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -95,6 +94,11 @@ impl UInt {
 
     pub fn to_le_bytes(&self) -> Vec<u8> {
         self.data.to_le_bytes()
+    }
+
+    /// Returns `true` if this value is zero.
+    pub fn is_zero(&self) -> bool {
+        self.data == UIntData::ZERO
     }
 }
 
@@ -362,6 +366,22 @@ impl Int {
     pub(crate) fn to_bigint(&self) -> BigInt {
         self.data.as_big_value().into_owned()
     }
+
+    /// Returns `true` if this value is zero.
+    pub fn is_zero(&self) -> bool {
+        self.data == IntData::ZERO
+    }
+
+    /// Returns the negation of this value.
+    #[allow(clippy::should_implement_trait)]
+    pub fn neg(self) -> Self {
+        self.data.neg().into()
+    }
+
+    /// Returns the sum of this value and `rhs`.
+    pub(crate) fn add(self, rhs: Self) -> Self {
+        self.data.add(rhs.data).into()
+    }
 }
 
 impl IonEq for Int {
@@ -379,70 +399,6 @@ impl IonDataOrd for Int {
 impl IonDataHash for Int {
     fn ion_data_hash<H: Hasher>(&self, state: &mut H) {
         self.hash(state)
-    }
-}
-
-impl Neg for Int {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output {
-        self.data.neg().into()
-    }
-}
-
-impl Add<Self> for Int {
-    type Output = Int;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        self.data.add(rhs.data).into()
-    }
-}
-
-impl Sub<Self> for Int {
-    type Output = Int;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        self.data.sub(rhs.data).into()
-    }
-}
-
-impl Zero for Int {
-    fn zero() -> Self {
-        Int {
-            data: IntData::ZERO,
-        }
-    }
-
-    fn is_zero(&self) -> bool {
-        self.data == IntData::ZERO
-    }
-}
-
-impl Add<Self> for UInt {
-    type Output = UInt;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        self.data.add(rhs.data).into()
-    }
-}
-
-impl Sub<Self> for UInt {
-    type Output = UInt;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        self.data.sub(rhs.data).into()
-    }
-}
-
-impl Zero for UInt {
-    fn zero() -> Self {
-        UInt {
-            data: UIntData::ZERO,
-        }
-    }
-
-    fn is_zero(&self) -> bool {
-        self.data == UIntData::ZERO
     }
 }
 
@@ -497,7 +453,6 @@ mod integer_tests {
 
     use super::*;
     use crate::types::UInt;
-    use num_traits::Zero;
     use rstest::*;
     use std::cmp::Ordering;
 
@@ -513,33 +468,7 @@ mod integer_tests {
 
     #[test]
     fn zero() {
-        assert!(Int::zero().is_zero());
-    }
-
-    #[test]
-    fn add() {
-        assert_eq!(Int::from(0) + Int::from(0), Int::from(0));
-        assert_eq!(Int::from(5) + Int::from(7), Int::from(12));
-        assert_eq!(Int::from(-5) + Int::from(7), Int::from(2));
-        assert_eq!(Int::from(100) + Int::from(1000i128), Int::from(1100i128));
-        assert_eq!(Int::from(100i128) + Int::from(1000), Int::from(1100i128));
-        assert_eq!(
-            Int::from(100i128) + Int::from(1000i128),
-            Int::from(1100i128)
-        );
-    }
-
-    #[test]
-    fn sub() {
-        assert_eq!(Int::from(0) - Int::from(0), Int::from(0));
-        assert_eq!(Int::from(5) - Int::from(7), Int::from(-2));
-        assert_eq!(Int::from(-5) - Int::from(7), Int::from(-12));
-        assert_eq!(Int::from(100) - Int::from(1000i128), Int::from(-900i128));
-        assert_eq!(Int::from(100i128) - Int::from(1000), Int::from(-900i128));
-        assert_eq!(
-            Int::from(100i128) - Int::from(1000i128),
-            Int::from(-900i128)
-        );
+        assert!(Int::ZERO.is_zero());
     }
 
     #[rstest]
@@ -731,7 +660,7 @@ mod integer_tests {
         let mut bytes = vec![0u8; 17];
         bytes[16] = 1;
         let big = Int::from_le_signed_bytes(&bytes);
-        let neg = -big;
+        let neg = big.neg();
         assert!(neg.is_negative());
         assert_eq!(neg.to_string(), "-340282366920938463463374607431768211456");
     }
@@ -777,7 +706,7 @@ mod integer_tests {
         assert!(big > small);
 
         // Negative heap < inline
-        let neg_big = -Int::from_le_signed_bytes(&bytes);
+        let neg_big = Int::from_le_signed_bytes(&bytes).neg();
         assert!(neg_big < small);
         assert!(small > neg_big);
     }

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -19,6 +19,9 @@ use std::hash::Hasher;
 /// # }
 /// ```
 /// To build a `List` incrementally, see [SequenceBuilder].
+///
+/// The inner [`Sequence`] is public to match `Value::List(Sequence)`, allowing
+/// direct construction and destructuring.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct List(pub Sequence);
 

--- a/src/types/lob.rs
+++ b/src/types/lob.rs
@@ -15,6 +15,9 @@ pub use crate::types::bytes::Bytes;
 /// assert_eq!(&blob, "hello".as_bytes());
 /// assert_eq!(blob.as_slice().len(), 5);
 /// ```
+///
+/// The inner [`Bytes`] is public to match `Value::Blob(Bytes)`, allowing
+/// direct construction and destructuring.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Blob(pub Bytes);
 
@@ -32,6 +35,9 @@ impl Blob {
 /// assert_eq!(&clob, "hello".as_bytes());
 /// assert_eq!(clob.as_slice().len(), 5);
 /// ```
+///
+/// The inner [`Bytes`] is public to match `Value::Clob(Bytes)`, allowing
+/// direct construction and destructuring.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Clob(pub Bytes);
 

--- a/src/types/sexp.rs
+++ b/src/types/sexp.rs
@@ -19,6 +19,9 @@ use std::hash::Hasher;
 /// # }
 /// ```
 /// To build a `SExp` incrementally, see [SequenceBuilder].
+///
+/// The inner [`Sequence`] is public to match `Value::SExp(Sequence)`, allowing
+/// direct construction and destructuring.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SExp(pub Sequence);
 

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -139,6 +139,7 @@ impl Timestamp {
     /// Converts a [`NaiveDateTime`] or [`DateTime<FixedOffset>`] to a Timestamp with the specified
     /// precision. If the precision is [`TimestampPrecision::Second`], nanosecond precision (the maximum
     /// supported by a [`Timelike`]) is assumed.
+    #[cfg(feature = "experimental-chrono")]
     pub fn from_datetime<D>(datetime: D, precision: TimestampPrecision) -> Timestamp
     where
         D: Datelike + Timelike + Into<Timestamp>,
@@ -149,6 +150,47 @@ impl Timestamp {
         }
         timestamp.precision = precision;
         timestamp
+    }
+
+    pub(crate) fn from_naive_datetime(date_time: NaiveDateTime) -> Self {
+        Timestamp {
+            date_time,
+            offset: None,
+            precision: TimestampPrecision::Second,
+            fractional_seconds: Some(Mantissa::Digits(9)),
+        }
+    }
+
+    pub(crate) fn from_fixed_offset_datetime(
+        fixed_offset_date_time: DateTime<FixedOffset>,
+    ) -> Self {
+        let date_time = fixed_offset_date_time.naive_utc();
+        let offset = Some(*fixed_offset_date_time.offset());
+        Timestamp {
+            date_time,
+            offset,
+            precision: TimestampPrecision::Second,
+            fractional_seconds: Some(Mantissa::Digits(9)),
+        }
+    }
+
+    pub(crate) fn try_to_naive_datetime(&self) -> IonResult<NaiveDateTime> {
+        if self.offset.is_some() {
+            return IonResult::illegal_operation(
+                "cannot convert a Timestamp with a known offset into a NaiveDateTime",
+            );
+        }
+        Ok(downconvert_to_naive_datetime_with_nanoseconds(self))
+    }
+
+    pub(crate) fn try_to_datetime_fixed_offset(&self) -> IonResult<DateTime<FixedOffset>> {
+        if self.offset.is_none() {
+            return IonResult::illegal_operation(
+                "cannot convert a Timestamp with an unknown offset into a DateTime<FixedOffset>",
+            );
+        }
+        let date_time = downconvert_to_naive_datetime_with_nanoseconds(self);
+        Ok(self.offset.unwrap().from_utc_datetime(&date_time))
     }
 
     /// If the precision is [TimestampPrecision::Second], returns the Decimal scale of this Timestamp's
@@ -391,14 +433,14 @@ impl Timestamp {
     pub(crate) fn format<W: std::fmt::Write>(&self, output: &mut W) -> IonResult<()> {
         let (offset_minutes, datetime) = if let Some(minutes) = self.offset {
             // Create a datetime with the appropriate offset that we can use for formatting.
-            let datetime: DateTime<FixedOffset> = self.clone().try_into()?;
+            let datetime: DateTime<FixedOffset> = self.try_to_datetime_fixed_offset()?;
             // Convert the offset to minutes --v
             (Some(minutes.local_minus_utc() / 60), datetime)
         } else {
             // Our timestamp has an unknown offset. Per the spec, this means it makes no
             // assertions about *where* it was recorded, but its fields are still in UTC.
             // Create a UTC datetime that we can use for formatting.
-            let datetime: NaiveDateTime = self.clone().try_into()?;
+            let datetime: NaiveDateTime = self.try_to_naive_datetime()?;
             let datetime: DateTime<FixedOffset> = datetime_at_offset(&datetime, 0);
             (None, datetime)
         };
@@ -568,7 +610,7 @@ impl Timestamp {
 
     /// Return a UTC timestamp for this [Timestamp]
     pub fn to_utc(&self) -> Timestamp {
-        self.date_time.into()
+        Self::from_naive_datetime(self.date_time)
     }
 
     /// Returns this Timestamp's fractional seconds in nanoseconds
@@ -976,12 +1018,16 @@ impl<T> TimestampBuilder<T> {
             let datetime_with_offset: DateTime<FixedOffset> =
                 Self::apply_offset(offset_minutes, self.fields_are_utc, datetime)?;
             // ...and convert the DateTime<FixedOffset> into a full Timestamp.
-            Timestamp::from_datetime(datetime_with_offset, self.precision)
+            Timestamp::from_fixed_offset_datetime(datetime_with_offset)
         } else {
             // Otherwise, there's not a known offset. We can directly convert our NaiveDateTime
             // into a full Timestamp.
-            Timestamp::from_datetime(datetime, self.precision)
+            Timestamp::from_naive_datetime(datetime)
         };
+        if self.precision < TimestampPrecision::Second {
+            timestamp.fractional_seconds = None;
+        }
+        timestamp.precision = self.precision;
 
         // Copy the fractional seconds from the builder to the Timestamp.
         if self.precision == TimestampPrecision::Second {
@@ -1211,61 +1257,35 @@ fn downconvert_to_naive_datetime_with_nanoseconds(timestamp: &Timestamp) -> Naiv
     }
 }
 
-// Allows a Timestamp with an unknown offset to be converted to a NaiveDateTime.
+#[cfg(feature = "experimental-chrono")]
 impl TryInto<NaiveDateTime> for Timestamp {
     type Error = IonError;
 
     fn try_into(self) -> Result<NaiveDateTime, Self::Error> {
-        if self.offset.is_some() {
-            return IonResult::illegal_operation(
-                "cannot convert a Timestamp with a known offset into a NaiveDateTime",
-            );
-        }
-        Ok(downconvert_to_naive_datetime_with_nanoseconds(&self))
+        self.try_to_naive_datetime()
     }
 }
 
+#[cfg(feature = "experimental-chrono")]
 impl TryInto<DateTime<FixedOffset>> for Timestamp {
     type Error = IonError;
 
     fn try_into(self) -> Result<DateTime<FixedOffset>, Self::Error> {
-        if self.offset.is_none() {
-            return IonResult::illegal_operation(
-                "cannot convert a Timestamp with an unknown offset into a DateTime<FixedOffset>",
-            );
-        }
-        let date_time = downconvert_to_naive_datetime_with_nanoseconds(&self);
-        Ok(self.offset.unwrap().from_utc_datetime(&date_time))
+        self.try_to_datetime_fixed_offset()
     }
 }
 
-// Allows a NaiveDateTime to be converted to a Timestamp with an unknown offset.
+#[cfg(feature = "experimental-chrono")]
 impl From<NaiveDateTime> for Timestamp {
     fn from(date_time: NaiveDateTime) -> Self {
-        Timestamp {
-            date_time,
-            offset: None,
-            precision: TimestampPrecision::Second,
-            fractional_seconds: Some(Mantissa::Digits(9)),
-        }
+        Self::from_naive_datetime(date_time)
     }
 }
 
-// Allows a DateTime<FixedOffset> to be converted to a Timestamp with the correct offset in minutes.
+#[cfg(feature = "experimental-chrono")]
 impl From<DateTime<FixedOffset>> for Timestamp {
     fn from(fixed_offset_date_time: DateTime<FixedOffset>) -> Self {
-        // Discard the offset
-        let date_time = fixed_offset_date_time.naive_utc();
-        // Get a copy of the offset to store separately
-        let offset = Some(*fixed_offset_date_time.offset());
-        let precision = TimestampPrecision::Second;
-        let fractional_seconds = Some(Mantissa::Digits(9));
-        Timestamp {
-            date_time,
-            offset,
-            precision,
-            fractional_seconds,
-        }
+        Self::from_fixed_offset_datetime(fixed_offset_date_time)
     }
 }
 
@@ -1559,6 +1579,7 @@ mod timestamp_tests {
         Ok(())
     }
 
+    #[cfg(feature = "experimental-chrono")]
     #[test]
     fn test_timestamp_try_into_naive_datetime() -> IonResult<()> {
         let timestamp = TimestampBuilder::with_ymd(2021, 4, 6)
@@ -1573,6 +1594,7 @@ mod timestamp_tests {
         Ok(())
     }
 
+    #[cfg(feature = "experimental-chrono")]
     #[test]
     fn test_timestamp_try_into_naive_datetime_fractional_seconds() -> IonResult<()> {
         let timestamp = TimestampBuilder::with_ymd(2021, 4, 6)
@@ -1590,6 +1612,7 @@ mod timestamp_tests {
         Ok(())
     }
 
+    #[cfg(feature = "experimental-chrono")]
     #[test]
     fn test_timestamp_try_into_naive_datetime_error() -> IonResult<()> {
         let timestamp = TimestampBuilder::with_ymd(2021, 1, 1)
@@ -1602,6 +1625,7 @@ mod timestamp_tests {
         Ok(())
     }
 
+    #[cfg(feature = "experimental-chrono")]
     #[test]
     fn test_timestamp_try_into_fixed_offset_datetime() -> IonResult<()> {
         let timestamp = TimestampBuilder::with_ymd(2021, 4, 6)
@@ -1623,6 +1647,7 @@ mod timestamp_tests {
         Ok(())
     }
 
+    #[cfg(feature = "experimental-chrono")]
     #[test]
     fn test_timestamp_try_into_fixed_offset_datetime_fractional_seconds() -> IonResult<()> {
         let timestamp = TimestampBuilder::with_ymd(2021, 4, 6)
@@ -1647,6 +1672,7 @@ mod timestamp_tests {
         Ok(())
     }
 
+    #[cfg(feature = "experimental-chrono")]
     #[test]
     fn test_timestamp_try_into_datetime_fixedoffset_error() -> IonResult<()> {
         let timestamp = TimestampBuilder::with_ymd(2021, 1, 1)

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -1,4 +1,4 @@
-use crate::decimal::coefficient::Sign;
+use crate::decimal::Sign;
 use crate::ion_data::{IonDataHash, IonDataOrd, IonEq};
 use crate::result::{IonError, IonFailure, IonResult};
 use crate::types::{CountDecimalDigits, Decimal};

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -6,7 +6,6 @@ use chrono::{
     DateTime, Datelike, FixedOffset, LocalResult, NaiveDate, NaiveDateTime, TimeZone, Timelike,
 };
 use std::cmp::Ordering;
-use std::convert::TryInto;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
@@ -1296,10 +1295,9 @@ mod timestamp_tests {
     use crate::result::IonResult;
     use crate::types::Mantissa;
     use crate::{Decimal, Int, Timestamp, TimestampPrecision};
-    use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, TimeZone, Timelike};
+    use chrono::NaiveDateTime;
     use rstest::*;
     use std::cmp::Ordering;
-    use std::convert::TryInto;
     use std::io::Write;
     use std::ops::Mul;
     use std::str::FromStr;

--- a/src/write_config.rs
+++ b/src/write_config.rs
@@ -63,7 +63,7 @@ impl WriteConfig<TextEncoding_1_0> {
 }
 
 impl WriteConfig<TextEncoding_1_1> {
-    pub fn new(text_kind: TextFormat) -> Self {
+    pub(crate) fn new(text_kind: TextFormat) -> Self {
         Self {
             kind: WriteConfigKind::Text(TextWriteConfig { text_kind }),
             phantom_data: Default::default(),
@@ -81,7 +81,7 @@ impl WriteConfig<BinaryEncoding_1_0> {
 }
 
 impl WriteConfig<BinaryEncoding_1_1> {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             kind: WriteConfigKind::Binary(BinaryWriteConfig),
             phantom_data: Default::default(),

--- a/tests/conformance_dsl/model.rs
+++ b/tests/conformance_dsl/model.rs
@@ -1,7 +1,7 @@
 use super::{
     parse_bytes_exp, parse_text_exp, Clause, ClauseType, ConformanceErrorKind, Context, InnerResult,
 };
-use ion_rs::decimal::coefficient::Coefficient;
+use ion_rs::decimal::Coefficient;
 use ion_rs::{v1_0::RawValueRef, Int, LazyRawValue, List, SExp, SymbolId, SymbolRef, Value};
 use ion_rs::{Decimal, Element, IonType, Sequence, Timestamp, ValueRef};
 

--- a/tests/ion_tests/lazy_element_ion_tests.rs
+++ b/tests/ion_tests/lazy_element_ion_tests.rs
@@ -1,13 +1,14 @@
 #![cfg(feature = "experimental-reader-writer")]
 
+use super::Format;
 use crate::good_round_trip;
 use crate::ion_tests::{
     bad, equivs, non_equivs, ElementApi, SkipList, ELEMENT_EQUIVS_SKIP_LIST,
     ELEMENT_GLOBAL_SKIP_LIST, ELEMENT_ROUND_TRIP_SKIP_LIST,
 };
 use ion_rs::Reader;
+use ion_rs::TextFormat;
 use ion_rs::{AnyEncoding, IonResult};
-use ion_rs::{Format, TextFormat};
 use test_generator::test_resources;
 
 struct LazyReaderElementApi;

--- a/tests/ion_tests/mod.rs
+++ b/tests/ion_tests/mod.rs
@@ -10,9 +10,15 @@ use std::path::MAIN_SEPARATOR_STR as PATH_SEPARATOR;
 use ion_rs::v1_0;
 use ion_rs::Writer;
 use ion_rs::{
-    Element, ElementReader, ElementWriter, Format, IonData, IonError, IonResult, SExp, Sequence,
-    Symbol, Value,
+    Element, ElementReader, ElementWriter, IonData, IonError, IonResult, SExp, Sequence, Symbol,
+    TextFormat, Value,
 };
+
+#[derive(Debug, Copy, Clone)]
+pub enum Format {
+    Text(TextFormat),
+    Binary,
+}
 
 pub mod lazy_element_ion_tests;
 
@@ -65,7 +71,6 @@ pub fn serialize(format: Format, elements: &Sequence) -> IonResult<Vec<u8>> {
             binary_writer.write_elements(elements)?;
             buffer = binary_writer.close()?;
         }
-        _ => unimplemented!("requested format '{:?}' is not supported", format),
     };
     Ok(buffer)
 }

--- a/tests/ion_tests_1_1.rs
+++ b/tests/ion_tests_1_1.rs
@@ -55,9 +55,10 @@ impl ElementApi for LazyReaderElementApi {
 // TODO: Update to write as Ion 1.1
 mod good_round_trip {
     use super::*;
-    use ion_rs::Format::Text;
+    use crate::ion_tests::Format;
     use ion_rs::TextFormat;
     use test_generator::test_resources;
+    use Format::Text;
 
     #[test_resources("ion-tests/iontestdata_1_1/good/**/*.ion")]
     fn round_trip(file_name: &str) {


### PR DESCRIPTION
Reduces the public API surface in preparation for v1.0.0. The goal is a minimal stable surface that we can grow from.
Items can always be added in minor releases but cannot be removed after 1.0.

This PR contains three commits:

1. `79484b5` — Gate, remove, or reorganize public API items
2. `f9858cb` — Remove arithmetic trait impls from numeric types
3. `8bf799c` — Gate chrono conversions behind `experimental-chrono`

If you're interested, the full output of `cargo public-api` is [available here](https://gist.github.com/popematt/022a994afe65de6cba2f2f92d6dfa804), but what follows is a summary of the changes and the reasoning for each.

----

#### Gate reader/writer-only types behind `experimental-reader-writer` (79484b5)

Several types were unconditionally public despite being useless without the streaming Reader/Writer. Consistent with the approach established in #576:

- `AnyEncoding` — only meaningful when constructing a `Reader`
- `ElementReader`, `ElementWriter` — only have implementations when
  the Reader/Writer is available
- `SymbolId` — no stable API method accepts or returns it
- `Catalog`, `EmptyCatalog`, `MapCatalog` — only consumed by `Reader`
- `SharedSymbolTable` — only useful with catalogs

#### Gate tooling types behind `experimental-tooling-apis` (79484b5)

`HasRange`, `HasSpan`, and `Span` expose encoding-level byte details.
Every implementor is already behind this feature flag, and users who need position info have `SourceLocation` in the stable API (#810).

#### Remove vestigial items (79484b5)

- `Format` enum — discussed in #246 but never wired up; zero usages
- `IonResultIterExt` — no known internal or external users

#### Restrict visibility of implementation details (79484b5)

- `OwnedSequenceIterator` — users receive it via `IntoIterator`, never need to name it
- `WriteConfig<*Encoding_1_1>::new()` — Ion 1.1 types not accessible without their feature flag

#### Fix un-nameable types in public signatures (79484b5)

- `SourceLocation` — re-exported at `ion_rs::SourceLocation` (#809)
- `IonInput` — re-exported at `ion_rs::IonInput`; enables generic functions over Ion input sources. Documented as sealed for now. (Long term intention is #783, so making it public but sealed is fine for now. )

#### Clean up decimal module exports (79484b5)

- `Coefficient` and `Sign` moved to `ion_rs::decimal::Coefficient`
  and `ion_rs::decimal::Sign`
- `coefficient` submodule now `pub(crate)`

#### Remove leaked trait bounds from `ConversionOperationError` (79484b5)

Internal traits (`ValueTypeExpectation`, `TypeExpectation`) removed
from the struct definition; moved to impl blocks only.

#### Prevent implicit feature flags (79484b5)

`digest` and `sha2` changed to `dep:digest`, `dep:sha2` so they can
only be enabled via `experimental-ion-hash`.

#### Remove arithmetic traits from `Int`, `UInt`, `Decimal` (f9858cb)

`Add`, `Sub`, `Neg`, and `num_traits::Zero` were unused outside of
tests and exposed `num_traits` as a public dependency. Issues #970
and #286 ask for arithmetic but have no design resolution —
committing now would lock in a premature decision. Inherent
`is_zero()` methods replace `Zero::is_zero()`.

#### Gate chrono behind `experimental-chrono` (8bf799c)

Chrono is an implementation detail (#838) that coupled ion-rs's
SemVer to chrono's. All `From`/`TryInto` impls between `Timestamp`
and chrono types now require the feature flag. Internal code uses
`pub(crate)` helper methods.

**Potential correctness concern:** The `From<NaiveDateTime>` conversion
is semantically suspect — Ion timestamps with unknown offset still
represent UTC instants, but `NaiveDateTime` carries no UTC guarantee.
This should be investigated before promoting the feature out of
experimental.

----


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
