### PR TITLE
perf(timestamp): replace internals with 16-byte packed representation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ experimental = [
 ]
 
 # Access to public conversions between Timestamp and chrono types (NaiveDateTime, DateTime<FixedOffset>).
-experimental-chrono = []
+experimental-chrono = ["dep:chrono"]
 
 # Feature for indicating explicit opt-in to Ion 1.1
 experimental-ion-1-1 = ["experimental-reader-writer"]
@@ -60,7 +60,7 @@ base64 = "0.12"
 # this makes it explicitly not do this as there is an advisory warning against this:
 # See: https://github.com/chronotope/chrono/issues/602
 compact_str = "0.8.0"
-chrono = { version = "0.4", default-features = false, features = ["clock", "std", "wasmbind"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "std", "wasmbind"], optional = true }
 delegate = "0.12.0"
 thiserror = "1.0"
 winnow = { version = "=0.6.24", features = ["simd"] }
@@ -90,7 +90,7 @@ serde_bytes = "0.11.17"
 walkdir = "2.5.0"
 test-generator = "0.3"
 criterion = "0.5.1"
-rand = "0.8.5"
+rand = "0.10"
 tempfile = "3.10.0"
 
 [[bench]]
@@ -112,6 +112,10 @@ bench = false
 
 [[bench]]
 name = "text_location_throughput"
+harness = false
+
+[[bench]]
+name = "timestamp"
 harness = false
 
 [profile.release]

--- a/api/default.txt
+++ b/api/default.txt
@@ -808,6 +808,8 @@ pub fn ion_rs::Value::from(ion_rs::Timestamp) -> Self
 impl core::convert::TryFrom<ion_rs::Element> for ion_rs::Timestamp
 pub type ion_rs::Timestamp::Error = ion_rs::ConversionOperationError<ion_rs::Element, ion_rs::Timestamp>
 pub fn ion_rs::Timestamp::try_from(ion_rs::Element) -> ion_rs::ConversionOperationResult<ion_rs::Element, ion_rs::Timestamp>
+impl core::fmt::Debug for ion_rs::Timestamp
+pub fn ion_rs::Timestamp::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::fmt::Display for ion_rs::Timestamp
 pub fn ion_rs::Timestamp::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
 pub struct ion_rs::UInt

--- a/benches/text_location_throughput.rs
+++ b/benches/text_location_throughput.rs
@@ -18,8 +18,6 @@ use criterion::{criterion_group, criterion_main};
 mod benchmark {
     use criterion::{black_box, Criterion, Throughput};
     use ion_rs::Element;
-    use std::path::PathBuf;
-    use std::time::Duration;
 
     /// 5000 integers, joined by `separator`. With `"\n"` this is a 5000-row input; with `" "` it
     /// is a single row of the same integers, so the two differ only in row count.

--- a/benches/timestamp.rs
+++ b/benches/timestamp.rs
@@ -1,0 +1,431 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use ion_rs::{v1_0, Element, IonData, IonResult, Timestamp};
+use std::collections::hash_map::DefaultHasher;
+use std::fmt::Write as FmtWrite;
+use std::hash::{Hash, Hasher};
+
+// Repeat for operations that are fast enough that they are running into the precision limit of
+// the system clock (i.e. operations that take nanoseconds).
+const ITERS: usize = 100;
+
+fn build_timestamps() -> Vec<Timestamp> {
+    vec![
+        // Year only
+        Timestamp::with_year(2024).build().unwrap(),
+        // YMD
+        Timestamp::with_ymd(2024, 8, 12).build().unwrap(),
+        // Second precision with UTC offset
+        Timestamp::with_ymd(2024, 8, 12)
+            .with_hms(14, 30, 45)
+            .with_offset(0)
+            .build()
+            .unwrap(),
+        // With milliseconds and positive offset
+        Timestamp::with_ymd(2024, 8, 12)
+            .with_hms(14, 30, 45)
+            .with_milliseconds(123)
+            .with_offset(330)
+            .build()
+            .unwrap(),
+        // With nanoseconds and negative offset
+        Timestamp::with_ymd(2024, 8, 12)
+            .with_hms(14, 30, 45)
+            .with_nanoseconds(123_456_789)
+            .with_offset(-480)
+            .build()
+            .unwrap(),
+        // Unknown offset (second precision)
+        Timestamp::with_ymd(2024, 8, 12)
+            .with_hms(14, 30, 45)
+            .build()
+            .unwrap(),
+    ]
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let timestamps = build_timestamps();
+
+    // --- Construction benchmarks ---
+    let mut construct_group = c.benchmark_group("timestamp construct");
+
+    construct_group.bench_function("year only", |b| {
+        b.iter(|| {
+            for _ in 0..ITERS {
+                black_box(Timestamp::with_year(black_box(2024)).build().unwrap());
+            }
+        })
+    });
+
+    construct_group.bench_function("ymd", |b| {
+        b.iter(|| {
+            for _ in 0..ITERS {
+                black_box(
+                    Timestamp::with_ymd(black_box(2024), black_box(8), black_box(12))
+                        .build()
+                        .unwrap(),
+                );
+            }
+        })
+    });
+
+    construct_group.bench_function("second precision UTC", |b| {
+        b.iter(|| {
+            for _ in 0..ITERS {
+                black_box(
+                    Timestamp::with_ymd(black_box(2024), black_box(8), black_box(12))
+                        .with_hms(black_box(14), black_box(30), black_box(45))
+                        .with_offset(black_box(0))
+                        .build()
+                        .unwrap(),
+                );
+            }
+        })
+    });
+
+    construct_group.bench_function("milliseconds +offset", |b| {
+        b.iter(|| {
+            for _ in 0..ITERS {
+                black_box(
+                    Timestamp::with_ymd(black_box(2024), black_box(8), black_box(12))
+                        .with_hms(black_box(14), black_box(30), black_box(45))
+                        .with_milliseconds(black_box(123))
+                        .with_offset(black_box(330))
+                        .build()
+                        .unwrap(),
+                );
+            }
+        })
+    });
+
+    construct_group.bench_function("nanoseconds -offset", |b| {
+        b.iter(|| {
+            for _ in 0..ITERS {
+                black_box(
+                    Timestamp::with_ymd(black_box(2024), black_box(8), black_box(12))
+                        .with_hms(black_box(14), black_box(30), black_box(45))
+                        .with_nanoseconds(black_box(123_456_789))
+                        .with_offset(black_box(-480))
+                        .build()
+                        .unwrap(),
+                );
+            }
+        })
+    });
+
+    construct_group.finish();
+
+    // --- Formatting benchmarks ---
+    let mut format_group = c.benchmark_group("timestamp format");
+    let mut buf = String::with_capacity(64);
+
+    for ts in &timestamps {
+        let label = format!("{}", ts);
+        format_group.bench_function(&label, |b| {
+            b.iter(|| {
+                for _ in 0..ITERS {
+                    buf.clear();
+                    write!(buf, "{}", black_box(ts)).unwrap();
+                    black_box(&buf);
+                }
+            })
+        });
+    }
+
+    format_group.finish();
+
+    // --- Equality, comparison, and hash benchmarks ---
+    let ts_utc = Timestamp::with_ymd(2024, 8, 12)
+        .with_hms(14, 30, 45)
+        .with_nanoseconds(123_456_789)
+        .with_offset(0)
+        .build()
+        .unwrap();
+    let ts_utc_clone = ts_utc.clone();
+    // Same instant, different offset (requires UTC normalization in Ord/PartialEq)
+    let ts_positive_offset = Timestamp::with_ymd(2024, 8, 12)
+        .with_hms(20, 0, 45)
+        .with_nanoseconds(123_456_789)
+        .with_offset(330)
+        .build()
+        .unwrap();
+    // Different instant
+    let ts_different = Timestamp::with_ymd(2024, 8, 13)
+        .with_hms(14, 30, 45)
+        .with_nanoseconds(123_456_789)
+        .with_offset(0)
+        .build()
+        .unwrap();
+
+    let mut cmp_group = c.benchmark_group("timestamp compare");
+
+    cmp_group.bench_function("eq (identical)", |b| {
+        b.iter(|| {
+            for _ in 0..ITERS {
+                black_box(black_box(&ts_utc) == black_box(&ts_utc_clone));
+            }
+        })
+    });
+
+    cmp_group.bench_function("eq (same instant, different offset)", |b| {
+        b.iter(|| {
+            for _ in 0..ITERS {
+                black_box(black_box(&ts_utc) == black_box(&ts_positive_offset));
+            }
+        })
+    });
+
+    cmp_group.bench_function("eq (different instant)", |b| {
+        b.iter(|| {
+            for _ in 0..ITERS {
+                black_box(black_box(&ts_utc) == black_box(&ts_different));
+            }
+        })
+    });
+
+    cmp_group.bench_function("cmp (identical)", |b| {
+        b.iter(|| {
+            for _ in 0..ITERS {
+                black_box(black_box(&ts_utc).cmp(black_box(&ts_utc_clone)));
+            }
+        })
+    });
+
+    cmp_group.bench_function("cmp (same instant, different offset)", |b| {
+        b.iter(|| {
+            for _ in 0..ITERS {
+                black_box(black_box(&ts_utc).cmp(black_box(&ts_positive_offset)));
+            }
+        })
+    });
+
+    cmp_group.bench_function("cmp (different instant)", |b| {
+        b.iter(|| {
+            for _ in 0..ITERS {
+                black_box(black_box(&ts_utc).cmp(black_box(&ts_different)));
+            }
+        })
+    });
+
+    // IonData wrapper uses IonEq for equality and IonDataOrd for ordering
+    let ion_data_utc = IonData::from(ts_utc.clone());
+    let ion_data_utc_clone = IonData::from(ts_utc_clone.clone());
+    let ion_data_positive_offset = IonData::from(ts_positive_offset.clone());
+    let ion_data_different = IonData::from(ts_different.clone());
+
+    cmp_group.bench_function("ion_eq (identical)", |b| {
+        b.iter(|| {
+            for _ in 0..ITERS {
+                black_box(black_box(&ion_data_utc) == black_box(&ion_data_utc_clone));
+            }
+        })
+    });
+
+    cmp_group.bench_function("ion_eq (same instant, different offset)", |b| {
+        b.iter(|| {
+            for _ in 0..ITERS {
+                black_box(black_box(&ion_data_utc) == black_box(&ion_data_positive_offset));
+            }
+        })
+    });
+
+    cmp_group.bench_function("ion_eq (different instant)", |b| {
+        b.iter(|| {
+            for _ in 0..ITERS {
+                black_box(black_box(&ion_data_utc) == black_box(&ion_data_different));
+            }
+        })
+    });
+
+    cmp_group.bench_function("ion_cmp (identical)", |b| {
+        b.iter(|| {
+            for _ in 0..ITERS {
+                black_box(black_box(&ion_data_utc).cmp(black_box(&ion_data_utc_clone)));
+            }
+        })
+    });
+
+    cmp_group.bench_function("ion_cmp (same instant, different offset)", |b| {
+        b.iter(|| {
+            for _ in 0..ITERS {
+                black_box(black_box(&ion_data_utc).cmp(black_box(&ion_data_positive_offset)));
+            }
+        })
+    });
+
+    cmp_group.bench_function("ion_cmp (different instant)", |b| {
+        b.iter(|| {
+            for _ in 0..ITERS {
+                black_box(black_box(&ion_data_utc).cmp(black_box(&ion_data_different)));
+            }
+        })
+    });
+
+    cmp_group.bench_function("ion_data_hash", |b| {
+        b.iter(|| {
+            for _ in 0..ITERS {
+                let mut hasher = DefaultHasher::new();
+                black_box(&ion_data_utc).hash(&mut hasher);
+                black_box(hasher.finish());
+            }
+        })
+    });
+
+    cmp_group.finish();
+
+    // --- Clone benchmarks ---
+    let mut clone_group = c.benchmark_group("timestamp clone");
+
+    clone_group.bench_function("year only", |b| {
+        let ts = &timestamps[0];
+        b.iter(|| {
+            for _ in 0..ITERS {
+                black_box(black_box(ts).clone());
+            }
+        })
+    });
+
+    clone_group.bench_function("nanoseconds with offset", |b| {
+        let ts = &timestamps[4];
+        b.iter(|| {
+            for _ in 0..ITERS {
+                black_box(black_box(ts).clone());
+            }
+        })
+    });
+
+    clone_group.finish();
+
+    // --- Read/Write via Element (text Ion) ---
+    let text_data = encode_timestamps_text(&timestamps).unwrap();
+    let binary_data = encode_timestamps_binary(&timestamps).unwrap();
+
+    println!("Timestamp text data: {} bytes", text_data.len());
+    println!("Timestamp binary data: {} bytes", binary_data.len());
+
+    let mut rw_group = c.benchmark_group("timestamp read/write element");
+
+    rw_group.bench_function("write text", |b| {
+        b.iter(|| {
+            let mut out = Vec::with_capacity(text_data.len());
+            for ts in &timestamps {
+                let elem: Element = ts.clone().into();
+                elem.encode_to(&mut out, v1_0::Text).unwrap();
+            }
+            black_box(out);
+        })
+    });
+
+    rw_group.bench_function("write binary", |b| {
+        b.iter(|| {
+            let mut out = Vec::with_capacity(binary_data.len());
+            for ts in &timestamps {
+                let elem: Element = ts.clone().into();
+                elem.encode_to(&mut out, v1_0::Binary).unwrap();
+            }
+            black_box(out);
+        })
+    });
+
+    rw_group.bench_function("read text", |b| {
+        b.iter(|| {
+            let seq = Element::read_all(black_box(text_data.as_slice())).unwrap();
+            black_box(seq);
+        })
+    });
+
+    rw_group.bench_function("read binary", |b| {
+        b.iter(|| {
+            let seq = Element::read_all(black_box(binary_data.as_slice())).unwrap();
+            black_box(seq);
+        })
+    });
+
+    rw_group.finish();
+
+    // --- Bulk read/write (many timestamps) for throughput signal ---
+    let many_timestamps: Vec<Timestamp> = (0..1000)
+        .map(|i| {
+            Timestamp::with_ymd(2020 + (i % 10), 1 + (i % 12), 1 + (i % 28))
+                .with_hms(i % 24, i % 60, i % 60)
+                .with_nanoseconds(i * 1_000_000)
+                .with_offset(((i as i32) % 25) * 60 - 720)
+                .build()
+                .unwrap()
+        })
+        .collect();
+
+    let bulk_text = encode_timestamps_text(&many_timestamps).unwrap();
+    let bulk_binary = encode_timestamps_binary(&many_timestamps).unwrap();
+
+    println!(
+        "Bulk timestamp text data: {} bytes ({} timestamps)",
+        bulk_text.len(),
+        many_timestamps.len()
+    );
+    println!(
+        "Bulk timestamp binary data: {} bytes ({} timestamps)",
+        bulk_binary.len(),
+        many_timestamps.len()
+    );
+
+    let mut bulk_group = c.benchmark_group("timestamp bulk (1000)");
+
+    bulk_group.bench_function("write text", |b| {
+        b.iter(|| {
+            let mut out = Vec::with_capacity(bulk_text.len());
+            for ts in &many_timestamps {
+                let elem: Element = ts.clone().into();
+                elem.encode_to(&mut out, v1_0::Text).unwrap();
+            }
+            black_box(out);
+        })
+    });
+
+    bulk_group.bench_function("write binary", |b| {
+        b.iter(|| {
+            let mut out = Vec::with_capacity(bulk_binary.len());
+            for ts in &many_timestamps {
+                let elem: Element = ts.clone().into();
+                elem.encode_to(&mut out, v1_0::Binary).unwrap();
+            }
+            black_box(out);
+        })
+    });
+
+    bulk_group.bench_function("read text", |b| {
+        b.iter(|| {
+            let seq = Element::read_all(black_box(bulk_text.as_slice())).unwrap();
+            black_box(seq);
+        })
+    });
+
+    bulk_group.bench_function("read binary", |b| {
+        b.iter(|| {
+            let seq = Element::read_all(black_box(bulk_binary.as_slice())).unwrap();
+            black_box(seq);
+        })
+    });
+
+    bulk_group.finish();
+}
+
+fn encode_timestamps_text(timestamps: &[Timestamp]) -> IonResult<Vec<u8>> {
+    let mut out = Vec::new();
+    for ts in timestamps {
+        let elem: Element = ts.clone().into();
+        elem.encode_to(&mut out, v1_0::Text)?;
+    }
+    Ok(out)
+}
+
+fn encode_timestamps_binary(timestamps: &[Timestamp]) -> IonResult<Vec<u8>> {
+    let mut out = Vec::new();
+    for ts in timestamps {
+        let elem: Element = ts.clone().into();
+        elem.encode_to(&mut out, v1_0::Binary)?;
+    }
+    Ok(out)
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/examples/write_log_events.rs
+++ b/examples/write_log_events.rs
@@ -19,9 +19,9 @@ mod example {
     use chrono::{DateTime, FixedOffset};
     use ion_rs::v1_1::Macro;
     use ion_rs::*;
+    use rand::prelude::IndexedRandom;
     use rand::rngs::StdRng;
-    use rand::seq::SliceRandom;
-    use rand::{Rng, SeedableRng};
+    use rand::{RngExt, SeedableRng};
     use std::env::args;
     use std::io::BufWriter;
     use std::ops::Range;
@@ -283,7 +283,7 @@ mod example {
     // Any time we need an integer, we'll generate a random one between 0 and 5,000.
     const INT_PARAMETER_RANGE: Range<i64> = 0..5_000;
     fn generate_int_parameter(rng: &mut StdRng) -> Parameter {
-        Parameter::Int(rng.gen_range(INT_PARAMETER_RANGE))
+        Parameter::Int(rng.random_range(INT_PARAMETER_RANGE))
     }
 
     // Any time we need a string, we'll select one at random from this collection of plural nouns.
@@ -356,8 +356,8 @@ mod example {
             .into();
         let timestamp: Timestamp = datetime.into();
 
-        let thread_id = rng.gen_range(1..=128);
-        let thread_name = format!("{THREAD_NAME_PREFIX}{}", rng.gen_range(1..=8));
+        let thread_id = rng.random_range(1..=128);
+        let thread_name = format!("{THREAD_NAME_PREFIX}{}", rng.random_range(1..=8));
         let statement = log_statements.choose(rng).unwrap();
 
         let parameters: Vec<Parameter> = statement

--- a/src/binary/timestamp.rs
+++ b/src/binary/timestamp.rs
@@ -1,17 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates.
 
 use std::io::Write;
-use std::ops::Neg;
 
 use arrayvec::ArrayVec;
-use chrono::{Datelike, Timelike};
 
 use crate::binary::decimal::DecimalBinaryEncoder;
 use crate::binary::var_int::VarInt;
 use crate::binary::var_uint::VarUInt;
 use crate::result::IonResult;
-use crate::types::{Mantissa, TimestampPrecision};
-use crate::{Decimal, Timestamp};
+use crate::types::TimestampPrecision;
+use crate::Timestamp;
 
 const MAX_INLINE_LENGTH: usize = 13;
 const MAX_TIMESTAMP_LENGTH: usize = 32;
@@ -37,59 +35,33 @@ where
     W: Write,
 {
     fn encode_timestamp(&mut self, timestamp: &Timestamp) -> IonResult<usize> {
-        const SECONDS_PER_MINUTE: f32 = 60f32;
         let mut bytes_written: usize = 0;
 
-        // Each unit of the binary-encoded timestamp (hour, minute, etc) is written in UTC.
-        // The reader is expected to apply the encoded offset (in minutes) to derive the local time.
+        // Ion 1.0 binary encodes timestamp fields in UTC.
+        // First, convert local fields to UTC by subtracting the offset.
+        let utc = timestamp.to_utc();
 
-        // [Timestamp]s are modeled as a UTC NaiveDateTime and an optional FixedOffset.
-        // We can use the UTC NaiveDateTime to query for the individual time fields (year, month,
-        // etc) that we need to write out.
-        let utc = timestamp.date_time;
-
-        // Write out the offset (minutes difference from UTC). If the offset is
-        // unknown, negative zero is used.
-        if let Some(offset) = timestamp.offset {
-            // Ion encodes offsets in minutes while chrono's DateTime stores it in seconds.
-            let offset_seconds = offset.local_minus_utc();
-            let offset_minutes = (offset_seconds as f32 / SECONDS_PER_MINUTE).round() as i64;
-            bytes_written += VarInt::write_i64(self, offset_minutes)?;
+        // Write offset (minutes from UTC). Unknown offset = negative zero.
+        if let Some(offset_minutes) = timestamp.offset() {
+            bytes_written += VarInt::write_i64(self, offset_minutes as i64)?;
         } else {
-            // The offset is unknown. Write negative zero.
             bytes_written += VarInt::write_negative_zero(self)?;
         }
 
         bytes_written += VarUInt::write_u64(self, utc.year() as u64)?;
 
-        // So far, we've written required fields. The rest are optional!
-        if timestamp.precision > TimestampPrecision::Year {
+        let precision = timestamp.precision();
+        if precision > TimestampPrecision::Year {
             bytes_written += VarUInt::write_u64(self, utc.month() as u64)?;
-            if timestamp.precision > TimestampPrecision::Month {
+            if precision > TimestampPrecision::Month {
                 bytes_written += VarUInt::write_u64(self, utc.day() as u64)?;
-                if timestamp.precision > TimestampPrecision::Day {
+                if precision > TimestampPrecision::Day {
                     bytes_written += VarUInt::write_u64(self, utc.hour() as u64)?;
                     bytes_written += VarUInt::write_u64(self, utc.minute() as u64)?;
-                    if timestamp.precision > TimestampPrecision::HourAndMinute {
+                    if precision > TimestampPrecision::HourAndMinute {
                         bytes_written += VarUInt::write_u64(self, utc.second() as u64)?;
-                        if let Some(ref mantissa) = timestamp.fractional_seconds {
-                            // TODO: Both branches encode directly due to one
-                            // branch owning vs borrowing the decimal
-                            // representation. #286 should provide a fix.
-                            match mantissa {
-                                Mantissa::Digits(precision) => {
-                                    // Consider the following case: `2000-01-01T00:00:00.123Z`.
-                                    // That's 123 millis, or 123,000,000 nanos.
-                                    // Our mantissa is 0.123, or 123d-3.
-                                    let scaled = utc.nanosecond() / 10u32.pow(9 - *precision); // 123,000,000 -> 123
-                                    let exponent = (*precision as i64).neg(); // -3
-                                    let fractional = Decimal::new(scaled, exponent); // 123d-3
-                                    bytes_written += self.encode_decimal(&fractional)?;
-                                }
-                                Mantissa::Arbitrary(decimal) => {
-                                    bytes_written += self.encode_decimal(decimal)?;
-                                }
-                            };
+                        if let Some(decimal) = timestamp.fractional_seconds_as_decimal() {
+                            bytes_written += self.encode_decimal(&decimal)?;
                         }
                     }
                 }

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -1056,7 +1056,6 @@ impl AsRef<Element> for Element {
 
 #[cfg(test)]
 mod tests {
-    use chrono::*;
     use rstest::*;
     use std::collections::HashSet;
     use std::iter::{once, Once};
@@ -1067,10 +1066,12 @@ mod tests {
     use crate::{ion_list, ion_sexp, ion_struct, Decimal, Int, IonType, Symbol, Timestamp, Value};
     use crate::{Annotations, Element, IntoAnnotatedElement, Struct};
 
-    /// Makes a timestamp from an RFC-3339 string and panics if it can't
+    /// Makes a timestamp from an Ion timestamp string
     fn make_timestamp<T: AsRef<str>>(text: T) -> Timestamp {
-        let dt = DateTime::parse_from_rfc3339(text.as_ref()).unwrap();
-        Timestamp::from_fixed_offset_datetime(dt)
+        Element::read_one(text.as_ref())
+            .unwrap()
+            .expect_timestamp()
+            .unwrap()
     }
 
     struct CaseAnnotations {

--- a/src/ion_data/ion_ord.rs
+++ b/src/ion_data/ion_ord.rs
@@ -122,6 +122,8 @@ mod ord_tests {
         1000d0
     "
     )]
+    // Current IonDataOrd implementation compares in this order:
+    // local-date-time -> precision -> offset -> attoseconds
     #[case::timestamps_sorted_by_point_in_time_and_precision(
         r"
         null.timestamp
@@ -131,8 +133,8 @@ mod ord_tests {
         2020-01-01T00:00Z
         2020-01-01T00:00:00Z
         2020-01-01T00:00:00.000Z
-        2020-01-01T00:00:00.000000Z
         2020-01-01T00:00:00.001Z
+        2020-01-01T00:00:00.000000Z
         2020-01-01T00:00:00.001000Z
         2020-01-01T00:00:01Z
         2020-01-01T00:01Z
@@ -143,13 +145,15 @@ mod ord_tests {
     )]
     #[case::timestamps_sorted_by_offset(
         r"
-        2020-01-01T06:00:00-00:00
         2020-01-01T05:00:00-01:00
-        2020-01-01T06:00:00+00:00
-        2020-01-01T07:00:00+01:00
-        2020-01-01T06:00:00.000-00:00
         2020-01-01T05:00:00.000-01:00
+        2020-01-01T06:00:00-00:00
+        2020-01-01T06:00:00-01:00
+        2020-01-01T06:00:00+00:00
+        2020-01-01T06:00:00+01:00
+        2020-01-01T06:00:00.000-00:00
         2020-01-01T06:00:00.000+00:00
+        2020-01-01T07:00:00+01:00
         2020-01-01T07:00:00.000+01:00
     "
     )]
@@ -239,12 +243,18 @@ mod ord_tests {
     "
     )]
     fn test_order(#[case] ion: &str) {
+        use rand::seq::SliceRandom;
+
         let original = Element::read_all(ion)
             .unwrap()
             .into_iter()
             .map(IonData::from)
             .collect::<Vec<_>>();
         let mut copy = original.clone();
+
+        // Shuffle to ensure that we don't succeed just because it works well enough to survive a stable sort.
+        let mut rng = rand::rng();
+        copy.shuffle(&mut rng);
         copy.sort();
 
         // Prints using display (i.e. as Ion text)
@@ -255,7 +265,7 @@ mod ord_tests {
             ))
         );
         println!(
-            "copy: {}",
+            "actual: {}",
             List::from(Sequence::new(copy.iter().cloned().map(IonData::into_inner)))
         );
         // Prints using debug

--- a/src/lazy/text/matched.rs
+++ b/src/lazy/text/matched.rs
@@ -1200,7 +1200,7 @@ mod tests {
     use crate::lazy::bytes_ref::BytesRef;
     use crate::lazy::expanded::{EncodingContext, EncodingContextRef};
     use crate::lazy::text::buffer::TextBuffer;
-    use crate::{Decimal, Int, IonResult, Timestamp};
+    use crate::{Decimal, Element, Int, IonResult, Timestamp};
     use winnow::combinator::peek;
     use winnow::Parser;
 
@@ -1460,30 +1460,31 @@ mod tests {
     }
 
     #[test]
-    fn read_timestamps_arbitrary_precision() -> IonResult<()> {
-        fn expect_timestamp(data: &str, expected: Timestamp) {
-            let encoding_context = EncodingContext::empty();
-            let context = encoding_context.get_ref();
-            let mut buffer = TextBuffer::new(context, data.as_bytes());
-            let matched = peek(TextBuffer::match_timestamp)
-                .parse_next(&mut buffer)
-                .unwrap();
-            let actual = matched.read(buffer).unwrap();
-            assert_eq!(
-                actual, expected,
-                "Actual didn't match expected for input '{data}'.\n{actual:?}\n!=\n{expected:?}",
-            );
+    fn read_timestamps_fractional_precision() -> IonResult<()> {
+        // Parse text timestamps at various fractional precisions
+        fn parse_timestamp(text: &str) -> IonResult<Timestamp> {
+            let elem = Element::read_one(text)?;
+            Ok(elem.expect_timestamp()?.clone())
         }
 
-        expect_timestamp(
-            "2023-08-13T10:30:45.727885129180488904360266563744972327436484050815Z",
-            Timestamp::with_ymd(2023, 8, 13)
-                .with_hour_and_minute(10, 30)
-                .with_second(45)
-                .with_fractional_seconds(Decimal::new(Int::from_le_signed_bytes(&[0x7F; 20]), -48))
-                .with_offset(0)
-                .build()?,
-        );
+        // Millisecond precision
+        let ts = parse_timestamp("2023-08-13T10:30:45.123Z")?;
+        assert_eq!(ts.subsecond_digit_count(), 3);
+
+        // Microsecond precision
+        let ts = parse_timestamp("2023-08-13T10:30:45.123456Z")?;
+        assert_eq!(ts.subsecond_digit_count(), 6);
+
+        // Nanosecond precision
+        let ts = parse_timestamp("2023-08-13T10:30:45.123456789Z")?;
+        assert_eq!(ts.subsecond_digit_count(), 9);
+
+        // 18-digit precision (max supported)
+        let ts = parse_timestamp("2023-08-13T10:30:45.123456789012345678Z")?;
+        assert_eq!(ts.subsecond_digit_count(), 18);
+
+        // >18 digits: rejected
+        assert!(parse_timestamp("2023-08-13T10:30:45.1234567890123456789Z").is_err());
 
         Ok(())
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -31,7 +31,7 @@ pub use string::Str;
 pub use symbol::Symbol;
 pub use timestamp::{
     HasDay, HasFractionalSeconds, HasHour, HasMinute, HasMonth, HasOffset, HasSeconds, HasYear,
-    Mantissa, Timestamp, TimestampBuilder, TimestampPrecision,
+    Timestamp, TimestampBuilder, TimestampPrecision,
 };
 
 use crate::ion_data::{IonDataHash, IonDataOrd};

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -1,140 +1,381 @@
-use crate::decimal::Sign;
 use crate::ion_data::{IonDataHash, IonDataOrd, IonEq};
-use crate::result::{IonError, IonFailure, IonResult};
-use crate::types::{CountDecimalDigits, Decimal};
-use chrono::{
-    DateTime, Datelike, FixedOffset, LocalResult, NaiveDate, NaiveDateTime, TimeZone, Timelike,
-};
+use crate::result::{IonFailure, IonResult};
+use crate::types::Decimal;
+#[cfg(feature = "experimental-chrono")]
+use crate::IonError;
+#[cfg(feature = "experimental-chrono")]
+use chrono::{DateTime, Datelike, FixedOffset, NaiveDate, NaiveDateTime, TimeZone, Timelike};
 use std::cmp::Ordering;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 
 /// Indicates the most precise time unit that has been specified in the accompanying [Timestamp].
+// IMPL NOTE: Discriminant values are cast to u64 and stored in the packed bit layout.
+// They must remain stable. They are not exposed in the public API.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Default, Hash)]
 pub enum TimestampPrecision {
     /// Year-level precision (e.g. `2020T`)
     #[default]
-    Year,
+    Year = 0,
     /// Month-level precision (e.g. `2020-08T`)
-    Month,
+    Month = 1,
     /// Day-level precision (e.g. `2020-08-01T`)
-    Day,
+    Day = 2,
     /// Minute-level precision (e.g. `2020-08-01T12:34Z`)
-    HourAndMinute,
+    HourAndMinute = 3,
     /// Second-level precision or greater. (e.g. `2020-08-01T12:34:56Z` or `2020-08-01T12:34:56.123456789Z`)
-    Second,
+    Second = 4,
 }
 
-// [Default] cannot be derived for enum types. Providing a manual implementation of this type
-// allows us to derive Default for [Timestamp].
-
-/// Stores the precision of a Timestamp's fractional seconds, if present. This type is not
-/// self-contained; if the Timestamp has a precision that is less than or equal to nanoseconds
-/// (i.e. fewer than 10 digits), the fractional seconds value will be stored in the Timestamp's
-/// NaiveDateTime component and the Mantissa will indicate the number of digits from that value
-/// that should be used. If the precision is 10 or more digits, the Mantissa will store the value
-/// itself as a Decimal with the correct precision.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Mantissa {
-    /// The number of digits of precision in the Timestamp's fractional seconds. For example, a
-    /// value of `3` would indicate millisecond precision. A value of `6` would indicate
-    /// microsecond precision. All precisions less than or equal to nanoseconds should use
-    /// this representation when possible.
-    Digits(u32),
-    /// Specifies the fractional seconds precisely as a `Decimal` in the range `>= 0` and `< 1`.
-    /// The Decimal will have the correct precision; the complete value can and should be used.
-    /// This representation should only be used for precisions greater than nanoseconds as it can
-    /// require allocations.
-    Arbitrary(Decimal),
-}
-
-impl Mantissa {
-    fn decimals_equal(d1: &Decimal, d2: &Decimal) -> bool {
-        // See the [EmptyMantissa] trait for details about `is_empty()`
-        (d1.is_empty() && d2.is_empty())
-            // Exact equality test
-            || d1.eq(d2)
-            // Coefficient zeros' signs don't have to match for fractional seconds.
-            || (d1.coefficient().is_zero() && d2.coefficient().is_zero() && d1.exponent == d2.exponent)
-    }
-
-    fn decimals_compare(d1: &Decimal, d2: &Decimal) -> Ordering {
-        // See the [EmptyMantissa] trait for details about `is_empty()`
-        if d1.is_empty() && d2.is_empty() {
-            Ordering::Equal
-        } else if d1.coefficient().is_zero() && d2.coefficient().is_zero() {
-            // Coefficient zeros' signs don't have to be compared for fractional seconds.
-            d1.exponent.cmp(&d2.exponent)
-        } else {
-            // Exact comparison test
-            d1.cmp(d2)
-        }
-    }
-}
-
-trait EmptyMantissa {
-    /// Returns true if the Mantissa's value is equivalent to not having specified a
-    /// sub-second precision at all. For example, `Mantissa::Digits(0)` or
-    /// `Mantissa::Arbitrary(Decimal::new(0, 0))`.
-    fn is_empty(&self) -> bool;
-}
-
-impl EmptyMantissa for Decimal {
-    fn is_empty(&self) -> bool {
-        self.coefficient().is_zero() && self.exponent == 0
-    }
-}
-
-impl EmptyMantissa for Mantissa {
-    fn is_empty(&self) -> bool {
-        match self {
-            // Look at zero digits of the DateTime's nanoseconds
-            Mantissa::Digits(0) => true,
-            // Or a Decimal with a coefficient of zero (any sign) and an exponent of zero.
-            Mantissa::Arbitrary(d) => d.is_empty(),
-            _ => false,
-        }
-    }
-}
-
-/// Returns the first `num_digits` digits of the specified `value`.
-// This is used in Timestamp's implementation of [PartialEq].
-fn first_n_digits_of(num_digits: u32, value: u32) -> u32 {
-    let total_digits = value.count_decimal_digits();
-    if total_digits <= num_digits {
-        return value;
-    }
-    // Truncate the trailing digits
-    value / 10u32.pow(total_digits - num_digits)
-}
-
-/// Constructs a [FixedOffset] at the specified offset seconds from UTC. If the specified offset
+/// Constructs a [`FixedOffset`] at the specified offset seconds from UTC. If the specified offset
 /// is out of bounds, this method will panic.
+// Only the tests below construct a `FixedOffset` this way; production conversions go through
+// `try_to_datetime_fixed_offset`, which reports an out-of-range offset as an `IonError`.
+#[cfg(all(test, feature = "experimental-chrono"))]
 fn offset_east(seconds_east: i32) -> FixedOffset {
-    FixedOffset::east_opt(seconds_east)
-        // This error case is expected to be handled before this method is called.
-        .expect("seconds_east was outside the supported range")
+    FixedOffset::east_opt(seconds_east).expect("seconds_east was outside the supported range")
 }
 
-/// Constructs a [`DateTime<FixedOffset>`] at the specified offset using the fields of
-/// [`NaiveDateTime`] representing the desired UTC datetime.
-fn datetime_at_offset(utc_datetime: &NaiveDateTime, seconds_east: i32) -> DateTime<FixedOffset> {
-    offset_east(seconds_east).from_utc_datetime(utc_datetime)
+// ─── Packed bit layout ────────────────────────────────────────────────
+//
+// All date-time fields are stored as LOCAL time in a single u64.
+// A second u64 holds the attoseconds payload.
+//
+// Date-time fields are in the HIGH bits (most-significant first) so that
+// a numeric comparison of the packed value yields chronological order.
+// Metadata (offset, precision, subsecond_digits) is in the LOW bits.
+//
+// Bit layout of `packed` (MSB = bit 63):
+//
+//   [63:50] year                (14 bits, 0-9999)
+//   [49:46] month               (4 bits, 1-12)
+//   [45:41] day                 (5 bits, 1-31)
+//   [40:36] hour                (5 bits, 0-23)
+//   [35:30] minute              (6 bits, 0-59)
+//   [29:24] second              (6 bits, 0-59)
+//   [23:21] precision           (3 bits, 0-4 maps to TimestampPrecision)
+//   [20:16] subsecond_precision (5 bits, 0 = none, 1-18 = digit count)
+//   [15:4]  offset              (12 bits, biased unsigned: stored = minutes + 1440;
+//                                valid range 1..=2879; 0 = unknown)
+//   [3:0]   spare               (4 bits)
+//
+// `attoseconds`: fractional seconds normalized to 10^-18 scale.
+// `subsecond_precision` records display precision (how many digits to render).
+//
+// Invariants:
+//
+// 1. Fields below the declared precision hold their default values:
+//    - Year:          month=1, day=1, hour=0, minute=0, second=0
+//    - Month:         day=1, hour=0, minute=0, second=0
+//    - Day:           hour=0, minute=0, second=0
+//    - HourAndMinute: second=0
+//    - Second:        (no fields required to be zero)
+//
+// 2. When precision < Second: attoseconds == 0 and subsecond_precision == 0.
+//
+// 3. When precision == Second and subsecond_precision == 0: attoseconds == 0.
+//    (No fractional part means the attoseconds payload is unused.)
+//
+// 4. attoseconds < 10^18 (strictly less than one full second).
+//
+// 5. attoseconds is consistent with subsecond_precision: the value must be
+//    representable in `subsecond_precision` decimal digits. Formally,
+//    attoseconds % 10^(18 - subsecond_precision) == 0.
+//    Example: subsecond_precision=3 (millis) → attoseconds is a multiple
+//    of 10^15.
+//
+// 6. offset == 0 (unknown) is valid at any precision. When precision <
+//    HourAndMinute, the offset field MUST be 0 (unknown) because sub-day
+//    precision timestamps cannot meaningfully carry a UTC offset.
+//
+// 7. year is in 1..=9999 for user-constructed timestamps. Internally,
+//    `to_utc` can produce year 0 (e.g., 0001-01-01T00:30+01:00 → year 0 UTC)
+//    and `from_fixed_offset_datetime` can produce year 10000 (e.g., UTC
+//    9999-12-31T23:30Z with offset -01:00 → local 10000-01-01). These values
+//    fit in the 14-bit field but must not escape through public constructors.
+//
+// 8. spare bits [3:0] are always 0.
+
+const YEAR_BITS: u64 = 14;
+const MONTH_BITS: u64 = 4;
+const DAY_BITS: u64 = 5;
+const HOUR_BITS: u64 = 5;
+const MINUTE_BITS: u64 = 6;
+const SECOND_BITS: u64 = 6;
+const OFFSET_BITS: u64 = 12;
+const PRECISION_BITS: u64 = 3;
+const SUBSECOND_PRECISION_BITS: u64 = 5;
+const SPARE_BITS: u64 = 4;
+
+// Shifts: metadata at bottom, date-time at top.
+// Within metadata: precision > subsecond_digits > offset (tiebreak order for IonDataOrd).
+const SPARE_SHIFT: u64 = 0;
+const OFFSET_SHIFT: u64 = SPARE_SHIFT + SPARE_BITS; // 4
+const SUBSECOND_PRECISION_SHIFT: u64 = OFFSET_SHIFT + OFFSET_BITS; // 16
+const PRECISION_SHIFT: u64 = SUBSECOND_PRECISION_SHIFT + SUBSECOND_PRECISION_BITS; // 21
+const SECOND_SHIFT: u64 = PRECISION_SHIFT + PRECISION_BITS; // 24
+const MINUTE_SHIFT: u64 = SECOND_SHIFT + SECOND_BITS; // 30
+const HOUR_SHIFT: u64 = MINUTE_SHIFT + MINUTE_BITS; // 36
+const DAY_SHIFT: u64 = HOUR_SHIFT + HOUR_BITS; // 41
+const MONTH_SHIFT: u64 = DAY_SHIFT + DAY_BITS; // 46
+const YEAR_SHIFT: u64 = MONTH_SHIFT + MONTH_BITS; // 50
+
+const YEAR_MASK: u64 = (1 << YEAR_BITS) - 1;
+const MONTH_MASK: u64 = (1 << MONTH_BITS) - 1;
+const DAY_MASK: u64 = (1 << DAY_BITS) - 1;
+const HOUR_MASK: u64 = (1 << HOUR_BITS) - 1;
+const MINUTE_MASK: u64 = (1 << MINUTE_BITS) - 1;
+const SECOND_MASK: u64 = (1 << SECOND_BITS) - 1;
+const OFFSET_MASK: u64 = (1 << OFFSET_BITS) - 1;
+const PRECISION_MASK: u64 = (1 << PRECISION_BITS) - 1;
+const SUBSECOND_PRECISION_MASK: u64 = (1 << SUBSECOND_PRECISION_BITS) - 1;
+
+/// Mask covering only the date-time fields (year through second).
+/// Comparing `packed & DATETIME_MASK` gives chronological order.
+const DATETIME_MASK: u64 = (YEAR_MASK << YEAR_SHIFT)
+    | (MONTH_MASK << MONTH_SHIFT)
+    | (DAY_MASK << DAY_SHIFT)
+    | (HOUR_MASK << HOUR_SHIFT)
+    | (MINUTE_MASK << MINUTE_SHIFT)
+    | (SECOND_MASK << SECOND_SHIFT);
+
+/// Bias added to offset-in-minutes before storage. With this bias the valid
+/// range (-1439..=+1439) maps to 1..=2879, leaving 0 free as the "unknown" sentinel.
+const OFFSET_BIAS: i16 = 1440;
+const OFFSET_UNKNOWN_SENTINEL: u16 = 0;
+
+// 18 digits = attosecond precision. Exceeds any system clock or commercial
+// atomic clock. Chosen over 19 to align with SI prefixes (multiples of 3)
+// and to leave one bit free in the u64 coefficient for future niche use.
+const MAX_FRAC_DIGITS: u8 = 18;
+
+/// The largest year the packed `year` field can represent.
+const MAX_YEAR: u16 = 9999;
+
+/// The smallest and largest offsets (in minutes) that Ion allows.
+const MIN_OFFSET_MINUTES: i16 = -1439;
+const MAX_OFFSET_MINUTES: i16 = 1439;
+
+fn days_in_month(year: u16, month: u8) -> u8 {
+    const DAYS_IN_MONTH: [u8; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let is_leap_year = |year| (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+
+    if month == 2 && is_leap_year(year) {
+        29
+    } else {
+        DAYS_IN_MONTH[(month - 1) as usize]
+    }
+}
+
+fn validate_fields(y: u16, m: u8, d: u8, h: u8, min: u8, s: u8) -> bool {
+    if y > MAX_YEAR {
+        return false;
+    }
+    if !(1..=12).contains(&m) {
+        return false;
+    }
+    let max_day = days_in_month(y, m);
+    d >= 1 && d <= max_day && h <= 23 && min <= 59 && s <= 59
+}
+
+/// Adds `offset_minutes` to a local time represented by the given fields,
+/// returning the adjusted (year, month, day, hour, minute).
+fn add_offset_to_utc(
+    year: u16,
+    month: u8,
+    day: u8,
+    hour: u8,
+    minute: u8,
+    offset_minutes: i16,
+) -> (u16, u8, u8, u8, u8) {
+    let total_minutes = hour as i32 * 60 + minute as i32 + offset_minutes as i32;
+    let (mut d, h, m) = if (0..24 * 60).contains(&total_minutes) {
+        // Common fast path: no day rollover
+        (
+            day as i32,
+            (total_minutes / 60) as u8,
+            (total_minutes % 60) as u8,
+        )
+    } else {
+        let day_offset = total_minutes.div_euclid(24 * 60);
+        let time_of_day = total_minutes.rem_euclid(24 * 60);
+        (
+            day as i32 + day_offset,
+            (time_of_day / 60) as u8,
+            (time_of_day % 60) as u8,
+        )
+    };
+
+    let mut mo = month as i32;
+    let mut y = year as i32;
+
+    // Offset is at most ±1439 minutes (< 24h), so day shifts by at most ±1.
+    if d > days_in_month(y as u16, mo as u8) as i32 {
+        d -= days_in_month(y as u16, mo as u8) as i32;
+        mo += 1;
+        if mo > 12 {
+            mo = 1;
+            y += 1;
+        }
+    } else if d < 1 {
+        mo -= 1;
+        if mo < 1 {
+            mo = 12;
+            y -= 1;
+        }
+        d += days_in_month(y as u16, mo as u8) as i32;
+    }
+
+    (y as u16, mo as u8, d as u8, h, m)
 }
 
 /// Represents a point in time to a specified degree of precision. Unlike `chrono`'s [NaiveDateTime]
-/// and [DateTime], a `Timestamp` has variable precision ranging from a year to fractional seconds
-/// of an arbitrary unit.
-#[derive(Debug, Clone)]
+/// and [DateTime], a `Timestamp` has variable precision ranging from a year to attoseconds.
+///
+/// NOTE: In an intentional divergence from the Ion Specification (which allows unlimited precision),
+/// this implementation is limited to attoseconds precision and will produce an error when
+/// attempting to read any value with more than attosecond precision.
+#[derive(Clone)]
 pub struct Timestamp {
-    pub(crate) date_time: NaiveDateTime,
-    pub(crate) offset: Option<FixedOffset>,
-    pub(crate) precision: TimestampPrecision,
-    pub(crate) fractional_seconds: Option<Mantissa>,
+    packed_fields: u64,
+    attoseconds: u64,
 }
 
 impl Timestamp {
+    /// Packs fields into the u64 bit-field.
+    ///
+    /// Callers typically validate their inputs before calling this helper. Each field is still
+    /// masked to its bit width so exceptional paths that intentionally pack out-of-range values
+    /// can only truncate within their own field rather than corrupt a neighboring one.
+    #[allow(clippy::too_many_arguments)]
+    fn pack_masked(
+        precision: TimestampPrecision,
+        year: u16,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+        offset_raw: u16,
+        subsecond_digits: u8,
+    ) -> u64 {
+        (year as u64 & YEAR_MASK) << YEAR_SHIFT
+            | (month as u64 & MONTH_MASK) << MONTH_SHIFT
+            | (day as u64 & DAY_MASK) << DAY_SHIFT
+            | (hour as u64 & HOUR_MASK) << HOUR_SHIFT
+            | (minute as u64 & MINUTE_MASK) << MINUTE_SHIFT
+            | (offset_raw as u64 & OFFSET_MASK) << OFFSET_SHIFT
+            | (second as u64 & SECOND_MASK) << SECOND_SHIFT
+            | (precision as u64 & PRECISION_MASK) << PRECISION_SHIFT
+            | (subsecond_digits as u64 & SUBSECOND_PRECISION_MASK) << SUBSECOND_PRECISION_SHIFT
+    }
+
+    /// Direct construction from LOCAL time fields.
+    /// `frac_digits`: number of fractional digits to display (0 = no fractional seconds).
+    /// `attoseconds`: the fractional seconds value normalized to 10^-18 scale.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn from_fields(
+        precision: TimestampPrecision,
+        offset: Option<i16>,
+        year: u16,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+        frac_digits: u8,
+        attoseconds: u64,
+    ) -> IonResult<Self> {
+        if year == 0 || year > MAX_YEAR {
+            return IonResult::illegal_operation(format!(
+                "Timestamp year '{}' out of range (1-{})",
+                year, MAX_YEAR
+            ));
+        }
+        if precision >= TimestampPrecision::Month
+            && !validate_fields(year, month, day, hour, minute, second)
+        {
+            return IonResult::illegal_operation("one or more timestamp fields are out of range");
+        }
+        if frac_digits > MAX_FRAC_DIGITS {
+            return IonResult::illegal_operation(format!(
+                "fractional seconds precision ({} digits) exceeds maximum ({})",
+                frac_digits, MAX_FRAC_DIGITS
+            ));
+        }
+
+        let offset_raw = match offset {
+            None => OFFSET_UNKNOWN_SENTINEL,
+            Some(m) => {
+                if !(MIN_OFFSET_MINUTES..=MAX_OFFSET_MINUTES).contains(&m) {
+                    return IonResult::illegal_operation(format!(
+                        "offset ({} minutes) exceeds valid range ({}..={})",
+                        m, MIN_OFFSET_MINUTES, MAX_OFFSET_MINUTES
+                    ));
+                }
+                (m + OFFSET_BIAS) as u16
+            }
+        };
+
+        let subsecond_digits = frac_digits;
+        let packed = Self::pack_masked(
+            precision,
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            offset_raw,
+            subsecond_digits,
+        );
+
+        Ok(Timestamp {
+            packed_fields: packed,
+            attoseconds,
+        })
+    }
+
+    /// Construction from UTC fields + offset. Adds offset to convert to local time.
+    /// `attoseconds`: fractional seconds normalized to 10^-18 scale.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn from_utc_fields(
+        precision: TimestampPrecision,
+        offset_minutes: i16,
+        year: u16,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+        frac_digits: u8,
+        attoseconds: u64,
+    ) -> IonResult<Self> {
+        // Validate the raw UTC fields before offset conversion
+        if precision >= TimestampPrecision::Month
+            && !validate_fields(year, month, day, hour, minute, second)
+        {
+            return IonResult::illegal_operation(
+                "one or more timestamp UTC fields are out of range",
+            );
+        }
+        let (ly, lmo, ld, lh, lmi) =
+            add_offset_to_utc(year, month, day, hour, minute, offset_minutes);
+        Self::from_fields(
+            precision,
+            Some(offset_minutes),
+            ly,
+            lmo,
+            ld,
+            lh,
+            lmi,
+            second,
+            frac_digits,
+            attoseconds,
+        )
+    }
+
     /// Converts a [`NaiveDateTime`] or [`DateTime<FixedOffset>`] to a Timestamp with the specified
     /// precision. If the precision is [`TimestampPrecision::Second`], nanosecond precision (the maximum
     /// supported by a [`Timelike`]) is assumed.
@@ -144,70 +385,132 @@ impl Timestamp {
         D: Datelike + Timelike + Into<Timestamp>,
     {
         let mut timestamp: Timestamp = datetime.into();
-        if precision < TimestampPrecision::Second {
-            timestamp.fractional_seconds = None;
+
+        // Zero fields below the requested precision to uphold invariants 1, 2, and 6.
+        match precision {
+            TimestampPrecision::Year => {
+                timestamp.packed_fields &= YEAR_MASK << YEAR_SHIFT;
+                // Restore month=1, day=1 (the default "unset" values)
+                timestamp.packed_fields |= 1 << MONTH_SHIFT | 1 << DAY_SHIFT;
+                timestamp.attoseconds = 0;
+            }
+            TimestampPrecision::Month => {
+                timestamp.packed_fields &= (YEAR_MASK << YEAR_SHIFT) | (MONTH_MASK << MONTH_SHIFT);
+                // Restore day=1
+                timestamp.packed_fields |= 1 << DAY_SHIFT;
+                timestamp.attoseconds = 0;
+            }
+            TimestampPrecision::Day => {
+                timestamp.packed_fields &= (YEAR_MASK << YEAR_SHIFT)
+                    | (MONTH_MASK << MONTH_SHIFT)
+                    | (DAY_MASK << DAY_SHIFT);
+                timestamp.attoseconds = 0;
+            }
+            TimestampPrecision::HourAndMinute => {
+                timestamp.packed_fields &= (YEAR_MASK << YEAR_SHIFT)
+                    | (MONTH_MASK << MONTH_SHIFT)
+                    | (DAY_MASK << DAY_SHIFT)
+                    | (HOUR_MASK << HOUR_SHIFT)
+                    | (MINUTE_MASK << MINUTE_SHIFT)
+                    | (OFFSET_MASK << OFFSET_SHIFT);
+                timestamp.attoseconds = 0;
+            }
+            TimestampPrecision::Second => {
+                // Keep everything; just strip subsecond if not already at Second precision
+            }
         }
-        timestamp.precision = precision;
+
+        // Set the precision field
+        timestamp.packed_fields &= !(PRECISION_MASK << PRECISION_SHIFT);
+        timestamp.packed_fields |= (precision as u64 & PRECISION_MASK) << PRECISION_SHIFT;
+
+        // Retain offset only at HourAndMinute or Second precision
+        if precision < TimestampPrecision::HourAndMinute {
+            timestamp.packed_fields &= !(OFFSET_MASK << OFFSET_SHIFT);
+        }
+
         timestamp
     }
 
+    #[cfg(feature = "experimental-chrono")]
     pub(crate) fn from_naive_datetime(date_time: NaiveDateTime) -> Self {
-        Timestamp {
-            date_time,
-            offset: None,
-            precision: TimestampPrecision::Second,
-            fractional_seconds: Some(Mantissa::Digits(9)),
-        }
+        let attoseconds = (date_time.nanosecond() as u64) * 1_000_000_000;
+        Self::from_fields(
+            TimestampPrecision::Second,
+            None,
+            date_time.year() as u16,
+            date_time.month() as u8,
+            date_time.day() as u8,
+            date_time.hour() as u8,
+            date_time.minute() as u8,
+            date_time.second() as u8,
+            9,
+            attoseconds,
+        )
+        .expect("chrono NaiveDateTime fields are always valid")
     }
 
+    #[cfg(feature = "experimental-chrono")]
     pub(crate) fn from_fixed_offset_datetime(
         fixed_offset_date_time: DateTime<FixedOffset>,
     ) -> Self {
-        let date_time = fixed_offset_date_time.naive_utc();
-        let offset = Some(*fixed_offset_date_time.offset());
+        let offset_seconds = fixed_offset_date_time.offset().local_minus_utc();
+        let offset_minutes = (offset_seconds / 60) as i16;
+        let local = fixed_offset_date_time.naive_local();
+        let attoseconds = (local.nanosecond() as u64) * 1_000_000_000;
+        // Pack directly from local fields — chrono guarantees validity of the
+        // DateTime, and local year may exceed 9999 (e.g., UTC year 9999 Dec 31
+        // with negative offset). We bypass from_fields validation to avoid panic.
+        let packed = Self::pack_masked(
+            TimestampPrecision::Second,
+            local.year() as u16,
+            local.month() as u8,
+            local.day() as u8,
+            local.hour() as u8,
+            local.minute() as u8,
+            local.second() as u8,
+            (offset_minutes + OFFSET_BIAS) as u16,
+            9,
+        );
         Timestamp {
-            date_time,
-            offset,
-            precision: TimestampPrecision::Second,
-            fractional_seconds: Some(Mantissa::Digits(9)),
+            packed_fields: packed,
+            attoseconds,
         }
     }
 
+    #[cfg(feature = "experimental-chrono")]
     pub(crate) fn try_to_naive_datetime(&self) -> IonResult<NaiveDateTime> {
-        if self.offset.is_some() {
+        if self.offset().is_some() {
             return IonResult::illegal_operation(
                 "cannot convert a Timestamp with a known offset into a NaiveDateTime",
             );
         }
-        Ok(downconvert_to_naive_datetime_with_nanoseconds(self))
+        downconvert_to_naive_datetime_with_nanoseconds(self)
     }
 
+    #[cfg(feature = "experimental-chrono")]
     pub(crate) fn try_to_datetime_fixed_offset(&self) -> IonResult<DateTime<FixedOffset>> {
-        if self.offset.is_none() {
+        if self.offset().is_none() {
             return IonResult::illegal_operation(
                 "cannot convert a Timestamp with an unknown offset into a DateTime<FixedOffset>",
             );
         }
-        let date_time = downconvert_to_naive_datetime_with_nanoseconds(self);
-        Ok(self.offset.unwrap().from_utc_datetime(&date_time))
+        let utc = self.to_utc();
+        let utc_naive = downconvert_to_naive_datetime_with_nanoseconds(&utc)?;
+        let offset = FixedOffset::east_opt(self.offset().unwrap_or_default() * 60);
+        Ok(offset.unwrap().from_utc_datetime(&utc_naive))
     }
 
     /// If the precision is [TimestampPrecision::Second], returns the Decimal scale of this Timestamp's
-    /// fractional seconds; otherwise, returns None.
+    /// fractional seconds; otherwise, returns None. If the Decimal scale is 0, it also returns None.
     ///
     /// For example, a Timestamp with 553 milliseconds would return a Decimal scale of 3.
     pub fn fractional_seconds_scale(&self) -> Option<i64> {
-        // This function is used when comparing two Timestamps with different Mantissa representations.
-        use Mantissa::*;
-        match self.fractional_seconds.as_ref() {
-            // number_of_digits represent number of digits of precision in the Timestamp's fractional seconds.
-            // this is equivalent to the decimal scale when we convert the fractional seconds into a decimal
-            // and return its scale
-            Some(Digits(number_of_digits)) => Some(*number_of_digits as i64),
-            // This timestamp already stores its fractional seconds as a Decimal; return the scale of this Decimal.
-            Some(Arbitrary(decimal)) => Some(decimal.scale()),
-            // This Timestamp's precision is too low to have a fractional seconds field.
-            None => None,
+        let scale = self.subsecond_digit_count();
+        if scale == 0 {
+            None
+        } else {
+            Some(scale as i64)
         }
     }
 
@@ -217,283 +520,85 @@ impl Timestamp {
     /// For example, a Timestamp with 553 milliseconds would return a Decimal with
     /// coefficient 553, exponent -3.
     pub(crate) fn fractional_seconds_as_decimal(&self) -> Option<Decimal> {
-        // This function is used when comparing two Timestamps with different Mantissa representations.
-        use Mantissa::*;
-        match self.fractional_seconds.as_ref() {
-            // This timestamp stores its fractional seconds in its `date_time` field.
-            // We'll need to convert the date_time's nanoseconds to a Decimal and return it.
-            Some(Digits(number_of_digits)) => {
-                const MAX_NANOSECOND_DIGITS: u32 = 9; // If it were 10, it'd be > a second
-                let nanoseconds = self.date_time.nanosecond();
-                let leading_zeros = MAX_NANOSECOND_DIGITS - nanoseconds.count_decimal_digits();
-                let coefficient = if leading_zeros >= *number_of_digits {
-                    0
-                } else {
-                    first_n_digits_of(*number_of_digits - leading_zeros, nanoseconds)
-                };
-                let exponent = -i64::from(*number_of_digits);
-                Some(Decimal::new(coefficient, exponent))
-            }
-            // This timestamp already stores its fractional seconds as a Decimal; return a clone.
-            Some(Arbitrary(decimal)) => Some(decimal.clone()),
-            // This Timestamp's precision is too low to have a fractional seconds field.
-            None => None,
+        let digits = self.subsecond_digit_count() as u32;
+        if digits == 0 {
+            return None;
         }
+        // Convert attoseconds to coefficient at the declared precision.
+        let divisor = 10u64.pow(MAX_FRAC_DIGITS as u32 - digits);
+        let coefficient = self.attoseconds / divisor;
+        Some(Decimal::new(coefficient, -(digits as i64)))
     }
 
-    /// If the precision is [TimestampPrecision::Second], returns a u32 representing
-    /// this Timestamp's fractional seconds in nanoseconds; otherwise, returns None.
-    ///
-    /// NOTE: This is a potentially lossy operation. A Timestamp with picoseconds would return a
-    /// number of nanoseconds, losing precision. Similarly, a Timestamp with milliseconds would
-    /// also return a number of nanoseconds, erroneously gaining precision.
-    fn fractional_seconds_as_nanoseconds(&self) -> Option<u32> {
-        // This function is used when converting a Timestamp to a DateTime<FixedOffset> or
-        // NaiveDateTime.
-        use Mantissa::*;
-        match self.fractional_seconds.as_ref() {
-            // This timestamp already stores its fractional seconds in its `date_time` field.
-            // We can ignore the `number_of_digits` (which tracks its precision) and simply return
-            // `self.date_time`'s nanoseconds.
-            Some(Digits(_number_of_digits)) => Some(self.date_time.nanosecond()),
-            // This timestamp stores its fractional seconds as a Decimal. Down-convert it to a u32
-            // representing the number of nanoseconds.
-            Some(Arbitrary(decimal)) => {
-                // nanoseconds = coefficient * 10^(exponent + 9)
-                let nano_exp = decimal.exponent + 9;
-                let mag = decimal.coefficient().magnitude();
-                let nanos: u128 = if nano_exp >= 0 {
-                    let factor = 10u128.saturating_pow(nano_exp as u32);
-                    mag.as_u128().unwrap_or(0).saturating_mul(factor)
-                } else {
-                    let divisor = 10u128.saturating_pow(nano_exp.unsigned_abs() as u32);
-                    let divided = mag.data / divisor;
-                    // Default value can only be reached if the fractional seconds are greater than 1.
-                    u128::try_from(divided).unwrap_or(0)
-                };
-                // The max number of nanos is 999,999,999 whereas u32::MAX is over 4 billion.
-                // This cast will only truncate if fractional_seconds decimal is >= 1, which is
-                // not allowed.
-                Some(nanos as u32)
-            }
-            // This Timestamp's precision is too low to have a fractional seconds field.
-            None => None,
-        }
-    }
-
-    /// Tests the fractional seconds fields of two timestamps for ordering. This function will
-    /// only be called if both Timestamps have a precision of [TimestampPrecision::Second].
-    fn fractional_seconds_compare(&self, other: &Timestamp) -> Ordering {
-        use Mantissa::*;
-        match (
-            self.fractional_seconds.as_ref(),
-            other.fractional_seconds.as_ref(),
-        ) {
-            (None, None) => Ordering::Equal,
-            (Some(_m), None) => {
-                let d1 = self.fractional_seconds_as_decimal().unwrap();
-                let d2 = Decimal::new(0u64, 0);
-                d1.cmp(&d2)
-            }
-            (None, Some(_m)) => {
-                let d1 = Decimal::new(0u64, 0);
-                let d2 = other.fractional_seconds_as_decimal().unwrap();
-                d1.cmp(&d2)
-            }
-            (Some(Digits(_d1)), Some(Digits(_d2))) => {
-                let d1 = self.date_time.nanosecond();
-                let d2 = other.date_time.nanosecond();
-                d1.cmp(&d2)
-            }
-            (Some(Arbitrary(d1)), Some(Arbitrary(d2))) => Mantissa::decimals_compare(d1, d2),
-            (Some(Digits(_d1)), Some(Arbitrary(d2))) => {
-                let d1 = &self.fractional_seconds_as_decimal().unwrap();
-                Mantissa::decimals_compare(d1, d2)
-            }
-            (Some(Arbitrary(d1)), Some(Digits(_d2))) => {
-                let d2 = &other.fractional_seconds_as_decimal().unwrap();
-                Mantissa::decimals_compare(d1, d2)
-            }
-        }
-    }
-
-    /// Tests the fractional seconds fields of two timestamps for equality. This function will
-    /// only be called if both Timestamps have a precision of [TimestampPrecision::Second].
-    fn fractional_seconds_equal(&self, other: &Timestamp) -> bool {
-        use Mantissa::*;
-
-        // TODO: make Timestamp::fractional_seconds to be Mantissa when creating a Timestamp to get rid of below conversion
-        // convert Option<&Mantissa> to &Mantissa
-        let m1 = match &self.fractional_seconds {
-            None => &Mantissa::Digits(0),
-            Some(m) => m,
-        };
-
-        let m2 = match &other.fractional_seconds {
-            None => &Mantissa::Digits(0),
-            Some(m) => m,
-        };
-
-        // compare fractional seconds
-        match (m1, m2) {
-            (Digits(d1), Digits(d2)) => {
-                if d1 != d2 {
-                    // Different precisions
-                    return false;
-                }
-                let d1 = first_n_digits_of(*d1, self.date_time.nanosecond());
-                let d2 = first_n_digits_of(*d2, other.date_time.nanosecond());
-                d1 == d2
-            }
-            (Arbitrary(d1), Arbitrary(d2)) => Mantissa::decimals_equal(d1, d2),
-            (Digits(_d1), Arbitrary(d2)) => {
-                let d1 = match self.fractional_seconds_as_decimal() {
-                    Some(decimal_value) => decimal_value,
-                    None => Decimal::new(0, 0),
-                };
-                Mantissa::decimals_equal(&d1, d2)
-            }
-            (Arbitrary(d1), Digits(_d2)) => {
-                let d2 = match other.fractional_seconds_as_decimal() {
-                    Some(decimal_value) => decimal_value,
-                    None => Decimal::new(0, 0),
-                };
-                Mantissa::decimals_equal(d1, &d2)
-            }
-        }
+    /// Number of subsecond digits of precision. Returns 0 when precision includes no subsecond
+    /// digits, regardless of the reason.
+    pub(crate) fn subsecond_digit_count(&self) -> u8 {
+        ((self.packed_fields >> SUBSECOND_PRECISION_SHIFT) & SUBSECOND_PRECISION_MASK) as u8
     }
 
     /// Writes the fractional seconds portion of a text timestamp, including a leading `.`.
     fn format_fractional_seconds<W: std::fmt::Write>(&self, output: &mut W) -> IonResult<()> {
-        if self.fractional_seconds.is_none() {
-            // Nothing to do.
-            return Ok(());
-        }
-        let mantissa = self.fractional_seconds.as_ref().unwrap();
-        if mantissa.is_empty() {
-            // No need to write anything.
-            return Ok(());
-        }
-        match mantissa {
-            Mantissa::Digits(num_digits) => {
-                // Scale the nanoseconds down to the requested number of digits.
-                // Example: if `num_digits` is 3 (that is: millisecond precision), we need to
-                // divide the nanoseconds by 10^(9-3) to get the correct precision:
-                //      123,000,000 nanoseconds / 10^(9-3) = 123 milliseconds
-                let scaled = self.date_time.nanosecond() / 10u32.pow(9 - *num_digits);
-                // If our scaled number has fewer digits than the precision states, add leading
-                // zeros to the output to make up the difference.
-                // Example: `num_digits` is 6 (microsecond precision) but our number of microseconds
-                // is `9500` (only 4 digits), we need to add two leading zeros to make: `009500`.
-                let actual_num_digits = scaled.count_decimal_digits();
-                let num_leading_zeros = *num_digits - actual_num_digits;
-                write!(output, ".")?;
-                for _ in 0..num_leading_zeros {
-                    write!(output, "0")?;
-                }
-                write!(output, "{scaled}")?;
-                Ok(())
-            }
-            Mantissa::Arbitrary(decimal) => {
-                let exponent = decimal.exponent;
-                let coefficient = &decimal.coefficient();
-                if exponent >= 0 {
-                    // We know that the coefficient is non-zero (the mantissa was not empty),
-                    // so having a positive exponent would result in an illegal fractional
-                    // seconds value.
-                    return IonResult::encoding_error(
-                        "found fractional seconds decimal that was >= 1.",
-                    );
-                }
-
-                let num_digits = decimal.coefficient().number_of_decimal_digits();
-                let abs_exponent = decimal.exponent.unsigned_abs();
-                // At this point, we know that the abs_exponent is greater than num_digits because
-                // the decimal has to be < 1.
-                let num_leading_zeros = abs_exponent - num_digits as u64;
-                write!(output, ".")?;
-                for _ in 0..num_leading_zeros {
-                    write!(output, "0")?;
-                }
-                if coefficient.is_negative_zero() {
-                    write!(output, "0")?;
-                } else if coefficient.sign() == Sign::Negative {
-                    return IonResult::encoding_error(
-                        "fractional seconds cannot have a negative coefficient (other than -0)",
-                    );
-                } else {
-                    write!(output, "{}", decimal.coefficient())?;
-                }
-                Ok(())
-            }
-        }
-    }
-
-    pub(crate) fn format<W: std::fmt::Write>(&self, output: &mut W) -> IonResult<()> {
-        let (offset_minutes, datetime) = if let Some(minutes) = self.offset {
-            // Create a datetime with the appropriate offset that we can use for formatting.
-            let datetime: DateTime<FixedOffset> = self.try_to_datetime_fixed_offset()?;
-            // Convert the offset to minutes --v
-            (Some(minutes.local_minus_utc() / 60), datetime)
-        } else {
-            // Our timestamp has an unknown offset. Per the spec, this means it makes no
-            // assertions about *where* it was recorded, but its fields are still in UTC.
-            // Create a UTC datetime that we can use for formatting.
-            let datetime: NaiveDateTime = self.try_to_naive_datetime()?;
-            let datetime: DateTime<FixedOffset> = datetime_at_offset(&datetime, 0);
-            (None, datetime)
-        };
-
-        write!(output, "{:0>4}", datetime.year())?;
-        //                  ^-- 0-padded, right aligned, 4-digit year
-        if self.precision == TimestampPrecision::Year {
-            write!(output, "T")?;
+        let digits = self.subsecond_digit_count() as u32;
+        if digits == 0 {
             return Ok(());
         }
 
-        write!(output, "-{:0>2}", datetime.month())?;
-        //                   ^-- delimiting hyphen and 0-padded, right aligned, 2-digit month
-        if self.precision == TimestampPrecision::Month {
-            write!(output, "T")?;
-            return Ok(());
-        }
-
-        write!(output, "-{:0>2}", datetime.day())?;
-        //                   ^-- delimiting hyphen and 0-padded, right aligned, 2-digit day
-        if self.precision == TimestampPrecision::Day {
-            write!(output, "T")?;
-            return Ok(());
-        }
-
-        write!(
-            output,
-            "T{:0>2}:{:0>2}",
-            // ^-- delimiting T, formatted hour, delimiting colon, formatted minute
-            datetime.hour(),
-            datetime.minute()
-        )?;
-        if self.precision == TimestampPrecision::HourAndMinute {
-            self.format_offset(offset_minutes, output)?;
-            return Ok(());
-        }
-
-        write!(output, ":{:0>2}", datetime.second())?;
-        //                   ^-- delimiting colon, formatted second
-        self.format_fractional_seconds(output)?;
-        self.format_offset(offset_minutes, output)?;
+        let divisor = 10u64.pow(MAX_FRAC_DIGITS as u32 - digits);
+        let coefficient = self.attoseconds / divisor;
+        write!(output, ".{coefficient:0>width$}", width = digits as usize)?;
         Ok(())
     }
 
-    fn format_offset<W: std::fmt::Write>(
-        &self,
-        offset_minutes: Option<i32>,
-        output: &mut W,
-    ) -> IonResult<()> {
+    pub(crate) fn format<W: std::fmt::Write>(&self, output: &mut W) -> IonResult<()> {
+        match self.precision() {
+            TimestampPrecision::Year => write!(output, "{:0>4}T", self.year())?,
+            TimestampPrecision::Month => {
+                write!(output, "{:0>4}-{:0>2}T", self.year(), self.month())?
+            }
+            TimestampPrecision::Day => write!(
+                output,
+                "{:0>4}-{:0>2}-{:0>2}T",
+                self.year(),
+                self.month(),
+                self.day()
+            )?,
+            TimestampPrecision::HourAndMinute => {
+                write!(
+                    output,
+                    "{:0>4}-{:0>2}-{:0>2}T{:0>2}:{:0>2}",
+                    self.year(),
+                    self.month(),
+                    self.day(),
+                    self.hour(),
+                    self.minute()
+                )?;
+                self.format_offset(output)?;
+            }
+            TimestampPrecision::Second => {
+                write!(
+                    output,
+                    "{:0>4}-{:0>2}-{:0>2}T{:0>2}:{:0>2}:{:0>2}",
+                    self.year(),
+                    self.month(),
+                    self.day(),
+                    self.hour(),
+                    self.minute(),
+                    self.second()
+                )?;
+                self.format_fractional_seconds(output)?;
+                self.format_offset(output)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn format_offset<W: std::fmt::Write>(&self, output: &mut W) -> IonResult<()> {
+        let offset_minutes = self.offset();
         let (sign, hours, minutes) = match offset_minutes {
             None => ("-", 0, 0),
             Some(offset_minutes) => {
-                const MINUTES_PER_HOUR: i32 = 60;
                 // Split the offset into a sign and magnitude for formatting
+                const MINUTES_PER_HOUR: i32 = 60;
                 let sign = if offset_minutes >= 0 { "+" } else { "-" };
                 let offset_minutes = offset_minutes.abs();
                 let hours = offset_minutes / MINUTES_PER_HOUR;
@@ -522,94 +627,94 @@ impl Timestamp {
     /// Returns the offset in minutes that has been specified in the [Timestamp].
     /// A positive value indicates Eastern Hemisphere, while a negative value indicates Western Hemisphere.
     pub fn offset(&self) -> Option<i32> {
-        self.offset.map(|offset| offset.local_minus_utc() / 60)
+        let raw = ((self.packed_fields >> OFFSET_SHIFT) & OFFSET_MASK) as u16;
+        if raw == OFFSET_UNKNOWN_SENTINEL {
+            return None;
+        }
+        Some(raw as i32 - OFFSET_BIAS as i32)
     }
 
     /// Returns the precision that has been specified in the [Timestamp].
     pub fn precision(&self) -> TimestampPrecision {
-        self.precision
+        match (self.packed_fields >> PRECISION_SHIFT) & PRECISION_MASK {
+            0 => TimestampPrecision::Year,
+            1 => TimestampPrecision::Month,
+            2 => TimestampPrecision::Day,
+            3 => TimestampPrecision::HourAndMinute,
+            _ => TimestampPrecision::Second,
+        }
     }
 
     /// Returns the year that has been specified in the [Timestamp].
     pub fn year(&self) -> u32 {
-        // verify if the timestamp has an offset
-        if let Some(offset) = self.offset {
-            // `NaiveDateTime#hours()` returns hours normalized as per UTC
-            // for local time we need to +/- the difference
-            let local_date_time =
-                DateTime::<FixedOffset>::from_naive_utc_and_offset(self.date_time, offset);
-            return local_date_time.year() as u32;
-        }
-        self.date_time.year() as u32
+        ((self.packed_fields >> YEAR_SHIFT) & YEAR_MASK) as u32
     }
 
     /// Returns the month that has been specified in the [Timestamp].
     /// Returns the month number starting from 1.
     /// The return value ranges from 1 to 12.
     pub fn month(&self) -> u32 {
-        // verify if the timestamp has an offset
-        if let Some(offset) = self.offset {
-            // `NaiveDateTime#hours()` returns hours normalized as per UTC
-            // for local time we need to +/- the difference
-            let local_date_time =
-                DateTime::<FixedOffset>::from_naive_utc_and_offset(self.date_time, offset);
-            return local_date_time.month();
-        }
-        self.date_time.month()
+        ((self.packed_fields >> MONTH_SHIFT) & MONTH_MASK) as u32
     }
 
     /// Returns the day that has been specified in the [Timestamp].
     /// Returns the day of month starting from 1.
-    // The return value ranges from 1 to 31. (The last day of month differs by months.)
     pub fn day(&self) -> u32 {
-        // verify if the timestamp has an offset
-        if let Some(offset) = self.offset {
-            // `NaiveDateTime#hours()` returns hours normalized as per UTC
-            // for local time we need to +/- the difference
-            let local_date_time =
-                DateTime::<FixedOffset>::from_naive_utc_and_offset(self.date_time, offset);
-            return local_date_time.day();
-        }
-        self.date_time.day()
+        ((self.packed_fields >> DAY_SHIFT) & DAY_MASK) as u32
     }
 
     /// Returns the hour(s) that has been specified in the [Timestamp].
     /// Returns the hour number from 0 to 23.
     pub fn hour(&self) -> u32 {
-        // verify if the timestamp has an offset
-        if let Some(offset) = self.offset {
-            // `NaiveDateTime#hours()` returns hours normalized as per UTC
-            // for local time we need to +/- the difference
-            let local_date_time =
-                DateTime::<FixedOffset>::from_naive_utc_and_offset(self.date_time, offset);
-            return local_date_time.hour();
-        }
-        self.date_time.hour()
+        ((self.packed_fields >> HOUR_SHIFT) & HOUR_MASK) as u32
     }
 
     /// Returns the minute(s) that has been specified in the [Timestamp].
     /// Returns the minute number from 0 to 59.
     pub fn minute(&self) -> u32 {
-        // verify if the timestamp has an offset
-        if let Some(offset) = self.offset {
-            // `NaiveDateTime#hours()` returns minutes normalized as per UTC
-            // for local time we need to +/- the difference
-            let local_date_time =
-                DateTime::<FixedOffset>::from_naive_utc_and_offset(self.date_time, offset);
-            return local_date_time.minute();
-        }
-        self.date_time.minute()
+        ((self.packed_fields >> MINUTE_SHIFT) & MINUTE_MASK) as u32
     }
 
     /// Returns the second(s) that has been specified in the [Timestamp].
     /// Returns the second number from 0 to 59.
     pub fn second(&self) -> u32 {
-        self.date_time.second()
+        ((self.packed_fields >> SECOND_SHIFT) & SECOND_MASK) as u32
     }
 
     /// Return a UTC timestamp for this [Timestamp]
     pub fn to_utc(&self) -> Timestamp {
-        Self::from_naive_datetime(self.date_time)
+        let offset_minutes = match self.offset() {
+            None => return self.clone(),
+            Some(m) => m as i16,
+        };
+        let (uy, umo, ud, uh, umi) = add_offset_to_utc(
+            self.year() as u16,
+            self.month() as u8,
+            self.day() as u8,
+            self.hour() as u8,
+            self.minute() as u8,
+            -offset_minutes,
+        );
+        // Pack directly without validation — the source timestamp was already
+        // valid, and UTC conversion can produce year 0 (e.g., 0001-01-01T00:30+01:00
+        // → 0000-12-31T23:30 UTC). This is fine for comparison purposes.
+        // TODO(#1033, #1034): to_utc should set offset to 0 (+00:00), not unknown.
+        // Keeping unknown offset to match prior behavior for now.
+        let packed = Self::pack_masked(
+            self.precision(),
+            uy,
+            umo,
+            ud,
+            uh,
+            umi,
+            self.second() as u8,
+            OFFSET_UNKNOWN_SENTINEL,
+            self.subsecond_digit_count(),
+        );
+        Timestamp {
+            packed_fields: packed,
+            attoseconds: self.attoseconds,
+        }
     }
 
     /// Returns this Timestamp's fractional seconds in nanoseconds
@@ -618,7 +723,7 @@ impl Timestamp {
     /// number of nanoseconds, losing precision. If it loses precision then truncation is performed.
     /// (e.g. a timestamp with fractional seconds of `0.000000000999` would return `0`)
     pub fn nanoseconds(&self) -> u32 {
-        self.fractional_seconds_as_nanoseconds().unwrap_or_default()
+        (self.attoseconds / 1_000_000_000) as u32
     }
 
     /// Returns this Timestamp's fractional seconds in microseconds
@@ -627,9 +732,7 @@ impl Timestamp {
     /// number of microseconds, losing precision. If it loses precision then truncation is performed.
     /// (e.g. a timestamp with fractional seconds of `0.000000999` would return `0`)
     pub fn microseconds(&self) -> u32 {
-        self.fractional_seconds_as_nanoseconds()
-            .map(|s| s / 1_000)
-            .unwrap_or_default()
+        (self.attoseconds / 1_000_000_000_000) as u32
     }
 
     /// Returns this Timestamp's fractional seconds in milliseconds
@@ -638,9 +741,7 @@ impl Timestamp {
     /// number of milliseconds, losing precision. If it loses precision then truncation is performed.
     /// (e.g. a timestamp with fractional seconds of `0.000999` would return `0`)
     pub fn milliseconds(&self) -> u32 {
-        self.fractional_seconds_as_nanoseconds()
-            .map(|s| s / 1_000_000)
-            .unwrap_or_default()
+        (self.attoseconds / 1_000_000_000_000_000) as u32
     }
 }
 
@@ -652,6 +753,12 @@ impl Display for Timestamp {
     }
 }
 
+impl Debug for Timestamp {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Timestamp({})", self)
+    }
+}
+
 impl PartialOrd for Timestamp {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
@@ -660,29 +767,94 @@ impl PartialOrd for Timestamp {
 
 impl Ord for Timestamp {
     fn cmp(&self, other: &Self) -> Ordering {
-        let self_datetime = self.date_time.with_nanosecond(0).unwrap();
-        let other_datetime = other.date_time.with_nanosecond(0).unwrap();
-
-        let self_datetime = self
-            .offset
-            .map(|offset| offset.from_utc_datetime(&self_datetime))
-            .unwrap_or_else(|| datetime_at_offset(&self_datetime, 0));
-        let other_datetime = other
-            .offset
-            .map(|offset| offset.from_utc_datetime(&other_datetime))
-            .unwrap_or_else(|| datetime_at_offset(&other_datetime, 0));
-
-        let date_time_comparison = self_datetime.cmp(&other_datetime);
-
-        match date_time_comparison {
-            // if the datetime comparison is Ordering::Equal,
-            // then return fractional seconds comparison result
-            Ordering::Equal => self.fractional_seconds_compare(other),
-            // if datetime comparison is not equal,
-            // then no need to check for fractional seconds comparison
-            _ => date_time_comparison,
+        // Fast path: identical packed + attoseconds means same instant.
+        if self.packed_fields == other.packed_fields && self.attoseconds == other.attoseconds {
+            return Ordering::Equal;
         }
+
+        let self_offset_raw = (self.packed_fields >> OFFSET_SHIFT) & OFFSET_MASK;
+        let other_offset_raw = (other.packed_fields >> OFFSET_SHIFT) & OFFSET_MASK;
+
+        if self_offset_raw == other_offset_raw {
+            // Same offset (or both unknown) — compare date-time fields directly.
+            return (self.packed_fields & DATETIME_MASK)
+                .cmp(&(other.packed_fields & DATETIME_MASK))
+                .then_with(|| self.attoseconds.cmp(&other.attoseconds));
+        }
+
+        // Different offsets: normalize other's local time to self's offset.
+        let delta_minutes =
+            offset_raw_to_minutes(self_offset_raw) - offset_raw_to_minutes(other_offset_raw);
+
+        if delta_minutes == 0 {
+            return (self.packed_fields & DATETIME_MASK)
+                .cmp(&(other.packed_fields & DATETIME_MASK))
+                .then_with(|| self.attoseconds.cmp(&other.attoseconds));
+        }
+
+        // Adjust other's time by delta and compare as linear minutes.
+        // No division or repacking needed for the common no-rollover case.
+        let other_hour = other.hour() as i32;
+        let other_minute = other.minute() as i32;
+        let other_total = other_hour * 60 + other_minute + delta_minutes as i32;
+
+        if (0..24 * 60).contains(&other_total) {
+            // No day rollover: date bits (year/month/day) unchanged.
+            // Compare date portion first.
+            const DATE_MASK: u64 =
+                (YEAR_MASK << YEAR_SHIFT) | (MONTH_MASK << MONTH_SHIFT) | (DAY_MASK << DAY_SHIFT);
+            let date_cmp = (self.packed_fields & DATE_MASK).cmp(&(other.packed_fields & DATE_MASK));
+            if date_cmp != Ordering::Equal {
+                return date_cmp;
+            }
+            // Compare time-of-day as linear minutes.
+            let self_total = self.hour() as i32 * 60 + self.minute() as i32;
+            let time_cmp = self_total.cmp(&other_total);
+            if time_cmp != Ordering::Equal {
+                return time_cmp;
+            }
+            return self
+                .second()
+                .cmp(&other.second())
+                .then_with(|| self.attoseconds.cmp(&other.attoseconds));
+        }
+
+        // Day rollover: full conversion needed.
+        let (ny, nmo, nd, nh, nmi) = add_offset_to_utc(
+            other.year() as u16,
+            other.month() as u8,
+            other.day() as u8,
+            other_hour as u8,
+            other_minute as u8,
+            delta_minutes,
+        );
+        let other_datetime = (ny as u64) << YEAR_SHIFT
+            | (nmo as u64) << MONTH_SHIFT
+            | (nd as u64) << DAY_SHIFT
+            | (nh as u64) << HOUR_SHIFT
+            | (nmi as u64) << MINUTE_SHIFT
+            | (other.packed_fields & (SECOND_MASK << SECOND_SHIFT));
+
+        (self.packed_fields & DATETIME_MASK)
+            .cmp(&other_datetime)
+            .then_with(|| self.attoseconds.cmp(&other.attoseconds))
     }
+}
+
+/// Convert biased raw offset to signed minutes.
+/// Sentinel 0 (unknown) maps to 0 minutes — no branch needed since 0 - BIAS = -BIAS,
+/// but we want unknown to be treated as +00:00 (= 0 minutes). Since sentinel is 0
+/// and bias is 1440, we get -1440 if we just subtract. Instead: sentinel means the
+/// offset field is 0, and we want the effective offset to be 0 (UTC). So we use
+/// the fact that (raw == 0) means unknown and skip the subtraction via branchless mask.
+#[inline(always)]
+fn offset_raw_to_minutes(raw: u64) -> i16 {
+    // When raw == 0 (unknown): result is 0.
+    // When raw != 0 (known):   result is raw - BIAS.
+    // Branchless: the mask is 0 when raw==0, all-ones otherwise.
+    let mask = ((raw | raw.wrapping_neg()) >> 63) as u16; // 0 if raw==0, 1 otherwise
+    let mask = mask.wrapping_neg(); // 0x0000 if raw==0, 0xFFFF otherwise
+    (raw as i16).wrapping_sub(OFFSET_BIAS) & (mask as i16)
 }
 
 /// Two Timestamps are considered equal (though not necessarily IonEq) if they represent the same
@@ -693,37 +865,21 @@ impl Ord for Timestamp {
 /// * `2022T-05-11T12:00:00.000Z` == `2022T-05-11T07:00:00.000-05:00`
 impl PartialEq for Timestamp {
     fn eq(&self, other: &Self) -> bool {
-        // First, compare the two Timestamps' fractional seconds. We do this first because
-        // Timestamps with different Mantissa representations are a bit tricky to compare. Once
-        // we've established that the fractional seconds match, we can compare all of the other
-        // fields in the timestamp by comparing their respective `DateTime`s.
-        if !self.fractional_seconds_equal(other) {
+        // Offset normalization never changes seconds or attoseconds,
+        // so if either differs the timestamps can't represent the same instant.
+        if self.attoseconds != other.attoseconds {
             return false;
         }
-
-        // When a Timestamp is created, any fields beyond its precision are set to the lowest
-        // legal value for that field. So the Timestamp `2022-05T` (which has `Month` precision)
-        // would have a `day` field of `1` and hour, minute, and seconds fields of `0`. This makes
-        // it easy to compare Timestamps with different precisions.
-
-        // Make copies of their respective DateTime values but with the fractional seconds zeroed
-        // out. We're not modifying `self` or `other`, and we've already compared their fractional
-        // seconds so it's ok to ignore them from here on.
-        let self_datetime = self.date_time.with_nanosecond(0).unwrap();
-        let other_datetime = other.date_time.with_nanosecond(0).unwrap();
-
-        // Apply each Timestamp's offset to the DateTime. If there's no offset, set it to UTC.
-        let self_datetime = self
-            .offset
-            .map(|offset| offset.from_utc_datetime(&self_datetime))
-            .unwrap_or_else(|| datetime_at_offset(&self_datetime, 0));
-        let other_datetime = other
-            .offset
-            .map(|offset| offset.from_utc_datetime(&other_datetime))
-            .unwrap_or_else(|| datetime_at_offset(&other_datetime, 0));
-
-        // Compare the resulting `DateTime<FixedOffset>`s
-        self_datetime == other_datetime
+        if self.second() != other.second() {
+            return false;
+        }
+        // Mask out precision and subsecond_digits — they don't affect instant equality.
+        const INSTANT_MASK: u64 = DATETIME_MASK | (OFFSET_MASK << OFFSET_SHIFT);
+        if (self.packed_fields & INSTANT_MASK) == (other.packed_fields & INSTANT_MASK) {
+            return true;
+        }
+        // Fallback to normalizing offsets.
+        self.cmp(other) == Ordering::Equal
     }
 }
 
@@ -731,114 +887,22 @@ impl Eq for Timestamp {}
 
 impl IonEq for Timestamp {
     fn ion_eq(&self, other: &Self) -> bool {
-        if self.precision != other.precision {
-            return false;
-        }
-        // Timestamps are only considered Ion-equal if they have the same offset, including "unknown".
-        if self.offset != other.offset {
-            return false;
-        }
-        let self_dt = self.date_time;
-        let other_dt = other.date_time;
-        if self_dt.year() != other_dt.year() {
-            return false;
-        }
-        if self.precision >= TimestampPrecision::Month && self_dt.month() != other_dt.month() {
-            return false;
-        }
-        if self.precision >= TimestampPrecision::Day && self_dt.day() != other_dt.day() {
-            return false;
-        }
-        if self.precision >= TimestampPrecision::HourAndMinute
-            && (self_dt.hour() != other_dt.hour() || self_dt.minute() != other_dt.minute())
-        {
-            return false;
-        }
-        if self.precision <= TimestampPrecision::HourAndMinute {
-            return true;
-        }
-
-        if self_dt.second() != other_dt.second() || !self.fractional_seconds_equal(other) {
-            return false;
-        }
-
-        true
+        self.packed_fields.eq(&other.packed_fields) && self.attoseconds.eq(&other.attoseconds)
     }
 }
 
 impl IonDataOrd for Timestamp {
     fn ion_cmp(&self, other: &Self) -> Ordering {
-        // Compare by point in time
-        let ord = self.cmp(other);
-        if ord != Ordering::Equal {
-            return ord;
-        };
-
-        // And then by precision
-        let ord = self.precision.cmp(&other.precision);
-        if ord != Ordering::Equal {
-            return ord;
-        };
-        match [
-            self.fractional_seconds_scale(),
-            other.fractional_seconds_scale(),
-        ] {
-            [None, Some(b)] if b > 0 => return Ordering::Less,
-            [Some(a), None] if a > 0 => return Ordering::Greater,
-            [Some(a), Some(b)] => {
-                let ord = a.cmp(&b);
-                if ord != Ordering::Equal {
-                    return ord;
-                }
-            }
-            _ => {}
-        }
-
-        // And finally by offset (unknown, then least to greatest)
-        match [self.offset, other.offset] {
-            [None, Some(_)] => Ordering::Less,
-            [None, None] => Ordering::Equal,
-            [Some(_), None] => Ordering::Greater,
-            [Some(o1), Some(o2)] => o1.local_minus_utc().cmp(&o2.local_minus_utc()),
-        }
+        self.packed_fields
+            .cmp(&other.packed_fields)
+            .then(self.attoseconds.cmp(&other.attoseconds))
     }
 }
 
 impl IonDataHash for Timestamp {
     fn ion_data_hash<H: Hasher>(&self, state: &mut H) {
-        self.precision.hash(state);
-        let self_dt = self.date_time;
-        self_dt.year().hash(state);
-        if self.precision >= TimestampPrecision::Month {
-            self_dt.month().hash(state)
-        }
-        if self.precision >= TimestampPrecision::Day {
-            self_dt.day().hash(state)
-        }
-        if self.precision >= TimestampPrecision::HourAndMinute {
-            self_dt.hour().hash(state);
-            self_dt.minute().hash(state);
-        }
-        if self.precision == TimestampPrecision::Second {
-            self_dt.second().hash(state);
-
-            let fractional_seconds_scale = self.fractional_seconds_scale();
-            match fractional_seconds_scale {
-                None | Some(0) => {}
-                Some(1..=9) => {
-                    fractional_seconds_scale.unwrap().hash(state);
-                    self.fractional_seconds_as_nanoseconds()
-                        .unwrap()
-                        .hash(state);
-                }
-                Some(_) => {
-                    self.fractional_seconds_as_decimal()
-                        .unwrap()
-                        .ion_data_hash(state);
-                }
-            }
-        }
-        self.offset.hash(state);
+        self.packed_fields.hash(state);
+        self.attoseconds.hash(state);
     }
 }
 
@@ -850,7 +914,6 @@ impl IonDataHash for Timestamp {
 #[derive(Debug, Clone)]
 pub struct TimestampBuilder<T> {
     _state: PhantomData<T>,
-    fields_are_utc: bool,
     precision: TimestampPrecision,
     offset: Option<i32>,
     // year..second are always set. Default is the implied value for the field if precision is less than that field.
@@ -860,8 +923,8 @@ pub struct TimestampBuilder<T> {
     hour: u32,
     minute: u32,
     second: u32,
-    fractional_seconds: Option<Mantissa>,
-    nanoseconds: Option<u32>,
+    attoseconds: u64,
+    fractional_digits: u8,
 }
 
 impl<T> TimestampBuilder<T> {
@@ -870,7 +933,6 @@ impl<T> TimestampBuilder<T> {
         // unsafe { std::mem::transmute(self) }
         TimestampBuilder {
             _state: PhantomData,
-            fields_are_utc: self.fields_are_utc,
             precision: self.precision,
             offset: self.offset,
             year: self.year,
@@ -879,186 +941,110 @@ impl<T> TimestampBuilder<T> {
             hour: self.hour,
             minute: self.minute,
             second: self.second,
-            fractional_seconds: self.fractional_seconds,
-            nanoseconds: self.nanoseconds,
+            attoseconds: self.attoseconds,
+            fractional_digits: self.fractional_digits,
         }
     }
 
-    /// Sets all of the fields on the given [`NaiveDateTime`] or [`DateTime<FixedOffset>`] using the
-    /// values from the TimestampBuilder. Only those fields required by the TimestampBuilder's
-    /// configured [`TimestampPrecision`] will be set.
-    fn configure_datetime<D>(&mut self, mut datetime: D) -> IonResult<D>
-    where
-        D: Datelike + Timelike + Debug,
-    {
-        if self.year == 0 || self.year > 9999 {
+    /// Confirms that each configured field fits in the corresponding field of the packed
+    /// [`Timestamp`] representation.
+    ///
+    /// [`Timestamp::from_fields`] performs the authoritative validation (including calendar
+    /// rules like the number of days in the given month), but it receives fields that have
+    /// already been narrowed from `u32`/`i32` to `u8`/`u16`/`i16`. This method runs first so
+    /// that a value too large for the narrower type is reported as an error instead of
+    /// silently wrapping into a different, possibly valid-looking value.
+    fn validate_field_ranges(&self) -> IonResult<()> {
+        const MAX_ATTOSECONDS: u64 = 1_000_000_000_000_000_000;
+        if self.attoseconds >= MAX_ATTOSECONDS {
             return IonResult::illegal_operation(format!(
-                "Timestamp year '{}' out of range (1-9999)",
-                self.year
+                "Timestamp fractional seconds out of range (attoseconds={})",
+                self.attoseconds
             ));
         }
-        datetime = datetime.with_year(self.year as i32).ok_or_else(|| {
-            IonError::illegal_operation(format!("specified year ('{}') is invalid", self.year))
-        })?;
-        if self.precision == TimestampPrecision::Year {
-            return Ok(datetime);
+        if self.year > MAX_YEAR as u32 {
+            return IonResult::illegal_operation(format!(
+                "Timestamp year '{}' out of range (1-{MAX_YEAR})",
+                self.year,
+            ));
         }
-
-        // If precision >= Month, the month must be set.
-        let month = self.month;
-        datetime = datetime.with_month(month).ok_or_else(|| {
-            IonError::illegal_operation(format!("specified month ('{month}') is invalid"))
-        })?;
-        if self.precision == TimestampPrecision::Month {
-            return Ok(datetime);
+        if self.month > 12 {
+            return IonResult::illegal_operation(format!(
+                "Timestamp month '{}' out of range (1-12)",
+                self.month
+            ));
         }
-
-        // If precision >= Day, the day must be set.
-        let day = self.day;
-        datetime = datetime.with_day(day).ok_or_else(|| {
-            IonError::illegal_operation(format!("specified day ('{day}') is invalid"))
-        })?;
-        if self.precision == TimestampPrecision::Day {
-            return Ok(datetime);
+        if self.day > 31 {
+            return IonResult::illegal_operation(format!(
+                "Timestamp day '{}' out of range (1-31)",
+                self.day
+            ));
         }
-
-        // If precision >= HourAndMinute, the hour and minute must be set.
-        let hour = self.hour;
-        datetime = datetime.with_hour(hour).ok_or_else(|| {
-            IonError::illegal_operation(format!("specified hour ('{hour}') is invalid"))
-        })?;
-        let minute = self.minute;
-        datetime = datetime.with_minute(minute).ok_or_else(|| {
-            IonError::illegal_operation(format!("specified minute ('{minute}') is invalid"))
-        })?;
-        if self.precision == TimestampPrecision::HourAndMinute {
-            return Ok(datetime);
+        if self.hour > 23 {
+            return IonResult::illegal_operation(format!(
+                "Timestamp hour '{}' out of range (0-23)",
+                self.hour
+            ));
         }
-
-        // If precision >= Second, the second must be set...
-        let second = self.second;
-        datetime = datetime.with_second(second).ok_or_else(|| {
-            IonError::illegal_operation(format!("provided second ('{second}') is invalid."))
-        })?;
-
-        // ...along with the fractional seconds.
-        // If fractional seconds is Digit, self.nanoseconds will be Some(_).
-        // If it's Arbitrary, self.nanoseconds will be None and we should set the nanoseconds
-        // field to 0. The real value will be stored in the Timestamp alongside the DateTime
-        // as a Decimal.
-        datetime = datetime
-            .with_nanosecond(self.nanoseconds.unwrap_or(0))
-            .ok_or_else(|| {
-                IonError::illegal_operation(format!("provided nanosecond ('{second}') is invalid"))
-            })?;
-
-        Ok(datetime)
-    }
-
-    // A [NaiveDateTime] has no offset. This function attempts to apply the provided offset to the
-    // NaiveDateTime, producing a DateTime<FixedOffset>. If the offset is invalid or the combination
-    // of offset and datetime would produce an invalid Timestamp, this function will return Err.
-    fn apply_offset(
-        offset_minutes: i32,
-        fields_are_utc: bool,
-        datetime: NaiveDateTime,
-    ) -> IonResult<DateTime<FixedOffset>> {
-        // The chrono APIs express their DateTime offsets in seconds, but the Ion APIs use minutes.
-        const SECONDS_PER_MINUTE: i32 = 60;
-        let offset_seconds = offset_minutes * SECONDS_PER_MINUTE;
-        let offset = FixedOffset::east_opt(offset_seconds).ok_or_else(|| {
-            IonError::illegal_operation(format!(
-                "specified offset ({offset_minutes} minutes) is invalid"
-            ))
-        })?;
-
-        // If the fields of the datetime are UTC, constructing a DateTime<FixedOffset> is guaranteed
-        // to succeed. Return it directly.
-        if fields_are_utc {
-            return Ok(offset.from_utc_datetime(&datetime));
+        if self.minute > 59 {
+            return IonResult::illegal_operation(format!(
+                "Timestamp minute '{}' out of range (0-59)",
+                self.minute
+            ));
         }
-
-        // Otherwise, apply the offset to our (local) NaiveDateTime and make sure the resulting
-        // DateTime<FixedOffset> is valid.
-        match offset.from_local_datetime(&datetime) {
-            LocalResult::None => {
-                IonResult::illegal_operation(
-                    format!(
-                        "specified offset/datetime pair is invalid (offset={offset_minutes}, datetime={datetime})"
-                    )
-                )
-            },
-            LocalResult::Single(datetime) => Ok(datetime),
-            LocalResult::Ambiguous(_min, _max) => {
-                IonResult::illegal_operation(
-                    format!(
-                        "specified offset/datetime pair produces an ambiguous timestamp (offset={offset_minutes}, datetime={datetime})"
-                    )
-                )
+        if self.second > 59 {
+            return IonResult::illegal_operation(format!(
+                "Timestamp second '{}' out of range (0-59)",
+                self.second
+            ));
+        }
+        if let Some(offset_minutes) = self.offset {
+            if !(MIN_OFFSET_MINUTES as i32..=MAX_OFFSET_MINUTES as i32).contains(&offset_minutes) {
+                return IonResult::illegal_operation(format!(
+                    "offset ({} minutes) exceeds valid range ({}..={})",
+                    offset_minutes, MIN_OFFSET_MINUTES, MAX_OFFSET_MINUTES
+                ));
             }
         }
+        Ok(())
     }
 
     /// Attempt to construct a [Timestamp] using the values configured on the [TimestampBuilder].
-    /// If any of the individual fields are invalid (for example, a `month` value that is greater
-    /// than `12`) or if the resulting timestamp would represent a non-existent point in time
-    /// (like those bypassed by daylight saving time), this method will return an `Err(IonError)`.
-    pub fn build(mut self) -> IonResult<Timestamp> {
-        // Start with a clean slate NaiveDateTime that we can configure. (These are cheap to copy.)
-        let mut datetime: NaiveDateTime = NaiveDate::from_ymd_opt(0, 1, 1)
-            .unwrap()
-            .and_hms_nano_opt(0, 0, 0, 0)
-            .unwrap();
-        // Set all of the time fields on the datetime using the data from our TimestampBuilder
-        datetime = self.configure_datetime(datetime)?;
-        // If the timestamp we're building has a known offset...
-        let mut timestamp: Timestamp = if let Some(offset_minutes) = self.offset {
-            // ...apply the offset to our NaiveDateTime, producing a DateTime<FixedOffset>
-            let datetime_with_offset: DateTime<FixedOffset> =
-                Self::apply_offset(offset_minutes, self.fields_are_utc, datetime)?;
-            // ...and convert the DateTime<FixedOffset> into a full Timestamp.
-            Timestamp::from_fixed_offset_datetime(datetime_with_offset)
-        } else {
-            // Otherwise, there's not a known offset. We can directly convert our NaiveDateTime
-            // into a full Timestamp.
-            Timestamp::from_naive_datetime(datetime)
-        };
-        if self.precision < TimestampPrecision::Second {
-            timestamp.fractional_seconds = None;
-        }
-        timestamp.precision = self.precision;
+    pub fn build(self) -> IonResult<Timestamp> {
+        // Each field is validated *before* it is narrowed; a `u32`-to-`u8`/`u16` cast of an
+        // out-of-range value would silently wrap and could produce a field that
+        // `Timestamp::from_fields` then accepts as valid (e.g. `month: 268` becomes `12`).
+        self.validate_field_ranges()?;
 
-        // Copy the fractional seconds from the builder to the Timestamp.
-        if self.precision == TimestampPrecision::Second {
-            timestamp.fractional_seconds = self.fractional_seconds;
-            if let Some(Mantissa::Arbitrary(ref decimal)) = &timestamp.fractional_seconds {
-                if decimal.is_less_than_zero() {
-                    return IonResult::illegal_operation(
-                        "cannot create a timestamp with negative fractional seconds",
-                    );
-                }
-                if decimal.is_greater_than_or_equal_to_one() {
-                    return IonResult::illegal_operation(
-                        "cannot create a timestamp with a fractional seconds >= 1.0",
-                    );
-                }
-                if decimal.is_zero() && decimal.exponent >= 0 {
-                    timestamp.fractional_seconds = None;
-                }
-            }
-        }
-        Ok(timestamp)
+        Timestamp::from_fields(
+            self.precision,
+            self.offset.map(|i| i as i16),
+            self.year as u16,
+            self.month as u8,
+            self.day as u8,
+            self.hour as u8,
+            self.minute as u8,
+            self.second as u8,
+            self.fractional_digits,
+            self.attoseconds,
+        )
     }
 
     /// Like [Self::build], but the fields provided for each time unit are understood
     /// to be in UTC rather than in the local time of the specified offset (if there is one).
-    pub(crate) fn build_utc_fields_at_offset(
-        mut self,
-        offset_minutes: i32,
-    ) -> IonResult<Timestamp> {
-        self.fields_are_utc = true;
-        self.offset = Some(offset_minutes);
-        self.build()
+    pub(crate) fn build_utc_fields_at_offset(self, offset_minutes: i32) -> IonResult<Timestamp> {
+        Timestamp::from_utc_fields(
+            self.precision,
+            offset_minutes as i16,
+            self.year as u16,
+            self.month as u8,
+            self.day as u8,
+            self.hour as u8,
+            self.minute as u8,
+            self.second as u8,
+            self.fractional_digits,
+            self.attoseconds,
+        )
     }
 }
 
@@ -1070,7 +1056,6 @@ impl TimestampBuilder<HasYear> {
     pub fn with_year(year: u32) -> Self {
         TimestampBuilder {
             _state: Default::default(),
-            fields_are_utc: false,
             precision: TimestampPrecision::Year,
             offset: None,
             year,
@@ -1079,8 +1064,8 @@ impl TimestampBuilder<HasYear> {
             hour: 0,
             minute: 0,
             second: 0,
-            fractional_seconds: None,
-            nanoseconds: None,
+            attoseconds: 0,
+            fractional_digits: 0,
         }
     }
 
@@ -1190,21 +1175,31 @@ impl TimestampBuilder<HasSeconds> {
     // Note that in order to create a `FractionalSecondSetter`, the user will have had to first
     // create a `SecondSetter`. Because of this, the builder's precision is already set to
     // `TimestampPrecision::Second`.
+
+    /// Sets the fractional seconds to `nanosecond`, which must be in the range `0..=999_999_999`.
+    /// An out-of-range value causes [`Self::build`] to return an error.
     pub fn with_nanoseconds(mut self, nanosecond: u32) -> TimestampBuilder<HasFractionalSeconds> {
-        self.fractional_seconds = Some(Mantissa::Digits(9));
-        self.nanoseconds = Some(nanosecond);
+        self.attoseconds = (nanosecond as u64).saturating_mul(1_000_000_000);
+        self.fractional_digits = 9;
+
         self.change_state()
     }
 
+    /// Sets the fractional seconds to `microsecond`, which must be in the range `0..=999_999`.
+    /// An out-of-range value causes [`Self::build`] to return an error.
     pub fn with_microseconds(mut self, microsecond: u32) -> TimestampBuilder<HasFractionalSeconds> {
-        self.fractional_seconds = Some(Mantissa::Digits(6));
-        self.nanoseconds = Some(microsecond * 1000);
+        self.attoseconds = (microsecond as u64).saturating_mul(1_000_000_000_000);
+        self.fractional_digits = 6;
+
         self.change_state()
     }
 
+    /// Sets the fractional seconds to `millisecond`, which must be in the range `0..=999`.
+    /// An out-of-range value causes [`Self::build`] to return an error.
     pub fn with_milliseconds(mut self, millisecond: u32) -> TimestampBuilder<HasFractionalSeconds> {
-        self.fractional_seconds = Some(Mantissa::Digits(3));
-        self.nanoseconds = Some(millisecond * 1_000_000);
+        self.attoseconds = (millisecond as u64).saturating_mul(1_000_000_000_000_000);
+        self.fractional_digits = 3;
+
         self.change_state()
     }
 
@@ -1213,8 +1208,9 @@ impl TimestampBuilder<HasSeconds> {
         nanoseconds: u32,
         precision_digits: u32,
     ) -> TimestampBuilder<HasFractionalSeconds> {
-        self.fractional_seconds = Some(Mantissa::Digits(precision_digits));
-        self.nanoseconds = Some(nanoseconds);
+        self.attoseconds = (nanoseconds as u64).saturating_mul(1_000_000_000);
+        self.fractional_digits = precision_digits as u8;
+
         self.change_state()
     }
 
@@ -1222,8 +1218,43 @@ impl TimestampBuilder<HasSeconds> {
         mut self,
         fractional_seconds: Decimal,
     ) -> TimestampBuilder<HasFractionalSeconds> {
-        self.fractional_seconds = Some(Mantissa::Arbitrary(fractional_seconds));
-        self.nanoseconds = None;
+        if fractional_seconds.is_less_than_zero()
+            || fractional_seconds.is_greater_than_or_equal_to_one()
+        {
+            // Invalid — store a sentinel that build() will reject.
+            self.fractional_digits = MAX_FRAC_DIGITS + 1;
+            self.attoseconds = 0;
+        } else if fractional_seconds.is_zero() {
+            if fractional_seconds.exponent >= 0 {
+                self.fractional_digits = 0;
+                self.attoseconds = 0;
+            } else {
+                let digits = fractional_seconds
+                    .exponent
+                    .unsigned_abs()
+                    .min(MAX_FRAC_DIGITS as u64) as u8;
+                self.fractional_digits = digits;
+                self.attoseconds = 0;
+            }
+        } else {
+            let digits = fractional_seconds.exponent.unsigned_abs();
+            let coefficient = fractional_seconds
+                .coefficient()
+                .magnitude()
+                .as_u128()
+                .unwrap_or(0) as u64;
+            // Convert coefficient at `digits` scale to attoseconds (10^-18).
+            // attoseconds = coefficient * 10^(18 - digits)
+            self.fractional_digits = digits.min(MAX_FRAC_DIGITS as u64) as u8;
+            if digits <= MAX_FRAC_DIGITS as u64 {
+                self.attoseconds =
+                    coefficient.saturating_mul(10u64.pow(MAX_FRAC_DIGITS as u32 - digits as u32));
+            } else {
+                // Precision exceeds limit — store sentinel for build() to reject.
+                self.fractional_digits = MAX_FRAC_DIGITS + 1;
+                self.attoseconds = 0;
+            }
+        }
         self.change_state()
     }
 
@@ -1240,20 +1271,23 @@ impl TimestampBuilder<HasFractionalSeconds> {
 pub struct HasOffset;
 // No impl for TimestampBuilder<HasOffset> because `build()` is included in TimestampBuilder<T>
 
-fn downconvert_to_naive_datetime_with_nanoseconds(timestamp: &Timestamp) -> NaiveDateTime {
-    if timestamp.precision == TimestampPrecision::Second {
-        // DateTime always uses nanosecond precision. If our Timestamp uses a Decimal for
-        // its fractional seconds, attempt to convert it to a number of nanoseconds.
-        // This operation may add or lose precision, but is necessary to conform with
-        // chrono's expectations.
-        let nanoseconds = timestamp.fractional_seconds_as_nanoseconds().unwrap_or(0);
-        // Copy `self.date_time` and set the copy's nanoseconds to this new value.
-        // Modifying the nanoseconds should never be invalid.
-        timestamp.date_time.with_nanosecond(nanoseconds).unwrap()
-    } else {
-        // NaiveDateTime implements `Copy`
-        timestamp.date_time
-    }
+#[cfg(feature = "experimental-chrono")]
+fn downconvert_to_naive_datetime_with_nanoseconds(
+    timestamp: &Timestamp,
+) -> IonResult<NaiveDateTime> {
+    let dt = NaiveDate::from_ymd_opt(timestamp.year() as i32, timestamp.month(), timestamp.day())
+        .and_then(|d| {
+            d.and_hms_nano_opt(
+                timestamp.hour(),
+                timestamp.minute(),
+                timestamp.second(),
+                timestamp.nanoseconds(),
+            )
+        })
+        .ok_or_else(|| {
+            IonError::illegal_operation("timestamp fields produce invalid NaiveDateTime")
+        })?;
+    Ok(dt)
 }
 
 #[cfg(feature = "experimental-chrono")]
@@ -1293,14 +1327,13 @@ mod timestamp_tests {
     use super::*;
     use crate::ion_data::IonEq;
     use crate::result::IonResult;
-    use crate::types::Mantissa;
     use crate::{Decimal, Int, Timestamp, TimestampPrecision};
-    use chrono::NaiveDateTime;
+    #[cfg(feature = "experimental-chrono")]
+    use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, Timelike};
     use rstest::*;
     use std::cmp::Ordering;
     use std::io::Write;
     use std::ops::Mul;
-    use std::str::FromStr;
 
     #[test]
     fn test_timestamps_with_same_ymd_hms_millis_at_known_offset_are_equal() -> IonResult<()> {
@@ -1322,7 +1355,7 @@ mod timestamp_tests {
             .with_milliseconds(192);
         let timestamp1 = builder.clone().with_offset(5 * 60).build()?;
         let timestamp2 = builder.with_offset(5 * 60).build()?;
-        assert!(timestamp1 == timestamp2);
+        assert_eq!(timestamp1, timestamp2);
         Ok(())
     }
 
@@ -1672,6 +1705,26 @@ mod timestamp_tests {
 
     #[cfg(feature = "experimental-chrono")]
     #[test]
+    fn test_fixed_offset_datetime_to_timestamp_offset_roundtrip() {
+        let offsets_minutes: &[i32] = &[0, 330, -330, 60, -60, 720, -720, 1, -1];
+        for &offset_min in offsets_minutes {
+            let offset = FixedOffset::east_opt(offset_min * 60).unwrap();
+            let dt = NaiveDate::from_ymd_opt(2024, 6, 15)
+                .unwrap()
+                .and_hms_opt(12, 30, 45)
+                .unwrap();
+            let fixed_dt = offset.from_local_datetime(&dt).unwrap();
+            let timestamp: Timestamp = fixed_dt.into();
+            assert_eq!(
+                timestamp.offset(),
+                Some(offset_min),
+                "offset roundtrip failed for {offset_min} minutes"
+            );
+        }
+    }
+
+    #[cfg(feature = "experimental-chrono")]
+    #[test]
     fn test_timestamp_try_into_datetime_fixedoffset_error() -> IonResult<()> {
         let timestamp = TimestampBuilder::with_ymd(2021, 1, 1)
             .with_hms(0, 0, 0)
@@ -1704,8 +1757,8 @@ mod timestamp_tests {
             .build()
             .unwrap_or_else(|e| panic!("Couldn't build timestamp: {e:?}"));
 
-        assert_eq!(timestamp1.precision, TimestampPrecision::Second);
-        assert_eq!(timestamp1.fractional_seconds, Some(Mantissa::Digits(3)));
+        assert_eq!(timestamp1.precision(), TimestampPrecision::Second);
+        assert_eq!(timestamp1.subsecond_digit_count(), 3);
         assert_eq!(timestamp1, timestamp2);
 
         assert!(timestamp1.ion_eq(&timestamp2));
@@ -1728,7 +1781,7 @@ mod timestamp_tests {
             .build()
             .unwrap_or_else(|e| panic!("Couldn't build timestamp: {e:?}"));
 
-        assert_eq!(timestamp1.precision, TimestampPrecision::HourAndMinute);
+        assert_eq!(timestamp1.precision(), TimestampPrecision::HourAndMinute);
         assert_eq!(timestamp1, timestamp2)
     }
 
@@ -1896,22 +1949,38 @@ mod timestamp_tests {
             .build()?;
         assert_eq!(timestamp_3.nanoseconds(), 0);
 
-        // Big fractional coefficient
+        // Big fractional coefficient (>18 digits) is rejected
         let big_coefficient: Int = Int::from(i128::MAX).data.mul(4).into();
-        let timestamp_4 = Timestamp::with_ymd(2023, 1, 1)
+        let result = Timestamp::with_ymd(2023, 1, 1)
             .with_hour_and_minute(0, 0)
             .with_second(0)
             .with_fractional_seconds(Decimal::new(big_coefficient, -39))
-            .build()?;
-        assert_eq!(timestamp_4.nanoseconds(), 680564733);
+            .build();
+        assert!(result.is_err());
 
-        // Exponent delta > 38: result should be 0
-        let timestamp_5 = Timestamp::with_ymd(2023, 1, 1)
+        // Exponent delta > 18 digits: also rejected
+        let result = Timestamp::with_ymd(2023, 1, 1)
             .with_hour_and_minute(0, 0)
             .with_second(0)
             .with_fractional_seconds(Decimal::new(1i64, -50))
+            .build();
+        assert!(result.is_err());
+
+        // 19 fractional digits: rejected (limit is 18)
+        let result = Timestamp::with_ymd(2023, 1, 1)
+            .with_hour_and_minute(0, 0)
+            .with_second(0)
+            .with_fractional_seconds(Decimal::new(1234567890123456789u64, -19))
+            .build();
+        assert!(result.is_err());
+
+        // 18 fractional digits (max allowed) should work
+        let timestamp_4 = Timestamp::with_ymd(2023, 1, 1)
+            .with_hour_and_minute(0, 0)
+            .with_second(0)
+            .with_fractional_seconds(Decimal::new(123456789u64, -9))
             .build()?;
-        assert_eq!(timestamp_5.nanoseconds(), 0);
+        assert_eq!(timestamp_4.nanoseconds(), 123456789);
 
         Ok(())
     }
@@ -1951,6 +2020,37 @@ mod timestamp_tests {
     }
 
     #[test]
+    fn test_timestamp_to_utc_year_boundary() -> IonResult<()> {
+        // UTC conversion that crosses year boundary to year 0 must not panic
+        let ts = TimestampBuilder::with_ymd(1, 1, 1)
+            .with_hour_and_minute(0, 30)
+            .with_offset(60)
+            .build()?;
+        let utc = ts.to_utc();
+        assert_eq!(utc.year(), 0);
+        assert_eq!(utc.month(), 12);
+        assert_eq!(utc.day(), 31);
+        assert_eq!(utc.hour(), 23);
+        assert_eq!(utc.minute(), 30);
+        Ok(())
+    }
+
+    #[test]
+    fn test_timestamp_comparison_year_boundary_no_panic() -> IonResult<()> {
+        // Comparing timestamps where UTC conversion yields year 0 must not panic
+        let ts1 = TimestampBuilder::with_ymd(1, 1, 1)
+            .with_hour_and_minute(0, 30)
+            .with_offset(60)
+            .build()?;
+        let ts2 = TimestampBuilder::with_ymd(1, 1, 1)
+            .with_hour_and_minute(1, 30)
+            .with_offset(60)
+            .build()?;
+        assert!(ts1 < ts2);
+        Ok(())
+    }
+
+    #[test]
     fn test_timestamp_fractional_seconds_scale() -> IonResult<()> {
         // Set fractional seconds as Decimal
         let timestamp_with_micro_seconds = TimestampBuilder::with_ymd(2021, 4, 6)
@@ -1974,7 +2074,7 @@ mod timestamp_tests {
             .with_offset(-5 * 60)
             .build()?;
         assert_eq!(
-            timestamp_with_redundant_fractional_seconds.precision,
+            timestamp_with_redundant_fractional_seconds.precision(),
             TimestampPrecision::Second
         );
         assert_eq!(
@@ -2008,28 +2108,50 @@ mod timestamp_tests {
     }
 
     #[test]
-    fn test_first_n_digits_of() {
-        assert_eq!(0, super::first_n_digits_of(1, 0));
-        assert_eq!(1, super::first_n_digits_of(1, 1));
-        assert_eq!(2, super::first_n_digits_of(1, 2));
+    fn test_timestamp_subsecond_digit_count() -> IonResult<()> {
+        // Set fractional seconds as Decimal
+        let timestamp_with_micro_seconds = TimestampBuilder::with_ymd(2021, 4, 6)
+            .with_hms(10, 15, 0)
+            .with_fractional_seconds(Decimal::new(553u64, -6))
+            .with_offset(-5 * 60)
+            .build()?;
 
-        assert_eq!(0, super::first_n_digits_of(3, 0));
-        assert_eq!(1, super::first_n_digits_of(3, 1));
-        assert_eq!(2, super::first_n_digits_of(3, 2));
-        assert_eq!(99, super::first_n_digits_of(9, 99));
-        assert_eq!(999, super::first_n_digits_of(9, 999));
-        assert_eq!(9999, super::first_n_digits_of(9, 9999));
+        assert_eq!(timestamp_with_micro_seconds.subsecond_digit_count(), 6);
 
-        assert_eq!(0, super::first_n_digits_of(0, 123456789));
-        assert_eq!(1, super::first_n_digits_of(1, 123456789));
-        assert_eq!(12, super::first_n_digits_of(2, 123456789));
-        assert_eq!(123, super::first_n_digits_of(3, 123456789));
-        assert_eq!(1234, super::first_n_digits_of(4, 123456789));
-        assert_eq!(12345, super::first_n_digits_of(5, 123456789));
-        assert_eq!(123456, super::first_n_digits_of(6, 123456789));
-        assert_eq!(1234567, super::first_n_digits_of(7, 123456789));
-        assert_eq!(12345678, super::first_n_digits_of(8, 123456789));
-        assert_eq!(123456789, super::first_n_digits_of(9, 123456789));
+        // Set fractional seconds as Decimal with 0 coefficient and non-negative exponent
+        // "Fractions whose coefficient is zero and exponent is greater than -1 are ignored."
+        let timestamp_with_redundant_fractional_seconds = TimestampBuilder::with_ymd(2021, 4, 6)
+            .with_hms(10, 15, 0)
+            .with_fractional_seconds(Decimal::new(0, 6))
+            .with_offset(-5 * 60)
+            .build()?;
+        assert_eq!(
+            timestamp_with_redundant_fractional_seconds.precision(),
+            TimestampPrecision::Second
+        );
+        assert_eq!(
+            timestamp_with_redundant_fractional_seconds.subsecond_digit_count(),
+            0
+        );
+
+        // Set fractional seconds with milliseconds
+        let timestamp_with_milliseconds = TimestampBuilder::with_ymd(2021, 4, 6)
+            .with_hms(10, 15, 0)
+            .with_milliseconds(449)
+            .with_offset(-5 * 60)
+            .build()?;
+
+        assert_eq!(timestamp_with_milliseconds.subsecond_digit_count(), 3);
+
+        // Set a fractional seconds as Decimal with low precision
+        let timestamp_with_seconds = TimestampBuilder::with_ymd(2021, 4, 6)
+            .with_hms(10, 15, 0)
+            .with_offset(-5 * 60)
+            .build()?;
+
+        // For low precision fractional_seconds_digits should return 0
+        assert_eq!(timestamp_with_seconds.subsecond_digit_count(), 0);
+        Ok(())
     }
 
     #[rstest]
@@ -2054,39 +2176,40 @@ mod timestamp_tests {
     }
 
     #[test]
-    fn ion_eq_fraction_seconds_mixed_mantissa() {
-        let t1 = Timestamp {
-            date_time: NaiveDateTime::from_str("1857-05-29T19:25:59.100").unwrap(),
-            offset: Some(offset_east(60 * 60 * 23 + 60 * 59)),
-            precision: TimestampPrecision::Second,
-            fractional_seconds: Some(Mantissa::Digits(1)),
-        };
-        let t2 = Timestamp {
-            date_time: NaiveDateTime::from_str("1857-05-29T19:25:59").unwrap(),
-            offset: Some(offset_east(60 * 60 * 23 + 60 * 59)),
-            precision: TimestampPrecision::Second,
-            fractional_seconds: Some(Mantissa::Arbitrary(Decimal::new(1u64, -1))),
-        };
-        assert_eq!(t1, t2);
-        assert!(t1.ion_eq(&t2));
+    fn ion_eq_same_instant_different_offset_not_ion_eq() {
+        // Same instant, different offsets → PartialEq but NOT ion_eq
+        let t1 = TimestampBuilder::with_ymd(2024, 1, 1)
+            .with_hms(12, 0, 0)
+            .with_offset(0)
+            .build()
+            .unwrap();
+        let t2 = TimestampBuilder::with_ymd(2024, 1, 1)
+            .with_hms(13, 0, 0)
+            .with_offset(60)
+            .build()
+            .unwrap();
+        assert_eq!(t1, t2); // same instant
+        assert!(!t1.ion_eq(&t2)); // different local representations
     }
 
     #[test]
-    fn ion_eq_fraction_seconds_mixed_mantissa_2() {
-        let t1 = Timestamp {
-            date_time: NaiveDateTime::from_str("2001-08-01T18:18:49.006").unwrap(),
-            offset: Some(offset_east(60 * 60 + 60)),
-            precision: TimestampPrecision::Second,
-            fractional_seconds: Some(Mantissa::Digits(5)),
-        };
-        let t2 = Timestamp {
-            date_time: NaiveDateTime::from_str("2001-08-01T18:18:49").unwrap(),
-            offset: Some(offset_east(60 * 60 + 60)),
-            precision: TimestampPrecision::Second,
-            fractional_seconds: Some(Mantissa::Arbitrary(Decimal::new(600u64, -5))),
-        };
-        assert_eq!(t1, t2);
-        assert!(t1.ion_eq(&t2));
+    fn ion_eq_different_fractional_precision_not_ion_eq() {
+        // Same value but different precision → NOT ion_eq
+        // 2024-01-01T00:00:00.100+00:00 vs 2024-01-01T00:00:00.1+00:00
+        let t1 = TimestampBuilder::with_ymd(2024, 1, 1)
+            .with_hms(0, 0, 0)
+            .with_milliseconds(100)
+            .with_offset(0)
+            .build()
+            .unwrap();
+        let t2 = TimestampBuilder::with_ymd(2024, 1, 1)
+            .with_hms(0, 0, 0)
+            .with_fractional_seconds(Decimal::new(1u64, -1))
+            .with_offset(0)
+            .build()
+            .unwrap();
+        assert_eq!(t1, t2); // same instant
+        assert!(!t1.ion_eq(&t2)); // different precision (3 digits vs 1 digit)
     }
 
     #[rstest]
@@ -2105,5 +2228,294 @@ mod timestamp_tests {
         let mut buf = Vec::new();
         write!(&mut buf, "{ts}").unwrap();
         assert_eq!(expect, String::from_utf8(buf).unwrap());
+    }
+
+    /// Fields that do not fit the packed representation must be reported as an error rather than
+    /// being silently narrowed. Several of these values would wrap into an in-range value if
+    /// cast without validation (e.g. month 268 truncates to 12, offset 65536 to 0), producing a
+    /// `Timestamp` that differs from what the caller asked for.
+    #[rstest]
+    #[case::year_too_large(TimestampBuilder::with_year(10_000).build())]
+    #[case::year_wraps_to_in_range(TimestampBuilder::with_year(65536 + 2021).build())]
+    #[case::month_too_large(TimestampBuilder::with_year(2021).with_month(13).build())]
+    #[case::month_wraps_to_in_range(TimestampBuilder::with_year(2021).with_month(268).build())]
+    #[case::day_too_large(TimestampBuilder::with_ymd(2021, 1, 32).build())]
+    #[case::day_wraps_to_in_range(TimestampBuilder::with_ymd(2021, 1, 256 + 5).build())]
+    #[case::hour_too_large(TimestampBuilder::with_ymd(2021, 1, 1).with_hour_and_minute(24, 0).build())]
+    #[case::hour_wraps_to_in_range(TimestampBuilder::with_ymd(2021, 1, 1).with_hour_and_minute(256 + 5, 0).build())]
+    #[case::minute_too_large(TimestampBuilder::with_ymd(2021, 1, 1).with_hour_and_minute(0, 60).build())]
+    #[case::minute_wraps_to_in_range(TimestampBuilder::with_ymd(2021, 1, 1).with_hour_and_minute(0, 256 + 5).build())]
+    #[case::second_too_large(TimestampBuilder::with_ymd(2021, 1, 1).with_hms(0, 0, 60).build())]
+    #[case::second_wraps_to_in_range(TimestampBuilder::with_ymd(2021, 1, 1).with_hms(0, 0, 256 + 5).build())]
+    #[case::offset_too_large(TimestampBuilder::with_ymd(2021, 1, 1).with_hms(0, 0, 0).with_offset(1440).build())]
+    #[case::offset_too_small(TimestampBuilder::with_ymd(2021, 1, 1).with_hms(0, 0, 0).with_offset(-1440).build())]
+    #[case::offset_wraps_to_in_range(TimestampBuilder::with_ymd(2021, 1, 1).with_hms(0, 0, 0).with_offset(65536).build())]
+    #[case::millis_too_large(TimestampBuilder::with_ymd(2021, 1, 1).with_hms(0, 0, 0).with_milliseconds(1000).build())]
+    #[case::micros_too_large(TimestampBuilder::with_ymd(2021, 1, 1).with_hms(0, 0, 0).with_microseconds(1_000_000).build())]
+    #[case::nanos_too_large(TimestampBuilder::with_ymd(2021, 1, 1).with_hms(0, 0, 0).with_nanoseconds(1_000_000_000).build())]
+    // `digits - 9` would be a 21-digit multiplier, overflowing before `from_fields` sees it.
+    #[case::frac_precision_too_large(TimestampBuilder::with_ymd(2021, 1, 1).with_hms(0, 0, 0).with_nanoseconds_and_precision(1, 30).build())]
+    fn test_out_of_range_fields_are_rejected(#[case] result: IonResult<Timestamp>) {
+        assert!(
+            result.is_err(),
+            "expected an out-of-range field to be rejected, but built {:?}",
+            result.ok()
+        );
+    }
+
+    /// The largest in-range value for each field must still build, confirming the range checks
+    /// above are not off by one.
+    #[rstest]
+    #[case::max_year(TimestampBuilder::with_year(9999).build(), "9999T")]
+    #[case::max_month(TimestampBuilder::with_year(2021).with_month(12).build(), "2021-12T")]
+    #[case::max_day(TimestampBuilder::with_ymd(2021, 1, 31).build(), "2021-01-31T")]
+    #[case::max_hour_and_minute(TimestampBuilder::with_ymd(2021, 1, 1).with_hour_and_minute(23, 59).build(), "2021-01-01T23:59-00:00")]
+    #[case::max_second(TimestampBuilder::with_ymd(2021, 1, 1).with_hms(23, 59, 59).build(), "2021-01-01T23:59:59-00:00")]
+    #[case::max_offset(TimestampBuilder::with_ymd(2021, 1, 1).with_hms(0, 0, 0).with_offset(1439).build(), "2021-01-01T00:00:00+23:59")]
+    #[case::min_offset(TimestampBuilder::with_ymd(2021, 1, 2).with_hms(0, 0, 0).with_offset(-1439).build(), "2021-01-02T00:00:00-23:59")]
+    #[case::max_millis(TimestampBuilder::with_ymd(2021, 1, 1).with_hms(0, 0, 0).with_milliseconds(999).build(), "2021-01-01T00:00:00.999-00:00")]
+    #[case::max_micros(TimestampBuilder::with_ymd(2021, 1, 1).with_hms(0, 0, 0).with_microseconds(999_999).build(), "2021-01-01T00:00:00.999999-00:00")]
+    #[case::max_nanos(TimestampBuilder::with_ymd(2021, 1, 1).with_hms(0, 0, 0).with_nanoseconds(999_999_999).build(), "2021-01-01T00:00:00.999999999-00:00")]
+    fn test_max_in_range_fields_are_accepted(
+        #[case] result: IonResult<Timestamp>,
+        #[case] expected: &str,
+    ) -> IonResult<()> {
+        assert_eq!(expected, result?.to_string());
+        Ok(())
+    }
+
+    // --- Day rollover in Ord ---
+
+    #[test]
+    fn cmp_day_rollover_forward() -> IonResult<()> {
+        // 2024-01-01T23:00+00:00 vs 2024-01-01T01:00-23:00
+        // Second timestamp's local time is 01:00, but offset is -23:00
+        // so UTC = 01:00 + 23:00 = 2024-01-02T00:00 UTC
+        // First is 2024-01-01T23:00 UTC
+        // Second > First
+        let t1 = TimestampBuilder::with_ymd(2024, 1, 1)
+            .with_hms(23, 0, 0)
+            .with_offset(0)
+            .build()?;
+        let t2 = TimestampBuilder::with_ymd(2024, 1, 1)
+            .with_hms(1, 0, 0)
+            .with_offset(-23 * 60)
+            .build()?;
+        assert_eq!(t1.cmp(&t2), Ordering::Less);
+        Ok(())
+    }
+
+    #[test]
+    fn cmp_day_rollover_backward() -> IonResult<()> {
+        // 2024-01-02T01:00+00:00 vs 2024-01-02T23:00+23:00
+        // Second: local 23:00, offset +23:00, UTC = 23:00 - 23:00 = 00:00 on same day
+        // = 2024-01-02T00:00 UTC
+        // First: 2024-01-02T01:00 UTC
+        // First > Second
+        let t1 = TimestampBuilder::with_ymd(2024, 1, 2)
+            .with_hms(1, 0, 0)
+            .with_offset(0)
+            .build()?;
+        let t2 = TimestampBuilder::with_ymd(2024, 1, 2)
+            .with_hms(23, 0, 0)
+            .with_offset(23 * 60)
+            .build()?;
+        assert_eq!(t1.cmp(&t2), Ordering::Greater);
+        Ok(())
+    }
+
+    #[test]
+    fn cmp_day_rollover_equal() -> IonResult<()> {
+        // Same instant across a day boundary via offset
+        let t1 = TimestampBuilder::with_ymd(2024, 3, 1)
+            .with_hms(0, 30, 0)
+            .with_offset(0)
+            .build()?;
+        let t2 = TimestampBuilder::with_ymd(2024, 2, 29)
+            .with_hms(23, 30, 0)
+            .with_offset(-60)
+            .build()?;
+        assert_eq!(t1.cmp(&t2), Ordering::Equal);
+        assert_eq!(t1, t2);
+        Ok(())
+    }
+
+    // --- Debug impl ---
+
+    #[test]
+    fn debug_impl() -> IonResult<()> {
+        let ts = TimestampBuilder::with_ymd(2024, 8, 12)
+            .with_hms(14, 30, 45)
+            .with_offset(0)
+            .build()?;
+        let debug = format!("{:?}", ts);
+        assert_eq!(debug, "Timestamp(2024-08-12T14:30:45+00:00)");
+        Ok(())
+    }
+
+    // --- with_month0 and with_day0 ---
+
+    #[test]
+    fn with_month0_zero_indexed() -> IonResult<()> {
+        // month0(0) = January, month0(11) = December
+        let jan = TimestampBuilder::with_year(2024).with_month0(0).build()?;
+        assert_eq!(jan.month(), 1);
+        let dec = TimestampBuilder::with_year(2024).with_month0(11).build()?;
+        assert_eq!(dec.month(), 12);
+        Ok(())
+    }
+
+    #[test]
+    fn with_day0_zero_indexed() -> IonResult<()> {
+        // day0(0) = day 1, day0(30) = day 31
+        let d1 = TimestampBuilder::with_year(2024)
+            .with_month(1)
+            .with_day0(0)
+            .build()?;
+        assert_eq!(d1.day(), 1);
+        let d31 = TimestampBuilder::with_year(2024)
+            .with_month(1)
+            .with_day0(30)
+            .build()?;
+        assert_eq!(d31.day(), 31);
+        Ok(())
+    }
+
+    // --- Boundary validation ---
+
+    #[test]
+    fn invalid_year_zero() {
+        assert!(TimestampBuilder::with_year(0).build().is_err());
+    }
+
+    #[test]
+    fn invalid_year_too_large() {
+        assert!(TimestampBuilder::with_year(10000).build().is_err());
+    }
+
+    #[test]
+    fn valid_year_boundaries() -> IonResult<()> {
+        let y1 = TimestampBuilder::with_year(1).build()?;
+        assert_eq!(y1.year(), 1);
+        let y9999 = TimestampBuilder::with_year(9999).build()?;
+        assert_eq!(y9999.year(), 9999);
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_month_zero() {
+        assert!(TimestampBuilder::with_year(2024)
+            .with_month(0)
+            .build()
+            .is_err());
+    }
+
+    #[test]
+    fn invalid_month_13() {
+        assert!(TimestampBuilder::with_year(2024)
+            .with_month(13)
+            .build()
+            .is_err());
+    }
+
+    #[test]
+    fn valid_month_boundaries() -> IonResult<()> {
+        let m1 = TimestampBuilder::with_year(2024).with_month(1).build()?;
+        assert_eq!(m1.month(), 1);
+        let m12 = TimestampBuilder::with_year(2024).with_month(12).build()?;
+        assert_eq!(m12.month(), 12);
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_day_zero() {
+        assert!(TimestampBuilder::with_ymd(2024, 1, 0).build().is_err());
+    }
+
+    #[test]
+    fn invalid_day_32() {
+        assert!(TimestampBuilder::with_ymd(2024, 1, 32).build().is_err());
+    }
+
+    #[test]
+    fn invalid_day_feb_29_non_leap() {
+        assert!(TimestampBuilder::with_ymd(2023, 2, 29).build().is_err());
+    }
+
+    #[test]
+    fn valid_day_feb_29_leap() -> IonResult<()> {
+        let ts = TimestampBuilder::with_ymd(2024, 2, 29).build()?;
+        assert_eq!(ts.day(), 29);
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_offset_too_negative() {
+        assert!(TimestampBuilder::with_ymd(2024, 1, 1)
+            .with_hms(0, 0, 0)
+            .with_offset(-1440)
+            .build()
+            .is_err());
+    }
+
+    #[test]
+    fn invalid_offset_too_positive() {
+        assert!(TimestampBuilder::with_ymd(2024, 1, 1)
+            .with_hms(0, 0, 0)
+            .with_offset(1440)
+            .build()
+            .is_err());
+    }
+
+    #[test]
+    fn valid_offset_boundaries() -> IonResult<()> {
+        let min = TimestampBuilder::with_ymd(2024, 1, 1)
+            .with_hms(0, 0, 0)
+            .with_offset(-1439)
+            .build()?;
+        assert_eq!(min.offset(), Some(-1439));
+        let max = TimestampBuilder::with_ymd(2024, 1, 1)
+            .with_hms(0, 0, 0)
+            .with_offset(1439)
+            .build()?;
+        assert_eq!(max.offset(), Some(1439));
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_nanoseconds_too_large() {
+        assert!(TimestampBuilder::with_ymd(2024, 1, 1)
+            .with_hms(0, 0, 0)
+            .with_nanoseconds(1_000_000_000)
+            .build()
+            .is_err());
+    }
+
+    #[test]
+    fn invalid_microseconds_too_large() {
+        assert!(TimestampBuilder::with_ymd(2024, 1, 1)
+            .with_hms(0, 0, 0)
+            .with_microseconds(1_000_000)
+            .build()
+            .is_err());
+    }
+
+    #[test]
+    fn invalid_milliseconds_too_large() {
+        assert!(TimestampBuilder::with_ymd(2024, 1, 1)
+            .with_hms(0, 0, 0)
+            .with_milliseconds(1000)
+            .build()
+            .is_err());
+    }
+
+    #[test]
+    fn valid_max_fractional_seconds() -> IonResult<()> {
+        let ts = TimestampBuilder::with_ymd(2024, 1, 1)
+            .with_hms(0, 0, 0)
+            .with_nanoseconds(999_999_999)
+            .build()?;
+        assert_eq!(ts.nanoseconds(), 999_999_999);
+        Ok(())
     }
 }

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -2401,7 +2401,7 @@ mod chrono_interop {
     use super::{
         Timestamp, TimestampPrecision, DAY_MASK, DAY_SHIFT, HOUR_MASK, HOUR_SHIFT, MINUTE_MASK,
         MINUTE_SHIFT, MONTH_MASK, MONTH_SHIFT, OFFSET_BIAS, OFFSET_MASK, OFFSET_SHIFT,
-        PRECISION_MASK, PRECISION_SHIFT, YEAR_MASK, YEAR_SHIFT,
+        OFFSET_UNKNOWN_SENTINEL, PRECISION_MASK, PRECISION_SHIFT, YEAR_MASK, YEAR_SHIFT,
     };
     use crate::result::{IonFailure, IonResult};
     use crate::IonError;
@@ -2466,19 +2466,26 @@ mod chrono_interop {
 
         fn from_naive_datetime(date_time: NaiveDateTime) -> Self {
             let attoseconds = (date_time.nanosecond() as u64) * 1_000_000_000;
-            Self::from_fields(
+            // Pack directly from the fields, bypassing `from_fields` validation. chrono permits
+            // years outside Ion's 1..=9999 range (e.g. year 0), which `from_fields` would reject;
+            // we accept them silently here so this conversion behaves consistently with
+            // `from_fixed_offset_datetime`. Making both conversions fallible is tracked in #1035.
+            // A `NaiveDateTime` has no offset, so the offset is stored as "unknown".
+            let packed = Self::pack_masked(
                 TimestampPrecision::Second,
-                None,
                 date_time.year() as u16,
                 date_time.month() as u8,
                 date_time.day() as u8,
                 date_time.hour() as u8,
                 date_time.minute() as u8,
                 date_time.second() as u8,
+                OFFSET_UNKNOWN_SENTINEL,
                 9,
+            );
+            Timestamp {
+                packed_fields: packed,
                 attoseconds,
-            )
-            .expect("chrono NaiveDateTime fields are always valid")
+            }
         }
 
         fn from_fixed_offset_datetime(fixed_offset_date_time: DateTime<FixedOffset>) -> Self {
@@ -2587,6 +2594,30 @@ mod chrono_interop {
         fn offset_east(seconds_east: i32) -> FixedOffset {
             FixedOffset::east_opt(seconds_east)
                 .expect("seconds_east was outside the supported range")
+        }
+
+        /// chrono permits years outside Ion's `1..=9999` range. Both `From` conversions accept
+        /// such values silently (masking the year to the packed field) rather than one panicking
+        /// and the other masking. This documents that agreed-upon behavior; making the conversions
+        /// fallible is tracked in #1035.
+        #[test]
+        fn out_of_range_year_is_accepted_consistently_by_both_conversions() {
+            // `From<NaiveDateTime>`: year 0 must not panic.
+            let naive_year_zero = NaiveDate::from_ymd_opt(0, 1, 1)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap();
+            let from_naive = Timestamp::from(naive_year_zero);
+
+            // `From<DateTime<FixedOffset>>`: year 0 at UTC.
+            let fixed_year_zero = offset_east(0)
+                .from_local_datetime(&naive_year_zero)
+                .unwrap();
+            let from_fixed = Timestamp::from(fixed_year_zero);
+
+            // Neither errored or panicked, and both masked year 0 into the 14-bit field the same
+            // way, so the two conversions agree.
+            assert_eq!(from_naive.year(), from_fixed.year());
         }
 
         #[test]

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -37,66 +37,6 @@ fn offset_east(seconds_east: i32) -> FixedOffset {
     FixedOffset::east_opt(seconds_east).expect("seconds_east was outside the supported range")
 }
 
-// ─── Packed bit layout ────────────────────────────────────────────────
-//
-// All date-time fields are stored as LOCAL time in a single u64.
-// A second u64 holds the attoseconds payload.
-//
-// Date-time fields are in the HIGH bits (most-significant first) so that
-// a numeric comparison of the packed value yields chronological order.
-// Metadata (offset, precision, subsecond_digits) is in the LOW bits.
-//
-// Bit layout of `packed` (MSB = bit 63):
-//
-//   [63:50] year                (14 bits, 0-9999)
-//   [49:46] month               (4 bits, 1-12)
-//   [45:41] day                 (5 bits, 1-31)
-//   [40:36] hour                (5 bits, 0-23)
-//   [35:30] minute              (6 bits, 0-59)
-//   [29:24] second              (6 bits, 0-59)
-//   [23:21] precision           (3 bits, 0-4 maps to TimestampPrecision)
-//   [20:16] subsecond_precision (5 bits, 0 = none, 1-18 = digit count)
-//   [15:4]  offset              (12 bits, biased unsigned: stored = minutes + 1440;
-//                                valid range 1..=2879; 0 = unknown)
-//   [3:0]   spare               (4 bits)
-//
-// `attoseconds`: fractional seconds normalized to 10^-18 scale.
-// `subsecond_precision` records display precision (how many digits to render).
-//
-// Invariants:
-//
-// 1. Fields below the declared precision hold their default values:
-//    - Year:          month=1, day=1, hour=0, minute=0, second=0
-//    - Month:         day=1, hour=0, minute=0, second=0
-//    - Day:           hour=0, minute=0, second=0
-//    - HourAndMinute: second=0
-//    - Second:        (no fields required to be zero)
-//
-// 2. When precision < Second: attoseconds == 0 and subsecond_precision == 0.
-//
-// 3. When precision == Second and subsecond_precision == 0: attoseconds == 0.
-//    (No fractional part means the attoseconds payload is unused.)
-//
-// 4. attoseconds < 10^18 (strictly less than one full second).
-//
-// 5. attoseconds is consistent with subsecond_precision: the value must be
-//    representable in `subsecond_precision` decimal digits. Formally,
-//    attoseconds % 10^(18 - subsecond_precision) == 0.
-//    Example: subsecond_precision=3 (millis) → attoseconds is a multiple
-//    of 10^15.
-//
-// 6. offset == 0 (unknown) is valid at any precision. When precision <
-//    HourAndMinute, the offset field MUST be 0 (unknown) because sub-day
-//    precision timestamps cannot meaningfully carry a UTC offset.
-//
-// 7. year is in 1..=9999 for user-constructed timestamps. Internally,
-//    `to_utc` can produce year 0 (e.g., 0001-01-01T00:30+01:00 → year 0 UTC)
-//    and `from_fixed_offset_datetime` can produce year 10000 (e.g., UTC
-//    9999-12-31T23:30Z with offset -01:00 → local 10000-01-01). These values
-//    fit in the 14-bit field but must not escape through public constructors.
-//
-// 8. spare bits [3:0] are always 0.
-
 const YEAR_BITS: u64 = 14;
 const MONTH_BITS: u64 = 4;
 const DAY_BITS: u64 = 5;
@@ -106,12 +46,12 @@ const SECOND_BITS: u64 = 6;
 const OFFSET_BITS: u64 = 12;
 const PRECISION_BITS: u64 = 3;
 const SUBSECOND_PRECISION_BITS: u64 = 5;
-const SPARE_BITS: u64 = 4;
+const RESERVED_BITS: u64 = 4;
 
 // Shifts: metadata at bottom, date-time at top.
 // Within metadata: precision > subsecond_digits > offset (tiebreak order for IonDataOrd).
-const SPARE_SHIFT: u64 = 0;
-const OFFSET_SHIFT: u64 = SPARE_SHIFT + SPARE_BITS; // 4
+const RESERVED_SHIFT: u64 = 0;
+const OFFSET_SHIFT: u64 = RESERVED_SHIFT + RESERVED_BITS; // 4
 const SUBSECOND_PRECISION_SHIFT: u64 = OFFSET_SHIFT + OFFSET_BITS; // 16
 const PRECISION_SHIFT: u64 = SUBSECOND_PRECISION_SHIFT + SUBSECOND_PRECISION_BITS; // 21
 const SECOND_SHIFT: u64 = PRECISION_SHIFT + PRECISION_BITS; // 24
@@ -140,15 +80,38 @@ const DATETIME_MASK: u64 = (YEAR_MASK << YEAR_SHIFT)
     | (MINUTE_MASK << MINUTE_SHIFT)
     | (SECOND_MASK << SECOND_SHIFT);
 
-/// Bias added to offset-in-minutes before storage. With this bias the valid
-/// range (-1439..=+1439) maps to 1..=2879, leaving 0 free as the "unknown" sentinel.
+// Compile-time guards on the bit layout. These enforce the invariants the
+// packing (and the `Ord`/`PartialEq`/`ion_cmp` integer comparisons) rely on, so
+// a future edit to the shifts, widths, or field order fails the build rather
+// than silently corrupting comparisons.
+const _: () = assert!(YEAR_SHIFT + YEAR_BITS == 64, "fields must fill the word");
+// The date-time region must be contiguous and top-aligned; `Ord` compares it as an integer.
+const _: () = assert!(DATETIME_MASK.leading_zeros() == 0);
+const _: () = assert!(DATETIME_MASK.trailing_zeros() == SECOND_SHIFT as u32);
+const _: () = assert!(DATETIME_MASK.count_ones() == 64 - SECOND_SHIFT as u32);
+
+/// Offset-in-minutes is stored biased so the field's zero value can serve as the
+/// "unknown offset" sentinel:
+///
+/// ```text
+/// stored  = minutes + OFFSET_BIAS   // -1439..=1439  ->  1..=2879
+/// minutes = stored  - OFFSET_BIAS
+/// ```
+///
+/// Note that `+00:00` stores as 1440, distinct from _unknown_.
 const OFFSET_BIAS: i16 = 1440;
+
+/// Stored `offset` value meaning "no offset specified" (Ion's `-00:00`).
 const OFFSET_UNKNOWN_SENTINEL: u16 = 0;
 
 // 18 digits = attosecond precision. Exceeds any system clock or commercial
 // atomic clock. Chosen over 19 to align with SI prefixes (multiples of 3)
 // and to leave one bit free in the u64 coefficient for future niche use.
 const MAX_FRAC_DIGITS: u8 = 18;
+const _: () = assert!(
+    10u128.pow(MAX_FRAC_DIGITS as u32) <= u64::MAX as u128,
+    "attoseconds scale must fit in the u64 payload"
+);
 
 /// The largest year the packed `year` field can represent.
 const MAX_YEAR: u16 = 9999;
@@ -236,6 +199,86 @@ fn add_offset_to_utc(
 /// NOTE: In an intentional divergence from the Ion Specification (which allows unlimited precision),
 /// this implementation is limited to attoseconds precision and will produce an error when
 /// attempting to read any value with more than attosecond precision.
+//
+// `Timestamp` is two 64-bit words. The time *value* needs 100 bits: 40 for the
+// date-time fields (year..second) and 60 for the fraction (10^18 - 1 < 2^60),
+// which is more than one word holds. It is intentional that the date-time
+// component and the fraction each get their own word: the date-time occupies the
+// top of `packed_fields`, and the fraction gets `attoseconds` to itself.
+//
+// The 24 bits left over in `packed_fields` hold the metadata, which is why
+// precision, subsecond_precision, and offset sit *between* `second` and the
+// fraction in significance order. Two consequences for future changes:
+//
+// - year..second must stay in the top bits, in descending significance, with no
+//   metadata interleaved: `Ord` and `PartialEq` compare `packed & DATETIME_MASK`
+//   as a single integer.
+// - `ion_cmp` compares `packed_fields` and then `attoseconds` as raw integers, so
+//   this layout *is* the `IonDataOrd` total order — date-time, precision,
+//   subsecond_precision, offset, fraction. Permuting the metadata fields changes
+//   how `IonData`-wrapped timestamps sort. (`IonDataOrd` makes no promise that
+//   this ordering stays consistent between releases, so the layout is free to
+//   change.)
+//
+// ─── Packed bit layout ────────────────────────────────────────────────
+//
+// All date-time fields are stored as LOCAL time in a single u64.
+// A second u64 holds the attoseconds payload.
+//
+// Date-time fields are in the HIGH bits (most-significant first) so that
+// a numeric comparison of the packed value yields chronological order.
+// Metadata (offset, precision, subsecond_digits) is in the LOW bits.
+//
+// Bit layout of `packed` (MSB = bit 63):
+//
+//   [63:50] year                (14 bits, 0-9999)
+//   [49:46] month               (4 bits, 1-12)
+//   [45:41] day                 (5 bits, 1-31)
+//   [40:36] hour                (5 bits, 0-23)
+//   [35:30] minute              (6 bits, 0-59)
+//   [29:24] second              (6 bits, 0-59)
+//   [23:21] precision           (3 bits, 0-4 maps to TimestampPrecision)
+//   [20:16] subsecond_precision (5 bits, 0 = none, 1-18 = digit count)
+//   [15:4]  offset              (12 bits, biased unsigned: stored = minutes + 1440;
+//                                valid range 1..=2879; 0 = unknown)
+//   [3:0]   reserved            (4 bits)
+//
+// `attoseconds`: fractional seconds normalized to 10^-18 scale.
+// `subsecond_precision` records display precision (how many digits to render).
+//
+// Invariants:
+//
+// 1. Fields below the declared precision hold their default values:
+//    - Year:          month=1, day=1, hour=0, minute=0, second=0
+//    - Month:         day=1, hour=0, minute=0, second=0
+//    - Day:           hour=0, minute=0, second=0
+//    - HourAndMinute: second=0
+//    - Second:        (no fields required to be zero)
+//
+// 2. When precision < Second: attoseconds == 0 and subsecond_precision == 0.
+//
+// 3. When precision == Second and subsecond_precision == 0: attoseconds == 0.
+//    (No fractional part means the attoseconds payload is unused.)
+//
+// 4. attoseconds < 10^18 (strictly less than one full second).
+//
+// 5. attoseconds is consistent with subsecond_precision: the value must be
+//    representable in `subsecond_precision` decimal digits. Formally,
+//    attoseconds % 10^(18 - subsecond_precision) == 0.
+//    Example: subsecond_precision=3 (millis) → attoseconds is a multiple
+//    of 10^15.
+//
+// 6. offset == 0 (unknown) is valid at any precision. When precision <
+//    HourAndMinute, the offset field MUST be 0 (unknown) because sub-day
+//    precision timestamps cannot meaningfully carry a UTC offset.
+//
+// 7. year is in 1..=9999 for user-constructed timestamps. Internally,
+//    `to_utc` can produce year 0 (e.g., 0001-01-01T00:30+01:00 → year 0 UTC)
+//    and `from_fixed_offset_datetime` can produce year 10000 (e.g., UTC
+//    9999-12-31T23:30Z with offset -01:00 → local 10000-01-01). These values
+//    fit in the 14-bit field but must not escape through public constructors.
+//
+// 8. reserved bits [3:0] are always 0.
 #[derive(Clone)]
 pub struct Timestamp {
     packed_fields: u64,

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -7,22 +7,33 @@ use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 
 /// Indicates the most precise time unit that has been specified in the accompanying [Timestamp].
-// IMPL NOTE: Discriminant values are cast to u64 and stored in the packed bit layout.
-// They must remain stable. They are not exposed in the public API.
+// IMPL NOTE: Discriminant values are cast to u64 and stored in the packed bit layout, so they must
+// remain stable. The discriminants are left implicit (rather than written as `= 0`, `= 1`, ...) so
+// they do not appear in the public API; the `const _` block below asserts the expected values, so
+// reordering the variants fails the build instead of silently changing the packed encoding.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Default, Hash)]
 pub enum TimestampPrecision {
     /// Year-level precision (e.g. `2020T`)
     #[default]
-    Year = 0,
+    Year,
     /// Month-level precision (e.g. `2020-08T`)
-    Month = 1,
+    Month,
     /// Day-level precision (e.g. `2020-08-01T`)
-    Day = 2,
+    Day,
     /// Minute-level precision (e.g. `2020-08-01T12:34Z`)
-    HourAndMinute = 3,
+    HourAndMinute,
     /// Second-level precision or greater. (e.g. `2020-08-01T12:34:56Z` or `2020-08-01T12:34:56.123456789Z`)
-    Second = 4,
+    Second,
 }
+
+// The packed layout depends on these exact discriminant values; guard them at compile time.
+const _: () = {
+    assert!(TimestampPrecision::Year as u64 == 0);
+    assert!(TimestampPrecision::Month as u64 == 1);
+    assert!(TimestampPrecision::Day as u64 == 2);
+    assert!(TimestampPrecision::HourAndMinute as u64 == 3);
+    assert!(TimestampPrecision::Second as u64 == 4);
+};
 
 const YEAR_BITS: u64 = 14;
 const MONTH_BITS: u64 = 4;

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -1,10 +1,6 @@
 use crate::ion_data::{IonDataHash, IonDataOrd, IonEq};
 use crate::result::{IonFailure, IonResult};
 use crate::types::Decimal;
-#[cfg(feature = "experimental-chrono")]
-use crate::IonError;
-#[cfg(feature = "experimental-chrono")]
-use chrono::{DateTime, Datelike, FixedOffset, NaiveDate, NaiveDateTime, TimeZone, Timelike};
 use std::cmp::Ordering;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
@@ -26,15 +22,6 @@ pub enum TimestampPrecision {
     HourAndMinute = 3,
     /// Second-level precision or greater. (e.g. `2020-08-01T12:34:56Z` or `2020-08-01T12:34:56.123456789Z`)
     Second = 4,
-}
-
-/// Constructs a [`FixedOffset`] at the specified offset seconds from UTC. If the specified offset
-/// is out of bounds, this method will panic.
-// Only the tests below construct a `FixedOffset` this way; production conversions go through
-// `try_to_datetime_fixed_offset`, which reports an out-of-range offset as an `IonError`.
-#[cfg(all(test, feature = "experimental-chrono"))]
-fn offset_east(seconds_east: i32) -> FixedOffset {
-    FixedOffset::east_opt(seconds_east).expect("seconds_east was outside the supported range")
 }
 
 const YEAR_BITS: u64 = 14;
@@ -193,8 +180,8 @@ fn add_offset_to_utc(
     (y as u16, mo as u8, d as u8, h, m)
 }
 
-/// Represents a point in time to a specified degree of precision. Unlike `chrono`'s [NaiveDateTime]
-/// and [DateTime], a `Timestamp` has variable precision ranging from a year to attoseconds.
+/// Represents a point in time to a specified degree of precision. Unlike `chrono`'s `NaiveDateTime`
+/// and `DateTime`, a `Timestamp` has variable precision ranging from a year to attoseconds.
 ///
 /// NOTE: In an intentional divergence from the Ion Specification (which allows unlimited precision),
 /// this implementation is limited to attoseconds precision and will produce an error when
@@ -417,131 +404,6 @@ impl Timestamp {
             frac_digits,
             attoseconds,
         )
-    }
-
-    /// Converts a [`NaiveDateTime`] or [`DateTime<FixedOffset>`] to a Timestamp with the specified
-    /// precision. If the precision is [`TimestampPrecision::Second`], nanosecond precision (the maximum
-    /// supported by a [`Timelike`]) is assumed.
-    #[cfg(feature = "experimental-chrono")]
-    pub fn from_datetime<D>(datetime: D, precision: TimestampPrecision) -> Timestamp
-    where
-        D: Datelike + Timelike + Into<Timestamp>,
-    {
-        let mut timestamp: Timestamp = datetime.into();
-
-        // Zero fields below the requested precision to uphold invariants 1, 2, and 6.
-        match precision {
-            TimestampPrecision::Year => {
-                timestamp.packed_fields &= YEAR_MASK << YEAR_SHIFT;
-                // Restore month=1, day=1 (the default "unset" values)
-                timestamp.packed_fields |= 1 << MONTH_SHIFT | 1 << DAY_SHIFT;
-                timestamp.attoseconds = 0;
-            }
-            TimestampPrecision::Month => {
-                timestamp.packed_fields &= (YEAR_MASK << YEAR_SHIFT) | (MONTH_MASK << MONTH_SHIFT);
-                // Restore day=1
-                timestamp.packed_fields |= 1 << DAY_SHIFT;
-                timestamp.attoseconds = 0;
-            }
-            TimestampPrecision::Day => {
-                timestamp.packed_fields &= (YEAR_MASK << YEAR_SHIFT)
-                    | (MONTH_MASK << MONTH_SHIFT)
-                    | (DAY_MASK << DAY_SHIFT);
-                timestamp.attoseconds = 0;
-            }
-            TimestampPrecision::HourAndMinute => {
-                timestamp.packed_fields &= (YEAR_MASK << YEAR_SHIFT)
-                    | (MONTH_MASK << MONTH_SHIFT)
-                    | (DAY_MASK << DAY_SHIFT)
-                    | (HOUR_MASK << HOUR_SHIFT)
-                    | (MINUTE_MASK << MINUTE_SHIFT)
-                    | (OFFSET_MASK << OFFSET_SHIFT);
-                timestamp.attoseconds = 0;
-            }
-            TimestampPrecision::Second => {
-                // Keep everything; just strip subsecond if not already at Second precision
-            }
-        }
-
-        // Set the precision field
-        timestamp.packed_fields &= !(PRECISION_MASK << PRECISION_SHIFT);
-        timestamp.packed_fields |= (precision as u64 & PRECISION_MASK) << PRECISION_SHIFT;
-
-        // Retain offset only at HourAndMinute or Second precision
-        if precision < TimestampPrecision::HourAndMinute {
-            timestamp.packed_fields &= !(OFFSET_MASK << OFFSET_SHIFT);
-        }
-
-        timestamp
-    }
-
-    #[cfg(feature = "experimental-chrono")]
-    pub(crate) fn from_naive_datetime(date_time: NaiveDateTime) -> Self {
-        let attoseconds = (date_time.nanosecond() as u64) * 1_000_000_000;
-        Self::from_fields(
-            TimestampPrecision::Second,
-            None,
-            date_time.year() as u16,
-            date_time.month() as u8,
-            date_time.day() as u8,
-            date_time.hour() as u8,
-            date_time.minute() as u8,
-            date_time.second() as u8,
-            9,
-            attoseconds,
-        )
-        .expect("chrono NaiveDateTime fields are always valid")
-    }
-
-    #[cfg(feature = "experimental-chrono")]
-    pub(crate) fn from_fixed_offset_datetime(
-        fixed_offset_date_time: DateTime<FixedOffset>,
-    ) -> Self {
-        let offset_seconds = fixed_offset_date_time.offset().local_minus_utc();
-        let offset_minutes = (offset_seconds / 60) as i16;
-        let local = fixed_offset_date_time.naive_local();
-        let attoseconds = (local.nanosecond() as u64) * 1_000_000_000;
-        // Pack directly from local fields — chrono guarantees validity of the
-        // DateTime, and local year may exceed 9999 (e.g., UTC year 9999 Dec 31
-        // with negative offset). We bypass from_fields validation to avoid panic.
-        let packed = Self::pack_masked(
-            TimestampPrecision::Second,
-            local.year() as u16,
-            local.month() as u8,
-            local.day() as u8,
-            local.hour() as u8,
-            local.minute() as u8,
-            local.second() as u8,
-            (offset_minutes + OFFSET_BIAS) as u16,
-            9,
-        );
-        Timestamp {
-            packed_fields: packed,
-            attoseconds,
-        }
-    }
-
-    #[cfg(feature = "experimental-chrono")]
-    pub(crate) fn try_to_naive_datetime(&self) -> IonResult<NaiveDateTime> {
-        if self.offset().is_some() {
-            return IonResult::illegal_operation(
-                "cannot convert a Timestamp with a known offset into a NaiveDateTime",
-            );
-        }
-        downconvert_to_naive_datetime_with_nanoseconds(self)
-    }
-
-    #[cfg(feature = "experimental-chrono")]
-    pub(crate) fn try_to_datetime_fixed_offset(&self) -> IonResult<DateTime<FixedOffset>> {
-        if self.offset().is_none() {
-            return IonResult::illegal_operation(
-                "cannot convert a Timestamp with an unknown offset into a DateTime<FixedOffset>",
-            );
-        }
-        let utc = self.to_utc();
-        let utc_naive = downconvert_to_naive_datetime_with_nanoseconds(&utc)?;
-        let offset = FixedOffset::east_opt(self.offset().unwrap_or_default() * 60);
-        Ok(offset.unwrap().from_utc_datetime(&utc_naive))
     }
 
     /// If the precision is [TimestampPrecision::Second], returns the Decimal scale of this Timestamp's
@@ -1314,65 +1176,12 @@ impl TimestampBuilder<HasFractionalSeconds> {
 pub struct HasOffset;
 // No impl for TimestampBuilder<HasOffset> because `build()` is included in TimestampBuilder<T>
 
-#[cfg(feature = "experimental-chrono")]
-fn downconvert_to_naive_datetime_with_nanoseconds(
-    timestamp: &Timestamp,
-) -> IonResult<NaiveDateTime> {
-    let dt = NaiveDate::from_ymd_opt(timestamp.year() as i32, timestamp.month(), timestamp.day())
-        .and_then(|d| {
-            d.and_hms_nano_opt(
-                timestamp.hour(),
-                timestamp.minute(),
-                timestamp.second(),
-                timestamp.nanoseconds(),
-            )
-        })
-        .ok_or_else(|| {
-            IonError::illegal_operation("timestamp fields produce invalid NaiveDateTime")
-        })?;
-    Ok(dt)
-}
-
-#[cfg(feature = "experimental-chrono")]
-impl TryInto<NaiveDateTime> for Timestamp {
-    type Error = IonError;
-
-    fn try_into(self) -> Result<NaiveDateTime, Self::Error> {
-        self.try_to_naive_datetime()
-    }
-}
-
-#[cfg(feature = "experimental-chrono")]
-impl TryInto<DateTime<FixedOffset>> for Timestamp {
-    type Error = IonError;
-
-    fn try_into(self) -> Result<DateTime<FixedOffset>, Self::Error> {
-        self.try_to_datetime_fixed_offset()
-    }
-}
-
-#[cfg(feature = "experimental-chrono")]
-impl From<NaiveDateTime> for Timestamp {
-    fn from(date_time: NaiveDateTime) -> Self {
-        Self::from_naive_datetime(date_time)
-    }
-}
-
-#[cfg(feature = "experimental-chrono")]
-impl From<DateTime<FixedOffset>> for Timestamp {
-    fn from(fixed_offset_date_time: DateTime<FixedOffset>) -> Self {
-        Self::from_fixed_offset_datetime(fixed_offset_date_time)
-    }
-}
-
 #[cfg(test)]
 mod timestamp_tests {
     use super::*;
     use crate::ion_data::IonEq;
     use crate::result::IonResult;
     use crate::{Decimal, Int, Timestamp, TimestampPrecision};
-    #[cfg(feature = "experimental-chrono")]
-    use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, Timelike};
     use rstest::*;
     use std::cmp::Ordering;
     use std::io::Write;
@@ -1650,131 +1459,6 @@ mod timestamp_tests {
         let timestamp2 = TimestampBuilder::with_year(2022).build()?;
         assert_ne!(timestamp1, timestamp2);
         assert!(!timestamp1.ion_eq(&timestamp2));
-        Ok(())
-    }
-
-    #[cfg(feature = "experimental-chrono")]
-    #[test]
-    fn test_timestamp_try_into_naive_datetime() -> IonResult<()> {
-        let timestamp = TimestampBuilder::with_ymd(2021, 4, 6)
-            .with_hms(10, 15, 0)
-            .build()?;
-        let naive_datetime: NaiveDateTime = timestamp.try_into()?;
-        let expected = NaiveDate::from_ymd_opt(2021, 4, 6)
-            .unwrap()
-            .and_hms_opt(10, 15, 0)
-            .unwrap();
-        assert_eq!(expected, naive_datetime);
-        Ok(())
-    }
-
-    #[cfg(feature = "experimental-chrono")]
-    #[test]
-    fn test_timestamp_try_into_naive_datetime_fractional_seconds() -> IonResult<()> {
-        let timestamp = TimestampBuilder::with_ymd(2021, 4, 6)
-            .with_hms(10, 15, 0)
-            .with_milliseconds(449)
-            .build()?;
-        let datetime: NaiveDateTime = timestamp.try_into()?;
-        let naive_datetime = NaiveDate::from_ymd_opt(2021, 4, 6)
-            .unwrap()
-            .and_hms_opt(10, 15, 0)
-            .unwrap()
-            .with_nanosecond(449000000)
-            .unwrap();
-        assert_eq!(datetime, naive_datetime);
-        Ok(())
-    }
-
-    #[cfg(feature = "experimental-chrono")]
-    #[test]
-    fn test_timestamp_try_into_naive_datetime_error() -> IonResult<()> {
-        let timestamp = TimestampBuilder::with_ymd(2021, 1, 1)
-            .with_hms(0, 0, 0)
-            .with_offset(0)
-            .build()?;
-        //     ^---- This timestamp has a known offset, so we cannot convert it into a NaiveDateTime
-        let result: IonResult<NaiveDateTime> = timestamp.try_into();
-        assert!(result.is_err());
-        Ok(())
-    }
-
-    #[cfg(feature = "experimental-chrono")]
-    #[test]
-    fn test_timestamp_try_into_fixed_offset_datetime() -> IonResult<()> {
-        let timestamp = TimestampBuilder::with_ymd(2021, 4, 6)
-            .with_hms(10, 15, 0)
-            .with_offset(-5 * 60)
-            .build()?;
-        //                    ^-- Timestamp's offset API takes minutes
-        let datetime: DateTime<FixedOffset> = timestamp.try_into()?;
-        // chrono's FixedOffset takes seconds ----------v
-        let expected_offset = offset_east(-5 * 60 * 60);
-        let naive_datetime = NaiveDate::from_ymd_opt(2021, 4, 6)
-            .unwrap()
-            .and_hms_opt(10, 15, 0)
-            .unwrap();
-        let expected_datetime = expected_offset
-            .from_local_datetime(&naive_datetime)
-            .unwrap();
-        assert_eq!(datetime, expected_datetime);
-        Ok(())
-    }
-
-    #[cfg(feature = "experimental-chrono")]
-    #[test]
-    fn test_timestamp_try_into_fixed_offset_datetime_fractional_seconds() -> IonResult<()> {
-        let timestamp = TimestampBuilder::with_ymd(2021, 4, 6)
-            .with_hms(10, 15, 0)
-            .with_milliseconds(449)
-            .with_offset(-5 * 60)
-            .build()?;
-        //                    ^-- Timestamp's offset API takes minutes
-        let datetime: DateTime<FixedOffset> = timestamp.try_into()?;
-        // chrono's FixedOffset takes seconds ----------v
-        let expected_offset = offset_east(-5 * 60 * 60);
-        let naive_datetime = NaiveDate::from_ymd_opt(2021, 4, 6)
-            .unwrap()
-            .and_hms_opt(10, 15, 0)
-            .unwrap()
-            .with_nanosecond(449000000)
-            .unwrap();
-        let expected_datetime = expected_offset
-            .from_local_datetime(&naive_datetime)
-            .unwrap();
-        assert_eq!(datetime, expected_datetime);
-        Ok(())
-    }
-
-    #[cfg(feature = "experimental-chrono")]
-    #[test]
-    fn test_fixed_offset_datetime_to_timestamp_offset_roundtrip() {
-        let offsets_minutes: &[i32] = &[0, 330, -330, 60, -60, 720, -720, 1, -1];
-        for &offset_min in offsets_minutes {
-            let offset = FixedOffset::east_opt(offset_min * 60).unwrap();
-            let dt = NaiveDate::from_ymd_opt(2024, 6, 15)
-                .unwrap()
-                .and_hms_opt(12, 30, 45)
-                .unwrap();
-            let fixed_dt = offset.from_local_datetime(&dt).unwrap();
-            let timestamp: Timestamp = fixed_dt.into();
-            assert_eq!(
-                timestamp.offset(),
-                Some(offset_min),
-                "offset roundtrip failed for {offset_min} minutes"
-            );
-        }
-    }
-
-    #[cfg(feature = "experimental-chrono")]
-    #[test]
-    fn test_timestamp_try_into_datetime_fixedoffset_error() -> IonResult<()> {
-        let timestamp = TimestampBuilder::with_ymd(2021, 1, 1)
-            .with_hms(0, 0, 0)
-            .build()?;
-        //     ^---- This timestamp has an unknown offset, so we cannot convert it into a DateTime<FixedOffset>
-        let result: IonResult<DateTime<FixedOffset>> = timestamp.try_into();
-        assert!(result.is_err());
         Ok(())
     }
 
@@ -2560,5 +2244,326 @@ mod timestamp_tests {
             .build()?;
         assert_eq!(ts.nanoseconds(), 999_999_999);
         Ok(())
+    }
+}
+
+/// `chrono` interop. All of `timestamp.rs`'s `experimental-chrono` code lives here so the
+/// feature's footprint in this file is a single gated module rather than gates scattered
+/// throughout. (`serde` support also compiles under this feature; see `src/serde/`.) As a
+/// descendant module it retains access to `Timestamp`'s private fields and the packed-layout
+/// constants.
+///
+/// Named `chrono_interop` rather than `chrono` so it does not shadow the extern crate for the
+/// rest of `timestamp.rs`.
+#[cfg(feature = "experimental-chrono")]
+mod chrono_interop {
+    use super::{
+        Timestamp, TimestampPrecision, DAY_MASK, DAY_SHIFT, HOUR_MASK, HOUR_SHIFT, MINUTE_MASK,
+        MINUTE_SHIFT, MONTH_MASK, MONTH_SHIFT, OFFSET_BIAS, OFFSET_MASK, OFFSET_SHIFT,
+        PRECISION_MASK, PRECISION_SHIFT, YEAR_MASK, YEAR_SHIFT,
+    };
+    use crate::result::{IonFailure, IonResult};
+    use crate::IonError;
+    use chrono::{DateTime, Datelike, FixedOffset, NaiveDate, NaiveDateTime, TimeZone, Timelike};
+
+    impl Timestamp {
+        /// Converts a [`NaiveDateTime`] or [`DateTime<FixedOffset>`] to a Timestamp with the specified
+        /// precision. If the precision is [`TimestampPrecision::Second`], nanosecond precision (the maximum
+        /// supported by a [`Timelike`]) is assumed.
+        pub fn from_datetime<D>(datetime: D, precision: TimestampPrecision) -> Timestamp
+        where
+            D: Datelike + Timelike + Into<Timestamp>,
+        {
+            let mut timestamp: Timestamp = datetime.into();
+
+            // Zero fields below the requested precision to uphold invariants 1, 2, and 6.
+            match precision {
+                TimestampPrecision::Year => {
+                    timestamp.packed_fields &= YEAR_MASK << YEAR_SHIFT;
+                    // Restore month=1, day=1 (the default "unset" values)
+                    timestamp.packed_fields |= 1 << MONTH_SHIFT | 1 << DAY_SHIFT;
+                    timestamp.attoseconds = 0;
+                }
+                TimestampPrecision::Month => {
+                    timestamp.packed_fields &=
+                        (YEAR_MASK << YEAR_SHIFT) | (MONTH_MASK << MONTH_SHIFT);
+                    // Restore day=1
+                    timestamp.packed_fields |= 1 << DAY_SHIFT;
+                    timestamp.attoseconds = 0;
+                }
+                TimestampPrecision::Day => {
+                    timestamp.packed_fields &= (YEAR_MASK << YEAR_SHIFT)
+                        | (MONTH_MASK << MONTH_SHIFT)
+                        | (DAY_MASK << DAY_SHIFT);
+                    timestamp.attoseconds = 0;
+                }
+                TimestampPrecision::HourAndMinute => {
+                    timestamp.packed_fields &= (YEAR_MASK << YEAR_SHIFT)
+                        | (MONTH_MASK << MONTH_SHIFT)
+                        | (DAY_MASK << DAY_SHIFT)
+                        | (HOUR_MASK << HOUR_SHIFT)
+                        | (MINUTE_MASK << MINUTE_SHIFT)
+                        | (OFFSET_MASK << OFFSET_SHIFT);
+                    timestamp.attoseconds = 0;
+                }
+                TimestampPrecision::Second => {
+                    // Keep everything; just strip subsecond if not already at Second precision
+                }
+            }
+
+            // Set the precision field
+            timestamp.packed_fields &= !(PRECISION_MASK << PRECISION_SHIFT);
+            timestamp.packed_fields |= (precision as u64 & PRECISION_MASK) << PRECISION_SHIFT;
+
+            // Retain offset only at HourAndMinute or Second precision
+            if precision < TimestampPrecision::HourAndMinute {
+                timestamp.packed_fields &= !(OFFSET_MASK << OFFSET_SHIFT);
+            }
+
+            timestamp
+        }
+
+        fn from_naive_datetime(date_time: NaiveDateTime) -> Self {
+            let attoseconds = (date_time.nanosecond() as u64) * 1_000_000_000;
+            Self::from_fields(
+                TimestampPrecision::Second,
+                None,
+                date_time.year() as u16,
+                date_time.month() as u8,
+                date_time.day() as u8,
+                date_time.hour() as u8,
+                date_time.minute() as u8,
+                date_time.second() as u8,
+                9,
+                attoseconds,
+            )
+            .expect("chrono NaiveDateTime fields are always valid")
+        }
+
+        fn from_fixed_offset_datetime(fixed_offset_date_time: DateTime<FixedOffset>) -> Self {
+            let offset_seconds = fixed_offset_date_time.offset().local_minus_utc();
+            let offset_minutes = (offset_seconds / 60) as i16;
+            let local = fixed_offset_date_time.naive_local();
+            let attoseconds = (local.nanosecond() as u64) * 1_000_000_000;
+            // Pack directly from local fields — chrono guarantees validity of the
+            // DateTime, and local year may exceed 9999 (e.g., UTC year 9999 Dec 31
+            // with negative offset). We bypass from_fields validation to avoid panic.
+            let packed = Self::pack_masked(
+                TimestampPrecision::Second,
+                local.year() as u16,
+                local.month() as u8,
+                local.day() as u8,
+                local.hour() as u8,
+                local.minute() as u8,
+                local.second() as u8,
+                (offset_minutes + OFFSET_BIAS) as u16,
+                9,
+            );
+            Timestamp {
+                packed_fields: packed,
+                attoseconds,
+            }
+        }
+
+        fn try_to_naive_datetime(&self) -> IonResult<NaiveDateTime> {
+            if self.offset().is_some() {
+                return IonResult::illegal_operation(
+                    "cannot convert a Timestamp with a known offset into a NaiveDateTime",
+                );
+            }
+            downconvert_to_naive_datetime_with_nanoseconds(self)
+        }
+
+        fn try_to_datetime_fixed_offset(&self) -> IonResult<DateTime<FixedOffset>> {
+            if self.offset().is_none() {
+                return IonResult::illegal_operation(
+                    "cannot convert a Timestamp with an unknown offset into a DateTime<FixedOffset>",
+                );
+            }
+            let utc = self.to_utc();
+            let utc_naive = downconvert_to_naive_datetime_with_nanoseconds(&utc)?;
+            let offset = FixedOffset::east_opt(self.offset().unwrap_or_default() * 60);
+            Ok(offset.unwrap().from_utc_datetime(&utc_naive))
+        }
+    }
+
+    fn downconvert_to_naive_datetime_with_nanoseconds(
+        timestamp: &Timestamp,
+    ) -> IonResult<NaiveDateTime> {
+        let dt =
+            NaiveDate::from_ymd_opt(timestamp.year() as i32, timestamp.month(), timestamp.day())
+                .and_then(|d| {
+                    d.and_hms_nano_opt(
+                        timestamp.hour(),
+                        timestamp.minute(),
+                        timestamp.second(),
+                        timestamp.nanoseconds(),
+                    )
+                })
+                .ok_or_else(|| {
+                    IonError::illegal_operation("timestamp fields produce invalid NaiveDateTime")
+                })?;
+        Ok(dt)
+    }
+
+    impl TryInto<NaiveDateTime> for Timestamp {
+        type Error = IonError;
+
+        fn try_into(self) -> Result<NaiveDateTime, Self::Error> {
+            self.try_to_naive_datetime()
+        }
+    }
+
+    impl TryInto<DateTime<FixedOffset>> for Timestamp {
+        type Error = IonError;
+
+        fn try_into(self) -> Result<DateTime<FixedOffset>, Self::Error> {
+            self.try_to_datetime_fixed_offset()
+        }
+    }
+
+    impl From<NaiveDateTime> for Timestamp {
+        fn from(date_time: NaiveDateTime) -> Self {
+            Self::from_naive_datetime(date_time)
+        }
+    }
+
+    impl From<DateTime<FixedOffset>> for Timestamp {
+        fn from(fixed_offset_date_time: DateTime<FixedOffset>) -> Self {
+            Self::from_fixed_offset_datetime(fixed_offset_date_time)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::types::TimestampBuilder;
+
+        /// Constructs a [`FixedOffset`] at the specified offset seconds from UTC. If the specified
+        /// offset is out of bounds, this method will panic.
+        // Only these tests construct a `FixedOffset` this way; production conversions build the
+        // offset from a `Timestamp` whose offset the builder has already bounded to ±1439 minutes.
+        fn offset_east(seconds_east: i32) -> FixedOffset {
+            FixedOffset::east_opt(seconds_east)
+                .expect("seconds_east was outside the supported range")
+        }
+
+        #[test]
+        fn test_timestamp_try_into_naive_datetime() -> IonResult<()> {
+            let timestamp = TimestampBuilder::with_ymd(2021, 4, 6)
+                .with_hms(10, 15, 0)
+                .build()?;
+            let naive_datetime: NaiveDateTime = timestamp.try_into()?;
+            let expected = NaiveDate::from_ymd_opt(2021, 4, 6)
+                .unwrap()
+                .and_hms_opt(10, 15, 0)
+                .unwrap();
+            assert_eq!(expected, naive_datetime);
+            Ok(())
+        }
+
+        #[test]
+        fn test_timestamp_try_into_naive_datetime_fractional_seconds() -> IonResult<()> {
+            let timestamp = TimestampBuilder::with_ymd(2021, 4, 6)
+                .with_hms(10, 15, 0)
+                .with_milliseconds(449)
+                .build()?;
+            let datetime: NaiveDateTime = timestamp.try_into()?;
+            let naive_datetime = NaiveDate::from_ymd_opt(2021, 4, 6)
+                .unwrap()
+                .and_hms_opt(10, 15, 0)
+                .unwrap()
+                .with_nanosecond(449000000)
+                .unwrap();
+            assert_eq!(datetime, naive_datetime);
+            Ok(())
+        }
+
+        #[test]
+        fn test_timestamp_try_into_naive_datetime_error() -> IonResult<()> {
+            let timestamp = TimestampBuilder::with_ymd(2021, 1, 1)
+                .with_hms(0, 0, 0)
+                .with_offset(0)
+                .build()?;
+            //     ^---- This timestamp has a known offset, so we cannot convert it into a NaiveDateTime
+            let result: IonResult<NaiveDateTime> = timestamp.try_into();
+            assert!(result.is_err());
+            Ok(())
+        }
+
+        #[test]
+        fn test_timestamp_try_into_fixed_offset_datetime() -> IonResult<()> {
+            let timestamp = TimestampBuilder::with_ymd(2021, 4, 6)
+                .with_hms(10, 15, 0)
+                .with_offset(-5 * 60)
+                .build()?;
+            //                    ^-- Timestamp's offset API takes minutes
+            let datetime: DateTime<FixedOffset> = timestamp.try_into()?;
+            // chrono's FixedOffset takes seconds ----------v
+            let expected_offset = offset_east(-5 * 60 * 60);
+            let naive_datetime = NaiveDate::from_ymd_opt(2021, 4, 6)
+                .unwrap()
+                .and_hms_opt(10, 15, 0)
+                .unwrap();
+            let expected_datetime = expected_offset
+                .from_local_datetime(&naive_datetime)
+                .unwrap();
+            assert_eq!(datetime, expected_datetime);
+            Ok(())
+        }
+
+        #[test]
+        fn test_timestamp_try_into_fixed_offset_datetime_fractional_seconds() -> IonResult<()> {
+            let timestamp = TimestampBuilder::with_ymd(2021, 4, 6)
+                .with_hms(10, 15, 0)
+                .with_milliseconds(449)
+                .with_offset(-5 * 60)
+                .build()?;
+            //                    ^-- Timestamp's offset API takes minutes
+            let datetime: DateTime<FixedOffset> = timestamp.try_into()?;
+            // chrono's FixedOffset takes seconds ----------v
+            let expected_offset = offset_east(-5 * 60 * 60);
+            let naive_datetime = NaiveDate::from_ymd_opt(2021, 4, 6)
+                .unwrap()
+                .and_hms_opt(10, 15, 0)
+                .unwrap()
+                .with_nanosecond(449000000)
+                .unwrap();
+            let expected_datetime = expected_offset
+                .from_local_datetime(&naive_datetime)
+                .unwrap();
+            assert_eq!(datetime, expected_datetime);
+            Ok(())
+        }
+
+        #[test]
+        fn test_fixed_offset_datetime_to_timestamp_offset_roundtrip() {
+            let offsets_minutes: &[i32] = &[0, 330, -330, 60, -60, 720, -720, 1, -1];
+            for &offset_min in offsets_minutes {
+                let offset = FixedOffset::east_opt(offset_min * 60).unwrap();
+                let dt = NaiveDate::from_ymd_opt(2024, 6, 15)
+                    .unwrap()
+                    .and_hms_opt(12, 30, 45)
+                    .unwrap();
+                let fixed_dt = offset.from_local_datetime(&dt).unwrap();
+                let timestamp: Timestamp = fixed_dt.into();
+                assert_eq!(
+                    timestamp.offset(),
+                    Some(offset_min),
+                    "offset roundtrip failed for {offset_min} minutes"
+                );
+            }
+        }
+
+        #[test]
+        fn test_timestamp_try_into_datetime_fixedoffset_error() -> IonResult<()> {
+            let timestamp = TimestampBuilder::with_ymd(2021, 1, 1)
+                .with_hms(0, 0, 0)
+                .build()?;
+            //     ^---- This timestamp has an unknown offset, so we cannot convert it into a DateTime<FixedOffset>
+            let result: IonResult<DateTime<FixedOffset>> = timestamp.try_into();
+            assert!(result.is_err());
+            Ok(())
+        }
     }
 }

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -129,6 +129,18 @@ fn validate_fields(y: u16, m: u8, d: u8, h: u8, min: u8, s: u8) -> bool {
     d >= 1 && d <= max_day && h <= 23 && min <= 59 && s <= 59
 }
 
+/// Returns an error if `offset_minutes` is outside Ion's valid UTC offset range. Takes an `i32`
+/// so callers can validate before narrowing to the stored `i16`.
+fn validate_offset_minutes(offset_minutes: i32) -> IonResult<()> {
+    if !(MIN_OFFSET_MINUTES as i32..=MAX_OFFSET_MINUTES as i32).contains(&offset_minutes) {
+        return IonResult::illegal_operation(format!(
+            "offset ({} minutes) exceeds valid range ({}..={})",
+            offset_minutes, MIN_OFFSET_MINUTES, MAX_OFFSET_MINUTES
+        ));
+    }
+    Ok(())
+}
+
 /// Adds `offset_minutes` to a local time represented by the given fields,
 /// returning the adjusted (year, month, day, hour, minute).
 fn add_offset_to_utc(
@@ -338,12 +350,7 @@ impl Timestamp {
         let offset_raw = match offset {
             None => OFFSET_UNKNOWN_SENTINEL,
             Some(m) => {
-                if !(MIN_OFFSET_MINUTES..=MAX_OFFSET_MINUTES).contains(&m) {
-                    return IonResult::illegal_operation(format!(
-                        "offset ({} minutes) exceeds valid range ({}..={})",
-                        m, MIN_OFFSET_MINUTES, MAX_OFFSET_MINUTES
-                    ));
-                }
+                validate_offset_minutes(m as i32)?;
                 (m + OFFSET_BIAS) as u16
             }
         };
@@ -904,12 +911,7 @@ impl<T> TimestampBuilder<T> {
             ));
         }
         if let Some(offset_minutes) = self.offset {
-            if !(MIN_OFFSET_MINUTES as i32..=MAX_OFFSET_MINUTES as i32).contains(&offset_minutes) {
-                return IonResult::illegal_operation(format!(
-                    "offset ({} minutes) exceeds valid range ({}..={})",
-                    offset_minutes, MIN_OFFSET_MINUTES, MAX_OFFSET_MINUTES
-                ));
-            }
+            validate_offset_minutes(offset_minutes)?;
         }
         Ok(())
     }
@@ -938,6 +940,14 @@ impl<T> TimestampBuilder<T> {
     /// Like [Self::build], but the fields provided for each time unit are understood
     /// to be in UTC rather than in the local time of the specified offset (if there is one).
     pub(crate) fn build_utc_fields_at_offset(self, offset_minutes: i32) -> IonResult<Timestamp> {
+        // Validate the fields *before* they are narrowed, for the same reason `build` does: a
+        // `u32`-to-`u8`/`u16` cast of an out-of-range value would silently wrap and could produce
+        // a field that `Timestamp::from_utc_fields` then accepts as valid (e.g. `month: 268`
+        // becomes `12`). `validate_field_ranges` covers the date-time fields and `self.offset`;
+        // the UTC offset arrives as a parameter here, so validate it before its own narrowing to
+        // `i16`.
+        self.validate_field_ranges()?;
+        validate_offset_minutes(offset_minutes)?;
         Timestamp::from_utc_fields(
             self.precision,
             offset_minutes as i16,
@@ -1181,11 +1191,142 @@ mod timestamp_tests {
     use super::*;
     use crate::ion_data::IonEq;
     use crate::result::IonResult;
-    use crate::{Decimal, Int, Timestamp, TimestampPrecision};
+    use crate::{Decimal, Element, Int, Timestamp, TimestampPrecision};
     use rstest::*;
     use std::cmp::Ordering;
     use std::io::Write;
     use std::ops::Mul;
+
+    // `build` validates its `u32`/`i32` fields before narrowing them to `u8`/`u16`/`i16`.
+    // `build_utc_fields_at_offset` must do the same: without pre-narrowing validation an
+    // out-of-range field wraps into a plausible wrong value that `from_utc_fields` accepts. This
+    // path is taken by binary 1.0 known-offset decoding and by binary 1.1 UTC-flag decoding (which
+    // passes offset 0); binary 1.1 known-offset decoding uses `with_offset` + `build` instead.
+
+    /// `build`'s own comment cites `month: 268` becoming `12` as the reason it validates before
+    /// narrowing. Its sibling must not skip that guard. Each value wraps into an in-range value
+    /// (e.g. `268 as u8 == 12`), so a rejection here can only come from pre-narrowing validation.
+    #[rstest]
+    #[case::year(67_557, 1, 1, 0, 0, 0)]
+    #[case::month(2021, 268, 1, 0, 0, 0)]
+    #[case::day(2021, 1, 261, 0, 0, 0)]
+    #[case::hour(2021, 1, 1, 261, 0, 0)]
+    #[case::minute(2021, 1, 1, 0, 286, 0)]
+    #[case::second(2021, 1, 1, 0, 0, 315)]
+    fn build_utc_fields_at_offset_rejects_out_of_range_fields(
+        #[case] year: u32,
+        #[case] month: u32,
+        #[case] day: u32,
+        #[case] hour: u32,
+        #[case] minute: u32,
+        #[case] second: u32,
+    ) {
+        let built = TimestampBuilder::with_ymd(year, month, day)
+            .with_hms(hour, minute, second)
+            .build_utc_fields_at_offset(0);
+        assert!(
+            built.is_err(),
+            "expected {year}-{month}-{day}T{hour}:{minute}:{second} to be rejected, got `{}`",
+            built.unwrap()
+        );
+    }
+
+    /// The offset parameter is narrowed `i32 as i16`, so out-of-range values must be rejected
+    /// before that cast. `MAX_OFFSET_MINUTES + 1` catches the ordinary out-of-range case; `65536`
+    /// is the boundary that survives `as i16` (it wraps to `0`), the one value the downstream
+    /// `from_fields` offset check cannot catch on its own.
+    #[rstest]
+    #[case(1440)]
+    #[case(-1440)]
+    #[case(65536)]
+    fn build_utc_fields_at_offset_rejects_out_of_range_offset(#[case] offset_minutes: i32) {
+        let built = TimestampBuilder::with_ymd(2021, 1, 1)
+            .with_hour_and_minute(0, 0)
+            .build_utc_fields_at_offset(offset_minutes);
+        assert!(
+            built.is_err(),
+            "expected offset {offset_minutes} to be rejected, got `{}`",
+            built.unwrap()
+        );
+    }
+
+    /// `from_utc_fields`/`from_fields` never check `attoseconds`, so `validate_field_ranges` is the
+    /// only guard against a subsecond value that outruns one full second (invariant 4). Reachable
+    /// from binary 1.1 short-form subseconds (e.g. the 10-bit millisecond field admits 1000..=1023).
+    #[test]
+    fn build_utc_fields_at_offset_rejects_over_range_subseconds() {
+        let built = TimestampBuilder::with_ymd(2024, 1, 1)
+            .with_hms(0, 0, 0)
+            .with_milliseconds(1023)
+            .build_utc_fields_at_offset(0);
+        assert!(
+            built.is_err(),
+            "1023 milliseconds (>= 1 second) should be rejected, got `{}`",
+            built.unwrap()
+        );
+    }
+
+    /// Guards against over-rejection: in-range fields must still build. Includes the `..=` offset
+    /// bounds (±1439) and the calendar extremes. The calendar max uses offset 0 because a positive
+    /// offset would push local time into year 10000 (a legitimate rejection, not over-rejection).
+    #[rstest]
+    #[case(2021, 6, 15, 12, 30, 45, 1439)]
+    #[case(2021, 6, 15, 12, 30, 45, -1439)]
+    #[case(9999, 12, 31, 23, 59, 59, 0)]
+    #[case(1, 1, 1, 0, 0, 0, 0)]
+    fn build_utc_fields_at_offset_accepts_in_range_extremes(
+        #[case] year: u32,
+        #[case] month: u32,
+        #[case] day: u32,
+        #[case] hour: u32,
+        #[case] minute: u32,
+        #[case] second: u32,
+        #[case] offset_minutes: i32,
+    ) {
+        let built = TimestampBuilder::with_ymd(year, month, day)
+            .with_hms(hour, minute, second)
+            .build_utc_fields_at_offset(offset_minutes);
+        assert!(
+            built.is_ok(),
+            "expected {year}-{month}-{day}T{hour}:{minute}:{second} at offset {offset_minutes} \
+             to build, got `{:?}`",
+            built.unwrap_err()
+        );
+    }
+
+    /// The same defect reached through the public API. A binary 1.0 timestamp with a known offset
+    /// at HourAndMinute precision routes to `build_utc_fields_at_offset`, so an out-of-range
+    /// VarUInt month must surface as an error rather than a plausible wrong month. The assertion
+    /// checks the error names the offending field, so a structurally malformed buffer (which fails
+    /// for an unrelated reason) can't pass this test by accident.
+    #[test]
+    fn binary_1_0_rejects_timestamp_with_out_of_range_month() {
+        const IVM: [u8; 4] = [0xE0, 0x01, 0x00, 0xEA];
+
+        // Control: month = 12 as a one-byte VarUInt reads as December.
+        let mut control = IVM.to_vec();
+        control.extend_from_slice(&[0x67, 0xBC, 0x0F, 0xE5, 0x8C, 0x81, 0x80, 0x80]);
+        let control = Element::read_one(&control).expect("control timestamp must decode");
+        assert_eq!(
+            control
+                .as_timestamp()
+                .expect("control is a timestamp")
+                .month(),
+            12
+        );
+
+        // month = 268 as a two-byte VarUInt, and `268 as u8` is also 12. Only the month bytes
+        // differ from the control (plus the length byte 0x67 -> 0x68 for the extra byte).
+        let mut wrapped = IVM.to_vec();
+        wrapped.extend_from_slice(&[0x68, 0xBC, 0x0F, 0xE5, 0x02, 0x8C, 0x81, 0x80, 0x80]);
+        let error = Element::read_one(&wrapped)
+            .expect_err("month 268 must not decode as a valid timestamp");
+        let message = error.to_string();
+        assert!(
+            message.contains("month"),
+            "expected an out-of-range month error, got: {message}"
+        );
+    }
 
     #[test]
     fn test_timestamps_with_same_ymd_hms_millis_at_known_offset_are_equal() -> IonResult<()> {

--- a/tests/element_display.rs
+++ b/tests/element_display.rs
@@ -8,6 +8,9 @@ use test_generator::test_resources;
 mod ion_tests;
 
 const TO_STRING_SKIP_LIST: &[&str] = &[
+    // Timestamp limits fractional seconds to 18 digits.
+    "ion-tests/iontestdata/good/equivs/timestampsLargeFractionalPrecision.ion",
+    "ion-tests/iontestdata/good/typecodes/T6-large.10n",
     // These tests have shared symbol table imports in them, which the Reader does not
     // yet support.
     "ion-tests/iontestdata/good/subfieldVarInt.ion",

--- a/tests/ion_data_consistency.rs
+++ b/tests/ion_data_consistency.rs
@@ -24,6 +24,8 @@ const SKIP_LIST: &[&str] = &[
     "ion-tests/iontestdata/good/equivs/localSymbolTableAppend.ion",
     "ion-tests/iontestdata/good/equivs/localSymbolTableNullSlots.ion",
     "ion-tests/iontestdata/good/equivs/nonIVMNoOps.ion",
+    // Timestamp limits fractional seconds to 18 digits.
+    "ion-tests/iontestdata/good/equivs/timestampsLargeFractionalPrecision.ion",
 ];
 
 #[test_resources("ion-tests/iontestdata/good/equivs/**/*.ion")]

--- a/tests/ion_tests/mod.rs
+++ b/tests/ion_tests/mod.rs
@@ -387,6 +387,9 @@ pub const ELEMENT_GLOBAL_SKIP_LIST: SkipList = &[
     // The binary reader does not check whether nested values are longer than their
     // parent container.
     "ion-tests/iontestdata/bad/listWithValueLargerThanSize.10n",
+    // Timestamp limits fractional seconds to 18 digits.
+    "ion-tests/iontestdata/good/equivs/timestampsLargeFractionalPrecision.ion",
+    "ion-tests/iontestdata/good/typecodes/T6-large.10n",
     // ROUND TRIP
     // These tests have shared symbol table imports in them, which the Reader does not
     // yet support.

--- a/tests/ion_tests_1_1.rs
+++ b/tests/ion_tests_1_1.rs
@@ -19,6 +19,8 @@ impl ElementApi for LazyReaderElementApi {
 
     fn global_skip_list() -> SkipList {
         &[
+            // Timestamp limits fractional seconds to 18 digits.
+            "ion-tests/iontestdata_1_1/good/equivs/timestampsLargeFractionalPrecision.ion",
             // TODO: Revisit these once the Ion 1.1 System Symbol Table is defined
             "ion-tests/iontestdata_1_1/good/equivs/localSymbolTableAppend.ion",
             "ion-tests/iontestdata_1_1/good/equivs/localSymbolTableNullSlots.ion",


### PR DESCRIPTION
### Issue #, if available:

Related to #476 

### Description of changes:

I am working on implementing my own Ion reader implementation, and discovered that reading a `Timestamp` was a significant bottleneck in my mixed-data workloads. Although the read/write performance of `ion-rust` doesn't change much with this PR, this refactoring of `Timestamp`, when combined with my own reader implementation resulted in a ~15x improvement in read speed relative to the `v1.0.1` release.

`Timestamp` previously used chrono's `NaiveDateTime`, an `Option<FixedOffset>`, a `TimestampPrecision` enum, and an
`Option<Mantissa>` for fractional seconds. This totaled 80 bytes per instance and required heap allocation for the `Decimal`-backed mantissa. This PR replaces all of that with two `u64` fields:

- `packed_fields` -- date-time components in the high bits (year, month, day, hour, minute, second) for natural chronological ordering via integer comparison; metadata (precision, subsecond digits, offset) in the low bits
- `attoseconds` -- fractional seconds normalized to 10^-18 scale

This PR also eliminates the unnecessary `Decimal` allocation in the `TimestampBuilder::build()` method.

#### Design Choices

- **`Ord` without division.** Cross-offset comparison normalizes via linear-minute arithmetic and in-place bit patching. Division is only needed when the offset requires the day-rollover path (which falls back to `add_offset_to_utc`).
- **`PartialEq` short-circuits.** Seconds and attoseconds are unaffected by offset normalization, so mismatches there reject early without entering the comparison machinery.
- **`IonEq` / `IonDataOrd` / `IonDataHash` are single-instruction operations** -- direct `u64` comparison or hash of the packed fields.
- **`Copy` deliberately not derived** -- leaves room for a future heap fallback if >18-digit fractional precision is ever needed, without a semver break.
- **chrono dependency moved behind `experimental-chrono` feature gate.** The default build has no chrono dependency any more.

#### Performance (Apple M-series / AWS Graviton, 1000-op batches)

| Operation                        | Improvement    |
| -------------------------------- | -------------- |
| Construction (TimestampBuilder)  | 2-4x faster    |
| Clone                            | 6-10x faster   |
| Equality / Ordering              | 1.3-6x faster  |
| IonEq / IonDataOrd / IonDataHash | 2-10x faster |
| Formatting (Display)             | 10-21% faster  |
| Element read/write               | 1-6% faster    |

#### Known limitations

- Fractional precision is capped at 18 digits (attosecond). The `timestampsLargeFractionalPrecision` and `T6_large` conformance tests are skipped.
- `cmp` for the specific case of same-instant-different-offset shows a ~30% regression on Graviton relative to the old chrono-backed implementation (which stored epoch seconds internally and could compare with a single i64 subtract). This case is still single-digit nanoseconds per operation, so unlikely to be an issue in practice, and well worth the improvements to construction and formatting.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
