### PR TITLE
perf: reduce large-document binary Ion 1.0 read costs on the Element and AnyEncoding paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,10 @@ name = "read_many_structs"
 harness = false
 
 [[bench]]
+name = "large_doc_read"
+harness = false
+
+[[bench]]
 name = "write_many_structs"
 harness = false
 

--- a/benches/large_doc_read.rs
+++ b/benches/large_doc_read.rs
@@ -17,8 +17,8 @@
 //!   * `element_read_one`: materializes the document with `Element::read_one` — the
 //!     stable, default-feature API.
 //!   * `element_struct_get_by_name`: materializes the document once (outside the timed
-//!     loop), then repeatedly looks up struct fields by name — a regression guard for
-//!     the DOM's field-name index.
+//!     loop), then repeatedly looks up struct fields by name — mostly present names,
+//!     plus ~15% absent names — a regression guard for the DOM's field-name index.
 //!   * `lazy_any_read_all` / `lazy_binary_read_all`: visits every value in the document
 //!     using the streaming `Reader` with `AnyEncoding` (encoding auto-detection) and
 //!     with the concrete `v1_0::Binary` encoding. Like the other benchmarks' streaming
@@ -198,13 +198,19 @@ fn default_feature_benchmarks(
         .elements()
         .map(|element| element.as_struct().unwrap())
         .collect();
-    // Precompute the lookup keys so the timed loop performs no allocations.
+    // Precompute the lookup keys so the timed loop performs no allocations. Roughly
+    // 15% of the keys are absent from every struct so that the index's miss path is
+    // exercised alongside its hit path.
+    let absent_keys = |struct_index: usize, count: usize| {
+        (0..count).map(move |index| format!("missingField{:02}", (struct_index + index) % 8))
+    };
     let lookup_keys: Vec<Vec<String>> = match flavor {
         "value_heavy" => (0..num_structs)
-            .map(|_| {
+            .map(|struct_index| {
                 VALUE_HEAVY_FIELD_NAMES
                     .iter()
                     .map(|name| (*name).to_owned())
+                    .chain(absent_keys(struct_index, 3))
                     .collect()
             })
             .collect(),
@@ -212,6 +218,7 @@ fn default_feature_benchmarks(
             .map(|struct_index| {
                 (0..SYMBOL_HEAVY_FIELDS_PER_STRUCT)
                     .map(|index| symbol_heavy_field_name(struct_index, index))
+                    .chain(absent_keys(struct_index, 2))
                     .collect()
             })
             .collect(),

--- a/benches/large_doc_read.rs
+++ b/benches/large_doc_read.rs
@@ -135,20 +135,17 @@ fn encode_binary_1_0(text: &str) -> IonResult<Vec<u8>> {
     Element::read_one(text)?.encode_as(v1_0::Binary)
 }
 
-/// Grows the number of structs produced by `generate` until the binary-encoded document
+/// Grows the number of structs produced by `flavor` until the binary-encoded document
 /// reaches `target_num_bytes`. Returns the encoded document and the struct count.
-fn make_document(
-    generate: fn(usize) -> String,
-    target_num_bytes: usize,
-) -> IonResult<(Vec<u8>, usize)> {
+fn make_document(flavor: Flavor, target_num_bytes: usize) -> IonResult<(Vec<u8>, usize)> {
     let mut num_structs = 8;
-    let mut binary_data = encode_binary_1_0(&generate(num_structs))?;
+    let mut binary_data = encode_binary_1_0(&flavor.generate(num_structs))?;
     // Take one proportional jump toward the target size, then fine-tune linearly.
     num_structs = (num_structs * target_num_bytes / binary_data.len().max(1)).max(1);
-    binary_data = encode_binary_1_0(&generate(num_structs))?;
+    binary_data = encode_binary_1_0(&flavor.generate(num_structs))?;
     while binary_data.len() < target_num_bytes {
         num_structs += 1;
-        binary_data = encode_binary_1_0(&generate(num_structs))?;
+        binary_data = encode_binary_1_0(&flavor.generate(num_structs))?;
     }
     Ok((binary_data, num_structs))
 }
@@ -172,23 +169,74 @@ fn visit_element(element: &Element) -> usize {
     }
 }
 
+/// A document flavor: which shape of test document to generate.
+#[derive(Clone, Copy, Debug)]
+enum Flavor {
+    /// Log-record-shaped structs reusing a small set of field names; the symbol table
+    /// stays small and nearly all of the document is value content.
+    ValueHeavy,
+    /// Structs in which every field name and symbol value is distinct; most of the read
+    /// cost is symbol table processing.
+    SymbolHeavy,
+}
+
+impl Flavor {
+    /// A short name for this flavor, used in benchmark IDs.
+    fn label(self) -> &'static str {
+        match self {
+            Flavor::ValueHeavy => "value_heavy",
+            Flavor::SymbolHeavy => "symbol_heavy",
+        }
+    }
+
+    /// Produces the text for a document of this flavor containing `num_structs` structs.
+    fn generate(self, num_structs: usize) -> String {
+        match self {
+            Flavor::ValueHeavy => value_heavy_text(num_structs),
+            Flavor::SymbolHeavy => symbol_heavy_text(num_structs),
+        }
+    }
+
+    /// The field names to look up in the `struct_index`th struct of a document of this
+    /// flavor: this struct's present field names followed by `num_absent` names that are
+    /// absent from every struct.
+    fn lookup_keys(self, struct_index: usize) -> Vec<String> {
+        let absent_keys = |count: usize| {
+            (0..count).map(move |index| format!("missingField{:02}", (struct_index + index) % 8))
+        };
+        match self {
+            Flavor::ValueHeavy => VALUE_HEAVY_FIELD_NAMES
+                .iter()
+                .map(|name| (*name).to_owned())
+                .chain(absent_keys(3))
+                .collect(),
+            Flavor::SymbolHeavy => (0..SYMBOL_HEAVY_FIELDS_PER_STRUCT)
+                .map(|index| symbol_heavy_field_name(struct_index, index))
+                .chain(absent_keys(2))
+                .collect(),
+        }
+    }
+}
+
 /// Benchmarks that only require the crate's default features.
 fn default_feature_benchmarks(
     c: &mut Criterion,
-    flavor: &str,
+    flavor: Flavor,
     size_label: &str,
     binary_data: &[u8],
     num_structs: usize,
 ) {
-    let mut group = c.benchmark_group(format!("large_doc {flavor} {size_label}"));
+    let case_id = format!("{}_{}", flavor.label(), size_label);
 
     // Materialize the whole document with the stable, default-feature API.
-    group.bench_function("element_read_one", |b| {
+    let mut group = c.benchmark_group("large_doc_read/element_read_one");
+    group.bench_function(&case_id, |b| {
         b.iter(|| {
             let element = Element::read_one(black_box(binary_data)).unwrap();
             black_box(element);
         })
     });
+    group.finish();
 
     // Materialize the document once, then repeatedly look up struct fields by name.
     let document = Element::read_one(binary_data).unwrap();
@@ -201,30 +249,11 @@ fn default_feature_benchmarks(
     // Precompute the lookup keys so the timed loop performs no allocations. Roughly
     // 15% of the keys are absent from every struct so that the index's miss path is
     // exercised alongside its hit path.
-    let absent_keys = |struct_index: usize, count: usize| {
-        (0..count).map(move |index| format!("missingField{:02}", (struct_index + index) % 8))
-    };
-    let lookup_keys: Vec<Vec<String>> = match flavor {
-        "value_heavy" => (0..num_structs)
-            .map(|struct_index| {
-                VALUE_HEAVY_FIELD_NAMES
-                    .iter()
-                    .map(|name| (*name).to_owned())
-                    .chain(absent_keys(struct_index, 3))
-                    .collect()
-            })
-            .collect(),
-        "symbol_heavy" => (0..num_structs)
-            .map(|struct_index| {
-                (0..SYMBOL_HEAVY_FIELDS_PER_STRUCT)
-                    .map(|index| symbol_heavy_field_name(struct_index, index))
-                    .chain(absent_keys(struct_index, 2))
-                    .collect()
-            })
-            .collect(),
-        other => unreachable!("unexpected flavor: {other}"),
-    };
-    group.bench_function("element_struct_get_by_name", |b| {
+    let lookup_keys: Vec<Vec<String>> = (0..num_structs)
+        .map(|struct_index| flavor.lookup_keys(struct_index))
+        .collect();
+    let mut group = c.benchmark_group("large_doc_read/element_struct_get_by_name");
+    group.bench_function(&case_id, |b| {
         b.iter(|| {
             let mut num_found = 0_usize;
             for (strukt, keys) in structs.iter().zip(lookup_keys.iter()) {
@@ -238,13 +267,12 @@ fn default_feature_benchmarks(
             black_box(num_found);
         })
     });
-
     group.finish();
 }
 
 /// Benchmarks that require the `experimental-reader-writer` feature.
 #[cfg(feature = "experimental-reader-writer")]
-fn lazy_reader_benchmarks(c: &mut Criterion, flavor: &str, size_label: &str, binary_data: &[u8]) {
+fn lazy_reader_benchmarks(c: &mut Criterion, flavor: Flavor, size_label: &str, binary_data: &[u8]) {
     use ion_rs::{AnyEncoding, Decoder, LazyStruct, LazyValue, Reader, ValueRef};
 
     /// Reads this value and, if it's a container, any nested values. Returns the number
@@ -283,9 +311,10 @@ fn lazy_reader_benchmarks(c: &mut Criterion, flavor: &str, size_label: &str, bin
         Ok(count)
     }
 
-    let mut group = c.benchmark_group(format!("large_doc {flavor} {size_label}"));
+    let case_id = format!("{}_{}", flavor.label(), size_label);
 
-    group.bench_function("lazy_any_read_all", |b| {
+    let mut group = c.benchmark_group("large_doc_read/lazy_any_read_all");
+    group.bench_function(&case_id, |b| {
         b.iter(|| {
             let mut reader = Reader::new(AnyEncoding, black_box(binary_data)).unwrap();
             let mut num_values = 0_usize;
@@ -295,8 +324,10 @@ fn lazy_reader_benchmarks(c: &mut Criterion, flavor: &str, size_label: &str, bin
             black_box(num_values);
         })
     });
+    group.finish();
 
-    group.bench_function("lazy_binary_read_all", |b| {
+    let mut group = c.benchmark_group("large_doc_read/lazy_binary_read_all");
+    group.bench_function(&case_id, |b| {
         b.iter(|| {
             let mut reader = Reader::new(v1_0::Binary, black_box(binary_data)).unwrap();
             let mut num_values = 0_usize;
@@ -306,26 +337,20 @@ fn lazy_reader_benchmarks(c: &mut Criterion, flavor: &str, size_label: &str, bin
             black_box(num_values);
         })
     });
-
     group.finish();
 }
 
-/// A document flavor: a label and a generator producing that flavor's text Ion.
-type Flavor = (&'static str, fn(usize) -> String);
-
 fn criterion_benchmark(c: &mut Criterion) {
     const SIZES: &[(usize, &str)] = &[(10 * 1024, "10KB"), (30 * 1024, "30KB")];
-    const FLAVORS: &[Flavor] = &[
-        ("value_heavy", value_heavy_text),
-        ("symbol_heavy", symbol_heavy_text),
-    ];
+    const FLAVORS: &[Flavor] = &[Flavor::ValueHeavy, Flavor::SymbolHeavy];
 
-    for &(flavor, generate) in FLAVORS {
+    for &flavor in FLAVORS {
         for &(target_num_bytes, size_label) in SIZES {
             let (binary_data, num_structs) =
-                make_document(generate, target_num_bytes).expect("failed to generate document");
+                make_document(flavor, target_num_bytes).expect("failed to generate document");
             println!(
-                "{flavor} {size_label}: {} bytes, {num_structs} structs",
+                "{} {size_label}: {} bytes, {num_structs} structs",
+                flavor.label(),
                 binary_data.len()
             );
 

--- a/benches/large_doc_read.rs
+++ b/benches/large_doc_read.rs
@@ -1,0 +1,340 @@
+//! Benchmarks reading larger (~10KB and ~30KB) binary Ion 1.0 documents.
+//!
+//! The existing benchmarks read very large streams (millions of bytes) through a single
+//! reader, which amortizes away both per-document fixed costs and mid-size scanning
+//! behavior. This benchmark measures the "one reader per document" pattern on documents
+//! large enough to be dominated by value scanning rather than reader construction.
+//!
+//! Each document is a single top-level list of structs, generated in two flavors:
+//!   * `value_heavy`: a small set of field names is reused across many struct instances
+//!     (log-record shaped). The local symbol table stays small; nearly all of the
+//!     document is value content.
+//!   * `symbol_heavy`: every field name and symbol value in the document is distinct,
+//!     so the local symbol table grows with the document (hundreds to thousands of
+//!     entries). Most of the read cost is symbol table processing.
+//!
+//! Cases:
+//!   * `element_read_one`: materializes the document with `Element::read_one` — the
+//!     stable, default-feature API.
+//!   * `element_struct_get_by_name`: materializes the document once (outside the timed
+//!     loop), then repeatedly looks up struct fields by name — a regression guard for
+//!     the DOM's field-name index.
+//!   * `lazy_any_read_all` / `lazy_binary_read_all`: visits every value in the document
+//!     using the streaming `Reader` with `AnyEncoding` (encoding auto-detection) and
+//!     with the concrete `v1_0::Binary` encoding. Like the other benchmarks' streaming
+//!     cases, these require the `experimental-reader-writer` feature.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use ion_rs::{v1_0, Element, IonResult, Sequence};
+use std::fmt::Write as _;
+
+/// Produces the text for a list of `num_structs` log-record-shaped structs. The same
+/// 20 field names appear in every struct, so the encoded document's symbol table stays
+/// small while the value region grows with `num_structs`.
+fn value_heavy_text(num_structs: usize) -> String {
+    let mut text = String::from("[\n");
+    for i in 0..num_structs {
+        write!(
+            text,
+            r#"{{
+                requestId: "req-{i:08x}-4f2a9b1c",
+                sessionId: "sess-{:08x}",
+                operation: "GetRecord",
+                status: "SUCCESS",
+                clientId: "client-{:03}",
+                host: "host-{:02}.example.com",
+                region: "us-east-1",
+                tenant: "example-tenant",
+                message: "processed request batch with standard options enabled",
+                level: INFO,
+                latencyMs: {},
+                retries: {},
+                itemCount: {},
+                byteSize: {},
+                epochMs: {},
+                shard: {},
+                cacheHit: {},
+                throttled: false,
+                score: 2.5e0,
+                timestamp: 2024-06-15T12:34:56.789Z
+            }},
+            "#,
+            i.wrapping_mul(0x9e37_79b9),
+            i % 50,
+            i % 20,
+            (i * 7) % 900 + 3,
+            i % 4,
+            (i * 13) % 5000,
+            (i * 131) % 100_000,
+            1_718_000_000_000_u64 + i as u64,
+            i % 16,
+            i % 3 == 0,
+        )
+        .unwrap();
+    }
+    text.push(']');
+    text
+}
+
+/// The field names used by `value_heavy_text`, for by-name lookups.
+const VALUE_HEAVY_FIELD_NAMES: &[&str] = &[
+    "requestId",
+    "sessionId",
+    "operation",
+    "status",
+    "clientId",
+    "host",
+    "region",
+    "tenant",
+    "message",
+    "level",
+    "latencyMs",
+    "retries",
+    "itemCount",
+    "byteSize",
+    "epochMs",
+    "shard",
+    "cacheHit",
+    "throttled",
+    "score",
+    "timestamp",
+];
+
+/// Number of fields in each struct produced by `symbol_heavy_text`.
+const SYMBOL_HEAVY_FIELDS_PER_STRUCT: usize = 10;
+
+/// Produces the text for a list of `num_structs` structs in which every field name and
+/// every (symbol) field value is distinct, so the encoded document's local symbol table
+/// grows by 2 × `SYMBOL_HEAVY_FIELDS_PER_STRUCT` entries per struct.
+fn symbol_heavy_text(num_structs: usize) -> String {
+    let mut text = String::from("[\n");
+    for i in 0..num_structs {
+        text.push('{');
+        for j in 0..SYMBOL_HEAVY_FIELDS_PER_STRUCT {
+            let id = i * SYMBOL_HEAVY_FIELDS_PER_STRUCT + j;
+            write!(text, "fieldName{id:05}: symValue{id:05},").unwrap();
+        }
+        text.pop(); // remove the trailing comma
+        text.push_str("},\n");
+    }
+    text.push(']');
+    text
+}
+
+/// The field name of the `index`th field of the `struct_index`th struct produced by
+/// `symbol_heavy_text`.
+fn symbol_heavy_field_name(struct_index: usize, index: usize) -> String {
+    format!(
+        "fieldName{:05}",
+        struct_index * SYMBOL_HEAVY_FIELDS_PER_STRUCT + index
+    )
+}
+
+/// Encodes the provided text Ion as binary Ion 1.0.
+fn encode_binary_1_0(text: &str) -> IonResult<Vec<u8>> {
+    Element::read_one(text)?.encode_as(v1_0::Binary)
+}
+
+/// Grows the number of structs produced by `generate` until the binary-encoded document
+/// reaches `target_num_bytes`. Returns the encoded document and the struct count.
+fn make_document(
+    generate: fn(usize) -> String,
+    target_num_bytes: usize,
+) -> IonResult<(Vec<u8>, usize)> {
+    let mut num_structs = 8;
+    let mut binary_data = encode_binary_1_0(&generate(num_structs))?;
+    // Take one proportional jump toward the target size, then fine-tune linearly.
+    num_structs = (num_structs * target_num_bytes / binary_data.len().max(1)).max(1);
+    binary_data = encode_binary_1_0(&generate(num_structs))?;
+    while binary_data.len() < target_num_bytes {
+        num_structs += 1;
+        binary_data = encode_binary_1_0(&generate(num_structs))?;
+    }
+    Ok((binary_data, num_structs))
+}
+
+/// Traverses a materialized document, visiting every nested value. Returns the number of
+/// values visited.
+fn visit_element(element: &Element) -> usize {
+    use ion_rs::Value;
+    match element.value() {
+        Value::List(seq) | Value::SExp(seq) => 1 + seq.elements().map(visit_element).sum::<usize>(),
+        Value::Struct(strukt) => {
+            1 + strukt
+                .fields()
+                .map(|(_name, value)| visit_element(value))
+                .sum::<usize>()
+        }
+        scalar => {
+            let _ = black_box(scalar);
+            1
+        }
+    }
+}
+
+/// Benchmarks that only require the crate's default features.
+fn default_feature_benchmarks(
+    c: &mut Criterion,
+    flavor: &str,
+    size_label: &str,
+    binary_data: &[u8],
+    num_structs: usize,
+) {
+    let mut group = c.benchmark_group(format!("large_doc {flavor} {size_label}"));
+
+    // Materialize the whole document with the stable, default-feature API.
+    group.bench_function("element_read_one", |b| {
+        b.iter(|| {
+            let element = Element::read_one(black_box(binary_data)).unwrap();
+            black_box(element);
+        })
+    });
+
+    // Materialize the document once, then repeatedly look up struct fields by name.
+    let document = Element::read_one(binary_data).unwrap();
+    let structs: Vec<_> = document
+        .as_sequence()
+        .unwrap()
+        .elements()
+        .map(|element| element.as_struct().unwrap())
+        .collect();
+    // Precompute the lookup keys so the timed loop performs no allocations.
+    let lookup_keys: Vec<Vec<String>> = match flavor {
+        "value_heavy" => (0..num_structs)
+            .map(|_| {
+                VALUE_HEAVY_FIELD_NAMES
+                    .iter()
+                    .map(|name| (*name).to_owned())
+                    .collect()
+            })
+            .collect(),
+        "symbol_heavy" => (0..num_structs)
+            .map(|struct_index| {
+                (0..SYMBOL_HEAVY_FIELDS_PER_STRUCT)
+                    .map(|index| symbol_heavy_field_name(struct_index, index))
+                    .collect()
+            })
+            .collect(),
+        other => unreachable!("unexpected flavor: {other}"),
+    };
+    group.bench_function("element_struct_get_by_name", |b| {
+        b.iter(|| {
+            let mut num_found = 0_usize;
+            for (strukt, keys) in structs.iter().zip(lookup_keys.iter()) {
+                for key in keys {
+                    if let Some(value) = strukt.get(key.as_str()) {
+                        black_box(value);
+                        num_found += 1;
+                    }
+                }
+            }
+            black_box(num_found);
+        })
+    });
+
+    group.finish();
+}
+
+/// Benchmarks that require the `experimental-reader-writer` feature.
+#[cfg(feature = "experimental-reader-writer")]
+fn lazy_reader_benchmarks(c: &mut Criterion, flavor: &str, size_label: &str, binary_data: &[u8]) {
+    use ion_rs::{AnyEncoding, Decoder, LazyStruct, LazyValue, Reader, ValueRef};
+
+    /// Reads this value and, if it's a container, any nested values. Returns the number
+    /// of values read.
+    fn count_value_and_children<D: Decoder>(lazy_value: &LazyValue<'_, D>) -> IonResult<usize> {
+        use ValueRef::*;
+        let child_count = match lazy_value.read()? {
+            List(s) => count_sequence_children(s.iter())?,
+            SExp(s) => count_sequence_children(s.iter())?,
+            Struct(s) => count_struct_children(&s)?,
+            scalar => {
+                let _ = black_box(scalar);
+                0
+            }
+        };
+        Ok(1 + child_count)
+    }
+
+    /// Reads the child values of a list or s-expression. Returns the number of values read.
+    fn count_sequence_children<'a, D: Decoder>(
+        lazy_sequence: impl Iterator<Item = IonResult<LazyValue<'a, D>>>,
+    ) -> IonResult<usize> {
+        let mut count = 0;
+        for value in lazy_sequence {
+            count += count_value_and_children(&value?)?;
+        }
+        Ok(count)
+    }
+
+    /// Reads the field values of a struct. Returns the number of values read.
+    fn count_struct_children<D: Decoder>(lazy_struct: &LazyStruct<'_, D>) -> IonResult<usize> {
+        let mut count = 0;
+        for field in lazy_struct {
+            count += count_value_and_children(&field?.value())?;
+        }
+        Ok(count)
+    }
+
+    let mut group = c.benchmark_group(format!("large_doc {flavor} {size_label}"));
+
+    group.bench_function("lazy_any_read_all", |b| {
+        b.iter(|| {
+            let mut reader = Reader::new(AnyEncoding, black_box(binary_data)).unwrap();
+            let mut num_values = 0_usize;
+            while let Some(item) = reader.next().unwrap() {
+                num_values += count_value_and_children(&item).unwrap();
+            }
+            black_box(num_values);
+        })
+    });
+
+    group.bench_function("lazy_binary_read_all", |b| {
+        b.iter(|| {
+            let mut reader = Reader::new(v1_0::Binary, black_box(binary_data)).unwrap();
+            let mut num_values = 0_usize;
+            while let Some(item) = reader.next().unwrap() {
+                num_values += count_value_and_children(&item).unwrap();
+            }
+            black_box(num_values);
+        })
+    });
+
+    group.finish();
+}
+
+/// A document flavor: a label and a generator producing that flavor's text Ion.
+type Flavor = (&'static str, fn(usize) -> String);
+
+fn criterion_benchmark(c: &mut Criterion) {
+    const SIZES: &[(usize, &str)] = &[(10 * 1024, "10KB"), (30 * 1024, "30KB")];
+    const FLAVORS: &[Flavor] = &[
+        ("value_heavy", value_heavy_text),
+        ("symbol_heavy", symbol_heavy_text),
+    ];
+
+    for &(flavor, generate) in FLAVORS {
+        for &(target_num_bytes, size_label) in SIZES {
+            let (binary_data, num_structs) =
+                make_document(generate, target_num_bytes).expect("failed to generate document");
+            println!(
+                "{flavor} {size_label}: {} bytes, {num_structs} structs",
+                binary_data.len()
+            );
+
+            // Sanity check: the document must round-trip as a single top-level list.
+            let document: Sequence = Element::read_all(binary_data.as_slice()).unwrap();
+            assert_eq!(document.len(), 1);
+            let element = document.elements().next().unwrap();
+            assert_eq!(element.as_sequence().unwrap().len(), num_structs);
+            assert!(visit_element(element) > num_structs);
+
+            default_feature_benchmarks(c, flavor, size_label, &binary_data, num_structs);
+            #[cfg(feature = "experimental-reader-writer")]
+            lazy_reader_benchmarks(c, flavor, size_label, &binary_data);
+        }
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -98,6 +98,7 @@ pub enum LazyRawAnyVersionMarkerKind<'top> {
 }
 
 impl LazyRawAnyVersionMarker<'_> {
+    #[inline]
     pub fn encoding(&self) -> IonEncoding {
         use crate::lazy::any_encoding::LazyRawAnyVersionMarkerKind::*;
         match self.encoding {
@@ -110,6 +111,7 @@ impl LazyRawAnyVersionMarker<'_> {
 }
 
 impl<'top> HasSpan<'top> for LazyRawAnyVersionMarker<'top> {
+    #[inline]
     fn span(&self) -> Span<'top> {
         use LazyRawAnyVersionMarkerKind::*;
         match self.encoding {
@@ -122,6 +124,7 @@ impl<'top> HasSpan<'top> for LazyRawAnyVersionMarker<'top> {
 }
 
 impl HasRange for LazyRawAnyVersionMarker<'_> {
+    #[inline]
     fn range(&self) -> Range<usize> {
         use LazyRawAnyVersionMarkerKind::*;
         match self.encoding {
@@ -134,6 +137,7 @@ impl HasRange for LazyRawAnyVersionMarker<'_> {
 }
 
 impl<'top> RawVersionMarker<'top> for LazyRawAnyVersionMarker<'top> {
+    #[inline]
     fn major_minor(&self) -> (u8, u8) {
         use LazyRawAnyVersionMarkerKind::*;
         match self.encoding {
@@ -144,6 +148,7 @@ impl<'top> RawVersionMarker<'top> for LazyRawAnyVersionMarker<'top> {
         }
     }
 
+    #[inline]
     fn stream_encoding_before_marker(&self) -> IonEncoding {
         use LazyRawAnyVersionMarkerKind::*;
         match self.encoding {
@@ -156,6 +161,7 @@ impl<'top> RawVersionMarker<'top> for LazyRawAnyVersionMarker<'top> {
 }
 
 impl<'top> From<LazyRawBinaryVersionMarker_1_0<'top>> for LazyRawAnyVersionMarker<'top> {
+    #[inline]
     fn from(value: LazyRawBinaryVersionMarker_1_0<'top>) -> Self {
         LazyRawAnyVersionMarker {
             encoding: LazyRawAnyVersionMarkerKind::Binary_1_0(value),
@@ -163,6 +169,7 @@ impl<'top> From<LazyRawBinaryVersionMarker_1_0<'top>> for LazyRawAnyVersionMarke
     }
 }
 impl<'top> From<LazyRawBinaryVersionMarker_1_1<'top>> for LazyRawAnyVersionMarker<'top> {
+    #[inline]
     fn from(value: LazyRawBinaryVersionMarker_1_1<'top>) -> Self {
         LazyRawAnyVersionMarker {
             encoding: LazyRawAnyVersionMarkerKind::Binary_1_1(value),
@@ -170,6 +177,7 @@ impl<'top> From<LazyRawBinaryVersionMarker_1_1<'top>> for LazyRawAnyVersionMarke
     }
 }
 impl<'top> From<LazyRawTextVersionMarker_1_0<'top>> for LazyRawAnyVersionMarker<'top> {
+    #[inline]
     fn from(value: LazyRawTextVersionMarker_1_0<'top>) -> Self {
         LazyRawAnyVersionMarker {
             encoding: LazyRawAnyVersionMarkerKind::Text_1_0(value),
@@ -177,6 +185,7 @@ impl<'top> From<LazyRawTextVersionMarker_1_0<'top>> for LazyRawAnyVersionMarker<
     }
 }
 impl<'top> From<LazyRawTextVersionMarker_1_1<'top>> for LazyRawAnyVersionMarker<'top> {
+    #[inline]
     fn from(value: LazyRawTextVersionMarker_1_1<'top>) -> Self {
         LazyRawAnyVersionMarker {
             encoding: LazyRawAnyVersionMarkerKind::Text_1_1(value),
@@ -196,10 +205,12 @@ pub enum LazyRawAnyEExpressionKind<'top> {
 }
 
 impl<'top> LazyRawAnyEExpression<'top> {
+    #[inline]
     pub fn kind(&self) -> LazyRawAnyEExpressionKind<'top> {
         self.encoding
     }
 
+    #[inline]
     pub fn encoding(&self) -> IonEncoding {
         use LazyRawAnyEExpressionKind::*;
         match self.encoding {
@@ -210,6 +221,7 @@ impl<'top> LazyRawAnyEExpression<'top> {
 }
 
 impl<'top> From<TextEExpression_1_1<'top>> for LazyRawAnyEExpression<'top> {
+    #[inline]
     fn from(text_invocation: TextEExpression_1_1<'top>) -> Self {
         LazyRawAnyEExpression {
             encoding: LazyRawAnyEExpressionKind::Text_1_1(text_invocation),
@@ -217,6 +229,7 @@ impl<'top> From<TextEExpression_1_1<'top>> for LazyRawAnyEExpression<'top> {
     }
 }
 impl<'top> From<&'top BinaryEExpression_1_1<'top>> for LazyRawAnyEExpression<'top> {
+    #[inline]
     fn from(binary_invocation: &'top BinaryEExpression_1_1<'top>) -> Self {
         LazyRawAnyEExpression {
             encoding: LazyRawAnyEExpressionKind::Binary_1_1(binary_invocation),
@@ -225,6 +238,7 @@ impl<'top> From<&'top BinaryEExpression_1_1<'top>> for LazyRawAnyEExpression<'to
 }
 
 impl<'top> HasSpan<'top> for LazyRawAnyEExpression<'top> {
+    #[inline]
     fn span(&self) -> Span<'top> {
         use LazyRawAnyEExpressionKind::*;
         match self.encoding {
@@ -235,6 +249,7 @@ impl<'top> HasSpan<'top> for LazyRawAnyEExpression<'top> {
 }
 
 impl HasRange for LazyRawAnyEExpression<'_> {
+    #[inline]
     fn range(&self) -> Range<usize> {
         use LazyRawAnyEExpressionKind::*;
         match self.encoding {
@@ -248,6 +263,7 @@ impl<'top> RawEExpression<'top, AnyEncoding> for LazyRawAnyEExpression<'top> {
     type RawArgumentsIterator = AnyEExpArgsIterator<'top>;
     type ArgGroup = AnyEExpArgGroup<'top>;
 
+    #[inline]
     fn id(self) -> MacroIdRef<'top> {
         use LazyRawAnyEExpressionKind::*;
         match self.encoding {
@@ -256,6 +272,7 @@ impl<'top> RawEExpression<'top, AnyEncoding> for LazyRawAnyEExpression<'top> {
         }
     }
 
+    #[inline]
     fn raw_arguments(&self) -> Self::RawArgumentsIterator {
         use LazyRawAnyEExpressionKind::*;
         match self.encoding {
@@ -268,6 +285,7 @@ impl<'top> RawEExpression<'top, AnyEncoding> for LazyRawAnyEExpression<'top> {
         }
     }
 
+    #[inline]
     fn context(&self) -> EncodingContextRef<'top> {
         use LazyRawAnyEExpressionKind::*;
         match self.encoding {
@@ -283,6 +301,7 @@ pub struct AnyEExpArgGroup<'top> {
 }
 
 impl<'a> AnyEExpArgGroup<'a> {
+    #[inline]
     pub fn kind(&self) -> AnyEExpArgGroupKind<'a> {
         self.kind
     }
@@ -296,6 +315,7 @@ pub enum AnyEExpArgGroupKind<'top> {
 
 impl AnyEExpArgGroupKind<'_> {
     #[allow(dead_code)] // TODO: Evaluate
+    #[inline]
     fn encoding(&self) -> &ParameterEncoding {
         match self {
             AnyEExpArgGroupKind::Text_1_1(g) => g.encoding(),
@@ -305,6 +325,7 @@ impl AnyEExpArgGroupKind<'_> {
 }
 
 impl HasRange for AnyEExpArgGroup<'_> {
+    #[inline]
     fn range(&self) -> Range<usize> {
         match self.kind {
             AnyEExpArgGroupKind::Text_1_1(group) => group.range(),
@@ -314,6 +335,7 @@ impl HasRange for AnyEExpArgGroup<'_> {
 }
 
 impl<'top> HasSpan<'top> for AnyEExpArgGroup<'top> {
+    #[inline]
     fn span(&self) -> Span<'top> {
         match self.kind {
             AnyEExpArgGroupKind::Text_1_1(group) => group.span(),
@@ -332,6 +354,7 @@ impl<
         D: Decoder<Value<'top> = LazyRawAnyValue<'top>, EExp<'top> = LazyRawAnyEExpression<'top>>,
     > IsExhaustedIterator<'top, D> for AnyEExpArgGroupIterator<'top>
 {
+    #[inline]
     fn is_exhausted(&self) -> bool {
         match self.kind {
             AnyEExpArgGroupIteratorKind::Text_1_1(ref i) => i.is_exhausted(),
@@ -344,6 +367,7 @@ impl<'top> IntoIterator for AnyEExpArgGroup<'top> {
     type Item = IonResult<LazyRawValueExpr<'top, AnyEncoding>>;
     type IntoIter = AnyEExpArgGroupIterator<'top>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         match self.kind {
             AnyEExpArgGroupKind::Text_1_1(group) => AnyEExpArgGroupIterator {
@@ -365,6 +389,7 @@ pub enum AnyEExpArgGroupIteratorKind<'top> {
 impl<'top> Iterator for AnyEExpArgGroupIterator<'top> {
     type Item = IonResult<LazyRawValueExpr<'top, AnyEncoding>>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         match self.kind {
             AnyEExpArgGroupIteratorKind::Text_1_1(ref mut i) => {
@@ -380,10 +405,12 @@ impl<'top> Iterator for AnyEExpArgGroupIterator<'top> {
 impl<'top> EExpressionArgGroup<'top, AnyEncoding> for AnyEExpArgGroup<'top> {
     type Iterator = AnyEExpArgGroupIterator<'top>;
 
+    #[inline]
     fn encoding(&self) -> &ParameterEncoding {
         self.kind.encoding()
     }
 
+    #[inline]
     fn resolve(self, context: EncodingContextRef<'top>) -> EExpArgGroup<'top, AnyEncoding> {
         EExpArgGroup::new(self, context)
     }
@@ -413,6 +440,7 @@ pub struct AnyEExpArgsIterator<'top> {
 impl<'top> Iterator for AnyEExpArgsIterator<'top> {
     type Item = IonResult<EExpArg<'top, AnyEncoding>>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         match &mut self.encoding {
             LazyRawAnyEExpArgsIteratorKind::Text_1_1(ref mut iter) => {
@@ -455,6 +483,7 @@ pub struct LazyRawAnyReader<'data> {
 }
 
 impl LazyRawAnyReader<'_> {
+    #[inline]
     fn detect_encoding(data: &[u8]) -> IonEncoding {
         match *data {
             [0xE0, 0x01, 0x00, 0xEA, ..] => IonEncoding::Binary_1_0,
@@ -465,6 +494,7 @@ impl LazyRawAnyReader<'_> {
 }
 
 impl<'data> From<RawReaderKind<'data>> for LazyRawAnyReader<'data> {
+    #[inline]
     fn from(encoding: RawReaderKind<'data>) -> Self {
         Self {
             new_encoding: None,
@@ -481,6 +511,7 @@ pub enum RawReaderKind<'data> {
 }
 
 impl<'data> RawReaderKind<'data> {
+    #[inline]
     fn resume_at_offset(
         context: EncodingContextRef<'data>,
         saved_state: RawReaderState<'data>,
@@ -502,6 +533,7 @@ impl<'data> RawReaderKind<'data> {
         }
     }
 
+    #[inline]
     fn context(&self) -> EncodingContextRef<'data> {
         match self {
             RawReaderKind::Text_1_0(r) => r.context(),
@@ -525,16 +557,19 @@ pub enum IonEncoding {
 }
 
 impl IonEncoding {
+    #[inline]
     pub fn is_text(&self) -> bool {
         use IonEncoding::*;
         matches!(*self, Text_1_0 | Text_1_1)
     }
 
+    #[inline]
     pub fn is_binary(&self) -> bool {
         use IonEncoding::*;
         matches!(*self, Binary_1_0 | Binary_1_1)
     }
 
+    #[inline]
     pub fn name(&self) -> &str {
         use IonEncoding::*;
         match self {
@@ -545,6 +580,7 @@ impl IonEncoding {
         }
     }
 
+    #[inline]
     pub fn version(&self) -> IonVersion {
         use IonEncoding::*;
         match self {
@@ -562,6 +598,7 @@ pub enum IonVersion {
 }
 
 impl IonVersion {
+    #[inline]
     pub fn major_minor(&self) -> (u8, u8) {
         use IonVersion::*;
         match self {
@@ -571,6 +608,7 @@ impl IonVersion {
     }
 
     /// Returns the system symbol table associated with this Ion version.
+    #[inline]
     pub fn system_symbol_table(&self) -> &'static SystemSymbolTable {
         match self {
             IonVersion::v1_0 => SYSTEM_SYMBOLS_1_0,
@@ -580,30 +618,35 @@ impl IonVersion {
 }
 
 impl<'data> From<LazyRawTextReader_1_0<'data>> for LazyRawAnyReader<'data> {
+    #[inline]
     fn from(reader: LazyRawTextReader_1_0<'data>) -> Self {
         RawReaderKind::Text_1_0(reader).into()
     }
 }
 
 impl<'data> From<LazyRawTextReader_1_1<'data>> for LazyRawAnyReader<'data> {
+    #[inline]
     fn from(reader: LazyRawTextReader_1_1<'data>) -> Self {
         RawReaderKind::Text_1_1(reader).into()
     }
 }
 
 impl<'data> From<LazyRawBinaryReader_1_0<'data>> for LazyRawAnyReader<'data> {
+    #[inline]
     fn from(reader: LazyRawBinaryReader_1_0<'data>) -> Self {
         RawReaderKind::Binary_1_0(reader).into()
     }
 }
 
 impl<'data> From<LazyRawBinaryReader_1_1<'data>> for LazyRawAnyReader<'data> {
+    #[inline]
     fn from(reader: LazyRawBinaryReader_1_1<'data>) -> Self {
         RawReaderKind::Binary_1_1(reader).into()
     }
 }
 
 impl<'data> LazyRawReader<'data, AnyEncoding> for LazyRawAnyReader<'data> {
+    #[inline]
     fn new(context: EncodingContextRef<'data>, data: &'data [u8], is_final_data: bool) -> Self {
         let encoding = Self::detect_encoding(data);
         let state = RawReaderState::new(data, 0, is_final_data, encoding);
@@ -613,6 +656,7 @@ impl<'data> LazyRawReader<'data, AnyEncoding> for LazyRawAnyReader<'data> {
         }
     }
 
+    #[inline]
     fn resume(context: EncodingContextRef<'data>, mut saved_state: RawReaderState<'data>) -> Self {
         let offset = saved_state.offset();
         let data = saved_state.data();
@@ -629,6 +673,7 @@ impl<'data> LazyRawReader<'data, AnyEncoding> for LazyRawAnyReader<'data> {
         }
     }
 
+    #[inline]
     fn save_state(&self) -> RawReaderState<'data> {
         use RawReaderKind::*;
         let reader_state = match &self.encoding_reader {
@@ -650,6 +695,7 @@ impl<'data> LazyRawReader<'data, AnyEncoding> for LazyRawAnyReader<'data> {
         reader_state
     }
 
+    #[inline]
     fn next(&mut self) -> IonResult<LazyRawStreamItem<'data, AnyEncoding>> {
         // If we previously ran into an IVM that changed the stream encoding, replace our reader
         // with one that can read the new encoding.
@@ -684,6 +730,7 @@ impl<'data> LazyRawReader<'data, AnyEncoding> for LazyRawAnyReader<'data> {
         Ok(item)
     }
 
+    #[inline]
     fn position(&self) -> usize {
         use RawReaderKind::*;
         match &self.encoding_reader {
@@ -694,6 +741,7 @@ impl<'data> LazyRawReader<'data, AnyEncoding> for LazyRawAnyReader<'data> {
         }
     }
 
+    #[inline]
     fn encoding(&self) -> IonEncoding {
         use RawReaderKind::*;
         // If we hit an IVM that changed the encoding but we haven't changed our reader yet,
@@ -723,10 +771,12 @@ pub struct LazyRawAnyValue<'top> {
 
 impl<'top> LazyRawAnyValue<'top> {
     /// Returns an enum indicating the encoding that backs this lazy value.
+    #[inline]
     pub fn kind(&self) -> LazyRawValueKind<'top> {
         self.encoding
     }
 
+    #[inline]
     pub fn encoding(&self) -> IonEncoding {
         use LazyRawValueKind::*;
         match &self.encoding {
@@ -740,13 +790,16 @@ impl<'top> LazyRawAnyValue<'top> {
 
 #[derive(Debug, Copy, Clone)]
 pub enum LazyRawValueKind<'top> {
-    Text_1_0(LazyRawTextValue_1_0<'top>),
+    // Binary 1.0 is declared first so that the most common encoding's variant is
+    // the zero discriminant, which the compiler can dispatch on most cheaply.
     Binary_1_0(&'top LazyRawBinaryValue_1_0<'top>),
+    Text_1_0(LazyRawTextValue_1_0<'top>),
     Text_1_1(LazyRawTextValue_1_1<'top>),
     Binary_1_1(&'top LazyRawBinaryValue_1_1<'top>),
 }
 
 impl<'top> From<LazyRawTextValue_1_0<'top>> for LazyRawAnyValue<'top> {
+    #[inline]
     fn from(value: LazyRawTextValue_1_0<'top>) -> Self {
         LazyRawAnyValue {
             encoding: LazyRawValueKind::Text_1_0(value),
@@ -755,6 +808,7 @@ impl<'top> From<LazyRawTextValue_1_0<'top>> for LazyRawAnyValue<'top> {
 }
 
 impl<'top> From<&'top LazyRawBinaryValue_1_0<'top>> for LazyRawAnyValue<'top> {
+    #[inline]
     fn from(value: &'top LazyRawBinaryValue_1_0<'top>) -> Self {
         LazyRawAnyValue {
             encoding: LazyRawValueKind::Binary_1_0(value),
@@ -763,6 +817,7 @@ impl<'top> From<&'top LazyRawBinaryValue_1_0<'top>> for LazyRawAnyValue<'top> {
 }
 
 impl<'top> From<LazyRawTextValue_1_1<'top>> for LazyRawAnyValue<'top> {
+    #[inline]
     fn from(value: LazyRawTextValue_1_1<'top>) -> Self {
         LazyRawAnyValue {
             encoding: LazyRawValueKind::Text_1_1(value),
@@ -771,6 +826,7 @@ impl<'top> From<LazyRawTextValue_1_1<'top>> for LazyRawAnyValue<'top> {
 }
 
 impl<'top> From<&'top LazyRawBinaryValue_1_1<'top>> for LazyRawAnyValue<'top> {
+    #[inline]
     fn from(value: &'top LazyRawBinaryValue_1_1<'top>) -> Self {
         LazyRawAnyValue {
             encoding: LazyRawValueKind::Binary_1_1(value),
@@ -779,6 +835,7 @@ impl<'top> From<&'top LazyRawBinaryValue_1_1<'top>> for LazyRawAnyValue<'top> {
 }
 
 impl<'top> From<LazyRawValueExpr<'top, TextEncoding_1_0>> for LazyRawValueExpr<'top, AnyEncoding> {
+    #[inline]
     fn from(value: LazyRawValueExpr<'top, TextEncoding_1_0>) -> Self {
         match value {
             RawValueExpr::ValueLiteral(v) => RawValueExpr::ValueLiteral(v.into()),
@@ -790,6 +847,7 @@ impl<'top> From<LazyRawValueExpr<'top, TextEncoding_1_0>> for LazyRawValueExpr<'
 impl<'top> From<LazyRawValueExpr<'top, BinaryEncoding_1_0>>
     for LazyRawValueExpr<'top, AnyEncoding>
 {
+    #[inline]
     fn from(value: LazyRawValueExpr<'top, BinaryEncoding_1_0>) -> Self {
         match value {
             RawValueExpr::ValueLiteral(v) => RawValueExpr::ValueLiteral(v.into()),
@@ -799,6 +857,7 @@ impl<'top> From<LazyRawValueExpr<'top, BinaryEncoding_1_0>>
 }
 
 impl<'top> From<LazyRawValueExpr<'top, TextEncoding_1_1>> for LazyRawValueExpr<'top, AnyEncoding> {
+    #[inline]
     fn from(value: LazyRawValueExpr<'top, TextEncoding_1_1>) -> Self {
         match value {
             RawValueExpr::ValueLiteral(v) => RawValueExpr::ValueLiteral(v.into()),
@@ -815,6 +874,7 @@ impl<'top> From<LazyRawValueExpr<'top, TextEncoding_1_1>> for LazyRawValueExpr<'
 impl<'top> From<LazyRawValueExpr<'top, BinaryEncoding_1_1>>
     for LazyRawValueExpr<'top, AnyEncoding>
 {
+    #[inline]
     fn from(value: LazyRawValueExpr<'top, BinaryEncoding_1_1>) -> Self {
         match value {
             RawValueExpr::ValueLiteral(v) => RawValueExpr::ValueLiteral(v.into()),
@@ -829,6 +889,7 @@ impl<'top> From<LazyRawValueExpr<'top, BinaryEncoding_1_1>>
 }
 
 impl<'top> From<RawValueRef<'top, TextEncoding_1_0>> for RawValueRef<'top, AnyEncoding> {
+    #[inline]
     fn from(value: RawValueRef<'top, TextEncoding_1_0>) -> Self {
         use RawValueRef::*;
         match value {
@@ -850,6 +911,7 @@ impl<'top> From<RawValueRef<'top, TextEncoding_1_0>> for RawValueRef<'top, AnyEn
 }
 
 impl<'top> From<RawValueRef<'top, BinaryEncoding_1_0>> for RawValueRef<'top, AnyEncoding> {
+    #[inline]
     fn from(value: RawValueRef<'top, BinaryEncoding_1_0>) -> Self {
         use RawValueRef::*;
         match value {
@@ -871,6 +933,7 @@ impl<'top> From<RawValueRef<'top, BinaryEncoding_1_0>> for RawValueRef<'top, Any
 }
 
 impl<'top> From<RawValueRef<'top, TextEncoding_1_1>> for RawValueRef<'top, AnyEncoding> {
+    #[inline]
     fn from(value: RawValueRef<'top, TextEncoding_1_1>) -> Self {
         use RawValueRef::*;
         match value {
@@ -892,6 +955,7 @@ impl<'top> From<RawValueRef<'top, TextEncoding_1_1>> for RawValueRef<'top, AnyEn
 }
 
 impl<'top> From<RawValueRef<'top, BinaryEncoding_1_1>> for RawValueRef<'top, AnyEncoding> {
+    #[inline]
     fn from(value: RawValueRef<'top, BinaryEncoding_1_1>) -> Self {
         use RawValueRef::*;
         match value {
@@ -915,6 +979,7 @@ impl<'top> From<RawValueRef<'top, BinaryEncoding_1_1>> for RawValueRef<'top, Any
 impl<'top> From<LazyRawStreamItem<'top, TextEncoding_1_0>>
     for LazyRawStreamItem<'top, AnyEncoding>
 {
+    #[inline]
     fn from(value: LazyRawStreamItem<'top, TextEncoding_1_0>) -> Self {
         match value {
             LazyRawStreamItem::<TextEncoding_1_0>::VersionMarker(marker) => {
@@ -936,6 +1001,7 @@ impl<'top> From<LazyRawStreamItem<'top, TextEncoding_1_0>>
 impl<'top> From<LazyRawStreamItem<'top, BinaryEncoding_1_0>>
     for LazyRawStreamItem<'top, AnyEncoding>
 {
+    #[inline]
     fn from(value: LazyRawStreamItem<'top, BinaryEncoding_1_0>) -> Self {
         match value {
             LazyRawStreamItem::<BinaryEncoding_1_0>::VersionMarker(marker) => {
@@ -957,6 +1023,7 @@ impl<'top> From<LazyRawStreamItem<'top, BinaryEncoding_1_0>>
 impl<'top> From<LazyRawStreamItem<'top, TextEncoding_1_1>>
     for LazyRawStreamItem<'top, AnyEncoding>
 {
+    #[inline]
     fn from(value: LazyRawStreamItem<'top, TextEncoding_1_1>) -> Self {
         match value {
             LazyRawStreamItem::<TextEncoding_1_1>::VersionMarker(marker) => {
@@ -980,6 +1047,7 @@ impl<'top> From<LazyRawStreamItem<'top, TextEncoding_1_1>>
 impl<'top> From<LazyRawStreamItem<'top, BinaryEncoding_1_1>>
     for LazyRawStreamItem<'top, AnyEncoding>
 {
+    #[inline]
     fn from(value: LazyRawStreamItem<'top, BinaryEncoding_1_1>) -> Self {
         match value {
             LazyRawStreamItem::<BinaryEncoding_1_1>::VersionMarker(marker) => {
@@ -999,6 +1067,7 @@ impl<'top> From<LazyRawStreamItem<'top, BinaryEncoding_1_1>>
 }
 
 impl<'top> HasSpan<'top> for LazyRawAnyValue<'top> {
+    #[inline]
     fn span(&self) -> Span<'top> {
         use LazyRawValueKind::*;
         match &self.encoding {
@@ -1011,6 +1080,7 @@ impl<'top> HasSpan<'top> for LazyRawAnyValue<'top> {
 }
 
 impl HasRange for LazyRawAnyValue<'_> {
+    #[inline]
     fn range(&self) -> Range<usize> {
         use LazyRawValueKind::*;
         match &self.encoding {
@@ -1023,6 +1093,7 @@ impl HasRange for LazyRawAnyValue<'_> {
 }
 
 impl<'top> LazyRawValue<'top, AnyEncoding> for LazyRawAnyValue<'top> {
+    #[inline]
     fn ion_type(&self) -> IonType {
         use LazyRawValueKind::*;
         match &self.encoding {
@@ -1033,6 +1104,7 @@ impl<'top> LazyRawValue<'top, AnyEncoding> for LazyRawAnyValue<'top> {
         }
     }
 
+    #[inline]
     fn is_null(&self) -> bool {
         use LazyRawValueKind::*;
         match &self.encoding {
@@ -1043,6 +1115,7 @@ impl<'top> LazyRawValue<'top, AnyEncoding> for LazyRawAnyValue<'top> {
         }
     }
 
+    #[inline]
     fn is_delimited(&self) -> bool {
         use LazyRawValueKind::*;
         match &self.encoding {
@@ -1053,6 +1126,7 @@ impl<'top> LazyRawValue<'top, AnyEncoding> for LazyRawAnyValue<'top> {
         }
     }
 
+    #[inline]
     fn has_annotations(&self) -> bool {
         use LazyRawValueKind::*;
         match &self.encoding {
@@ -1063,6 +1137,7 @@ impl<'top> LazyRawValue<'top, AnyEncoding> for LazyRawAnyValue<'top> {
         }
     }
 
+    #[inline]
     fn annotations(&self) -> RawAnyAnnotationsIterator<'top> {
         use LazyRawValueKind::*;
         match &self.encoding {
@@ -1081,6 +1156,7 @@ impl<'top> LazyRawValue<'top, AnyEncoding> for LazyRawAnyValue<'top> {
         }
     }
 
+    #[inline]
     fn read(&self) -> IonResult<RawValueRef<'top, AnyEncoding>> {
         use LazyRawValueKind::*;
         match &self.encoding {
@@ -1091,6 +1167,7 @@ impl<'top> LazyRawValue<'top, AnyEncoding> for LazyRawAnyValue<'top> {
         }
     }
 
+    #[inline]
     fn annotations_span(&self) -> Span<'top> {
         match &self.encoding {
             LazyRawValueKind::Text_1_0(v) => v.annotations_span(),
@@ -1100,6 +1177,7 @@ impl<'top> LazyRawValue<'top, AnyEncoding> for LazyRawAnyValue<'top> {
         }
     }
 
+    #[inline]
     fn value_span(&self) -> Span<'top> {
         match &self.encoding {
             LazyRawValueKind::Text_1_0(v) => v.value_span(),
@@ -1109,6 +1187,7 @@ impl<'top> LazyRawValue<'top, AnyEncoding> for LazyRawAnyValue<'top> {
         }
     }
 
+    #[inline]
     fn with_backing_data(&self, span: Span<'top>) -> Self {
         Self {
             encoding: match &self.encoding {
@@ -1128,6 +1207,7 @@ impl<'top> LazyRawValue<'top, AnyEncoding> for LazyRawAnyValue<'top> {
         }
     }
 
+    #[inline]
     fn encoding(&self) -> IonEncoding {
         match self.encoding {
             LazyRawValueKind::Text_1_0(_) => IonEncoding::Text_1_0,
@@ -1154,6 +1234,7 @@ pub enum RawAnnotationsIteratorKind<'top> {
 impl<'top> Iterator for RawAnyAnnotationsIterator<'top> {
     type Item = IonResult<RawSymbolRef<'top>>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         match &mut self.encoding {
             RawAnnotationsIteratorKind::Text_1_0(i) => i.next(),
@@ -1172,6 +1253,7 @@ pub struct LazyRawAnyList<'top> {
 }
 
 impl<'top> LazyRawAnyList<'top> {
+    #[inline]
     pub fn as_value(&self) -> LazyRawAnyValue<'top> {
         use LazyRawListKind::*;
         match self.encoding {
@@ -1184,6 +1266,7 @@ impl<'top> LazyRawAnyList<'top> {
 }
 
 impl<'top> LazyRawAnyList<'top> {
+    #[inline]
     pub fn kind(&self) -> LazyRawListKind<'top> {
         self.encoding
     }
@@ -1198,6 +1281,7 @@ pub enum LazyRawListKind<'top> {
 }
 
 impl<'top> LazyContainerPrivate<'top, AnyEncoding> for LazyRawAnyList<'top> {
+    #[inline]
     fn from_value(value: LazyRawAnyValue<'top>) -> Self {
         use LazyRawValueKind::*;
         match value.encoding {
@@ -1233,6 +1317,7 @@ pub enum RawAnyListIteratorKind<'data> {
 impl<'data> Iterator for RawAnyListIterator<'data> {
     type Item = IonResult<LazyRawValueExpr<'data, AnyEncoding>>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         match &mut self.encoding {
             RawAnyListIteratorKind::Text_1_0(i) => i
@@ -1252,6 +1337,7 @@ impl<'data> Iterator for RawAnyListIterator<'data> {
 }
 
 impl<'top> LazyRawContainer<'top, AnyEncoding> for LazyRawAnyList<'top> {
+    #[inline]
     fn as_value(&self) -> <AnyEncoding as Decoder>::Value<'top> {
         match &self.encoding {
             LazyRawListKind::Text_1_0(s) => s.as_value().into(),
@@ -1265,10 +1351,12 @@ impl<'top> LazyRawContainer<'top, AnyEncoding> for LazyRawAnyList<'top> {
 impl<'top> LazyRawSequence<'top, AnyEncoding> for LazyRawAnyList<'top> {
     type Iterator = RawAnyListIterator<'top>;
 
+    #[inline]
     fn annotations(&self) -> <AnyEncoding as Decoder>::AnnotationsIterator<'top> {
         self.as_value().annotations()
     }
 
+    #[inline]
     fn ion_type(&self) -> IonType {
         match &self.encoding {
             LazyRawListKind::Text_1_0(s) => s.ion_type(),
@@ -1278,6 +1366,7 @@ impl<'top> LazyRawSequence<'top, AnyEncoding> for LazyRawAnyList<'top> {
         }
     }
 
+    #[inline]
     fn iter(&self) -> Self::Iterator {
         match &self.encoding {
             LazyRawListKind::Text_1_0(s) => RawAnyListIterator {
@@ -1297,6 +1386,7 @@ impl<'top> LazyRawSequence<'top, AnyEncoding> for LazyRawAnyList<'top> {
 }
 
 impl<'data> From<RawTextList<'data, TextEncoding_1_0>> for LazyRawAnyList<'data> {
+    #[inline]
     fn from(value: RawTextList<'data, TextEncoding_1_0>) -> Self {
         LazyRawAnyList {
             encoding: LazyRawListKind::Text_1_0(value),
@@ -1305,6 +1395,7 @@ impl<'data> From<RawTextList<'data, TextEncoding_1_0>> for LazyRawAnyList<'data>
 }
 
 impl<'data> From<LazyRawBinaryList_1_0<'data>> for LazyRawAnyList<'data> {
+    #[inline]
     fn from(value: LazyRawBinaryList_1_0<'data>) -> Self {
         LazyRawAnyList {
             encoding: LazyRawListKind::Binary_1_0(value),
@@ -1313,6 +1404,7 @@ impl<'data> From<LazyRawBinaryList_1_0<'data>> for LazyRawAnyList<'data> {
 }
 
 impl<'data> From<RawTextList<'data, TextEncoding_1_1>> for LazyRawAnyList<'data> {
+    #[inline]
     fn from(value: RawTextList<'data, TextEncoding_1_1>) -> Self {
         LazyRawAnyList {
             encoding: LazyRawListKind::Text_1_1(value),
@@ -1321,6 +1413,7 @@ impl<'data> From<RawTextList<'data, TextEncoding_1_1>> for LazyRawAnyList<'data>
 }
 
 impl<'data> From<LazyRawBinaryList_1_1<'data>> for LazyRawAnyList<'data> {
+    #[inline]
     fn from(value: LazyRawBinaryList_1_1<'data>) -> Self {
         LazyRawAnyList {
             encoding: LazyRawListKind::Binary_1_1(value),
@@ -1336,6 +1429,7 @@ pub struct LazyRawAnySExp<'data> {
 }
 
 impl<'top> LazyRawAnySExp<'top> {
+    #[inline]
     pub fn kind(&self) -> LazyRawSExpKind<'top> {
         self.encoding
     }
@@ -1350,6 +1444,7 @@ pub enum LazyRawSExpKind<'data> {
 }
 
 impl<'top> LazyRawContainer<'top, AnyEncoding> for LazyRawAnySExp<'top> {
+    #[inline]
     fn as_value(&self) -> <AnyEncoding as Decoder>::Value<'top> {
         use LazyRawSExpKind::*;
         match self.encoding {
@@ -1362,6 +1457,7 @@ impl<'top> LazyRawContainer<'top, AnyEncoding> for LazyRawAnySExp<'top> {
 }
 
 impl<'data> LazyContainerPrivate<'data, AnyEncoding> for LazyRawAnySExp<'data> {
+    #[inline]
     fn from_value(value: LazyRawAnyValue<'data>) -> Self {
         match value.encoding {
             LazyRawValueKind::Text_1_0(v) => LazyRawAnySExp {
@@ -1396,6 +1492,7 @@ pub enum RawAnySExpIteratorKind<'data> {
 impl<'data> Iterator for RawAnySExpIterator<'data> {
     type Item = IonResult<LazyRawValueExpr<'data, AnyEncoding>>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         match &mut self.encoding {
             RawAnySExpIteratorKind::Text_1_0(i) => i
@@ -1417,10 +1514,12 @@ impl<'data> Iterator for RawAnySExpIterator<'data> {
 impl<'top> LazyRawSequence<'top, AnyEncoding> for LazyRawAnySExp<'top> {
     type Iterator = RawAnySExpIterator<'top>;
 
+    #[inline]
     fn annotations(&self) -> <AnyEncoding as Decoder>::AnnotationsIterator<'top> {
         self.as_value().annotations()
     }
 
+    #[inline]
     fn ion_type(&self) -> IonType {
         match &self.encoding {
             LazyRawSExpKind::Text_1_0(s) => s.ion_type(),
@@ -1430,6 +1529,7 @@ impl<'top> LazyRawSequence<'top, AnyEncoding> for LazyRawAnySExp<'top> {
         }
     }
 
+    #[inline]
     fn iter(&self) -> Self::Iterator {
         match &self.encoding {
             LazyRawSExpKind::Text_1_0(s) => RawAnySExpIterator {
@@ -1449,6 +1549,7 @@ impl<'top> LazyRawSequence<'top, AnyEncoding> for LazyRawAnySExp<'top> {
 }
 
 impl<'data> From<RawTextSExp<'data, TextEncoding_1_0>> for LazyRawAnySExp<'data> {
+    #[inline]
     fn from(value: RawTextSExp<'data, TextEncoding_1_0>) -> Self {
         LazyRawAnySExp {
             encoding: LazyRawSExpKind::Text_1_0(value),
@@ -1457,6 +1558,7 @@ impl<'data> From<RawTextSExp<'data, TextEncoding_1_0>> for LazyRawAnySExp<'data>
 }
 
 impl<'data> From<LazyRawBinarySExp_1_0<'data>> for LazyRawAnySExp<'data> {
+    #[inline]
     fn from(value: LazyRawBinarySExp_1_0<'data>) -> Self {
         LazyRawAnySExp {
             encoding: LazyRawSExpKind::Binary_1_0(value),
@@ -1465,6 +1567,7 @@ impl<'data> From<LazyRawBinarySExp_1_0<'data>> for LazyRawAnySExp<'data> {
 }
 
 impl<'data> From<RawTextSExp<'data, TextEncoding_1_1>> for LazyRawAnySExp<'data> {
+    #[inline]
     fn from(value: RawTextSExp<'data, TextEncoding_1_1>) -> Self {
         LazyRawAnySExp {
             encoding: LazyRawSExpKind::Text_1_1(value),
@@ -1473,6 +1576,7 @@ impl<'data> From<RawTextSExp<'data, TextEncoding_1_1>> for LazyRawAnySExp<'data>
 }
 
 impl<'data> From<LazyRawBinarySExp_1_1<'data>> for LazyRawAnySExp<'data> {
+    #[inline]
     fn from(value: LazyRawBinarySExp_1_1<'data>) -> Self {
         LazyRawAnySExp {
             encoding: LazyRawSExpKind::Binary_1_1(value),
@@ -1496,6 +1600,7 @@ pub enum LazyRawStructKind<'data> {
 }
 
 impl<'top> LazyRawContainer<'top, AnyEncoding> for LazyRawAnyStruct<'top> {
+    #[inline]
     fn as_value(&self) -> <AnyEncoding as Decoder>::Value<'top> {
         match self.encoding {
             LazyRawStructKind::Text_1_0(s) => s.as_value().into(),
@@ -1513,13 +1618,15 @@ pub struct LazyRawAnyFieldName<'data> {
 
 #[derive(Debug, Copy, Clone)]
 pub enum LazyRawFieldNameKind<'data> {
-    Text_1_0(LazyRawTextFieldName<'data, TextEncoding_1_0>),
+    // See the comment on `LazyRawValueKind` regarding variant order.
     Binary_1_0(LazyRawBinaryFieldName_1_0<'data>),
+    Text_1_0(LazyRawTextFieldName<'data, TextEncoding_1_0>),
     Text_1_1(LazyRawTextFieldName<'data, TextEncoding_1_1>),
     Binary_1_1(LazyRawBinaryFieldName_1_1<'data>),
 }
 
 impl<'top> HasSpan<'top> for LazyRawAnyFieldName<'top> {
+    #[inline]
     fn span(&self) -> Span<'top> {
         use LazyRawFieldNameKind::*;
         match self.encoding {
@@ -1532,6 +1639,7 @@ impl<'top> HasSpan<'top> for LazyRawAnyFieldName<'top> {
 }
 
 impl HasRange for LazyRawAnyFieldName<'_> {
+    #[inline]
     fn range(&self) -> Range<usize> {
         use LazyRawFieldNameKind::*;
         match self.encoding {
@@ -1544,6 +1652,7 @@ impl HasRange for LazyRawAnyFieldName<'_> {
 }
 
 impl<'top> LazyRawFieldName<'top, AnyEncoding> for LazyRawAnyFieldName<'top> {
+    #[inline]
     fn read(&self) -> IonResult<RawSymbolRef<'top>> {
         use LazyRawFieldNameKind::*;
         match self.encoding {
@@ -1556,30 +1665,35 @@ impl<'top> LazyRawFieldName<'top, AnyEncoding> for LazyRawAnyFieldName<'top> {
 }
 
 impl<'top> From<LazyRawFieldNameKind<'top>> for LazyRawAnyFieldName<'top> {
+    #[inline]
     fn from(value: LazyRawFieldNameKind<'top>) -> Self {
         LazyRawAnyFieldName { encoding: value }
     }
 }
 
 impl<'top> From<LazyRawTextFieldName<'top, TextEncoding_1_0>> for LazyRawAnyFieldName<'top> {
+    #[inline]
     fn from(value: LazyRawTextFieldName<'top, TextEncoding_1_0>) -> Self {
         LazyRawFieldNameKind::Text_1_0(value).into()
     }
 }
 
 impl<'top> From<LazyRawTextFieldName<'top, TextEncoding_1_1>> for LazyRawAnyFieldName<'top> {
+    #[inline]
     fn from(value: LazyRawTextFieldName<'top, TextEncoding_1_1>) -> Self {
         LazyRawFieldNameKind::Text_1_1(value).into()
     }
 }
 
 impl<'top> From<LazyRawBinaryFieldName_1_0<'top>> for LazyRawAnyFieldName<'top> {
+    #[inline]
     fn from(value: LazyRawBinaryFieldName_1_0<'top>) -> Self {
         LazyRawFieldNameKind::Binary_1_0(value).into()
     }
 }
 
 impl<'top> From<LazyRawBinaryFieldName_1_1<'top>> for LazyRawAnyFieldName<'top> {
+    #[inline]
     fn from(value: LazyRawBinaryFieldName_1_1<'top>) -> Self {
         LazyRawFieldNameKind::Binary_1_1(value).into()
     }
@@ -1592,8 +1706,9 @@ pub struct RawAnyStructIterator<'data> {
 
 #[derive(Debug, Copy, Clone)]
 pub enum RawAnyStructIteratorKind<'data> {
-    Text_1_0(RawTextStructCacheIterator<'data, TextEncoding_1_0>),
+    // See the comment on `LazyRawValueKind` regarding variant order.
     Binary_1_0(RawBinaryStructIterator_1_0<'data>),
+    Text_1_0(RawTextStructCacheIterator<'data, TextEncoding_1_0>),
     Text_1_1(RawTextStructCacheIterator<'data, TextEncoding_1_1>),
     Binary_1_1(RawBinaryStructIterator_1_1<'data>),
 }
@@ -1601,6 +1716,7 @@ pub enum RawAnyStructIteratorKind<'data> {
 impl<'data> Iterator for RawAnyStructIterator<'data> {
     type Item = IonResult<LazyRawFieldExpr<'data, AnyEncoding>>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         match &mut self.encoding {
             RawAnyStructIteratorKind::Text_1_0(i) => i
@@ -1622,6 +1738,7 @@ impl<'data> Iterator for RawAnyStructIterator<'data> {
 impl<'data> From<LazyRawFieldExpr<'data, TextEncoding_1_0>>
     for LazyRawFieldExpr<'data, AnyEncoding>
 {
+    #[inline]
     fn from(text_field: LazyRawFieldExpr<'data, TextEncoding_1_0>) -> Self {
         use LazyRawFieldExpr::*;
         match text_field {
@@ -1635,6 +1752,7 @@ impl<'data> From<LazyRawFieldExpr<'data, TextEncoding_1_0>>
 impl<'data> From<LazyRawFieldExpr<'data, BinaryEncoding_1_0>>
     for LazyRawFieldExpr<'data, AnyEncoding>
 {
+    #[inline]
     fn from(binary_field: LazyRawFieldExpr<'data, BinaryEncoding_1_0>) -> Self {
         use LazyRawFieldExpr::*;
         match binary_field {
@@ -1648,6 +1766,7 @@ impl<'data> From<LazyRawFieldExpr<'data, BinaryEncoding_1_0>>
 impl<'data> From<LazyRawFieldExpr<'data, TextEncoding_1_1>>
     for LazyRawFieldExpr<'data, AnyEncoding>
 {
+    #[inline]
     fn from(text_field: LazyRawFieldExpr<'data, TextEncoding_1_1>) -> Self {
         use LazyRawFieldExpr::*;
         match text_field {
@@ -1661,6 +1780,7 @@ impl<'data> From<LazyRawFieldExpr<'data, TextEncoding_1_1>>
 impl<'data> From<LazyRawFieldExpr<'data, BinaryEncoding_1_1>>
     for LazyRawFieldExpr<'data, AnyEncoding>
 {
+    #[inline]
     fn from(binary_field: LazyRawFieldExpr<'data, BinaryEncoding_1_1>) -> Self {
         use LazyRawFieldExpr::*;
         match binary_field {
@@ -1672,6 +1792,7 @@ impl<'data> From<LazyRawFieldExpr<'data, BinaryEncoding_1_1>>
 }
 
 impl<'data> LazyContainerPrivate<'data, AnyEncoding> for LazyRawAnyStruct<'data> {
+    #[inline]
     fn from_value(value: LazyRawAnyValue<'data>) -> Self {
         match value.encoding {
             LazyRawValueKind::Text_1_0(v) => LazyRawAnyStruct {
@@ -1697,6 +1818,7 @@ impl<'data> LazyContainerPrivate<'data, AnyEncoding> for LazyRawAnyStruct<'data>
 impl<'top> LazyRawStruct<'top, AnyEncoding> for LazyRawAnyStruct<'top> {
     type Iterator = RawAnyStructIterator<'top>;
 
+    #[inline]
     fn annotations(&self) -> <AnyEncoding as Decoder>::AnnotationsIterator<'top> {
         match &self.encoding {
             LazyRawStructKind::Text_1_0(s) => RawAnyAnnotationsIterator {
@@ -1714,6 +1836,7 @@ impl<'top> LazyRawStruct<'top, AnyEncoding> for LazyRawAnyStruct<'top> {
         }
     }
 
+    #[inline]
     fn iter(&self) -> Self::Iterator {
         match &self.encoding {
             LazyRawStructKind::Text_1_0(s) => RawAnyStructIterator {
@@ -1733,6 +1856,7 @@ impl<'top> LazyRawStruct<'top, AnyEncoding> for LazyRawAnyStruct<'top> {
 }
 
 impl<'data> From<LazyRawTextStruct<'data, TextEncoding_1_0>> for LazyRawAnyStruct<'data> {
+    #[inline]
     fn from(value: LazyRawTextStruct<'data, TextEncoding_1_0>) -> Self {
         LazyRawAnyStruct {
             encoding: LazyRawStructKind::Text_1_0(value),
@@ -1741,6 +1865,7 @@ impl<'data> From<LazyRawTextStruct<'data, TextEncoding_1_0>> for LazyRawAnyStruc
 }
 
 impl<'data> From<LazyRawBinaryStruct_1_0<'data>> for LazyRawAnyStruct<'data> {
+    #[inline]
     fn from(value: LazyRawBinaryStruct_1_0<'data>) -> Self {
         LazyRawAnyStruct {
             encoding: LazyRawStructKind::Binary_1_0(value),
@@ -1749,6 +1874,7 @@ impl<'data> From<LazyRawBinaryStruct_1_0<'data>> for LazyRawAnyStruct<'data> {
 }
 
 impl<'data> From<LazyRawTextStruct<'data, TextEncoding_1_1>> for LazyRawAnyStruct<'data> {
+    #[inline]
     fn from(value: LazyRawTextStruct<'data, TextEncoding_1_1>) -> Self {
         LazyRawAnyStruct {
             encoding: LazyRawStructKind::Text_1_1(value),
@@ -1757,6 +1883,7 @@ impl<'data> From<LazyRawTextStruct<'data, TextEncoding_1_1>> for LazyRawAnyStruc
 }
 
 impl<'data> From<LazyRawBinaryStruct_1_1<'data>> for LazyRawAnyStruct<'data> {
+    #[inline]
     fn from(value: LazyRawBinaryStruct_1_1<'data>) -> Self {
         LazyRawAnyStruct {
             encoding: LazyRawStructKind::Binary_1_1(value),
@@ -1768,6 +1895,7 @@ impl<'data> IntoIterator for LazyRawAnyStruct<'data> {
     type Item = IonResult<LazyRawFieldExpr<'data, AnyEncoding>>;
     type IntoIter = RawAnyStructIterator<'data>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }

--- a/src/lazy/any_encoding.rs
+++ b/src/lazy/any_encoding.rs
@@ -1,5 +1,15 @@
 #![allow(non_camel_case_types)]
 
+// ## `#[inline]` convention in this module
+//
+// The enum-dispatch wrappers in this file sit on the hot path of every `AnyEncoding` read.
+// Because `#[inline]` is what allows a *non-LTO downstream build* to inline these
+// single-match dispatch methods across the crate boundary, small dispatch wrappers and
+// `From` conversion shims here carry `#[inline]`. Large multi-branch functions and generic
+// functions (which monomorphize into the caller's crate anyway) are deliberately left
+// un-annotated. The effect is measured in aggregate via `benches/large_doc_read.rs`, not
+// per-annotation. New small dispatch/`From` shims added to this file should follow suit.
+
 use crate::lazy::binary::raw::annotations_iterator::RawBinaryAnnotationsIterator as RawBinaryAnnotationsIterator_1_0;
 use crate::lazy::binary::raw::r#struct::{
     LazyRawBinaryFieldName_1_0, LazyRawBinaryStruct_1_0, RawBinaryStructIterator_1_0,
@@ -656,7 +666,6 @@ impl<'data> LazyRawReader<'data, AnyEncoding> for LazyRawAnyReader<'data> {
         }
     }
 
-    #[inline]
     fn resume(context: EncodingContextRef<'data>, mut saved_state: RawReaderState<'data>) -> Self {
         let offset = saved_state.offset();
         let data = saved_state.data();
@@ -673,7 +682,6 @@ impl<'data> LazyRawReader<'data, AnyEncoding> for LazyRawAnyReader<'data> {
         }
     }
 
-    #[inline]
     fn save_state(&self) -> RawReaderState<'data> {
         use RawReaderKind::*;
         let reader_state = match &self.encoding_reader {
@@ -695,7 +703,6 @@ impl<'data> LazyRawReader<'data, AnyEncoding> for LazyRawAnyReader<'data> {
         reader_state
     }
 
-    #[inline]
     fn next(&mut self) -> IonResult<LazyRawStreamItem<'data, AnyEncoding>> {
         // If we previously ran into an IVM that changed the stream encoding, replace our reader
         // with one that can read the new encoding.
@@ -790,8 +797,8 @@ impl<'top> LazyRawAnyValue<'top> {
 
 #[derive(Debug, Copy, Clone)]
 pub enum LazyRawValueKind<'top> {
-    // Binary 1.0 is declared first so that the most common encoding's variant is
-    // the zero discriminant, which the compiler can dispatch on most cheaply.
+    // Placing the most common encoding (binary Ion 1.0) first measured faster on the
+    // large-document benchmarks; no compiler layout guarantee is assumed.
     Binary_1_0(&'top LazyRawBinaryValue_1_0<'top>),
     Text_1_0(LazyRawTextValue_1_0<'top>),
     Text_1_1(LazyRawTextValue_1_1<'top>),
@@ -979,7 +986,6 @@ impl<'top> From<RawValueRef<'top, BinaryEncoding_1_1>> for RawValueRef<'top, Any
 impl<'top> From<LazyRawStreamItem<'top, TextEncoding_1_0>>
     for LazyRawStreamItem<'top, AnyEncoding>
 {
-    #[inline]
     fn from(value: LazyRawStreamItem<'top, TextEncoding_1_0>) -> Self {
         match value {
             LazyRawStreamItem::<TextEncoding_1_0>::VersionMarker(marker) => {
@@ -1001,7 +1007,6 @@ impl<'top> From<LazyRawStreamItem<'top, TextEncoding_1_0>>
 impl<'top> From<LazyRawStreamItem<'top, BinaryEncoding_1_0>>
     for LazyRawStreamItem<'top, AnyEncoding>
 {
-    #[inline]
     fn from(value: LazyRawStreamItem<'top, BinaryEncoding_1_0>) -> Self {
         match value {
             LazyRawStreamItem::<BinaryEncoding_1_0>::VersionMarker(marker) => {
@@ -1023,7 +1028,6 @@ impl<'top> From<LazyRawStreamItem<'top, BinaryEncoding_1_0>>
 impl<'top> From<LazyRawStreamItem<'top, TextEncoding_1_1>>
     for LazyRawStreamItem<'top, AnyEncoding>
 {
-    #[inline]
     fn from(value: LazyRawStreamItem<'top, TextEncoding_1_1>) -> Self {
         match value {
             LazyRawStreamItem::<TextEncoding_1_1>::VersionMarker(marker) => {
@@ -1047,7 +1051,6 @@ impl<'top> From<LazyRawStreamItem<'top, TextEncoding_1_1>>
 impl<'top> From<LazyRawStreamItem<'top, BinaryEncoding_1_1>>
     for LazyRawStreamItem<'top, AnyEncoding>
 {
-    #[inline]
     fn from(value: LazyRawStreamItem<'top, BinaryEncoding_1_1>) -> Self {
         match value {
             LazyRawStreamItem::<BinaryEncoding_1_1>::VersionMarker(marker) => {
@@ -1792,7 +1795,6 @@ impl<'data> From<LazyRawFieldExpr<'data, BinaryEncoding_1_1>>
 }
 
 impl<'data> LazyContainerPrivate<'data, AnyEncoding> for LazyRawAnyStruct<'data> {
-    #[inline]
     fn from_value(value: LazyRawAnyValue<'data>) -> Self {
         match value.encoding {
             LazyRawValueKind::Text_1_0(v) => LazyRawAnyStruct {

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -487,6 +487,10 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
             // We're setting the symbols list, not appending to it.
             symbol_table.reset_to_prefix_only();
         }
+        // The number of incoming symbols is known, so reserve capacity for them up front
+        // rather than growing the table incrementally as they are added.
+        symbol_table
+            .reserve(pending_changes.imported_symbols.len() + pending_changes.symbols.len());
         // `drain()` empties the pending `imported_symbols` and `symbols` lists
         for symbol in pending_changes.imported_symbols.drain(..) {
             symbol_table.add_symbol(symbol);

--- a/src/lazy/expanded/mod.rs
+++ b/src/lazy/expanded/mod.rs
@@ -488,9 +488,16 @@ impl<Encoding: Decoder, Input: IonInput> ExpandingReader<Encoding, Input> {
             symbol_table.reset_to_prefix_only();
         }
         // The number of incoming symbols is known, so reserve capacity for them up front
-        // rather than growing the table incrementally as they are added.
-        symbol_table
-            .reserve(pending_changes.imported_symbols.len() + pending_changes.symbols.len());
+        // rather than growing the table incrementally as they are added. The text-to-ID
+        // map only receives entries for symbols with known text.
+        let num_imported = pending_changes.imported_symbols.len();
+        let num_imported_with_text = pending_changes
+            .imported_symbols
+            .iter()
+            .filter(|symbol| symbol.text().is_some())
+            .count();
+        let num_local = pending_changes.symbols.len();
+        symbol_table.reserve(num_imported + num_local, num_imported_with_text + num_local);
         // `drain()` empties the pending `imported_symbols` and `symbols` lists
         for symbol in pending_changes.imported_symbols.drain(..) {
             symbol_table.add_symbol(symbol);

--- a/src/lazy/raw_value_ref.rs
+++ b/src/lazy/raw_value_ref.rs
@@ -34,6 +34,7 @@ pub enum RawValueRef<'top, D: Decoder> {
 
 // Provides equality for scalar types, but not containers.
 impl<D: Decoder> PartialEq for RawValueRef<'_, D> {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         use RawValueRef::*;
         match (self, other) {
@@ -55,6 +56,7 @@ impl<D: Decoder> PartialEq for RawValueRef<'_, D> {
 }
 
 impl<D: Decoder> Debug for RawValueRef<'_, D> {
+    #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             RawValueRef::Null(ion_type) => write!(f, "null.{ion_type}"),
@@ -75,6 +77,7 @@ impl<D: Decoder> Debug for RawValueRef<'_, D> {
 }
 
 impl<'top, D: Decoder> RawValueRef<'top, D> {
+    #[inline]
     pub fn resolve(self, context: EncodingContextRef<'top>) -> IonResult<ValueRef<'top, D>> {
         let value_ref = match self {
             RawValueRef::Null(ion_type) => ValueRef::Null(ion_type),
@@ -100,6 +103,7 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         Ok(value_ref)
     }
 
+    #[inline]
     pub fn expect_null(self) -> IonResult<IonType> {
         if let RawValueRef::Null(ion_type) = self {
             Ok(ion_type)
@@ -108,6 +112,7 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
+    #[inline]
     pub fn expect_bool(self) -> IonResult<bool> {
         if let RawValueRef::Bool(b) = self {
             Ok(b)
@@ -116,6 +121,7 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
+    #[inline]
     pub fn expect_int(self) -> IonResult<Int> {
         if let RawValueRef::Int(i) = self {
             Ok(i)
@@ -124,6 +130,7 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
+    #[inline]
     pub fn expect_i64(self) -> IonResult<i64> {
         if let RawValueRef::Int(i) = self {
             i.expect_i64()
@@ -132,6 +139,7 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
+    #[inline]
     pub fn expect_float(self) -> IonResult<f64> {
         if let RawValueRef::Float(f) = self {
             Ok(f)
@@ -140,6 +148,7 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
+    #[inline]
     pub fn expect_decimal(self) -> IonResult<Decimal> {
         if let RawValueRef::Decimal(d) = self {
             Ok(d)
@@ -148,6 +157,7 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
+    #[inline]
     pub fn expect_timestamp(self) -> IonResult<Timestamp> {
         if let RawValueRef::Timestamp(t) = self {
             Ok(t)
@@ -156,6 +166,7 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
+    #[inline]
     pub fn expect_string(self) -> IonResult<StrRef<'top>> {
         if let RawValueRef::String(s) = self {
             Ok(s)
@@ -164,6 +175,7 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
+    #[inline]
     pub fn expect_symbol(self) -> IonResult<RawSymbolRef<'top>> {
         if let RawValueRef::Symbol(s) = self {
             Ok(s)
@@ -172,6 +184,7 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
+    #[inline]
     pub fn expect_blob(self) -> IonResult<BytesRef<'top>> {
         if let RawValueRef::Blob(b) = self {
             Ok(b)
@@ -180,6 +193,7 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
+    #[inline]
     pub fn expect_clob(self) -> IonResult<BytesRef<'top>> {
         if let RawValueRef::Clob(c) = self {
             Ok(c)
@@ -188,6 +202,7 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
+    #[inline]
     pub fn expect_list(self) -> IonResult<D::List<'top>> {
         if let RawValueRef::List(s) = self {
             Ok(s)
@@ -196,6 +211,7 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
+    #[inline]
     pub fn expect_sexp(self) -> IonResult<D::SExp<'top>> {
         if let RawValueRef::SExp(s) = self {
             Ok(s)
@@ -204,6 +220,7 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
+    #[inline]
     pub fn expect_struct(self) -> IonResult<D::Struct<'top>> {
         if let RawValueRef::Struct(s) = self {
             Ok(s)

--- a/src/lazy/raw_value_ref.rs
+++ b/src/lazy/raw_value_ref.rs
@@ -56,7 +56,6 @@ impl<D: Decoder> PartialEq for RawValueRef<'_, D> {
 }
 
 impl<D: Decoder> Debug for RawValueRef<'_, D> {
-    #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             RawValueRef::Null(ion_type) => write!(f, "null.{ion_type}"),
@@ -103,7 +102,6 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         Ok(value_ref)
     }
 
-    #[inline]
     pub fn expect_null(self) -> IonResult<IonType> {
         if let RawValueRef::Null(ion_type) = self {
             Ok(ion_type)
@@ -112,7 +110,6 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
-    #[inline]
     pub fn expect_bool(self) -> IonResult<bool> {
         if let RawValueRef::Bool(b) = self {
             Ok(b)
@@ -121,7 +118,6 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
-    #[inline]
     pub fn expect_int(self) -> IonResult<Int> {
         if let RawValueRef::Int(i) = self {
             Ok(i)
@@ -130,7 +126,6 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
-    #[inline]
     pub fn expect_i64(self) -> IonResult<i64> {
         if let RawValueRef::Int(i) = self {
             i.expect_i64()
@@ -139,7 +134,6 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
-    #[inline]
     pub fn expect_float(self) -> IonResult<f64> {
         if let RawValueRef::Float(f) = self {
             Ok(f)
@@ -148,7 +142,6 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
-    #[inline]
     pub fn expect_decimal(self) -> IonResult<Decimal> {
         if let RawValueRef::Decimal(d) = self {
             Ok(d)
@@ -157,7 +150,6 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
-    #[inline]
     pub fn expect_timestamp(self) -> IonResult<Timestamp> {
         if let RawValueRef::Timestamp(t) = self {
             Ok(t)
@@ -166,7 +158,6 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
-    #[inline]
     pub fn expect_string(self) -> IonResult<StrRef<'top>> {
         if let RawValueRef::String(s) = self {
             Ok(s)
@@ -175,7 +166,6 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
-    #[inline]
     pub fn expect_symbol(self) -> IonResult<RawSymbolRef<'top>> {
         if let RawValueRef::Symbol(s) = self {
             Ok(s)
@@ -184,7 +174,6 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
-    #[inline]
     pub fn expect_blob(self) -> IonResult<BytesRef<'top>> {
         if let RawValueRef::Blob(b) = self {
             Ok(b)
@@ -193,7 +182,6 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
-    #[inline]
     pub fn expect_clob(self) -> IonResult<BytesRef<'top>> {
         if let RawValueRef::Clob(c) = self {
             Ok(c)
@@ -202,7 +190,6 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
-    #[inline]
     pub fn expect_list(self) -> IonResult<D::List<'top>> {
         if let RawValueRef::List(s) = self {
             Ok(s)
@@ -211,7 +198,6 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
-    #[inline]
     pub fn expect_sexp(self) -> IonResult<D::SExp<'top>> {
         if let RawValueRef::SExp(s) = self {
             Ok(s)
@@ -220,7 +206,6 @@ impl<'top, D: Decoder> RawValueRef<'top, D> {
         }
     }
 
-    #[inline]
     pub fn expect_struct(self) -> IonResult<D::Struct<'top>> {
         if let RawValueRef::Struct(s) = self {
             Ok(s)

--- a/src/lazy/raw_value_ref.rs
+++ b/src/lazy/raw_value_ref.rs
@@ -34,7 +34,6 @@ pub enum RawValueRef<'top, D: Decoder> {
 
 // Provides equality for scalar types, but not containers.
 impl<D: Decoder> PartialEq for RawValueRef<'_, D> {
-    #[inline]
     fn eq(&self, other: &Self) -> bool {
         use RawValueRef::*;
         match (self, other) {
@@ -76,7 +75,6 @@ impl<D: Decoder> Debug for RawValueRef<'_, D> {
 }
 
 impl<'top, D: Decoder> RawValueRef<'top, D> {
-    #[inline]
     pub fn resolve(self, context: EncodingContextRef<'top>) -> IonResult<ValueRef<'top, D>> {
         let value_ref = match self {
             RawValueRef::Null(ion_type) => ValueRef::Null(ion_type),

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -177,10 +177,12 @@ impl SymbolTable {
 
     /// Reserves capacity for at least `additional` more symbols, avoiding repeated
     /// reallocation and rehashing when the number of incoming symbols is known up front
-    /// (for example, when applying a parsed local symbol table).
-    pub(crate) fn reserve(&mut self, additional: usize) {
+    /// (for example, when applying a parsed local symbol table). Only
+    /// `additional_with_text` of those symbols are expected to have known text; symbols
+    /// with unknown text never get an entry in the text-to-ID map.
+    pub(crate) fn reserve(&mut self, additional: usize, additional_with_text: usize) {
         self.symbols_by_id.reserve(additional);
-        self.ids_by_text.reserve(additional);
+        self.ids_by_text.reserve(additional_with_text);
     }
 
     /// Assigns unknown text to the next available symbol ID. This is used when an Ion reader

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -175,6 +175,14 @@ impl SymbolTable {
         id
     }
 
+    /// Reserves capacity for at least `additional` more symbols, avoiding repeated
+    /// reallocation and rehashing when the number of incoming symbols is known up front
+    /// (for example, when applying a parsed local symbol table).
+    pub(crate) fn reserve(&mut self, additional: usize) {
+        self.symbols_by_id.reserve(additional);
+        self.ids_by_text.reserve(additional);
+    }
+
     /// Assigns unknown text to the next available symbol ID. This is used when an Ion reader
     /// encounters null or non-string values in a stream's symbol table.
     pub(crate) fn add_placeholder(&mut self) -> SymbolId {

--- a/src/types/struct.rs
+++ b/src/types/struct.rs
@@ -4,9 +4,10 @@ use crate::ion_data::{IonDataHash, IonDataOrd, IonEq};
 use crate::symbol_ref::AsSymbolRef;
 use crate::text::text_formatter::FmtValueFormatter;
 use crate::Symbol;
+use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use std::cmp::Ordering;
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::fmt::{Display, Formatter};
 use std::hash::Hasher;
 
@@ -20,7 +21,7 @@ struct Fields {
     // Key/value pairs in the order they were inserted
     by_index: Vec<(Symbol, Element)>,
     // Maps symbols to a list of indexes where values may be found in `by_index` above
-    by_name: HashMap<Symbol, IndexVec>,
+    by_name: FxHashMap<Symbol, IndexVec>,
 }
 
 impl Fields {
@@ -322,7 +323,7 @@ where
     /// Returns an owned struct from the given iterator of field names/values.
     fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
         let mut by_index: Vec<(Symbol, Element)> = Vec::new();
-        let mut by_name: HashMap<Symbol, IndexVec> = HashMap::new();
+        let mut by_name: FxHashMap<Symbol, IndexVec> = FxHashMap::default();
         for (field_name, field_value) in iter {
             let field_name = field_name.into();
             let field_value = field_value.into();

--- a/src/types/struct.rs
+++ b/src/types/struct.rs
@@ -8,7 +8,7 @@ use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use std::cmp::Ordering;
 use std::collections::VecDeque;
-use std::fmt::{Display, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hasher;
 
 // A convenient type alias for a vector capable of storing a single `usize` inline
@@ -16,12 +16,25 @@ use std::hash::Hasher;
 type IndexVec = SmallVec<[usize; 1]>;
 
 // This collection is broken out into its own type to allow instances of it to be shared with Arc/Rc.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct Fields {
     // Key/value pairs in the order they were inserted
     by_index: Vec<(Symbol, Element)>,
-    // Maps symbols to a list of indexes where values may be found in `by_index` above
+    // Maps symbols to a list of indexes where values may be found in `by_index` above.
+    // `FxHashMap` is used for its faster hashing; field names are the same untrusted
+    // symbol text that the symbol table already indexes with an `FxHashMap`
+    // (see `ids_by_text` in `symbol_table.rs`).
     by_name: FxHashMap<Symbol, IndexVec>,
+}
+
+impl Debug for Fields {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // `by_name` is omitted because a hash map's iteration order is arbitrary; it is
+        // derived entirely from `by_index`, which preserves insertion order.
+        f.debug_struct("Fields")
+            .field("by_index", &self.by_index)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Fields {


### PR DESCRIPTION
### Summary

This PR reduces read costs for large (~10–30 KB) binary Ion 1.0 documents
on the `Element`/DOM path (the API that parses a whole document into an
in-memory tree) and the lazy `AnyEncoding` path (the reader mode that
auto-detects text vs binary), and adds a large-document benchmark
covering them. The optimizations are independent: reserving
symbol-table capacity when applying a local symbol table, an `FxHashMap`
field-name index on `Struct`, and an inlining/variant-ordering pass over
the `AnyEncoding` dispatch layer. On value-heavy documents,
`Element::read_one` improves 10–13% on the criterion benchmark (7–8%
under an independent profiling harness; both aarch64), `Struct::get` by
name improves
30–37%, and the lazy `AnyEncoding` reader improves 9–12%. No public API
changes. Follows discussion in #1038.

### Motivation

Large documents spend their time in different places than small ones.
Profiling large binary Ion 1.0 documents (value-heavy and symbol-heavy
flavors at ~10 KB and ~30 KB, one reader per document) shows:

- On a ~30 KB value-heavy document, `Element::read_one` costs **~3.8x**
  the concrete lazy reader (`v1_0::Binary`) reading the same bytes.
- The `AnyEncoding` layer adds **+48–49%** over `v1_0::Binary` on
  value-heavy documents at both sizes. The gap grows with document size,
  so large documents do not amortize it away.
- Building `Struct`'s by-name field index shows **~12%** of
  `Element`-path profile samples inside SipHash hashing frames (SipHash
  is the DoS-resistant hasher Rust's `HashMap` uses by default).
- Local symbol table (LST) processing allocates per symbol with **no
  capacity reservation**, so symbol-heavy documents pay repeated map/vec
  growth.

The existing benchmark suite has no large-document
one-reader-per-document case and no by-name field lookup case, so none of
these paths had a regression guard.

### What changed

- `b6cfb07` **perf: add large-document read benchmark**: new
  `benches/large_doc_read.rs`. Value-heavy and symbol-heavy documents at
  ~10 KB and ~30 KB; `Element::read_one` (default features); lazy
  `AnyEncoding` and `v1_0::Binary` readers (feature-gated like the
  existing benches); and a `Struct::get` by-name lookup flavor that
  includes ~13–17% miss lookups, so both hit and miss paths are guarded.
- `6d6e61f` **perf: reserve symbol table capacity when applying a local
  symbol table**: reserves capacity up front from the parsed
  pending-symbol count at LST-apply time. (The count is only known after
  parsing: the binary symbols-list length prefix is in bytes, not
  elements.) Removes growth-reallocation churn on symbol-heavy documents.
- `4f0bcfd` **perf: use FxHashMap for Struct's by-name field index**:
  swaps the index `HashMap` to `FxHashMap` (a much faster hasher that is
  not DoS-resistant). Rationale: field names are the same untrusted-input
  class as symbol text, and the existing `ids_by_text` index in
  `symbol_table.rs` already uses `FxHashMap` for that. The exposure
  profiles do differ: the symbol table precedent is per-stream and
  transient, while `Struct` is a retained DOM value; that difference is
  part of why the commit is severable. The hasher does not appear in any
  public signature. `Struct`'s `Debug` output changes: the field-name
  index is no longer printed (it is derived data with arbitrary map
  ordering). **Note for maintainers**: if you prefer
  DoS-resistant default hashing on DOM types (the `serde_json::Map`
  convention), we're happy to drop this commit; it's severable.
- `3a20f19` **perf: inline AnyEncoding delegation and reorder hot
  dispatch enums**: adds `#[inline]` to ~150 small `AnyEncoding`
  conversion/delegation functions, letting the compiler eliminate call
  overhead in this thin wrapper layer, and declares the `Binary_1_0`
  variants first in three internal-dispatch enums so the hot variant is
  matched first. Source-compatible: the three enums derive only
  `Debug`/`Copy`/`Clone`, with no `Ord`, no explicit `repr`, and no
  discriminant reads (verified). `Debug::fmt` and the `expect_*` error-path functions
  were deliberately excluded from inlining. The annotations were
  measured in aggregate via the new benchmark, not individually; the win
  survived the trim in the review commit (−10 to −13% re-measured).
- `ea09fc7` **review polish**: naming, comments, and bench cleanup from
  self-review.
- `bd3eb06` **refactor: apply local review feedback**: trims the
  `#[inline]` set to small dispatch/`From` shims and documents that
  convention at the module level; comment corrections; the capacity
  reservation now counts only symbols that enter the text index.

### Benchmarks

Median of 3 interleaved before/after runs (aarch64, release; baseline =
`main` plus the new benchmark commit; x86_64 run to follow before merge;
see caveat below). Values shown as 10 KB / 30 KB:

| Case | 10 KB | 30 KB |
|---|---:|---:|
| `element_read_one` (value-heavy) | **−10.4%** | **−13.5%** |
| `struct_get_by_name` (incl. miss lookups) | **−30%** | **−37%** |
| `lazy_any_read_all` (value-heavy) | **−8.9%** | **−11.7%** |
| `lazy_binary_1_0` (value-heavy) | ±0 | ±0 |
| `lazy_binary_1_0` (symbol-heavy) | −6.4% | −9.1% |

The concrete `v1_0::Binary` value-heavy case is unchanged, as expected:
none of the three optimizations touches that path. Its symbol-heavy
improvement comes from the capacity reservation, which runs on every
path.

Existing suite, before/after: `read_many_structs` and
`encoding_primitives`, 35 cases total, no sustained change >2%.

We also cross-checked the results with a second, independent profiler
([dial9-tokio-telemetry](https://github.com/dial9-rs/dial9-tokio-telemetry),
perf-based CPU sampling). By-name lookups reproduced at −42 to −44%, with
the baseline SipHash frames disappearing from the profile entirely.
`Element::read_one` reproduced directionally at −7 to −8% under that
profiler's harness. Output checksums were identical between baseline and
patched builds on every run.

### Severability

The three optimizations are independent: each commit stands alone,
individually measurable and individually revertable. Happy to split any
of them out (in particular the `FxHashMap` commit, per the hashing note
above) or reshape scope on request.

### Relationship to the small-document PR

Complements our small-document fixed-cost PR (#1039). That PR targets per-document setup costs
(reader construction, IVM/LST processing); this one targets the
value-scanning and DOM costs that dominate on large documents. The
branches are independent; either can merge first. Both PRs touch
`symbol_table.rs` and `apply_pending_context_changes` in adjacent hunks,
so whichever lands second expects a small manual rebase; the bench
helper duplicated between the two will be consolidated by whichever
lands second.

### Test plan

- `cargo test --workspace --all-features`: 15,003 tests pass.
- `cargo clippy --workspace --all-features -- -D warnings` and
  `cargo fmt --check`: clean.
- No public API changes.

### Caveat

All numbers above are aarch64. An x86_64 before/after run will be posted
on this PR before it's ready for merge.

_By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license._