### PR TITLE
Substitute padded tables for unresolvable imports with max_id

### DIFF
--- a/api/default.txt
+++ b/api/default.txt
@@ -765,6 +765,12 @@ pub fn ion_rs::SymbolRef<'a>::with_text(&'a str) -> ion_rs::SymbolRef<'a>
 pub fn ion_rs::SymbolRef<'a>::with_unknown_text() -> Self
 impl core::borrow::Borrow<str> for ion_rs::SymbolRef<'_>
 pub fn ion_rs::SymbolRef<'_>::borrow(&self) -> &str
+impl core::cmp::Ord for ion_rs::SymbolRef<'_>
+pub fn ion_rs::SymbolRef<'_>::cmp(&self, &Self) -> core::cmp::Ordering
+impl core::cmp::PartialEq for ion_rs::SymbolRef<'_>
+pub fn ion_rs::SymbolRef<'_>::eq(&self, &Self) -> bool
+impl core::cmp::PartialOrd for ion_rs::SymbolRef<'_>
+pub fn ion_rs::SymbolRef<'_>::partial_cmp(&self, &Self) -> core::option::Option<core::cmp::Ordering>
 impl core::convert::From<ion_rs::SymbolRef<'_>> for ion_rs::Value
 pub fn ion_rs::Value::from(ion_rs::SymbolRef<'_>) -> Self
 impl core::fmt::Debug for ion_rs::SymbolRef<'_>

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -9,6 +9,10 @@ pub trait Catalog {
     /// If a table with the given name doesn't exists or if the table name is an empty string
     /// then returns None
     /// If a table with multiple versions exists for the given name then it will return the latest version of table
+    ///
+    /// The reader uses this method to perform the spec-mandated fallback to the greatest
+    /// available version of a table when an import's exact `(name, version)` match is
+    /// unavailable and the import declares a `max_id`.
     fn get_table(&self, name: &str) -> Option<&SharedSymbolTable>;
     /// Returns the Shared Symbol Table with given table name and version
     /// If a table with given name and version doesn't exists then it returns None

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -697,9 +697,9 @@ impl Element {
             Value::Symbol(sym) => match sym.text {
                 SymbolText::Shared(shared) => Ok((*shared).to_string()),
                 SymbolText::Owned(owned) => Ok(owned),
-                SymbolText::Unknown => {
+                text @ (SymbolText::Unknown | SymbolText::UnknownImport) => {
                     let sym = Self {
-                        value: Value::Symbol(Symbol::unknown_text()),
+                        value: Value::Symbol(Symbol { text }),
                         annotations,
                         location,
                     };

--- a/src/lazy/encoder/write_as_ion.rs
+++ b/src/lazy/encoder/write_as_ion.rs
@@ -25,12 +25,27 @@ use crate::lazy::expanded::macro_evaluator::RawEExpression;
 use crate::lazy::text::raw::v1_1::arg_group::{EExpArg, EExpArgExpr};
 use crate::lazy::value::LazyValue;
 use crate::lazy::value_ref::ValueRef;
+use crate::result::IonFailure;
 use crate::v1_0::RawValueRef;
 use crate::{
     Blob, Clob, Decimal, Element, Int, IonResult, IonType, LazyList, LazyRawFieldExpr,
     LazyRawFieldName, LazyRawSequence, LazyRawStruct, LazyRawValue, LazySExp, LazyStruct, Null,
     RawSymbolRef, Symbol, SymbolRef, Timestamp, Value, WriteConfig,
 };
+
+/// Returns an `Err` explaining that the writer refuses to encode a symbol that is a
+/// placeholder for a symbol ID in a shared symbol table import that could not be resolved.
+/// Such a symbol has no text of its own, but unlike a genuine `$0` (whose text is unknown by
+/// construction), encoding it as `$0` would silently and irreversibly discard the fact that
+/// the symbol has text in the (unavailable) shared table.
+fn unknown_import_placeholder_error<T>() -> IonResult<T> {
+    IonResult::encoding_error(
+        "cannot write a symbol that is a placeholder for an unresolvable shared symbol table \
+         import; encoding it would silently replace it with `$0`; to resolve these symbols, \
+         provide a Catalog containing the imported shared symbol table when constructing the \
+         reader",
+    )
+}
 
 /// Defines how a Rust type should be serialized as Ion in terms of the methods available
 /// on [`ValueWriter`].
@@ -82,6 +97,13 @@ impl WriteAsIon for Element {
         if self.annotations().is_empty() {
             self.value().write_as_ion(writer)
         } else {
+            if self
+                .annotations()
+                .iter()
+                .any(Symbol::is_unknown_import_placeholder)
+            {
+                return unknown_import_placeholder_error();
+            }
             self.value()
                 .write_as_ion(writer.with_annotations(self.annotations().as_ref())?)
         }
@@ -136,13 +158,22 @@ impl_write_as_ion_value!(
     Int => write_int,
     Decimal => write_decimal,
     Timestamp => write_timestamp,
-    Symbol => write_symbol,
     &str => write_string,
     String => write_string,
     &[u8] => write_blob,
     Blob => write_blob,
     Clob => write_clob,
 );
+
+impl WriteAsIon for Symbol {
+    #[inline]
+    fn write_as_ion<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
+        if self.is_unknown_import_placeholder() {
+            return unknown_import_placeholder_error();
+        }
+        writer.write_symbol(self)
+    }
+}
 
 impl WriteAsIon for RawSymbolRef<'_> {
     #[inline]
@@ -154,6 +185,9 @@ impl WriteAsIon for RawSymbolRef<'_> {
 impl WriteAsIon for SymbolRef<'_> {
     #[inline]
     fn write_as_ion<V: ValueWriter>(&self, writer: V) -> IonResult<()> {
+        if self.is_unknown_import_placeholder() {
+            return unknown_import_placeholder_error();
+        }
         writer.write_symbol(self)
     }
 }
@@ -267,13 +301,22 @@ impl WriteAsIon for Value {
             Float(f) => value_writer.write_f64(*f),
             Decimal(d) => value_writer.write_decimal(d),
             Timestamp(t) => value_writer.write_timestamp(t),
-            Symbol(s) => value_writer.write_symbol(s),
+            // Delegating to `Symbol`'s implementation refuses to write placeholder symbols
+            // that were substituted for an unresolvable shared symbol table import.
+            Symbol(s) => s.write_as_ion(value_writer),
             String(s) => value_writer.write_string(s),
             Clob(c) => value_writer.write_clob(c),
             Blob(b) => value_writer.write_blob(b),
             List(l) => value_writer.write_list(l),
             SExp(s) => value_writer.write_sexp(s),
-            Struct(s) => value_writer.write_struct(s.iter()),
+            Struct(s) => {
+                if s.fields()
+                    .any(|(name, _)| name.is_unknown_import_placeholder())
+                {
+                    return unknown_import_placeholder_error();
+                }
+                value_writer.write_struct(s.iter())
+            }
         }
     }
 }
@@ -283,7 +326,11 @@ impl<D: Decoder> WriteAsIon for LazyValue<'_, D> {
         if self.has_annotations() {
             let mut annotations = AnnotationsVec::new();
             for annotation in self.annotations() {
-                annotations.push(annotation?.into());
+                let annotation = annotation?;
+                if annotation.is_unknown_import_placeholder() {
+                    return unknown_import_placeholder_error();
+                }
+                annotations.push(annotation.into());
             }
             self.read()?
                 .write_as_ion(writer.with_annotations(annotations)?)
@@ -492,7 +539,9 @@ impl<D: Decoder> WriteAsIon for ValueRef<'_, D> {
             Float(f) => value_writer.write_f64(*f),
             Decimal(d) => value_writer.write_decimal(d),
             Timestamp(t) => value_writer.write_timestamp(t),
-            Symbol(s) => value_writer.write_symbol(s),
+            // Delegating to `SymbolRef`'s implementation refuses to write placeholder symbols
+            // that were substituted for an unresolvable shared symbol table import.
+            Symbol(s) => s.write_as_ion(value_writer),
             String(s) => value_writer.write_string(s.text()),
             Clob(c) => value_writer.write_clob(c.data()),
             Blob(b) => value_writer.write_blob(b.data()),
@@ -528,7 +577,11 @@ impl<D: Decoder> WriteAsIon for LazyStruct<'_, D> {
         let mut struct_writer = writer.struct_writer()?;
         for field_result in self {
             let field = field_result?;
-            struct_writer.write(field.name()?, field.value())?;
+            let name = field.name()?;
+            if name.is_unknown_import_placeholder() {
+                return unknown_import_placeholder_error();
+            }
+            struct_writer.write(name, field.value())?;
         }
         struct_writer.close()
     }
@@ -563,5 +616,52 @@ mod tests {
         let encoded: String = element.encode_as(v1_0::Text)?;
         assert_eq!(encoded.trim(), "foo::42");
         Ok(())
+    }
+
+    #[test]
+    fn writing_a_genuine_unknown_text_symbol_is_allowed() -> IonResult<()> {
+        // A symbol with unknown text that did NOT come from an unresolvable shared symbol
+        // table import (i.e. a genuine `$0`) can be encoded as usual.
+        let element: Element = Value::Symbol(Symbol::unknown_text()).into();
+        let encoded: String = element.encode_as(v1_0::Text)?;
+        assert_eq!(encoded.trim(), "$0");
+        Ok(())
+    }
+
+    #[test]
+    fn refuse_to_write_unknown_import_placeholder_as_value() {
+        // A symbol that stands in for a symbol ID in an unresolvable shared symbol table
+        // import has no text, but writing it as `$0` would silently discard the fact that
+        // it has text in the (unavailable) shared table. The writer refuses.
+        let element: Element = Value::Symbol(Symbol::unknown_import_placeholder()).into();
+        let result: IonResult<String> = element.encode_as(v1_0::Text);
+        assert!(
+            matches!(result, Err(crate::IonError::Encoding(_))),
+            "expected an encoding error, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn refuse_to_write_unknown_import_placeholder_as_annotation() {
+        let element: Element =
+            Element::from(42).with_annotations(vec![Symbol::unknown_import_placeholder()]);
+        let result: IonResult<String> = element.encode_as(v1_0::Text);
+        assert!(
+            matches!(result, Err(crate::IonError::Encoding(_))),
+            "expected an encoding error, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn refuse_to_write_unknown_import_placeholder_as_field_name() {
+        let strukt = crate::Struct::builder()
+            .with_field(Symbol::unknown_import_placeholder(), 42)
+            .build();
+        let element: Element = Value::Struct(strukt).into();
+        let result: IonResult<String> = element.encode_as(v1_0::Text);
+        assert!(
+            matches!(result, Err(crate::IonError::Encoding(_))),
+            "expected an encoding error, got: {result:?}"
+        );
     }
 }

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -23,6 +23,23 @@ use crate::{
 use std::ops::Deref;
 use std::sync::Arc;
 
+/// The maximum number of placeholder (unknown-text) symbols that the reader is willing to
+/// materialize while processing a single symbol table directive's `imports` list.
+///
+/// When a shared symbol table import cannot be resolved, the Ion 1.0 spec requires the reader
+/// to reserve exactly `max_id` symbol IDs for it, padding with unknown-text placeholders as
+/// needed. Because `max_id` is attacker-controlled and each placeholder occupies memory, a
+/// tiny stream could otherwise instruct the reader to allocate an enormous symbol table (for
+/// example, a `max_id` of 2^31 would materialize billions of placeholder symbols). Capping
+/// the number of placeholders bounds that amplification: streams whose unresolvable imports
+/// require more placeholders than this limit produce a decoding error instead.
+///
+/// One million placeholder symbols occupy tens of megabytes--far more than any known
+/// legitimate use of substituted imports requires, but small enough to keep a malicious
+/// stream from exhausting memory. Symbols that are actually present in a matching catalog
+/// entry do not count against this limit.
+pub(crate) const MAX_IMPORT_PLACEHOLDER_SYMBOLS: usize = 1_000_000;
+
 /// A binary reader that only reads each value that it visits upon request (that is: lazily).
 ///
 /// Unlike [`crate::lazy::reader::Reader`], which only exposes values that are part
@@ -570,6 +587,9 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
         catalog: &dyn Catalog,
         imports: LazyValue<'_, Encoding>,
     ) -> IonResult<()> {
+        // The number of placeholder symbols materialized for unresolvable imports so far
+        // while processing this symbol table directive's `imports` list.
+        let mut total_placeholders: usize = 0;
         match imports.read()? {
             // Any symbol other than `$ion_symbol_table` is ignored.
             ValueRef::Symbol(symbol_ref) if symbol_ref == "$ion_symbol_table" => {
@@ -597,37 +617,95 @@ impl<Encoding: Decoder, Input: IonInput> SystemReader<Encoding, Input> {
                         _ => Ok(1),
                     }?;
 
-                    let shared_table = match catalog.get_table_with_version(name.as_ref(), version) {
-                        Some(table) => table,
-                        None => return IonResult::decoding_error(
-                            format!("symbol table import failed, could not find table with name='{name}' and version={version}")
-                        ),
-                    };
-
-                    let max_id = match import.get("max_id")? {
+                    // If the max_id is unspecified, null, negative, or an invalid data type,
+                    // we treat it as undefined.
+                    // See: https://amazon-ion.github.io/ion-docs/docs/symbols.html
+                    let max_id: Option<usize> = match import.get("max_id")? {
                         Some(ValueRef::Int(i)) if i >= Int::ZERO => {
-                            usize::try_from(i).map_err(|_| {
+                            Some(usize::try_from(i).map_err(|_| {
                                 IonError::decoding_error(
                                     "found a `max_id` beyond the range of usize",
                                 )
-                            })?
+                            })?)
                         }
-                        // If the max_id is unspecified, negative, or an invalid data type, we'll import all of the symbols from the requested table.
-                        _ => shared_table.symbols().len(),
+                        _ => None,
                     };
 
-                    let num_symbols_to_import = shared_table.symbols().len().min(max_id);
+                    // Look for an exact match in the catalog. If the requested version is not
+                    // available and `max_id` is defined, fall back to the highest available
+                    // version of the named table; if the catalog has no table with that name,
+                    // substitute a dummy table by padding with `max_id` unknown-text symbols.
+                    // If there is no exact match and `max_id` is undefined, the reader cannot
+                    // know how many symbol IDs the import occupies; this is an error.
+                    let shared_table = match catalog.get_table_with_version(name.as_ref(), version)
+                    {
+                        Some(table) => Some(table),
+                        None if max_id.is_none() => return IonResult::decoding_error(
+                            format!("symbol table import failed, could not find table with name='{name}' and version={version} and no valid max_id was specified")
+                        ),
+                        None => catalog.get_table(name.as_ref()),
+                    };
+
+                    let table_symbols: &[Symbol] =
+                        shared_table.map(|table| table.symbols()).unwrap_or(&[]);
+
+                    // If `max_id` is undefined, import all of the found table's symbols.
+                    // (An exact match is guaranteed to have been found in that case.)
+                    let max_id = max_id.unwrap_or(table_symbols.len());
+
+                    // Import up to `max_id` symbols from the table...
+                    let num_symbols_to_import = table_symbols.len().min(max_id);
 
                     pending_lst
                         .imported_symbols
-                        .extend_from_slice(&shared_table.symbols()[..num_symbols_to_import]);
+                        .extend_from_slice(&table_symbols[..num_symbols_to_import]);
 
-                    if max_id > shared_table.symbols().len() {
+                    // ...and if the table did not have enough symbols (or was not found at all),
+                    // pad the remaining symbol IDs with unknown text.
+                    if max_id > num_symbols_to_import {
                         let num_pending_symbols = pending_lst.imported_symbols().len();
-                        let num_placeholders = max_id - shared_table.symbols().len();
+                        let num_placeholders = max_id - num_symbols_to_import;
+                        // Placeholder symbols are materialized eagerly, so `max_id` values
+                        // (which are attacker-controlled) must be capped to keep a small
+                        // stream from demanding an enormous allocation. See the doc comment
+                        // on `MAX_IMPORT_PLACEHOLDER_SYMBOLS` for details.
+                        total_placeholders = total_placeholders
+                            .checked_add(num_placeholders)
+                            .filter(|&total| total <= MAX_IMPORT_PLACEHOLDER_SYMBOLS)
+                            .ok_or_else(|| {
+                                IonError::decoding_error(format!(
+                                    "symbol table import (name='{name}', max_id={max_id}) requires \
+                                     padding with more placeholder symbols than this implementation \
+                                     is willing to materialize (limit: {MAX_IMPORT_PLACEHOLDER_SYMBOLS})"
+                                ))
+                            })?;
+                        // In practice this addition cannot overflow: `num_placeholders` was
+                        // just capped at `MAX_IMPORT_PLACEHOLDER_SYMBOLS` (above), and
+                        // `num_pending_symbols` is the length of an existing `Vec<Symbol>`,
+                        // which is far smaller than `usize::MAX - MAX_IMPORT_PLACEHOLDER_SYMBOLS`.
+                        // The checked arithmetic is retained purely as defense in depth.
+                        let num_symbols_after_import = num_pending_symbols
+                            .checked_add(num_placeholders)
+                            .ok_or_else(|| {
+                                IonError::decoding_error(
+                                    "internal error: combined symbol table size overflowed usize",
+                                )
+                            })?;
+                        // The cap above bounds the allocation to a modest size; reserve the
+                        // space fallibly anyway so that allocation failure (e.g. under severe
+                        // memory pressure) surfaces as a decoding error instead of aborting
+                        // the process.
+                        pending_lst
+                            .imported_symbols
+                            .try_reserve(num_placeholders)
+                            .map_err(|_| {
+                                IonError::decoding_error(format!(
+                                    "could not allocate space for a symbol table import with max_id {max_id}"
+                                ))
+                            })?;
                         pending_lst.imported_symbols.resize(
-                            num_pending_symbols + num_placeholders,
-                            Symbol::unknown_text(),
+                            num_symbols_after_import,
+                            Symbol::unknown_import_placeholder(),
                         );
                     }
                 }
@@ -908,26 +986,648 @@ mod tests {
     }
 
     #[test]
-    fn non_existent_shared_symbol_table_imports() -> IonResult<()> {
+    fn non_existent_shared_symbol_table_imports_with_max_id() -> IonResult<()> {
         let mut map_catalog = MapCatalog::new();
         map_catalog.insert_table(SharedSymbolTable::new("shared_table_1", 1, ["foo"])?);
         map_catalog.insert_table(SharedSymbolTable::new("shared_table_2", 1, ["bar"])?);
-        // The stream contains a local symbol table that is not an append.
+        // `shared_table_3` and `shared_table_4` do not exist in the catalog, but their imports
+        // declare a `max_id`. Per the spec, the reader substitutes a dummy table containing
+        // `max_id` symbols with unknown text for each of them and continues.
         let mut reader = system_reader_with_catalog_for(
             r#"
                 $ion_symbol_table::{
                     imports: [ { name:"shared_table_3", version: 1, max_id: 3 }, { name:"shared_table_2", version: 1 }, { name:"shared_table_4", version: 1, max_id: 1 } ],
                     symbols: [ "local_symbol" ]
                 }
+                $10 // == $0
+                $11 // == $0
+                $12 // == $0
                 $13 // "bar"
+                $14 // == $0
+                $15 // "local_symbol"
+            "#,
+            map_catalog,
+        );
+        // $10 through $12 are the placeholders for `shared_table_3`.
+        for _ in 0..3 {
+            assert_eq!(
+                reader.expect_next_value()?.read()?.expect_symbol()?,
+                SymbolRef::with_unknown_text()
+            );
+        }
+        // $13 comes from `shared_table_2`, which was found in the catalog.
+        assert_eq!(reader.expect_next_value()?.read()?.expect_symbol()?, "bar");
+        // $14 is the placeholder for `shared_table_4`.
+        assert_eq!(
+            reader.expect_next_value()?.read()?.expect_symbol()?,
+            SymbolRef::with_unknown_text()
+        );
+        // $15 is the first local symbol following the imports.
+        assert_eq!(
+            reader.expect_next_value()?.read()?.expect_symbol()?,
+            "local_symbol"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn resolved_import_with_overstated_max_id_pads_with_placeholders() -> IonResult<()> {
+        use crate::{Element, Value};
+        let mut map_catalog = MapCatalog::new();
+        map_catalog.insert_table(SharedSymbolTable::new("shared_table", 1, ["foo"])?);
+        // `shared_table` v1 IS in the catalog, but it only defines one symbol while the
+        // import declares `max_id: 3`. Per the spec, the two extra symbol IDs are padded
+        // with unknown-text symbols. Like the padding for an entirely unresolvable import,
+        // these gap SIDs are substitute symbols: a later version of the table could define
+        // their text, so they are placeholders (which the transcription layer refuses to
+        // write), not genuine `$0`s.
+        let mut reader = system_reader_with_catalog_for(
+            r#"
+                $ion_symbol_table::{
+                    imports: [ { name:"shared_table", version: 1, max_id: 3 } ],
+                    symbols: [ "local_symbol" ]
+                }
+                $10 // "foo"
+                $11 // gap SID (padding placeholder)
+                $13 // "local_symbol"
+            "#,
+            map_catalog,
+        );
+        assert_eq!(reader.expect_next_value()?.read()?.expect_symbol()?, "foo");
+        // Reading the gap SID succeeds; the symbol has unknown text (equivalent to `$0`).
+        let gap_symbol = reader.expect_next_value()?.read()?.expect_symbol()?;
+        assert_eq!(gap_symbol, SymbolRef::with_unknown_text());
+        // ...but transcribing it as an Element refuses with the placeholder error.
+        let element: Element = Value::Symbol(gap_symbol.to_owned()).into();
+        let result: IonResult<String> = element.encode_as(v1_0::Text);
+        let error = result.expect_err("expected the writer to refuse the padding placeholder");
+        assert!(matches!(error, IonError::Encoding(_)));
+        assert!(
+            error.to_string().contains("placeholder"),
+            "unexpected error message: {error}"
+        );
+        // The local symbol that follows the padded gap still resolves correctly.
+        assert_eq!(
+            reader.expect_next_value()?.read()?.expect_symbol()?,
+            "local_symbol"
+        );
+        Ok(())
+    }
+
+    #[cfg(feature = "experimental-ion-1-1")]
+    #[test]
+    fn ion_1_1_unresolvable_import_with_max_id_takes_substitution_path() -> IonResult<()> {
+        // An Ion 1.1 stream can still carry a 1.0-style `$ion_symbol_table` local symbol
+        // table; its `imports` list is processed by the same resolution path as in Ion 1.0
+        // (`process_imports` is not version-gated), so an unresolvable import with a
+        // defined `max_id` is substituted with placeholder symbols. In Ion 1.1 the active
+        // table's permanent prefix is only `$0`, so the import occupies $1-$2 and the
+        // local symbol is $3.
+        let map_catalog = MapCatalog::new();
+        let mut reader = system_reader_with_catalog_for(
+            r#"
+                $ion_1_1
+                $ion_symbol_table::{
+                    imports: [ { name:"missing_table", version: 1, max_id: 2 } ],
+                    symbols: [ "local_symbol" ]
+                }
+                $1 // gap SID (placeholder)
+                $3 // "local_symbol"
+            "#,
+            map_catalog,
+        );
+        // The gap SID reads successfully as a symbol with unknown text...
+        assert_eq!(
+            reader.expect_next_value()?.read()?.expect_symbol()?,
+            SymbolRef::with_unknown_text()
+        );
+        // ...and the local symbol that follows the substituted import still resolves.
+        assert_eq!(
+            reader.expect_next_value()?.read()?.expect_symbol()?,
+            "local_symbol"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn non_existent_shared_symbol_table_import_without_max_id() -> IonResult<()> {
+        let mut map_catalog = MapCatalog::new();
+        map_catalog.insert_table(SharedSymbolTable::new("shared_table_2", 1, ["bar"])?);
+        // `shared_table_3` does not exist in the catalog and its import does not declare a
+        // `max_id`, so the reader cannot know how many symbol IDs the import occupies.
+        let mut reader = system_reader_with_catalog_for(
+            r#"
+                $ion_symbol_table::{
+                    imports: [ { name:"shared_table_3", version: 1 }, { name:"shared_table_2", version: 1 } ],
+                    symbols: [ "local_symbol" ]
+                }
+                $10
             "#,
             map_catalog,
         );
         // We step over the LST...
         assert!(
             matches!(reader.next_item(), Err(IonError::Decoding(_))),
-            "expected a decoding error because shared_table_3 does not exist"
+            "expected a decoding error because shared_table_3 does not exist and its import has no max_id"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn non_existent_shared_symbol_table_import_with_zero_max_id() -> IonResult<()> {
+        let map_catalog = MapCatalog::new();
+        // A `max_id` of 0 means the unresolvable import occupies no symbol IDs at all.
+        let mut reader = system_reader_with_catalog_for(
+            r#"
+                $ion_symbol_table::{
+                    imports: [ { name:"shared_table", version: 1, max_id: 0 } ],
+                    symbols: [ "local_symbol" ]
+                }
+                $10 // "local_symbol"
+            "#,
+            map_catalog,
+        );
+        assert_eq!(
+            reader.expect_next_value()?.read()?.expect_symbol()?,
+            "local_symbol"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn non_existent_shared_symbol_table_import_with_invalid_max_id() -> IonResult<()> {
+        // Per the spec, a `max_id` that is null, not an int, or less than zero is treated as
+        // though it were undefined. An undefined `max_id` on an unresolvable import is an error.
+        for max_id in ["null", "null.int", "-2", "max", "2.5"] {
+            let map_catalog = MapCatalog::new();
+            let mut reader = system_reader_with_catalog_for(
+                format!(
+                    r#"
+                        $ion_symbol_table::{{
+                            imports: [ {{ name:"shared_table", version: 1, max_id: {max_id} }} ],
+                            symbols: [ "local_symbol" ]
+                        }}
+                        $10
+                    "#
+                ),
+                map_catalog,
+            );
+            assert!(
+                matches!(reader.next_item(), Err(IonError::Decoding(_))),
+                "expected a decoding error for an unresolvable import with max_id: {max_id}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn shared_symbol_table_imports_with_max_ids_summing_past_usize() -> IonResult<()> {
+        // Each import's `max_id` fits in a usize on its own, but together they describe more
+        // symbol IDs than a usize can represent. The reader must detect this and return a
+        // decoding error rather than silently wrapping (which would truncate the previously
+        // imported symbols and misalign all subsequent SIDs). In practice the placeholder
+        // cap check catches this case: its running total is computed with `checked_add`, so
+        // the sum either overflows (an error) or exceeds `MAX_IMPORT_PLACEHOLDER_SYMBOLS`
+        // (also an error).
+        let map_catalog = MapCatalog::new();
+        let mut reader = system_reader_with_catalog_for(
+            format!(
+                r#"
+                    $ion_symbol_table::{{
+                        imports: [
+                            {{ name:"shared_table_a", version: 1, max_id: 1 }},
+                            {{ name:"shared_table_b", version: 1, max_id: {} }},
+                        ],
+                        symbols: [ "local_symbol" ]
+                    }}
+                    $10
+                "#,
+                usize::MAX
+            ),
+            map_catalog,
+        );
+        assert!(
+            matches!(reader.next_item(), Err(IonError::Decoding(_))),
+            "expected a decoding error when imports' max_id values sum past usize::MAX"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn shared_symbol_table_import_with_absurd_max_id_fails_cleanly() -> IonResult<()> {
+        // A `max_id` of usize::MAX is representable, but the placeholder symbols it describes
+        // could never be materialized. The placeholder cap (`MAX_IMPORT_PLACEHOLDER_SYMBOLS`)
+        // rejects the import with a decoding error before any allocation is attempted.
+        let map_catalog = MapCatalog::new();
+        let mut reader = system_reader_with_catalog_for(
+            format!(
+                r#"
+                    $ion_symbol_table::{{
+                        imports: [ {{ name:"shared_table", version: 1, max_id: {} }} ],
+                        symbols: [ "local_symbol" ]
+                    }}
+                    $10
+                "#,
+                usize::MAX
+            ),
+            map_catalog,
+        );
+        assert!(
+            matches!(reader.next_item(), Err(IonError::Decoding(_))),
+            "expected a decoding error for an import with max_id = usize::MAX"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn import_placeholders_exceeding_cap_fail_cleanly() -> IonResult<()> {
+        // A single unresolvable import whose `max_id` requires more placeholder symbols than
+        // `MAX_IMPORT_PLACEHOLDER_SYMBOLS` is rejected with a decoding error that mentions
+        // the cap, before any placeholders are materialized.
+        let map_catalog = MapCatalog::new();
+        let mut reader = system_reader_with_catalog_for(
+            format!(
+                r#"
+                    $ion_symbol_table::{{
+                        imports: [ {{ name:"shared_table", version: 1, max_id: {} }} ],
+                        symbols: [ "local_symbol" ]
+                    }}
+                    $10
+                "#,
+                MAX_IMPORT_PLACEHOLDER_SYMBOLS + 1
+            ),
+            map_catalog,
+        );
+        let error = reader
+            .next_item()
+            .expect_err("expected a decoding error for an import exceeding the placeholder cap");
+        assert!(matches!(error, IonError::Decoding(_)));
+        assert!(
+            error
+                .to_string()
+                .contains(&MAX_IMPORT_PLACEHOLDER_SYMBOLS.to_string()),
+            "the error message should mention the placeholder cap: {error}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn import_placeholder_cap_applies_across_imports() -> IonResult<()> {
+        // Each import's `max_id` is under the cap on its own, but the total number of
+        // placeholder symbols required by the directive's `imports` list exceeds it.
+        let map_catalog = MapCatalog::new();
+        let mut reader = system_reader_with_catalog_for(
+            format!(
+                r#"
+                    $ion_symbol_table::{{
+                        imports: [
+                            {{ name:"shared_table_a", version: 1, max_id: {max_id} }},
+                            {{ name:"shared_table_b", version: 1, max_id: {max_id} }},
+                        ]
+                    }}
+                    $10
+                "#,
+                max_id = (MAX_IMPORT_PLACEHOLDER_SYMBOLS / 2) + 1
+            ),
+            map_catalog,
+        );
+        assert!(
+            matches!(reader.next_item(), Err(IonError::Decoding(_))),
+            "expected a decoding error when imports' combined placeholder count exceeds the cap"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn refuse_to_transcribe_unknown_import_placeholder_symbols() -> IonResult<()> {
+        // Symbol IDs in the range of an unresolvable import can be read (as symbols with
+        // unknown text), but the writer refuses to transcribe them: encoding them as `$0`
+        // would silently discard the fact that they have text in the (unavailable) shared
+        // table.
+        let map_catalog = MapCatalog::new();
+        let mut reader = system_reader_with_catalog_for(
+            r#"
+                $ion_symbol_table::{
+                    imports: [ { name:"shared_table", version: 1, max_id: 1 } ]
+                }
+                $10
+            "#,
+            map_catalog,
+        );
+        let value = reader.expect_next_value()?;
+        // Reading the placeholder works; it is equivalent to `$0`.
+        assert_eq!(
+            value.read()?.expect_symbol()?,
+            SymbolRef::with_unknown_text()
+        );
+        // Writing it does not.
+        let mut writer = Writer::new(v1_0::Text, Vec::new())?;
+        let result = writer.write(value);
+        assert!(
+            matches!(result, Err(IonError::Encoding(_))),
+            "expected an encoding error when transcribing a placeholder symbol"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn refuse_to_transcribe_placeholders_nested_in_containers() -> IonResult<()> {
+        // Placeholder symbols nested inside containers are also refused when the containing
+        // `Element` is transcribed.
+        use crate::element::element_writer::ElementWriter;
+        use crate::element::reader::ElementReader;
+        use crate::lazy::reader::Reader;
+        for document in [
+            "[1, $10, 3]",   // list
+            "(foo $10 bar)", // s-expression
+        ] {
+            let input = format!(
+                r#"
+                    $ion_symbol_table::{{
+                        imports: [ {{ name:"shared_table", version: 1, max_id: 1 }} ]
+                    }}
+                    {document}
+                "#
+            );
+            let mut reader = Reader::new(AnyEncoding.with_catalog(MapCatalog::new()), input)?;
+            let element = reader
+                .read_next_element()?
+                .expect("expected to read an element");
+            let mut writer = Writer::new(v1_0::Text, Vec::new())?;
+            let result = writer.write_element(&element);
+            assert!(
+                matches!(result, Err(IonError::Encoding(_))),
+                "expected an encoding error transcribing {document}, got {result:?}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn refuse_to_transcribe_placeholder_annotations_lazily() -> IonResult<()> {
+        // Lazy transcription refuses placeholder symbols in annotation position, not just in
+        // value position.
+        let map_catalog = MapCatalog::new();
+        let mut reader = system_reader_with_catalog_for(
+            r#"
+                $ion_symbol_table::{
+                    imports: [ { name:"shared_table", version: 1, max_id: 1 } ]
+                }
+                $10::5
+            "#,
+            map_catalog,
+        );
+        let value = reader.expect_next_value()?;
+        let mut writer = Writer::new(v1_0::Text, Vec::new())?;
+        let result = writer.write(value);
+        assert!(
+            matches!(result, Err(IonError::Encoding(_))),
+            "expected an encoding error when transcribing a placeholder annotation"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn refuse_to_transcribe_placeholder_field_names_lazily() -> IonResult<()> {
+        // Lazy transcription refuses placeholder symbols in struct field name position, not
+        // just in value position.
+        let map_catalog = MapCatalog::new();
+        let mut reader = system_reader_with_catalog_for(
+            r#"
+                $ion_symbol_table::{
+                    imports: [ { name:"shared_table", version: 1, max_id: 1 } ]
+                }
+                { $10: 5 }
+            "#,
+            map_catalog,
+        );
+        let value = reader.expect_next_value()?;
+        let mut writer = Writer::new(v1_0::Text, Vec::new())?;
+        let result = writer.write(value);
+        assert!(
+            matches!(result, Err(IonError::Encoding(_))),
+            "expected an encoding error when transcribing a placeholder field name"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn value_writer_apis_emit_placeholders_as_sid_zero() -> IonResult<()> {
+        // The typed transcription layer (`WriteAsIon`) refuses to encode placeholder symbols
+        // (see the tests above), but the value writer APIs accept symbol tokens through
+        // infallible conversions to `RawSymbolRef`. Those conversions are an intentional lossy
+        // escape hatch: the placeholder flag is discarded and the token is written as `$0`.
+        // This test pins that documented behavior for all three symbol token positions.
+        use crate::lazy::encoder::value_writer::StructWriter;
+        let placeholder = Symbol::unknown_import_placeholder();
+
+        // Value position: both the `Symbol` and `SymbolRef` conversions are lossy.
+        let mut writer = Writer::new(v1_0::Text, Vec::new())?;
+        writer.value_writer().write_symbol(&placeholder)?;
+        writer
+            .value_writer()
+            .write_symbol(SymbolRef::from(&placeholder))?;
+        let output = String::from_utf8(writer.close()?).unwrap();
+        assert_eq!(output.split_whitespace().collect::<Vec<_>>(), ["$0", "$0"]);
+
+        // Struct field name position
+        let mut writer = Writer::new(v1_0::Text, Vec::new())?;
+        let mut struct_writer = writer.value_writer().struct_writer()?;
+        struct_writer
+            .field_writer(SymbolRef::from(&placeholder))
+            .write_i64(1)?;
+        struct_writer.close()?;
+        let output = String::from_utf8(writer.close()?).unwrap();
+        assert!(
+            output.contains("$0"),
+            "expected a $0 field name in the output: {output}"
+        );
+
+        // Annotation position
+        let mut writer = Writer::new(v1_0::Text, Vec::new())?;
+        writer
+            .value_writer()
+            .with_annotations(vec![SymbolRef::from(&placeholder)])?
+            .write_i64(1)?;
+        let output = String::from_utf8(writer.close()?).unwrap();
+        assert!(
+            output.contains("$0::"),
+            "expected a $0 annotation in the output: {output}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn shared_symbol_table_import_falls_back_to_highest_version() -> IonResult<()> {
+        let mut map_catalog = MapCatalog::new();
+        // The catalog has v2 of `shared_table` but the import requests v1. Because the import
+        // declares a `max_id`, the reader falls back to the highest available version of the
+        // table and sizes its symbol subsequence to exactly `max_id` (truncating here).
+        map_catalog.insert_table(SharedSymbolTable::new(
+            "shared_table",
+            2,
+            ["foo", "bar", "baz"],
+        )?);
+        let mut reader = system_reader_with_catalog_for(
+            r#"
+                $ion_symbol_table::{
+                    imports: [ { name:"shared_table", version: 1, max_id: 2 } ],
+                    symbols: [ "local_symbol" ]
+                }
+                $10 // "foo"
+                $11 // "bar"
+                $12 // "local_symbol"
+            "#,
+            map_catalog,
+        );
+        assert_eq!(reader.expect_next_value()?.read()?.expect_symbol()?, "foo");
+        assert_eq!(reader.expect_next_value()?.read()?.expect_symbol()?, "bar");
+        assert_eq!(
+            reader.expect_next_value()?.read()?.expect_symbol()?,
+            "local_symbol"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn shared_symbol_table_version_fallback_pads_to_max_id() -> IonResult<()> {
+        let mut map_catalog = MapCatalog::new();
+        // The catalog has v2 of `shared_table` (with a single symbol) but the import requests
+        // v1 with a max_id of 3. The reader falls back to v2 and pads its symbols with unknown
+        // text to reach exactly `max_id` symbols.
+        map_catalog.insert_table(SharedSymbolTable::new("shared_table", 2, ["foo"])?);
+        let mut reader = system_reader_with_catalog_for(
+            r#"
+                $ion_symbol_table::{
+                    imports: [ { name:"shared_table", version: 1, max_id: 3 } ],
+                    symbols: [ "local_symbol" ]
+                }
+                $10 // "foo"
+                $11 // == $0
+                $12 // == $0
+                $13 // "local_symbol"
+            "#,
+            map_catalog,
+        );
+        assert_eq!(reader.expect_next_value()?.read()?.expect_symbol()?, "foo");
+        for _ in 0..2 {
+            assert_eq!(
+                reader.expect_next_value()?.read()?.expect_symbol()?,
+                SymbolRef::with_unknown_text()
+            );
+        }
+        assert_eq!(
+            reader.expect_next_value()?.read()?.expect_symbol()?,
+            "local_symbol"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn lst_append_after_substituted_import() -> IonResult<()> {
+        let map_catalog = MapCatalog::new();
+        // `shared_table` is not in the catalog, so the reader substitutes a dummy table with
+        // two placeholder symbols ($10 and $11). The second LST imports `$ion_symbol_table`,
+        // appending to the current table: the placeholders must keep their positions and the
+        // appended symbol must be assigned the next available symbol ID.
+        let mut reader = system_reader_with_catalog_for(
+            r#"
+                $ion_symbol_table::{
+                    imports: [ { name:"shared_table", version: 1, max_id: 2 } ],
+                    symbols: [ "local_symbol" ]
+                }
+                $ion_symbol_table::{
+                    imports: $ion_symbol_table,
+                    symbols: [ "appended_symbol" ]
+                }
+                $10 // == $0
+                $11 // == $0
+                $12 // "local_symbol"
+                $13 // "appended_symbol"
+            "#,
+            map_catalog,
+        );
+        for _ in 0..2 {
+            assert_eq!(
+                reader.expect_next_value()?.read()?.expect_symbol()?,
+                SymbolRef::with_unknown_text()
+            );
+        }
+        assert_eq!(
+            reader.expect_next_value()?.read()?.expect_symbol()?,
+            "local_symbol"
+        );
+        assert_eq!(
+            reader.expect_next_value()?.read()?.expect_symbol()?,
+            "appended_symbol"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn ivm_discards_substituted_import_context() -> IonResult<()> {
+        let map_catalog = MapCatalog::new();
+        // Before the IVM, $10 and $11 are placeholders from the substituted import and $12 is
+        // the local symbol that follows them. The IVM resets the symbol table to the system
+        // symbols; after a fresh LST (with no imports), $10 is the first new local symbol
+        // rather than a placeholder from the discarded import context.
+        let mut reader = system_reader_with_catalog_for(
+            r#"
+                $ion_symbol_table::{
+                    imports: [ { name:"shared_table", version: 1, max_id: 2 } ],
+                    symbols: [ "local_symbol" ]
+                }
+                $12 // "local_symbol"
+                $ion_1_0
+                $ion_symbol_table::{
+                    symbols: [ "fresh_symbol" ]
+                }
+                $10 // "fresh_symbol"
+            "#,
+            map_catalog,
+        );
+        assert_eq!(
+            reader.expect_next_value()?.read()?.expect_symbol()?,
+            "local_symbol"
+        );
+        assert_eq!(
+            reader.expect_next_value()?.read()?.expect_symbol()?,
+            "fresh_symbol"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn substituted_import_symbols_as_field_name_and_annotation() -> IonResult<()> {
+        let map_catalog = MapCatalog::new();
+        // $10 and $11 are placeholders from the substituted import. Using them as a field
+        // name and as an annotation must parse successfully and surface unknown text.
+        let mut reader = system_reader_with_catalog_for(
+            r#"
+                $ion_symbol_table::{
+                    imports: [ { name:"shared_table", version: 1, max_id: 3 } ],
+                    symbols: [ "local_symbol" ]
+                }
+                { $10: 1 }
+                $11::true
+            "#,
+            map_catalog,
+        );
+        let struct_ = reader.expect_next_value()?.read()?.expect_struct()?;
+        let field = struct_
+            .iter()
+            .next()
+            .expect("the struct should have a field")?;
+        assert_eq!(field.name()?, SymbolRef::with_unknown_text());
+        assert_eq!(field.value().read()?.expect_i64()?, 1);
+
+        let annotated = reader.expect_next_value()?;
+        let annotation = annotated
+            .annotations()
+            .next()
+            .expect("the value should have an annotation")?;
+        assert_eq!(annotation, SymbolRef::with_unknown_text());
+        assert!(annotated.read()?.expect_bool()?);
         Ok(())
     }
 

--- a/src/lazy/value_ref.rs
+++ b/src/lazy/value_ref.rs
@@ -330,6 +330,17 @@ mod tests {
     use crate::{v1_0, Decimal, IonResult, IonType, Reader, SymbolRef, Timestamp};
 
     #[test]
+    fn value_ref_size_regression() {
+        use crate::lazy::any_encoding::AnyEncoding;
+        // `SymbolRef` gained a one-byte flag (padded to 24 bytes; see the size regression
+        // test in `symbol_ref.rs`), but `ValueRef`'s size is dominated by larger variants,
+        // so it remains 96 bytes — the same as before the flag was added. This test guards
+        // against the enum accidentally growing (e.g. if a variant's payload expands past
+        // the current maximum).
+        assert_eq!(std::mem::size_of::<ValueRef<'_, AnyEncoding>>(), 96);
+    }
+
+    #[test]
     fn expect_type() -> IonResult<()> {
         let ion_data = to_binary_ion(
             r#"

--- a/src/raw_symbol_ref.rs
+++ b/src/raw_symbol_ref.rs
@@ -115,6 +115,18 @@ impl AsRawSymbolRef for &str {
     }
 }
 
+// This conversion is infallible and therefore intentionally lossy: a `Symbol` that is a
+// placeholder for a symbol ID in an unresolvable shared symbol table import (see
+// `SymbolText::UnknownImport`) is mapped to `$0` (symbol ID 0), discarding the placeholder
+// flag. Raw-level writers legitimately emit `$0`; only the typed transcription layer
+// (`WriteAsIon`/`Element`) refuses to encode placeholders.
+//
+// Reachability on the default-features API: the writer APIs that consume this conversion
+// (`Writer`, `ValueWriter`, `StructWriter`, etc.) are only public with the
+// `experimental-reader-writer` feature, and the default-features encoding entry points
+// (`Element::encode_as`/`encode_to`) go through `WriteAsIon` and refuse placeholders.
+// However, the `Display` impls for `Element`/`Value` (Ion text rendering) also use this
+// conversion and are available on default features; they render placeholders as `$0`.
 impl AsRawSymbolRef for Symbol {
     fn as_raw_symbol_ref(&self) -> RawSymbolRef<'_> {
         match self.text() {
@@ -163,6 +175,15 @@ impl<'a> From<&'a SymbolId> for RawSymbolRef<'a> {
     }
 }
 
+// This conversion is infallible and therefore intentionally lossy: a `SymbolRef` that is a
+// placeholder for a symbol ID in an unresolvable shared symbol table import (see
+// `SymbolText::UnknownImport`) is mapped to `$0` (symbol ID 0), discarding the placeholder
+// flag. Raw-level writers legitimately emit `$0`; only the typed transcription layer
+// (`WriteAsIon`/`Element`) refuses to encode placeholders.
+//
+// Reachability on the default-features API: see the note on `impl AsRawSymbolRef for Symbol`
+// above — the writer APIs consuming this conversion are feature-gated, but the `Display`
+// impls for `Element`/`Value` also use it and render placeholders as `$0`.
 impl<'a> From<SymbolRef<'a>> for RawSymbolRef<'a> {
     fn from(value: SymbolRef<'a>) -> Self {
         match value.text() {

--- a/src/symbol_ref.rs
+++ b/src/symbol_ref.rs
@@ -7,14 +7,55 @@ use std::hash::{Hash, Hasher};
 
 /// A reference to a fully resolved symbol. Like `Symbol` (a fully resolved symbol with a
 /// static lifetime), a `SymbolRef` may have known or undefined text (i.e. `$0`).
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[derive(Eq, Clone, Copy)]
 pub struct SymbolRef<'a> {
     text: Option<&'a str>,
+    // `true` if this symbol is a placeholder for a symbol ID in a shared symbol table import
+    // that could not be resolved. See `SymbolText::UnknownImport`. This flag does not
+    // participate in equality, ordering, or hashing: a placeholder is equivalent to `$0`
+    // everywhere except during transcription (the `WriteAsIon` implementations used when
+    // writing an `Element`, `Value`, `LazyValue`, `SymbolRef`, or `Symbol`), which refuses
+    // to encode it. Conversions to `RawSymbolRef` (used by the value writer APIs for symbol
+    // values, struct field names, and annotations) are infallible and intentionally lossy:
+    // they discard this flag and map the placeholder to `$0` (symbol ID 0).
+    //
+    // TODO: absorb into the symbol table representation (tracked SID ranges of unresolved
+    //       imports) when symbol tables move to a slab/Vec<Arc<SymbolTable>> design; that
+    //       also enables import-location preservation for round-trip.
+    is_unknown_import_placeholder: bool,
+}
+
+// `is_unknown_import_placeholder` is intentionally not part of equality.
+impl PartialEq<Self> for SymbolRef<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.text == other.text
+    }
+}
+
+// `is_unknown_import_placeholder` is intentionally not part of ordering.
+impl PartialOrd<Self> for SymbolRef<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+// `is_unknown_import_placeholder` is intentionally not part of ordering.
+impl Ord for SymbolRef<'_> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.text.cmp(&other.text)
+    }
 }
 
 impl Debug for SymbolRef<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.text().unwrap_or("$0"))
+        match self.text() {
+            Some(text) => write!(f, "{text}"),
+            // Debug output (unlike `Display`, which renders Ion text and must remain `$0`)
+            // distinguishes a placeholder for an unresolvable shared symbol table import
+            // from a genuine `$0`.
+            None if self.is_unknown_import_placeholder => write!(f, "$0 (unresolved import)"),
+            None => write!(f, "$0"),
+        }
     }
 }
 
@@ -26,16 +67,29 @@ impl<'a> SymbolRef<'a> {
 
     /// Constructs a `SymbolRef` with unknown text.
     pub fn with_unknown_text() -> Self {
-        SymbolRef { text: None }
+        SymbolRef {
+            text: None,
+            is_unknown_import_placeholder: false,
+        }
     }
 
     /// Constructs a `SymbolRef` with the specified text.
     pub fn with_text(text: &'a str) -> SymbolRef<'a> {
-        SymbolRef { text: Some(text) }
+        SymbolRef {
+            text: Some(text),
+            is_unknown_import_placeholder: false,
+        }
+    }
+
+    /// Returns `true` if this symbol is a placeholder for a symbol ID in a shared symbol
+    /// table import that could not be resolved. See `SymbolText::UnknownImport`.
+    pub(crate) fn is_unknown_import_placeholder(&self) -> bool {
+        self.is_unknown_import_placeholder
     }
 
     pub fn to_owned(self) -> Symbol {
         match self.text {
+            None if self.is_unknown_import_placeholder => Symbol::unknown_import_placeholder(),
             None => Symbol::unknown_text(),
             Some(text) => Symbol::owned(Str::from(text)),
         }
@@ -70,10 +124,12 @@ impl<A: AsRef<str>> AsSymbolRef for A {
     fn as_symbol_ref(&self) -> SymbolRef<'_> {
         SymbolRef {
             text: Some(self.as_ref()),
+            is_unknown_import_placeholder: false,
         }
     }
 }
 
+// `is_unknown_import_placeholder` is intentionally not part of hashing.
 impl Hash for SymbolRef<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self.text() {
@@ -85,7 +141,10 @@ impl Hash for SymbolRef<'_> {
 
 impl<'a> From<&'a str> for SymbolRef<'a> {
     fn from(text: &'a str) -> Self {
-        Self { text: Some(text) }
+        Self {
+            text: Some(text),
+            is_unknown_import_placeholder: false,
+        }
     }
 }
 
@@ -93,6 +152,7 @@ impl<'a> From<&'a Symbol> for SymbolRef<'a> {
     fn from(symbol: &'a Symbol) -> Self {
         Self {
             text: symbol.text(),
+            is_unknown_import_placeholder: symbol.is_unknown_import_placeholder(),
         }
     }
 }
@@ -110,20 +170,28 @@ impl Borrow<str> for SymbolRef<'_> {
 // trait definitions, this cannot be achieved with `AsRef` or `Borrow`.
 impl AsSymbolRef for Symbol {
     fn as_symbol_ref(&self) -> SymbolRef<'_> {
-        self.text()
-            .map(SymbolRef::with_text)
-            .unwrap_or_else(SymbolRef::with_unknown_text)
+        SymbolRef::from(self)
     }
 }
 
 impl AsSymbolRef for &Symbol {
     fn as_symbol_ref(&self) -> SymbolRef<'_> {
-        self.text()
-            .map(SymbolRef::with_text)
-            .unwrap_or_else(SymbolRef::with_unknown_text)
+        SymbolRef::from(*self)
     }
 }
 
+// This conversion is infallible and therefore intentionally lossy: a `SymbolRef` that is a
+// placeholder for a symbol ID in an unresolvable shared symbol table import (see
+// `SymbolText::UnknownImport`) is mapped to `$0` (symbol ID 0), discarding the placeholder
+// flag. Raw-level writers legitimately emit `$0`; only the typed transcription layer
+// (`WriteAsIon`/`Element`) refuses to encode placeholders.
+//
+// Reachability on the default-features API: the writer APIs that consume this conversion
+// (`Writer`, `ValueWriter`, `StructWriter`, etc.) are only public with the
+// `experimental-reader-writer` feature, and the default-features encoding entry points
+// (`Element::encode_as`/`encode_to`) go through `WriteAsIon` and refuse placeholders.
+// However, the `Display` impls for `Element`/`Value` (Ion text rendering) also use this
+// conversion and are available on default features; they render placeholders as `$0`.
 impl AsRawSymbolRef for SymbolRef<'_> {
     fn as_raw_symbol_ref(&self) -> RawSymbolRef<'_> {
         match &self.text {
@@ -136,6 +204,18 @@ impl AsRawSymbolRef for SymbolRef<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn symbol_ref_size_regression() {
+        // A `SymbolRef` is an `Option<&str>` (16 bytes, thanks to the niche optimization)
+        // plus the one-byte `is_unknown_import_placeholder` flag, padded to the pointer
+        // alignment of `&str`: 24 bytes total. Before the flag was added it was 16 bytes.
+        // `ValueRef` (see the size regression test in `value_ref.rs`) absorbed the growth
+        // because its size is dominated by larger variants. If this assertion fails, the
+        // type has changed size; check whether `ValueRef` (and other containing types)
+        // grew with it.
+        assert_eq!(std::mem::size_of::<SymbolRef<'_>>(), 24);
+    }
 
     #[test]
     fn symbol_ref_with_text() {

--- a/src/types/symbol.rs
+++ b/src/types/symbol.rs
@@ -21,6 +21,17 @@ pub(crate) enum SymbolText {
     Static(&'static str),
     // This Symbol is equivalent to SID zero (`$0`)
     Unknown,
+    // This Symbol is a placeholder for a symbol ID in a shared symbol table import that could
+    // not be resolved. Like `Unknown`, it has no text and is equivalent to `$0` when read
+    // (it compares equal to `Unknown`). The typed transcription layer -- the `WriteAsIon`
+    // implementations for `Element`, `Value`, `Symbol`, `SymbolRef`, and the lazy value types
+    // -- refuses to encode it (whether it appears in value position, as a struct field name,
+    // or as an annotation): emitting it as `$0` would silently and irreversibly discard the
+    // fact that the symbol had text in the (unavailable) shared table. However, the infallible
+    // conversions to `RawSymbolRef` used by the value writer APIs (e.g. `write_symbol`,
+    // `field_writer`, `with_annotations`) are an intentional lossy escape hatch: they map the
+    // placeholder to `$0` (symbol ID 0).
+    UnknownImport,
 }
 
 impl SymbolText {
@@ -29,7 +40,7 @@ impl SymbolText {
             SymbolText::Shared(s) => s.as_ref(),
             SymbolText::Owned(s) => s.as_str(),
             SymbolText::Static(s) => s,
-            SymbolText::Unknown => return None,
+            SymbolText::Unknown | SymbolText::UnknownImport => return None,
         };
         Some(text)
     }
@@ -49,6 +60,7 @@ impl Clone for SymbolText {
             SymbolText::Shared(text) => SymbolText::Shared(Arc::clone(text)),
             SymbolText::Static(text) => SymbolText::Static(text),
             SymbolText::Unknown => SymbolText::Unknown,
+            SymbolText::UnknownImport => SymbolText::UnknownImport,
         }
     }
 }
@@ -109,6 +121,23 @@ impl Symbol {
         Symbol {
             text: SymbolText::Unknown,
         }
+    }
+
+    /// Constructs a `Symbol` that stands in for a symbol ID in a shared symbol table import
+    /// that could not be resolved. Like [`Symbol::unknown_text`], the resulting symbol has no
+    /// text and is equivalent to `$0` when read, but the typed transcription layer
+    /// (`WriteAsIon`/`Element`) refuses to encode it. See [`SymbolText::UnknownImport`] for
+    /// details, including the lossy raw-level escape hatch.
+    pub(crate) fn unknown_import_placeholder() -> Symbol {
+        Symbol {
+            text: SymbolText::UnknownImport,
+        }
+    }
+
+    /// Returns `true` if this symbol is a placeholder for a symbol ID in a shared symbol
+    /// table import that could not be resolved. See [`SymbolText::UnknownImport`].
+    pub(crate) fn is_unknown_import_placeholder(&self) -> bool {
+        matches!(self.text, SymbolText::UnknownImport)
     }
 
     pub fn text(&self) -> Option<&str> {
@@ -262,5 +291,22 @@ mod symbol_tests {
         // Equality testing for a rust str with symbol
         let expected = vec!["bar", "baz", "foo", "quux"];
         assert_eq!(symbols, expected)
+    }
+
+    #[test]
+    fn unknown_import_placeholder_is_equivalent_to_unknown_text() {
+        // A placeholder for an unresolvable shared symbol table import has no text; for the
+        // purposes of equality, ordering, hashing, and Ion data equivalence it is
+        // indistinguishable from a genuine `$0`. (Only the writer treats them differently.)
+        let placeholder = Symbol::unknown_import_placeholder();
+        let unknown = Symbol::unknown_text();
+        assert_eq!(placeholder, unknown);
+        assert!(placeholder.ion_eq(&unknown));
+        assert_eq!(placeholder.cmp(&unknown), Ordering::Equal);
+        assert_eq!(placeholder.text(), None);
+        assert!(placeholder.is_unknown_import_placeholder());
+        assert!(!unknown.is_unknown_import_placeholder());
+        // Cloning preserves the placeholder marker.
+        assert!(placeholder.clone().is_unknown_import_placeholder());
     }
 }

--- a/tests/ion_tests/mod.rs
+++ b/tests/ion_tests/mod.rs
@@ -388,23 +388,19 @@ pub const ELEMENT_GLOBAL_SKIP_LIST: SkipList = &[
     // parent container.
     "ion-tests/iontestdata/bad/listWithValueLargerThanSize.10n",
     // ROUND TRIP
-    // These tests have shared symbol table imports in them, which the Reader does not
-    // yet support.
-    "ion-tests/iontestdata/good/subfieldVarInt.ion",
+    // These tests have shared symbol table imports with a `max_id` so large (~268 million
+    // and ~2.1 billion respectively) that reading them exceeds the reader's placeholder
+    // materialization cap (`MAX_IMPORT_PLACEHOLDER_SYMBOLS`, one million) and fails with
+    // a decoding error.
+    // TODO(follow-up): the planned non-materialized substitute-table work (representing an
+    // unresolved import's SID range in the symbol table instead of materializing placeholder
+    // symbols eagerly) would remove the cap and un-skip these. (No issue filed yet.)
     "ion-tests/iontestdata/good/subfieldVarUInt.ion",
-    "ion-tests/iontestdata/good/subfieldVarUInt15bit.ion",
-    "ion-tests/iontestdata/good/subfieldVarUInt16bit.ion",
     "ion-tests/iontestdata/good/subfieldVarUInt32bit.ion",
     // This test requires the reader to be able to read symbols whose ID is encoded
     // with more than 8 bytes. Having a symbol table with more than 18 quintillion
     // symbols is not very practical.
     "ion-tests/iontestdata/good/typecodes/T7-large.10n",
-    // ---
-    // Requires importing shared symbol tables
-    "ion-tests/iontestdata/good/item1.10n",
-    "ion-tests/iontestdata/good/localSymbolTableImportZeroMaxId.ion",
-    // Requires importing shared symbol tables
-    "ion-tests/iontestdata/good/testfile35.ion",
     // These files are encoded in utf16 and utf32; the reader currently assumes utf8.
     "ion-tests/iontestdata/good/utf16.ion",
     "ion-tests/iontestdata/good/utf32.ion",
@@ -414,15 +410,21 @@ pub const ELEMENT_GLOBAL_SKIP_LIST: SkipList = &[
 ];
 
 pub const ELEMENT_ROUND_TRIP_SKIP_LIST: SkipList = &[
+    // This test's data contains symbol values whose IDs fall in the range of an
+    // unresolvable shared symbol table import. Reading them produces placeholder symbols
+    // with unknown text, and the writer refuses to encode such placeholders (writing them
+    // as `$0` would silently discard the fact that they have text in the unavailable
+    // shared table).
+    // TODO(follow-up): the planned non-materialized substitute-table work (preserving the
+    // import location of unresolved SIDs) would allow round-tripping these symbols with
+    // their original import context and un-skip this file. (No issue filed yet.)
     "ion-tests/iontestdata/good/item1.10n",
-    "ion-tests/iontestdata/good/localSymbolTableImportZeroMaxId.ion",
     "ion-tests/iontestdata/good/notVersionMarkers.ion",
     "ion-tests/iontestdata/good/subfieldInt.ion",
     "ion-tests/iontestdata/good/subfieldUInt.ion",
+    // This test has a decimal that is too large for the binary writer's encoding buffer.
     "ion-tests/iontestdata/good/subfieldVarInt.ion",
     "ion-tests/iontestdata/good/subfieldVarUInt.ion",
-    "ion-tests/iontestdata/good/subfieldVarUInt15bit.ion",
-    "ion-tests/iontestdata/good/subfieldVarUInt16bit.ion",
     "ion-tests/iontestdata/good/subfieldVarUInt32bit.ion",
     "ion-tests/iontestdata/good/utf16.ion",
     "ion-tests/iontestdata/good/utf32.ion",


### PR DESCRIPTION
Fixes #1036.

## What

Per the [Ion 1.0 symbols spec](https://amazon-ion.github.io/ion-docs/docs/symbols.html) (*Local Symbol Tables → Imports*), when a shared symbol table import cannot be resolved to an exact `(name, version)` match in the catalog:

- If `max_id` is undefined (missing, null, not an int, or negative), this remains a decoding error — unchanged.
- Otherwise, the reader falls back to the greatest available version of the named table (`Catalog::get_table`), and if the catalog has no table with that name at all, substitutes a dummy table. In both cases the imported subsequence is sized to exactly `max_id`, truncating or padding with placeholder symbols.

This revision implements the notes from @popematt's comment on #1036:

1. **Limit on placeholder materialization**: `MAX_IMPORT_PLACEHOLDER_SYMBOLS` (1,000,000), accounted cumulatively across all imports in a directive and checked before any allocation (`checked_add` + `try_reserve` as backstops). Worst case ≈ tens of MB. The two ion-tests vectors with pathological `max_id` values (~268M and ~2.1B) now fail with a clear cap error instead of exhausting memory; a non-materialized (lazy) substitute-table representation would remove the cap entirely and un-skip them — happy to file that as a follow-up issue (it dovetails with the `Vec<Arc<SymbolTable>>` restructure you sketched, which I assessed but deferred: the run-length variant is blocked by `symbol_for(&self) -> Option<&Symbol>` returning a reference).
2. **`SymbolText::UnknownImport` + refuse to write**: placeholder symbols carry a distinct variant (internal enum — no public API shape change; the baseline gains three hand-written comparison impls semantically identical to the previous derives). Equality/ordering/hashing remain text-based, so `Eq`/`IonDataEq` contracts are preserved (placeholder ≡ `$0`, consistent with the existing unknown-text handling; spec-strict substitute-symbol equivalence by import location is intentionally not implemented yet and is noted in the docs). Writing refuses at the typed transcription layer — value, annotation, and field-name positions, eager and lazy — with an error that tells the user the catalog fix.
3. Import-location preservation for round-trip is left for a later issue/PR, per your comment; the placeholder flag carries a TODO pointing at the table-side representation so that work knows where to absorb it.

## Behavior changes (explicit disclosure)

- **error→ok**: documents with unresolvable imports that declare `max_id` now parse (previously an unconditional decoding error). This matches ion-java, which reads the equivalent documents successfully.
- **ok→error (one edge)**: a *resolved* import whose `max_id` overstates the table's size previously padded the gap with plain unknown-text symbols, which wrote out as `$0`. Those gap SIDs are substitute symbols too (a later version of the table could define their text), so they now use the placeholder variant and refuse to write. Pinned by a dedicated test. If you'd rather keep `$0`-writability for the resolved-import case, that's a two-line change — flagging it for an explicit decision.
- **Write-refusal boundary**: on the default-features API, typed encoding (`Element::encode_as`/`encode_to`) refuses placeholders everywhere. `Display` renders them as `$0` (it produces Ion text and has no error channel); `Debug` distinguishes them (`$0 (unresolved import)`). The raw-level conversions (`From<SymbolRef> for RawSymbolRef` etc.) are infallible and lower placeholders to `$0`; they are documented as an intentional lossy escape hatch, are pinned by test, and are only consumed by writer APIs behind `experimental-reader-writer`.

## Conformance vectors

Un-skipped and passing: `good/item1.10n`, `good/localSymbolTableImportZeroMaxId.ion`, `good/testfile35.ion`, `good/subfieldVarInt.ion` (global list), `good/subfieldVarUInt15bit.ion`, `good/subfieldVarUInt16bit.ion` — including round-trip permutations where applicable. Still skipped, with updated comments: `subfieldVarUInt.ion` / `subfieldVarUInt32bit.ion` (placeholder cap; see follow-up above), `item1.10n` round-trip (writes a gap-SID placeholder, which now refuses), `subfieldVarInt.ion` round-trip (pre-existing unrelated decimal-buffer writer error).

## Tests

Spec-branch coverage (exact match / greatest-version fallback / dummy substitution / undefined-`max_id` error / invalid-`max_id`-as-undefined / truncate & pad / `max_id: 0`), LST-append after substitution, IVM reset, gap SIDs as field names and annotations, refusal in nested containers and lazy transcription, the resolved-import overstated-`max_id` edge, an Ion 1.1 stream carrying a 1.0-style LST (same path), overflow/`try_reserve` regression tests, and size-regression pins for `SymbolRef`/`ValueRef` (`ValueRef` is unchanged at 96 bytes; `SymbolRef` grows 16→24, absorbed by larger variants).

`cargo test --workspace --all-features`, clippy with `-D warnings`, fmt, docs, and the public-API baseline checks are all green.

## Context

I'm not an Ion expert — I validated the intended behavior against the spec text and empirically against ion-java 1.11.10. Happy to rework any of the design points above, and to file the follow-up issues (lazy substitute tables / configurable cap / import-location round-trip) if this direction looks right.
