### PR TITLE
Version bump to v1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
     "**/ion-tests/iontestdata/**",
     "*.pdf"
 ]
-version = "1.0.0-rc.12"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.82"
 


### PR DESCRIPTION
*Issue #, if available:*

None.

*Description of changes:*

Release v1.0.0, the first stable version of `ion-rust`.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
