### PR TITLE
Fix quadratic source-location lookup in the text reader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,10 @@ name = "byod"
 harness = false
 bench = false
 
+[[bench]]
+name = "text_location_throughput"
+harness = false
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/benches/text_location_throughput.rs
+++ b/benches/text_location_throughput.rs
@@ -1,0 +1,67 @@
+//! Measures read throughput (bytes/second) for text Ion, exercising the source-location
+//! row lookup in `SourceLocationState::calculate_location_for_span`.
+//!
+//! `Element::read_all` attaches a `SourceLocation` to every value it materializes, so each
+//! value costs one offset-to-row resolution against a table of row start offsets.
+//!
+//! Data:
+//! * `ints_5000_multiline` / `ints_5000_oneline` -- the same 5000 integers in the same number of
+//!   bytes, differing only in row count (5000 vs 1). Isolates the row lookup from parsing. Both
+//!   are generated in-process from one source, so the byte counts match structurally and these
+//!   two cases always run.
+//!
+//! Criterion reports throughput in bytes/second because each case sets `Throughput::Bytes`,
+//! which makes the differently-sized inputs directly comparable.
+
+use criterion::{criterion_group, criterion_main};
+
+mod benchmark {
+    use criterion::{black_box, Criterion, Throughput};
+    use ion_rs::Element;
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    /// 5000 integers, joined by `separator`. With `"\n"` this is a 5000-row input; with `" "` it
+    /// is a single row of the same integers, so the two differ only in row count.
+    fn generated_ints(separator: &str) -> String {
+        let mut data = (0..5000u64)
+            .map(|i| (1_000_000_000 + i * 7919).to_string())
+            .collect::<Vec<_>>()
+            .join(separator);
+        data.push('\n');
+        data
+    }
+
+    pub fn criterion_benchmark(c: &mut Criterion) {
+        // The generated cases are the controlled comparison, so they go first: they always run,
+        // and they are the cheapest.
+        let generated_cases = [
+            ("ints_5000_multiline", generated_ints("\n")),
+            ("ints_5000_oneline", generated_ints(" ")),
+        ];
+
+        let mut group = c.benchmark_group("text location throughput");
+        for (id, data) in &generated_cases {
+            bench_case(&mut group, id, data);
+        }
+
+        group.finish();
+    }
+
+    fn bench_case(
+        group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+        id: &str,
+        data: &str,
+    ) {
+        group.throughput(Throughput::Bytes(data.len() as u64));
+        group.bench_function(id, |b| {
+            b.iter(|| {
+                let elements = Element::read_all(data).unwrap();
+                black_box(elements);
+            })
+        });
+    }
+}
+
+criterion_group!(benches, benchmark::criterion_benchmark);
+criterion_main!(benches);

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -280,6 +280,13 @@ impl<'top> EncodingContextRef<'top> {
     }
 
     pub fn location_for_span(&self, span: Option<Span<'_>>) -> Option<SourceLocation> {
+        // SAFETY: `io_buffer_source` is an `UnsafeCell` so that the `StreamingRawReader` can set it
+        //         after each top-level value; it is only ever mutated between `'top` lifetimes, so
+        //         no mutation can be in flight while this reference is live. The reference does not
+        //         escape this function -- the returned `SourceLocation` is owned and borrows nothing
+        //         from the `IoBufferSource` -- so callers cannot hold it across a mutation. That is
+        //         what allows `impl TryFrom<LazyValue> for Element` to hoist its `location()` call
+        //         above `read()`.
         match unsafe { &*self.io_buffer_source.get() } {
             IoBufferSource::IoBuffer(ref buffer) => Some(
                 buffer

--- a/src/lazy/value.rs
+++ b/src/lazy/value.rs
@@ -304,14 +304,25 @@ impl<'top, D: Decoder> TryFrom<LazyValue<'top, D>> for Element {
     type Error = IonError;
 
     fn try_from(lazy_value: LazyValue<'top, D>) -> Result<Self, Self::Error> {
+        // Resolve this value's location before reading it, because reading a container
+        // recursively materializes its children. Doing this first means locations are
+        // requested in ascending offset order, which is what allows the row lookup in
+        // `SourceLocationState::calculate_location_for_span` to be O(1) amortized.
+        //
+        // INVARIANT: this call must stay ahead of `read()`. The ordering is load-bearing for
+        // performance, not correctness: moving it below `read()?`, or inlining it into the
+        // `with_location(location)` calls below, changes no result but makes every container's
+        // lookup arrive after its children's, so each one takes the O(log rows) binary search
+        // fallback instead of the cursor's fast path. `no_fallback_lookups_when_reading_elements`
+        // guards this. The hoist is sound with respect to the `unsafe` read inside `location()`
+        // only because a `SourceLocation` is owned and borrows nothing from the reader's input.
+        let location = lazy_value.location();
         let value: Value = lazy_value.read()?.try_into()?;
         if lazy_value.has_annotations() {
             let annotations: Annotations = lazy_value.annotations().try_into()?;
-            Ok(value
-                .with_annotations(annotations)
-                .with_location(lazy_value.location()))
+            Ok(value.with_annotations(annotations).with_location(location))
         } else {
-            Ok(<Value as Into<Element>>::into(value).with_location(lazy_value.location()))
+            Ok(<Value as Into<Element>>::into(value).with_location(location))
         }
     }
 }
@@ -484,8 +495,10 @@ mod tests {
     use std::io;
     use std::io::{Cursor, Read};
 
+    use crate::element::reader::ElementReader;
     use crate::lazy::binary::test_utilities::to_binary_ion;
     use crate::lazy::expanded::lazy_element::LazyElement;
+    use crate::lazy::streaming_raw_reader::{IoBufferHandle, IonSlice};
     use crate::location::SourceLocation;
     use crate::{
         ion_list, ion_sexp, ion_struct, v1_0, AnyEncoding, Decimal, Decoder, IonResult, IonType,
@@ -789,6 +802,105 @@ mod tests {
             .filter_map(|it| it.row_column())
             .collect();
         assert_eq!(&expected_locations, actual_locations.as_slice());
+        Ok(())
+    }
+
+    /// The locations of `Element`s materialized by `Element::read_all`, unlike those of the
+    /// `LazyElement`s above, are attached by `impl TryFrom<LazyValue> for Element`.
+    #[rstest]
+    #[case::values_in_multiline_struct("{\n  foo:1,\n  bar:2,\n}", [(1, 1), (2, 7), (3, 7)])]
+    #[case::values_in_multiline_lists(
+        "[\n  1,\n  2,\n  3,\n  4\n]",
+        [(1, 1), (2, 3), (3, 3), (4, 3), (5, 3)],
+    )]
+    #[case::deeply_nested_containers(
+        "{\n  foo:{a:1,b:2},\n  bar:[a,b,c],\n  baz:(foo (bar)\n           (quux)),\n}",
+        // {
+        [(1, 1),
+        // foo: {       a:1,     b:2    },
+               (2, 7), (2, 10), (2, 14),
+        // bar: [       a,      b,       c      ],
+               (3, 7), (3, 8), (3, 10), (3, 12),
+        // baz: (       foo     (        bar    )
+               (4, 7), (4, 8), (4, 12), (4, 13),
+        //                      (        quux   ) )
+                               (5, 12), (5, 13),
+        // }
+        ],
+    )]
+    #[case::multiple_top_level_containers(
+        "{foo:1,bar:2}\n{\n  foo:1,\n  bar:[a,b,c],\n}",
+        [(1, 1), (1, 6), (1, 12), (2, 1), (3, 7), (4, 7), (4, 8), (4, 10), (4, 12)],
+    )]
+    fn element_locations<const N: usize>(
+        #[case] ion_text: &str,
+        #[case] expected_locations: [(usize, usize); N],
+    ) -> IonResult<()> {
+        let mut actual_locations = vec![];
+        for element in Element::read_all(ion_text)?.elements() {
+            collect_element_locations(element, &mut actual_locations)?;
+        }
+        assert_eq!(
+            expected_locations.map(Some).as_slice(),
+            actual_locations.as_slice()
+        );
+        Ok(())
+    }
+
+    /// Appends the location of `element` and of each of its descendants, in depth-first order.
+    fn collect_element_locations(
+        element: &Element,
+        locations: &mut Vec<Option<(usize, usize)>>,
+    ) -> IonResult<()> {
+        locations.push(element.location().row_column());
+        match element.ion_type() {
+            IonType::Struct => {
+                for (_name, value) in element.expect_struct()? {
+                    collect_element_locations(value, locations)?;
+                }
+            }
+            IonType::List => {
+                for value in element.expect_list()?.elements() {
+                    collect_element_locations(value, locations)?;
+                }
+            }
+            IonType::SExp => {
+                for value in element.expect_sexp()?.elements() {
+                    collect_element_locations(value, locations)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// The ordering in `impl TryFrom<LazyValue> for Element` -- resolving a value's location before
+    /// recursively materializing its children -- is what keeps the row lookup in
+    /// `SourceLocationState::calculate_location_for_span` on its amortized-O(1) fast path. Moving
+    /// the `location()` call after `read()` produces identical `Element`s, so only the number of
+    /// binary-search fallbacks can detect it.
+    #[rstest]
+    #[case::nested_containers(
+        "{\n  foo:{a:1,b:2},\n  bar:[a,b,c],\n  baz:(foo (bar)\n           (quux)),\n}"
+    )]
+    #[case::multiple_top_level_containers(
+        "{foo:1,bar:2}\n{\n  foo:1,\n  bar:[a,b,c],\n}\n{foo:1,bar:2}"
+    )]
+    fn locations_are_requested_in_ascending_order(#[case] ion_text: &str) -> IonResult<()> {
+        // Initializing the location state up front hands back a handle to the same shared state the
+        // reader will use, which is otherwise unreachable once the input has been moved into it.
+        let input = IonSlice::new(ion_text);
+        let location_state = input.source_location_state().clone();
+        let elements: Vec<Element> = Reader::new(AnyEncoding, input)?
+            .into_elements()
+            .collect::<IonResult<_>>()?;
+        assert!(!elements.is_empty());
+        assert_eq!(
+            0,
+            location_state.fallback_lookups(),
+            "locations were requested out of order; is `location()` still called before `read()` \
+             in `impl TryFrom<LazyValue> for Element`?"
+        );
         Ok(())
     }
 

--- a/src/location.rs
+++ b/src/location.rs
@@ -1,5 +1,5 @@
 use crate::Span;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 /// Represents the source location (row, column) of this element in the original Ion text.
@@ -81,26 +81,95 @@ mod source_location_tests {
 
 /// Encapsulates location tracking state and functionality.
 ///
-/// This struct is cheap to clone because all of its state is behind a reference-counted pointer.
+/// This struct is cheap to clone because all of its state is behind a single reference-counted
+/// pointer, which is shared with every clone.
 #[derive(Debug, Clone)]
 pub(crate) struct SourceLocationState {
-    /// A non-empty vec containing the offset of the start of each row.
-    /// The first row always starts at offset 0.
-    row_start_offsets: Rc<RefCell<Vec<usize>>>,
+    state: Rc<SourceLocationStateInner>,
 }
+
+/// The state shared by a [`SourceLocationState`] and all of its clones.
+///
+/// Both fields live behind the same `Rc` so that it is impossible to construct or replace one
+/// without the other; see the invariants on `last_row`.
+#[derive(Debug)]
+struct SourceLocationStateInner {
+    /// A non-empty vec containing the offset of the start of each row.
+    ///
+    /// INVARIANTS:
+    /// * The first row always starts at offset 0.
+    /// * The offsets are sorted in ascending order. [`SourceLocationState::calculate_location_for_span`]
+    ///   binary searches this vec, which is meaningful only if it is sorted, and subtracts the
+    ///   located row's offset from the span's start, which would underflow if it were not.
+    /// * The vec is append-only: rows are never removed, reordered, or rewritten, so a row index
+    ///   that was once in bounds remains in bounds.
+    row_start_offsets: RefCell<Vec<usize>>,
+    /// The 0-based index into `row_start_offsets` that was resolved by the most recent call to
+    /// [`SourceLocationState::calculate_location_for_span`] -- made through this
+    /// `SourceLocationState` or any of its clones, as the cache is shared with all of them. (The
+    /// [`SourceLocation`] that call returns is 1-based; this is the raw vec index.) It is
+    /// used as the starting point for the next lookup, which then only has to walk forward.
+    ///
+    /// Lookups that arrive in ascending order of span offset are O(1) amortized, because the cursor
+    /// advances at most once per row per ascending run. `impl TryFrom<LazyValue> for Element`
+    /// guarantees that order for literal-backed values by resolving a container's location before
+    /// reading -- and thereby recursively materializing -- its children. Lookups that arrive out of
+    /// order still get correct results, but pay for a binary search; Ion 1.1 template argument
+    /// reordering is a known non-ascending case, because `ExpandedValueSource::via_variable`
+    /// preserves the original argument's span, so a template body that references its parameters
+    /// out of positional order yields descending spans. (This is a separate property from the
+    /// monotonically non-decreasing `stream_offset` that
+    /// [`SourceLocationState::update_from_source`] requires: that one is an invariant, this one is
+    /// only an optimization.)
+    ///
+    /// INVARIANT: this is always a valid index into `row_start_offsets`, because that vec is
+    /// append-only and the two fields are always constructed and replaced together.
+    ///
+    /// The value is purely an optimization: any value satisfying the invariant above still yields
+    /// a correct result, because the cached row is re-validated against each span before it is
+    /// used.
+    last_row: Cell<usize>,
+    /// The number of lookups that could not start from `last_row` and had to binary search
+    /// `row_start_offsets` instead.
+    ///
+    /// Because the cursor is only an optimization, nothing observable depends on this count; it
+    /// exists so that tests can assert the ascending-order property described on `last_row`, which
+    /// no other assertion can detect. It is `#[cfg(test)]` so that production builds do not pay
+    /// for it.
+    #[cfg(test)]
+    fallback_lookups: Cell<usize>,
+}
+
 impl SourceLocationState {
     pub fn new() -> Self {
         Self {
-            row_start_offsets: Rc::from(RefCell::new(vec![0])),
+            state: Rc::new(SourceLocationStateInner {
+                row_start_offsets: RefCell::new(vec![0]),
+                last_row: Cell::new(0),
+                #[cfg(test)]
+                fallback_lookups: Cell::new(0),
+            }),
         }
     }
 
+    /// The number of lookups made through this `SourceLocationState` or any of its clones that had
+    /// to fall back to a binary search. See `SourceLocationStateInner::fallback_lookups`.
+    #[cfg(test)]
+    pub(crate) fn fallback_lookups(&self) -> usize {
+        self.state.fallback_lookups.get()
+    }
+
     /// Updates the location tracking state from the given source data.
+    ///
+    /// `stream_offset` is the offset of `data` within the stream as a whole. Callers must supply
+    /// successive pieces of the stream with monotonically non-decreasing `stream_offset` values;
+    /// otherwise the ascending-order invariant of `row_start_offsets` would be violated.
     pub fn update_from_source<T: AsRef<[u8]>>(&mut self, stream_offset: usize, data: T) {
         let data = data.as_ref();
         if !data.is_empty() {
             let newlines = memchr::memchr_iter(b'\n', data);
-            self.row_start_offsets
+            self.state
+                .row_start_offsets
                 .borrow_mut()
                 .extend(newlines.map(|it| it + stream_offset + 1));
         }
@@ -108,17 +177,133 @@ impl SourceLocationState {
 
     pub fn calculate_location_for_span(&self, span: Span<'_>) -> SourceLocation {
         let range = span.range();
-        let (row, row_start_offset) = self
-            .row_start_offsets
-            .borrow()
-            .iter()
-            .copied()
-            .enumerate()
-            .rfind(|&(_, newline_offset)| newline_offset <= range.start)
-            // Always safe to unwrap because of the invariant that `newlines` is never empty.
-            .unwrap();
+        let row_start_offsets = self.state.row_start_offsets.borrow();
+
+        // `row_start_offsets` is sorted, so the row containing `range.start` is the last one whose
+        // offset does not exceed it. `impl TryFrom<LazyValue> for Element` requests locations in
+        // ascending order for literal-backed values, so the cached row is normally the answer or is
+        // a short walk behind it. (Ion 1.1 template argument reordering is a known exception; see
+        // the docs on `last_row`.)
+        let last_row = self.state.last_row.get();
+        let row = if row_start_offsets
+            .get(last_row)
+            .is_some_and(|&start| start <= range.start)
+        {
+            // Advance while the following row also starts at or before `range.start`. Within an
+            // ascending run of lookups the cursor only moves forward, so it advances at most `rows`
+            // times over the whole run -- O(1) amortized per lookup, and a single comparison when
+            // consecutive spans share a row. (The `else` branch below can reset the cursor
+            // backwards, which starts a new run; a forward walk after such a reset is O(rows).)
+            // For a fixed-slice input, where the whole row index is built up front, searching
+            // from scratch on every lookup would instead cost O(log rows) at best and O(rows) for
+            // a linear scan, making a complete read O(rows * spans).
+            let mut row = last_row;
+            while row_start_offsets
+                .get(row + 1)
+                .is_some_and(|&next| next <= range.start)
+            {
+                row += 1;
+            }
+            row
+        } else {
+            // `range.start` precedes the cached row, so the caller is not querying in ascending
+            // order. Still correct, just without the amortized bound.
+            //
+            // `partition_point` counts the offsets at or before `range.start`; the row index is one
+            // less. The count is always at least 1 because of the invariant that the first row
+            // starts at offset 0.
+            #[cfg(test)]
+            self.state
+                .fallback_lookups
+                .set(self.state.fallback_lookups.get() + 1);
+            row_start_offsets.partition_point(|&offset| offset <= range.start) - 1
+        };
+
+        self.state.last_row.set(row);
+        let row_start_offset = row_start_offsets[row];
+        debug_assert!(
+            row_start_offset <= range.start,
+            "row {row} starts at offset {row_start_offset}, which is after the span's start ({})",
+            range.start
+        );
         let column = range.start - row_start_offset;
         // Both of these are 0-based counts, and must be incremented to be 1-based row/column
         SourceLocation::new(row + 1, column + 1)
+    }
+}
+
+#[cfg(test)]
+mod source_location_state_tests {
+    use crate::location::SourceLocationState;
+    use crate::Span;
+    use rstest::rstest;
+
+    /// `"a\nbb\n\nccc"` -- rows start at offsets 0, 2, 5, and 6.
+    fn state() -> SourceLocationState {
+        let mut state = SourceLocationState::new();
+        state.update_from_source(0, b"a\nbb\n\nccc");
+        state
+    }
+
+    fn location_at(state: &SourceLocationState, offset: usize) -> Option<(usize, usize)> {
+        state
+            .calculate_location_for_span(Span::with_offset(offset, b""))
+            .row_column()
+    }
+
+    #[rstest]
+    #[case::first_row_start(0, (1, 1))]
+    #[case::first_row_terminator(1, (1, 2))]
+    #[case::second_row_start(2, (2, 1))]
+    #[case::second_row_interior(3, (2, 2))]
+    #[case::second_row_terminator(4, (2, 3))]
+    #[case::empty_row(5, (3, 1))]
+    #[case::last_row_start(6, (4, 1))]
+    #[case::last_row_interior(8, (4, 3))]
+    fn location_for_offset(#[case] offset: usize, #[case] expected: (usize, usize)) {
+        assert_eq!(Some(expected), location_at(&state(), offset));
+    }
+
+    /// Lookups are cached across calls, so a sequence of them must produce the same locations as
+    /// the same lookups made in isolation, regardless of the order they arrive in. Readers query
+    /// offsets in increasing order, but nothing in the API requires it. Each case is a sequence of
+    /// `(offset, expected location)` pairs applied to a single state instance; each pair is also
+    /// checked against a state whose cache is cold.
+    #[rstest]
+    #[case::ascending([(0, (1, 1)), (1, (1, 2)), (2, (2, 1)), (3, (2, 2)), (4, (2, 3)), (5, (3, 1)), (6, (4, 1)), (8, (4, 3))])]
+    #[case::descending([(8, (4, 3)), (6, (4, 1)), (5, (3, 1)), (4, (2, 3)), (3, (2, 2)), (2, (2, 1)), (1, (1, 2)), (0, (1, 1))])]
+    #[case::repeated_same_row([(6, (4, 1)), (8, (4, 3)), (6, (4, 1)), (8, (4, 3)), (6, (4, 1))])]
+    #[case::alternating_distant_rows([(0, (1, 1)), (8, (4, 3)), (1, (1, 2)), (6, (4, 1)), (2, (2, 1)), (5, (3, 1))])]
+    // Each lookup below must reject the cached row and resolve an earlier one.
+    #[case::backward_cache_misses([(8, (4, 3)), (2, (2, 1)), (0, (1, 1))])]
+    fn lookups_are_order_independent<const N: usize>(
+        #[case] lookups: [(usize, (usize, usize)); N],
+    ) {
+        let warm_state = state();
+        for (offset, expected) in lookups {
+            assert_eq!(
+                Some(expected),
+                location_at(&warm_state, offset),
+                "offset {offset} was wrong when the cache was warm"
+            );
+            assert_eq!(
+                Some(expected),
+                location_at(&state(), offset),
+                "offset {offset} was wrong when the cache was cold"
+            );
+        }
+    }
+
+    /// Rows can be appended after lookups have already populated the cache.
+    #[test]
+    fn location_after_appending_source() {
+        let mut state = state();
+        assert_eq!(Some((4, 3)), location_at(&state, 8));
+        state.update_from_source(9, b"\ndddd");
+        assert_eq!(Some((4, 3)), location_at(&state, 8));
+        assert_eq!(Some((5, 2)), location_at(&state, 11));
+        // Resolving an offset that precedes the cached row forces the binary search fallback to run
+        // over the grown offset table.
+        assert_eq!(Some((2, 2)), location_at(&state, 3));
     }
 }


### PR DESCRIPTION
### Problem

`Element::read_all()` on Ion text scales as O(rows × values) (effectively quadratic for pretty-printed text) instead of O(bytes). Every materialized value converts its byte offset into a (row, column) pair, and `calculate_location_for_span` searched the list of row offsets linearly from the end with `rfind`. Since readers consume a stream from the front, the earliest values scan nearly the entire vector — the cost per lookup is highest exactly where it is paid most often.

On pretty-printed input with many rows this dominates runtime: profiling shows 96% of samples in `location_for_span` on a 91,875-row file, while it does not appear at all on the same data re-encoded onto a single row. Therefore, the trigger is row count, not whitespace.

### Solution

Two changes eliminate the quadratic factor:

1. **Forward-advancing cursor.** Replace the `rfind` reverse linear scan with a monotonic cursor
  that walks forward from a cached row index, falling back to `partition_point` (O(log rows)) only
  when a query arrives out of ascending order. Within an ascending run the cursor advances at most
  `rows` times total — O(1) amortized per lookup.
2. **Ascending-order guarantee.** Hoist `lazy_value.location()` above `lazy_value.read()?` in
  `impl TryFrom<LazyValue> for Element`, so a container resolves its own location before
  recursively materializing its children. This makes location queries arrive in ascending offset
  order, which is what allows the cursor to be amortized rather than logarithmic.

The ordering contract is guarded by a `#[cfg(test)]` fallback counter with an end-to-end test that fails if the hoist is reverted. Coverage for `Element::location()` values through nested traversal is also added (previously unasserted anywhere in the crate).

### Results

I was able to run benchmarks against a minimal reproduction of the problem in addition to my original workload. For the minimal reproduction, I created a file with 5000 top-level integers both pretty-printed and compact versions, but you could also reproduce similar results with almost any other sufficiently large Ion stream.

Measured with `criterion`, `Throughput::Bytes`, `Element::read_all`:

| Input                 |     Bytes |   Rows | Before (MiB/s) | After (MiB/s) | Change   |
| --------------------- | ---------:| ------:| --------------:| -------------:| -----:|
| `ints_5000_oneline`   |    55,001 |      1 |          46.27 |         48.50 | +5% |
| `ints_5000_multiline` |    55,000 |  5,000 |          12.15 |         47.56 | +290%  |
| My original workload   | 1,831,190 | 91,875 |           2.62 |         79.55 | +3040% |

The two integer files isolate the effect: same values, same byte count, differing only in row count — before, the multiline file was 3.8× slower; after, the difference in throughput is ~2%. Single-row inputs have no regression from this change. My original workload, a much larger file with lots of pretty-printed nested data, is way better now.

This will also have significant _cumulative_ benefits for Ion Schema Rust users, given that hand-authored Ion Schema files are going to be formatted most like pretty-printed text and are more likely to contain comments that result in even more newlines.

----

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
