### PR TITLE
perf: reduce per-document fixed costs for small binary Ion 1.0 documents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,10 @@ bench = false
 name = "text_location_throughput"
 harness = false
 
+[[bench]]
+name = "small_doc_read"
+harness = false
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/benches/small_doc_read.rs
+++ b/benches/small_doc_read.rs
@@ -1,0 +1,230 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+/// Benchmarks the cost of reading *small* binary Ion 1.0 documents, constructing a fresh
+/// reader for each document.
+///
+/// The other benchmarks in this suite amortize per-document fixed costs (reader construction,
+/// IVM handling, and local symbol table processing) by streaming many values through a single
+/// reader. Workloads that read one document per record, message, or database item pay those
+/// fixed costs on every read. This benchmark measures them directly:
+///
+/// * `element_read_one`: `Element::read_one` on a single document (stable API, no experimental
+///   features required).
+/// * `lazy_reader_any` / `lazy_reader_binary`: the lazy `Reader` with `AnyEncoding` and
+///   `v1_0::Binary` respectively, reading all values in a single document (requires the
+///   `experimental-reader-writer` feature, like the other benchmarks in this suite).
+/// * `multi_ivm`: many small documents concatenated into one stream (each preceded by an IVM),
+///   read through a *single* reader. This exercises the encoding-context reset that runs at
+///   every IVM boundary.
+///
+/// Documents are structs with a mixed scalar field profile (strings, ints, bools, a timestamp)
+/// whose field names require a local symbol table. Three sizes (~200 B, ~2 KB, ~20 KB) show how
+/// the fixed costs amortize as documents grow.
+mod data {
+    use ion_rs::v1_0::Binary;
+    use ion_rs::Element;
+    use std::fmt::Write;
+
+    /// Returns the text of a struct document containing `num_groups` repetitions of a ten-field
+    /// group of mixed scalars. Field names are suffixed with the group index to produce
+    /// progressively larger local symbol tables.
+    fn small_doc_text(num_groups: usize) -> String {
+        let mut text = String::new();
+        text.push('{');
+        for group in 0..num_groups {
+            write!(
+                &mut text,
+                r#"
+                recordId_{group}: "R{group:04}AB{group:04}CD",
+                displayName_{group}: "widget display name {group}",
+                region_{group}: "north-region-{group}",
+                category_{group}: "general-category-{group}",
+                count_{group}: {},
+                sizeBytes_{group}: {},
+                active_{group}: true,
+                archived_{group}: false,
+                created_{group}: 2024-11-05T12:34:56.789Z,
+                score_{group}: {},
+                "#,
+                42 + group,
+                1_048_576 + group,
+                98_765 + group,
+            )
+            .unwrap();
+        }
+        text.push('}');
+        text
+    }
+
+    /// Encodes a document with `num_groups` field groups as binary Ion 1.0
+    /// (IVM + local symbol table + struct).
+    pub fn small_doc_binary(num_groups: usize) -> Vec<u8> {
+        Element::read_one(small_doc_text(num_groups))
+            .expect("failed to parse benchmark document text")
+            .encode_as(Binary)
+            .expect("failed to encode benchmark document")
+    }
+
+    /// The `num_groups` values that produce documents of roughly 200 B, 2 KB, and 20 KB.
+    pub const GROUP_COUNTS: &[usize] = &[1, 12, 120];
+}
+
+/// Benchmarks `Element::read_one` — the stable, default-feature entry point.
+fn element_benchmark(c: &mut Criterion) {
+    use criterion::{black_box, BenchmarkId, Throughput};
+
+    let mut group = c.benchmark_group("small_doc_read/element_read_one");
+    for &num_groups in data::GROUP_COUNTS {
+        let binary = data::small_doc_binary(num_groups);
+        group.throughput(Throughput::Bytes(binary.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{}B", binary.len())),
+            &binary,
+            |b, binary| {
+                b.iter(|| {
+                    let element = ion_rs::Element::read_one(black_box(binary.as_slice())).unwrap();
+                    black_box(element);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+#[cfg(feature = "experimental-reader-writer")]
+mod lazy_benchmark {
+    use super::data;
+    use criterion::{black_box, BenchmarkId, Criterion, Throughput};
+    use ion_rs::{
+        AnyEncoding, Decoder, IonInput, IonResult, LazyStruct, LazyValue, Reader, ValueRef,
+    };
+
+    /// Reads this value and, if it's a container, any nested values. Returns the number of
+    /// values read.
+    fn count_value_and_children<D: Decoder>(lazy_value: &LazyValue<'_, D>) -> IonResult<usize> {
+        use ValueRef::*;
+        let child_count = match lazy_value.read()? {
+            List(s) => count_sequence_children(s.iter())?,
+            SExp(s) => count_sequence_children(s.iter())?,
+            Struct(s) => count_struct_children(&s)?,
+            scalar => {
+                let _ = black_box(scalar);
+                0
+            }
+        };
+        Ok(1 + child_count)
+    }
+
+    /// Reads the child values of a list or s-expression. Returns the number of values read.
+    fn count_sequence_children<'a, D: Decoder>(
+        lazy_sequence: impl Iterator<Item = IonResult<LazyValue<'a, D>>>,
+    ) -> IonResult<usize> {
+        let mut count = 0;
+        for value in lazy_sequence {
+            count += count_value_and_children(&value?)?;
+        }
+        Ok(count)
+    }
+
+    /// Reads the field values of a struct. Returns the number of values read.
+    fn count_struct_children<D: Decoder>(lazy_struct: &LazyStruct<'_, D>) -> IonResult<usize> {
+        let mut count = 0;
+        for field in lazy_struct {
+            count += count_value_and_children(&field?.value())?;
+        }
+        Ok(count)
+    }
+
+    /// Reads every value in the stream, leaving the reader exhausted.
+    fn read_all_values<D: Decoder, I: IonInput>(reader: &mut Reader<D, I>) -> IonResult<usize> {
+        let mut count = 0;
+        while let Some(value) = reader.next()? {
+            count += count_value_and_children(&value)?;
+        }
+        Ok(count)
+    }
+
+    /// Benchmarks reading a single small document through a freshly constructed lazy `Reader`,
+    /// once with `AnyEncoding` and once with `v1_0::Binary`.
+    fn single_document(c: &mut Criterion) {
+        for &num_groups in data::GROUP_COUNTS {
+            let binary = data::small_doc_binary(num_groups);
+            let label = format!("{}B", binary.len());
+
+            let mut group = c.benchmark_group("small_doc_read/lazy_reader_any");
+            group.throughput(Throughput::Bytes(binary.len() as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(&label), &binary, |b, binary| {
+                b.iter(|| {
+                    let mut reader =
+                        Reader::new(AnyEncoding, black_box(binary.as_slice())).unwrap();
+                    black_box(read_all_values(&mut reader).unwrap());
+                });
+            });
+            group.finish();
+
+            let mut group = c.benchmark_group("small_doc_read/lazy_reader_binary");
+            group.throughput(Throughput::Bytes(binary.len() as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(&label), &binary, |b, binary| {
+                b.iter(|| {
+                    let mut reader =
+                        Reader::new(ion_rs::v1_0::Binary, black_box(binary.as_slice())).unwrap();
+                    black_box(read_all_values(&mut reader).unwrap());
+                });
+            });
+            group.finish();
+        }
+    }
+
+    /// Benchmarks reading many small documents concatenated into a single stream — each document
+    /// preceded by its own IVM — through a single reader. The encoding context (symbol table and
+    /// macro table) is reset at every IVM boundary, so this measures the per-document reset cost
+    /// in isolation from reader construction.
+    fn multi_ivm(c: &mut Criterion) {
+        const NUM_DOCS: usize = 100;
+        let mut group = c.benchmark_group("small_doc_read/multi_ivm");
+        for &num_groups in data::GROUP_COUNTS {
+            let one_doc = data::small_doc_binary(num_groups);
+            let stream: Vec<u8> = one_doc.repeat(NUM_DOCS);
+            group.throughput(Throughput::Bytes(stream.len() as u64));
+            group.bench_with_input(
+                BenchmarkId::from_parameter(format!("{NUM_DOCS}x{}B", one_doc.len())),
+                &stream,
+                |b, stream| {
+                    b.iter(|| {
+                        let mut reader =
+                            Reader::new(AnyEncoding, black_box(stream.as_slice())).unwrap();
+                        black_box(read_all_values(&mut reader).unwrap());
+                    });
+                },
+            );
+        }
+        group.finish();
+    }
+
+    pub fn criterion_benchmark(c: &mut Criterion) {
+        single_document(c);
+        multi_ivm(c);
+    }
+}
+
+#[cfg(not(feature = "experimental-reader-writer"))]
+mod lazy_benchmark {
+    use criterion::Criterion;
+
+    /// The lazy `Reader` cases require the `experimental-reader-writer` feature; without it,
+    /// only the `Element::read_one` cases run.
+    pub fn criterion_benchmark(_c: &mut Criterion) {
+        eprintln!(
+            "note: skipping lazy Reader benchmark cases; \
+             enable the 'experimental-reader-writer' feature to include them"
+        );
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    element_benchmark(c);
+    lazy_benchmark::criterion_benchmark(c);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/small_doc_read.rs
+++ b/benches/small_doc_read.rs
@@ -1,26 +1,27 @@
+//! Benchmarks the cost of reading *small* binary Ion 1.0 documents, constructing a fresh
+//! reader for each document.
+//!
+//! The other benchmarks in this suite amortize per-document fixed costs (reader construction,
+//! IVM handling, and local symbol table processing) by streaming many values through a single
+//! reader. Workloads that read one document per record, message, or database item pay those
+//! fixed costs on every read. This benchmark measures them directly:
+//!
+//! * `element_read_one`: `Element::read_one` on a single document (stable API, no experimental
+//!   features required).
+//! * `lazy_reader_any` / `lazy_reader_binary`: the lazy `Reader` with `AnyEncoding` and
+//!   `v1_0::Binary` respectively, reading all values in a single document (requires the
+//!   `experimental-reader-writer` feature, like the other benchmarks in this suite).
+//! * `multi_ivm`: many small documents concatenated into one stream (each preceded by an IVM),
+//!   read through a *single* reader. This exercises the encoding-context reset and local symbol
+//!   table processing that run at every IVM boundary, with reader construction amortized across
+//!   the documents in the stream.
+//!
+//! Documents are structs with a mixed scalar field profile (strings, ints, bools, a timestamp)
+//! whose field names require a local symbol table. Three sizes (~200 B, ~2 KB, ~20 KB) show how
+//! the fixed costs amortize as documents grow.
+
 use criterion::{criterion_group, criterion_main, Criterion};
 
-/// Benchmarks the cost of reading *small* binary Ion 1.0 documents, constructing a fresh
-/// reader for each document.
-///
-/// The other benchmarks in this suite amortize per-document fixed costs (reader construction,
-/// IVM handling, and local symbol table processing) by streaming many values through a single
-/// reader. Workloads that read one document per record, message, or database item pay those
-/// fixed costs on every read. This benchmark measures them directly:
-///
-/// * `element_read_one`: `Element::read_one` on a single document (stable API, no experimental
-///   features required).
-/// * `lazy_reader_any` / `lazy_reader_binary`: the lazy `Reader` with `AnyEncoding` and
-///   `v1_0::Binary` respectively, reading all values in a single document (requires the
-///   `experimental-reader-writer` feature, like the other benchmarks in this suite).
-/// * `multi_ivm`: many small documents concatenated into one stream (each preceded by an IVM),
-///   read through a *single* reader. This exercises the encoding-context reset and local symbol
-///   table processing that run at every IVM boundary, with reader construction amortized across
-///   the documents in the stream.
-///
-/// Documents are structs with a mixed scalar field profile (strings, ints, bools, a timestamp)
-/// whose field names require a local symbol table. Three sizes (~200 B, ~2 KB, ~20 KB) show how
-/// the fixed costs amortize as documents grow.
 mod data {
     use ion_rs::v1_0::Binary;
     use ion_rs::Element;

--- a/benches/small_doc_read.rs
+++ b/benches/small_doc_read.rs
@@ -14,8 +14,9 @@ use criterion::{criterion_group, criterion_main, Criterion};
 ///   `v1_0::Binary` respectively, reading all values in a single document (requires the
 ///   `experimental-reader-writer` feature, like the other benchmarks in this suite).
 /// * `multi_ivm`: many small documents concatenated into one stream (each preceded by an IVM),
-///   read through a *single* reader. This exercises the encoding-context reset that runs at
-///   every IVM boundary.
+///   read through a *single* reader. This exercises the encoding-context reset and local symbol
+///   table processing that run at every IVM boundary, with reader construction amortized across
+///   the documents in the stream.
 ///
 /// Documents are structs with a mixed scalar field profile (strings, ints, bools, a timestamp)
 /// whose field names require a local symbol table. Three sizes (~200 B, ~2 KB, ~20 KB) show how
@@ -177,8 +178,9 @@ mod lazy_benchmark {
 
     /// Benchmarks reading many small documents concatenated into a single stream — each document
     /// preceded by its own IVM — through a single reader. The encoding context (symbol table and
-    /// macro table) is reset at every IVM boundary, so this measures the per-document reset cost
-    /// in isolation from reader construction.
+    /// macro table) is reset at every IVM boundary. Reader construction happens once per
+    /// iteration (amortized across `NUM_DOCS` documents), so the measurement is dominated by the
+    /// per-document reset and local symbol table processing.
     fn multi_ivm(c: &mut Criterion) {
         const NUM_DOCS: usize = 100;
         let mut group = c.benchmark_group("small_doc_read/multi_ivm");

--- a/src/lazy/expanded/macro_table.rs
+++ b/src/lazy/expanded/macro_table.rs
@@ -888,10 +888,15 @@ impl MacroTable {
         Ok(())
     }
 
-    pub(crate) fn reset_to_system_macros(&mut self) {
+    /// Resets the macro table to the initial state for the given Ion version: empty for
+    /// Ion 1.0 (which has no e-expressions and so cannot reference the macro table), or the
+    /// system macro table for Ion 1.1. This mirrors [`MacroTable::with_system_macros`].
+    pub(crate) fn reset_to_system_macros(&mut self, ion_version: IonVersion) {
         self.macros_by_name.clear();
         self.macros_by_address.clear();
-        self.append_all_macros_from(&ION_1_1_SYSTEM_MACROS).unwrap()
+        if ion_version == IonVersion::v1_1 {
+            self.append_all_macros_from(&ION_1_1_SYSTEM_MACROS).unwrap()
+        }
     }
 
     pub(crate) fn macros_tail(&self, num_tail_macros: usize) -> &[Arc<MacroDef>] {

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -463,17 +463,10 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
         macro_table: &mut MacroTable,
     ) {
         if let Some(new_version) = pending_changes.switch_to_version.take() {
-            if new_version == IonVersion::v1_0 && symbol_table.ion_version() == IonVersion::v1_0 {
-                // An IVM that re-declares the stream's current version still resets the local
-                // symbol table. In Ion 1.0, the permanent system prefix is identical to the
-                // table's initial state, so truncating to the prefix (which also restores any
-                // system text-to-SID mappings that user symbols had shadowed) produces the same
-                // table state as a full rebuild at a fraction of the cost. See the unit test
-                // `reset_paths_equivalent_for_v1_0` in `symbol_table.rs`.
-                symbol_table.reset_to_prefix_only();
-            } else {
-                symbol_table.reset_to_version(new_version);
-            }
+            // An IVM that re-declares the stream's current version still resets the local
+            // symbol table. `reset_to_version` internally takes a cheaper prefix-only path
+            // when the version is unchanged (Ion 1.0).
+            symbol_table.reset_to_version(new_version);
             macro_table.reset_to_system_macros(new_version);
             pending_changes.has_changes = false;
             pending_changes.is_lst_append = false;

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -463,7 +463,15 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
         macro_table: &mut MacroTable,
     ) {
         if let Some(new_version) = pending_changes.switch_to_version.take() {
-            symbol_table.reset_to_version(new_version);
+            if new_version == IonVersion::v1_0 && symbol_table.ion_version() == IonVersion::v1_0 {
+                // An IVM that re-declares the stream's current version still resets the local
+                // symbol table. In Ion 1.0, the permanent system prefix is identical to the
+                // table's initial state, so truncating to the prefix is equivalent to (and much
+                // cheaper than) rebuilding the table.
+                symbol_table.reset_to_prefix_only();
+            } else {
+                symbol_table.reset_to_version(new_version);
+            }
             macro_table.reset_to_system_macros();
             pending_changes.has_changes = false;
             pending_changes.is_lst_append = false;

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -466,8 +466,10 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
             if new_version == IonVersion::v1_0 && symbol_table.ion_version() == IonVersion::v1_0 {
                 // An IVM that re-declares the stream's current version still resets the local
                 // symbol table. In Ion 1.0, the permanent system prefix is identical to the
-                // table's initial state, so truncating to the prefix is equivalent to (and much
-                // cheaper than) rebuilding the table.
+                // table's initial state, so truncating to the prefix (which also restores any
+                // system text-to-SID mappings that user symbols had shadowed) produces the same
+                // table state as a full rebuild at a fraction of the cost. See the unit test
+                // `reset_paths_equivalent_for_v1_0` in `symbol_table.rs`.
                 symbol_table.reset_to_prefix_only();
             } else {
                 symbol_table.reset_to_version(new_version);

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -472,7 +472,7 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
             } else {
                 symbol_table.reset_to_version(new_version);
             }
-            macro_table.reset_to_system_macros();
+            macro_table.reset_to_system_macros(new_version);
             pending_changes.has_changes = false;
             pending_changes.is_lst_append = false;
             // If we're switching to a new version, the last stream item was a version marker

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -1149,4 +1149,102 @@ mod tests {
         assert_eq!(reader.expect_next_value()?.read()?.expect_i64()?, 12);
         Ok(())
     }
+
+    /// An Ion 1.0 IVM mid-stream resets the symbol table via the cheap truncate-to-prefix path.
+    /// If a user symbol's text duplicated a system symbol's text (here: "name"), it shadowed the
+    /// system entry in the text -> SID mapping; the reset must restore that mapping, leaving the
+    /// table indistinguishable from a freshly constructed Ion 1.0 table.
+    #[test]
+    fn ivm_reset_restores_shadowed_system_symbol_mappings() -> IonResult<()> {
+        const DATA: &str = r#"
+            $ion_symbol_table::{
+                symbols: ["name", "version", "imports", "symbols", "max_id", "user_symbol"]
+            }
+            $10 // user-space copy of "name"
+            $ion_1_0
+            0
+        "#;
+        let mut reader = SystemReader::new(AnyEncoding, DATA);
+        assert_eq!(reader.expect_next_value()?.read()?.expect_symbol()?, "name");
+        // While the user symbols are active, the text "name" resolves to the user-space SID.
+        assert_eq!(reader.symbol_table().sid_for("name"), Some(10));
+        // Advancing to the value that follows the IVM applies the pending symbol table reset.
+        assert_eq!(reader.expect_next_value()?.read()?.expect_i64()?, 0);
+
+        let table = reader.symbol_table();
+        let fresh = SymbolTable::new(IonVersion::v1_0);
+        assert_eq!(table.len(), fresh.len());
+        for sid in 0..fresh.len() {
+            assert_eq!(table.text_for(sid), fresh.text_for(sid), "SID: {sid}");
+        }
+        for &text in crate::constants::v1_0::SYSTEM_SYMBOLS {
+            assert_eq!(table.sid_for(text), fresh.sid_for(text), "text: {text}");
+        }
+        assert_eq!(table.sid_for("name"), Some(4));
+        assert_eq!(table.text_for(4), Some("name"));
+        assert_eq!(table.sid_for("user_symbol"), None);
+        Ok(())
+    }
+
+    /// An LST append (`imports: $ion_symbol_table`) extends the active table; a subsequent
+    /// Ion 1.0 IVM must still reset it to the initial system state.
+    #[test]
+    fn ivm_reset_after_lst_append() -> IonResult<()> {
+        const DATA: &str = r#"
+            $ion_symbol_table::{ symbols: ["foo"] }
+            $10 // "foo"
+            $ion_symbol_table::{ imports: $ion_symbol_table, symbols: ["bar"] }
+            $11 // "bar"
+            $ion_1_0
+            0
+        "#;
+        let mut reader = SystemReader::new(AnyEncoding, DATA);
+        assert_eq!(reader.expect_next_value()?.read()?.expect_symbol()?, "foo");
+        assert_eq!(reader.expect_next_value()?.read()?.expect_symbol()?, "bar");
+        // Both the original LST and the appended symbols are active: $0-$9 system + foo + bar.
+        assert_eq!(reader.symbol_table().len(), 12);
+        // Advancing to the value that follows the IVM applies the pending symbol table reset.
+        assert_eq!(reader.expect_next_value()?.read()?.expect_i64()?, 0);
+
+        let table = reader.symbol_table();
+        let fresh = SymbolTable::new(IonVersion::v1_0);
+        assert_eq!(table.len(), fresh.len());
+        for sid in 0..fresh.len() {
+            assert_eq!(table.text_for(sid), fresh.text_for(sid), "SID: {sid}");
+        }
+        assert_eq!(table.sid_for("foo"), None);
+        assert_eq!(table.sid_for("bar"), None);
+        Ok(())
+    }
+
+    /// The macro table must match the initial state for whichever Ion version the most recent
+    /// IVM declared: empty for Ion 1.0, the full system macro table for Ion 1.1 — including
+    /// when the stream switches back and forth between versions.
+    #[cfg(feature = "experimental-ion-1-1")]
+    #[test]
+    fn macro_table_reset_across_version_switches() -> IonResult<()> {
+        const DATA: &str = r#"
+            0
+            $ion_1_1
+            1
+            $ion_1_0
+            2
+            $ion_1_1
+            3
+        "#;
+        let mut reader = SystemReader::new(AnyEncoding, DATA);
+        // An Ion 1.0 stream begins with an empty macro table.
+        assert_eq!(reader.expect_next_value()?.read()?.expect_i64()?, 0);
+        assert_eq!(reader.macro_table().len(), 0);
+        // Switching to Ion 1.1 installs the system macros.
+        assert_eq!(reader.expect_next_value()?.read()?.expect_i64()?, 1);
+        assert_eq!(reader.macro_table().len(), MacroTable::NUM_SYSTEM_MACROS);
+        // Switching back to Ion 1.0 empties the macro table again.
+        assert_eq!(reader.expect_next_value()?.read()?.expect_i64()?, 2);
+        assert_eq!(reader.macro_table().len(), 0);
+        // A later Ion 1.1 IVM repopulates it in full.
+        assert_eq!(reader.expect_next_value()?.read()?.expect_i64()?, 3);
+        assert_eq!(reader.macro_table().len(), MacroTable::NUM_SYSTEM_MACROS);
+        Ok(())
+    }
 }

--- a/src/lazy/system_reader.rs
+++ b/src/lazy/system_reader.rs
@@ -742,6 +742,41 @@ mod tests {
         Ok(())
     }
 
+    /// A user symbol whose text duplicates a system symbol's (e.g. `"name"`) shadows the
+    /// system entry in the text -> SID map. When a later LST *replaces* (rather than appends
+    /// to) the table -- with no intervening IVM -- the reset must restore the shadowed
+    /// system mapping.
+    #[test]
+    fn lst_replacement_restores_shadowed_system_mappings() -> IonResult<()> {
+        let mut reader = SystemReader::new(
+            AnyEncoding,
+            r#"
+                $ion_symbol_table::{ symbols: ["name"] }
+                $10 // user-space copy of "name"
+                // This LST does not import `$ion_symbol_table`, so it replaces the previous
+                // table rather than appending to it. There is no IVM between the tables.
+                $ion_symbol_table::{ symbols: ["other"] }
+                $10 // "other"
+            "#,
+        );
+        // Step over the first LST; advancing to the value applies it.
+        let _symtab = reader.next_item()?.expect_symbol_table()?;
+        assert_eq!(reader.expect_next_value()?.read()?.expect_symbol()?, "name");
+        // The user-space copy of "name" ($10) shadows system SID 4 in the text -> SID map.
+        assert_eq!(reader.symbol_table().sid_for("name"), Some(10));
+
+        // Advance past the second (replacement) LST to the value that follows it.
+        let _symtab = reader.next_item()?.expect_symbol_table()?;
+        assert_eq!(
+            reader.expect_next_value()?.read()?.expect_symbol()?,
+            "other"
+        );
+        // The replacement reset restored the system mapping for "name".
+        assert_eq!(reader.symbol_table().sid_for("name"), Some(4));
+        assert_eq!(reader.symbol_table().sid_for("other"), Some(10));
+        Ok(())
+    }
+
     // === Shared Symbol Tables ===
 
     use crate::catalog::MapCatalog;

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -112,8 +112,6 @@ impl SymbolTable {
 
     /// Adds **all** of the system symbols to the table, not just the permanent prefix symbols.
     pub(crate) fn initialize_with_all_system_symbols(&mut self) {
-        // TODO: Make thread local system symbol tables that are materialized (i.e. using Arc<str>)
-        //       so we can avoid doing new heap allocations each time
         self.add_placeholder(); // $0
 
         let system_symbols = match self.ion_version {
@@ -121,8 +119,10 @@ impl SymbolTable {
             IonVersion::v1_1 => v1_1::SYSTEM_SYMBOLS,
         };
 
+        // The system symbol texts are `&'static str`s, so the symbols can refer to them
+        // directly instead of heap-allocating a copy of each one.
         system_symbols.iter().copied().for_each(|text| {
-            let _sid = self.add_symbol_for_text(text);
+            let _sid = self.add_symbol(Symbol::static_text(text));
         });
     }
 
@@ -277,5 +277,27 @@ impl Debug for SymbolTable {
             write!(f, "{}: {:?}, ", address, symbol.text())?;
         }
         write!(f, "}}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The system symbols are stored as `Symbol`s with static text; confirm that they can
+    /// still be resolved in both directions (text -> SID and SID -> text) like any other symbol.
+    #[test]
+    fn system_symbols_resolve_by_text_and_sid() {
+        let mut table = SymbolTable::new(IonVersion::v1_0);
+        assert_eq!(table.len(), 10);
+        for (index, &text) in v1_0::SYSTEM_SYMBOLS.iter().enumerate() {
+            let sid = index + 1; // SID 0 is the unknown-text placeholder `$0`
+            assert_eq!(table.sid_for(text), Some(sid));
+            assert_eq!(table.text_for(sid), Some(text));
+        }
+        // Symbols with heap-allocated text can coexist with the static system symbols.
+        let sid = table.add_symbol_for_text("hello");
+        assert_eq!(table.sid_for("hello"), Some(sid));
+        assert_eq!(table.text_for(sid), Some("hello"));
     }
 }

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -167,7 +167,19 @@ impl SymbolTable {
         };
     }
 
+    /// Resets the symbol table to the 'default' state for `new_version`, as used at the
+    /// beginning of a stream of that version.
+    ///
+    /// When the version is unchanged and is Ion 1.0, this takes a cheaper path: the
+    /// permanent system prefix is identical to the table's initial state, so truncating to
+    /// the prefix (which also restores any system text-to-SID mappings that user symbols
+    /// had shadowed) produces the same table state as a full rebuild at a fraction of the
+    /// cost. See the unit test `reset_paths_equivalent_for_v1_0` below.
     pub(crate) fn reset_to_version(&mut self, new_version: IonVersion) {
+        if new_version == IonVersion::v1_0 && self.ion_version == IonVersion::v1_0 {
+            self.reset_to_prefix_only();
+            return;
+        }
         self.ion_version = new_version;
         self.reset_to_default();
     }

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -135,7 +135,7 @@ impl SymbolTable {
     }
 
     /// Sets the symbol table's contents to the permanent prefix used by the current Ion version.
-    /// In Ion 1.0, this is the system symbol table (`$0`-`$10`). In Ion 1.1, it is only `$0`.
+    /// In Ion 1.0, this is the system symbol table (`$0`-`$9`). In Ion 1.1, it is only `$0`.
     pub(crate) fn reset_to_prefix_only(&mut self) {
         match self.ion_version {
             IonVersion::v1_0 => {
@@ -145,6 +145,17 @@ impl SymbolTable {
                 // Remove any symbol text mappings that point to an address from userspace ($10+)
                 self.ids_by_text
                     .retain(|_symbol, address| *address < Self::NUM_PREFIX_SYSTEM_SYMBOLS_1_0);
+                // If a user symbol's text duplicated a system symbol's text, adding it overwrote
+                // the system symbol's entry in `ids_by_text` with a user-space address--an entry
+                // the `retain` above then removed. Restore any missing system text mappings so
+                // the table is indistinguishable from a freshly initialized one. (This is
+                // allocation-free: the keys are `&'static str`-backed symbols, and `or_insert`
+                // leaves already-present entries untouched.)
+                for (index, &text) in v1_0::SYSTEM_SYMBOLS.iter().enumerate() {
+                    self.ids_by_text
+                        .entry(Symbol::static_text(text))
+                        .or_insert(index + 1); // SID 0 is the unknown-text placeholder `$0`
+                }
             }
             IonVersion::v1_1 => {
                 // Remove all symbols except for $0
@@ -299,5 +310,37 @@ mod tests {
         let sid = table.add_symbol_for_text("hello");
         assert_eq!(table.sid_for("hello"), Some(sid));
         assert_eq!(table.text_for(sid), Some("hello"));
+    }
+
+    /// `reset_to_prefix_only` must produce exactly the same Ion 1.0 table state as a full
+    /// rebuild, even when user symbols shadowed system symbol texts. A user symbol whose text
+    /// duplicates a system symbol's (e.g. `"name"`) overwrites the system entry in the
+    /// text -> SID map; the reset must restore it.
+    #[test]
+    fn reset_paths_equivalent_for_v1_0() {
+        let mut table = SymbolTable::new(IonVersion::v1_0);
+        // Shadow every system symbol text with a user symbol, and add an ordinary user symbol.
+        for &text in v1_0::SYSTEM_SYMBOLS {
+            table.add_symbol_for_text(text);
+        }
+        table.add_symbol_for_text("user_symbol");
+        // The shadowing user symbols have replaced the system entries in the text -> SID map:
+        // "name" (system SID 4) now resolves to its user-space copy.
+        assert_eq!(table.sid_for("name"), Some(13));
+
+        table.reset_to_prefix_only();
+
+        // The reset table must be indistinguishable from a freshly constructed one.
+        let fresh = SymbolTable::new(IonVersion::v1_0);
+        assert_eq!(table.len(), fresh.len());
+        for sid in 0..fresh.len() {
+            assert_eq!(table.text_for(sid), fresh.text_for(sid), "SID: {sid}");
+        }
+        for &text in v1_0::SYSTEM_SYMBOLS {
+            assert_eq!(table.sid_for(text), fresh.sid_for(text), "text: {text}");
+        }
+        assert_eq!(table.sid_for("name"), Some(4));
+        assert_eq!(table.text_for(4), Some("name"));
+        assert_eq!(table.sid_for("user_symbol"), None);
     }
 }

--- a/src/types/symbol.rs
+++ b/src/types/symbol.rs
@@ -252,6 +252,36 @@ mod symbol_tests {
     }
 
     #[test]
+    fn static_shared_and_owned_text_are_interchangeable() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::collections::HashMap;
+        use std::hash::{Hash, Hasher};
+
+        fn hash_of(symbol: &Symbol) -> u64 {
+            let mut hasher = DefaultHasher::new();
+            symbol.hash(&mut hasher);
+            hasher.finish()
+        }
+
+        // Symbols with the same text are equal and hash identically regardless of whether
+        // their text is static, shared, or owned.
+        let static_symbol = Symbol::static_text("name");
+        let shared_symbol = Symbol::shared(Arc::from("name"));
+        let owned_symbol = Symbol::owned("name");
+        assert_eq!(static_symbol, shared_symbol);
+        assert_eq!(static_symbol, owned_symbol);
+        assert_eq!(hash_of(&static_symbol), hash_of(&shared_symbol));
+        assert_eq!(hash_of(&static_symbol), hash_of(&owned_symbol));
+
+        // A map keyed on a static-text symbol can be queried with the equivalent
+        // shared- or owned-text symbol and vice versa.
+        let mut map: HashMap<Symbol, usize> = HashMap::new();
+        map.insert(static_symbol, 1);
+        assert_eq!(map.get(&shared_symbol), Some(&1));
+        assert_eq!(map.get(&owned_symbol), Some(&1));
+    }
+
+    #[test]
     fn partial_eq_str() {
         let symbols = vec![
             Symbol::shared(Arc::from("bar")),


### PR DESCRIPTION
### Summary

This PR reduces the fixed costs paid once per binary Ion 1.0 document:
reader construction, IVM (Ion Version Marker) handling, and local symbol
table (LST) processing. It also adds a small-document benchmark that
measures them. On a ~228-byte document read via the stable API,
`Element::read_one` improves ~25%; the lazy binary path improves ~40%.
Allocations per document drop from 52 to 26. Follows discussion in
#1038.

### Motivation

Workloads that read one document per record, message, or database item
pay per-document setup on every read, and for small documents that setup
dominates. On a ~228-byte binary document, `Element::read_one` (the
stable, default-feature API) costs ~11.2 µs. Of that, ~6.2 µs is
construction plus IVM/LST fixed cost, measured on the binary lazy path
(phase split: construction 875 ns, IVM + LST 5,324 ns, value reads
1,123 ns). Of 52 heap allocations per document, the fixed phases own 50.

The existing benchmarks could not observe this: they amortize fixed costs
over 10,000 structs read through a single reader.

### What changed

- `aa33e35` **perf: add small-document read benchmark**: new
  `benches/small_doc_read.rs`. Fresh reader per iteration at ~200 B /
  ~2 KB / ~20 KB. Covers `Element::read_one` (default features), the lazy
  `AnyEncoding` and `v1_0::Binary` readers (gated on
  `experimental-reader-writer`, like the existing benches), and a
  many-documents-concatenated-with-IVMs case that exercises the per-IVM
  encoding-context reset.
- `947cf2c` **perf: avoid per-document symbol table rebuild costs**: uses
  `Symbol::static_text` for the 9 built-in system symbol strings instead
  of heap-allocating them with `Arc::from` on every document (this
  addresses the in-code TODO in `symbol_table.rs`), and, when an IVM
  re-declares the version already in use, resets the symbol table via the
  existing prefix-only truncation instead of a full rebuild. The
  spec-mandated reset still occurs.
- `747eaeb` **perf: reset the macro table to match the Ion version
  declared by an IVM**: an Ion 1.0 IVM now resets to the empty macro
  table matching the documented initial 1.0 state, instead of rebuilding
  all 24 Ion 1.1 system macros. Mirrors `MacroTable::with_system_macros`.
  (Severable; see Disclosures.)
- `f31193b` **perf: restore shadowed system symbol mappings on cheap IVM
  reset**: a user symbol can have the same text as a system symbol
  (e.g. `"name"`), which "shadows" the system entry in the text->SID
  index. After the prefix-only reset, this commit re-inserts any shadowed
  system mappings. It also fixes the same pre-existing hole in the
  non-append LST path, which has always used the prefix-only reset:
  previously, `sid_for` of a user-shadowed system text failed to resolve
  after that reset.
- `3c86ef9` **refactor: apply local review feedback**: moves the cheap
  reset logic into `SymbolTable::reset_to_version`, so callers need no
  special case, and adds a test covering LST replacement without an IVM.

### Benchmarks

New `small_doc_read` bench, before/after (aarch64, release; criterion
output with confidence intervals attached). An x86_64 run will follow:
the largest win is `Arc` refcount traffic, and atomics costs differ by
architecture.

| Case | ~228 B | ~2.5 KB | ~20 KB |
|---|---:|---:|---:|
| `element_read_one` | **−25%** | −2.9% | −0.5% |
| `lazy_any_encoding` | **−33%** | −5.1% | — |
| `lazy_binary_1_0` | **−40%** | −5.4% | — |
| `multi_ivm` (concatenated docs, one reader) | **−28%** | — | +1.3% |
| allocations/doc (228 B) | 52 -> 26 | | |

The large `multi_ivm` case is a ~2% regression: baseline 49.2 ms vs
branch 49.9–50.5 ms across 3 interleaved before/after runs on matched
configurations. Profiling shows the functions this PR actually changes at
parity or better on that case; the delta is consistent with a diffuse
code-layout shift. We consider it acceptable because 28 KB documents
amortize per-document fixed costs by construction, while the 228-byte
case this PR targets improves ~24%.

Existing suite, before/after (no sustained regressions >2%):

| Bench | Change |
|---|---:|
| `read_many_structs`, binary 1.0, read all values | −0.7% |
| `read_many_structs`, binary 1.0, scan all values | −4.7% |
| `encoding_primitives` | within ±1.2% |

We also cross-checked the results with a second, independent profiler
([dial9-tokio-telemetry](https://github.com/dial9-rs/dial9-tokio-telemetry),
perf-based CPU sampling). It reproduced the improvement on the small-document
`v1_0::Binary` case (−38% in both wall clock and CPU samples) and the
mechanism: symbol-table and hash-map stacks halved, and `Arc` refcount
atomics fell from 12.5% to 3.5% of the profile. Output checksums were
identical between baseline and patched builds on every run.

### Disclosures

1. **~2% regression on large multi-IVM streams** (100 × ~28 KB documents,
   one reader): characterized above; the small-document cases this PR
   targets improve 25–40%.
2. **Behavior change (experimental API)**: on an Ion 1.0 reader after an
   IVM, `register_template_src` no longer resolves *unqualified* system
   macro names. Those previously resolved only because the Ion 1.1 macro
   table was (we believe accidentally) populated on a 1.0 IVM. Qualified
   names (`$ion::values`) are unaffected. This restores symmetry between
   the pre-IVM and post-IVM 1.0 states.
3. **Severability**: the macro-table commit (`747eaeb`) can be dropped
   from this PR on request, without affecting the symbol-table changes or
   the benchmark.
4. The shadowed-symbol commit (`f31193b`) also fixes a **pre-existing**
   hole in the non-append local-symbol-table path (which has always used
   the prefix-only reset): `sid_for` of a system symbol text shadowed by
   a user symbol did not resolve after that reset. With this PR, a
   shadowed system text resolves again after an LST is replaced without
   any IVM; a new test covers this.
5. **Alternative we considered**: the existing phf
   `SYSTEM_SYMBOL_TEXT_TO_ID` table could make system symbols never
   enter the text->SID index at all (look up the user map first, fall
   back to the phf table). That has a larger blast radius, so we kept
   the narrower fix here, but we're open to that direction.
6. **Capacity**: the prefix-only reset truncates but never shrinks
   capacity, matching the previous `clear()` behavior. A reader that
   once saw a very large symbol table retains that capacity across
   later documents (pre-existing, unchanged).

### Relationship to the large-document PR

Our large-document PR (#1038) touches
`symbol_table.rs` and `apply_pending_context_changes` in adjacent hunks;
whichever PR lands second expects a small manual rebase, and the bench
helper duplicated between the two will be consolidated by whichever
lands second.

### Test plan

- `cargo test --workspace --all-features`: 15,009 tests pass.
- `cargo clippy --workspace --all-features -- -D warnings` and
  `cargo fmt --check`: clean.
- The #1022 regression test
  (`ivm_resets_symbol_table_in_concatenated_documents`) passes
  **unmodified**: the IVM reset path is behaviorally equivalent, only
  cheaper.
- New tests: `system_symbols_resolve_by_text_and_sid`,
  `static_shared_and_owned_text_are_interchangeable`,
  `reset_paths_equivalent_for_v1_0`,
  `ivm_reset_restores_shadowed_system_symbol_mappings`,
  `ivm_reset_after_lst_append`,
  `lst_replacement_restores_shadowed_system_mappings`,
  `macro_table_reset_across_version_switches`.

_By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license._
