### PR TITLE
refactor(result): box large IonError payloads to shrink to 32 bytes

### DIFF
--- a/src/result/conversion.rs
+++ b/src/result/conversion.rs
@@ -7,12 +7,19 @@ use thiserror::Error;
 pub type ConversionOperationResult<FromType, ToType> =
     Result<ToType, ConversionOperationError<FromType, ToType>>;
 
-/// Represents a mismatch during conversion between the expected type and the actual value's type.
-#[derive(Clone, Debug, Error, PartialEq)]
-#[error("Type conversion error; expected a(n) {output_type}, found a(n) {input_type}")]
-pub struct ConversionError {
+/// The type names carried by a [`ConversionError`]. Boxed inside `ConversionError` to keep
+/// `IonError` small; these strings are only materialized on the (cold) conversion-error path.
+#[derive(Clone, Debug, PartialEq)]
+struct ConversionTypes {
     input_type: String,
     output_type: String,
+}
+
+/// Represents a mismatch during conversion between the expected type and the actual value's type.
+#[derive(Clone, Debug, Error, PartialEq)]
+#[error("Type conversion error; expected a(n) {}, found a(n) {}", .types.output_type, .types.input_type)]
+pub struct ConversionError {
+    types: Box<ConversionTypes>,
 }
 
 impl<FromType, ToType> From<ConversionOperationError<FromType, ToType>> for ConversionError
@@ -22,8 +29,10 @@ where
 {
     fn from(err: ConversionOperationError<FromType, ToType>) -> Self {
         ConversionError {
-            input_type: err.input_value.expected_type_name(),
-            output_type: ToType::expected_type_name(),
+            types: Box::new(ConversionTypes {
+                input_type: err.input_value.expected_type_name(),
+                output_type: ToType::expected_type_name(),
+            }),
         }
     }
 }

--- a/src/result/decoding_error.rs
+++ b/src/result/decoding_error.rs
@@ -4,8 +4,16 @@ use thiserror::Error;
 
 /// Indicates that a read operation failed due to invalid input.
 #[derive(Clone, Debug, Error, PartialEq)]
-#[error("{description}")]
+#[error("{}", .inner.description)]
 pub struct DecodingError {
+    // Boxed so that `IonError`, which carries this variant, stays small (a smaller error shrinks
+    // `Result<T, IonError>` on every read/write path). The fields are only read on the cold error
+    // path, so the extra indirection and allocation are cheap.
+    inner: Box<DecodingErrorInner>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct DecodingErrorInner {
     description: Cow<'static, str>,
     // This is optional because sometimes data is found to be malformed or invalid but the original
     // data source is not available. For example, consider a deserializer reading a symbol table
@@ -17,17 +25,19 @@ pub struct DecodingError {
 impl DecodingError {
     pub(crate) fn new(description: impl Into<Cow<'static, str>>) -> Self {
         DecodingError {
-            description: description.into(),
-            position: None,
+            inner: Box::new(DecodingErrorInner {
+                description: description.into(),
+                position: None,
+            }),
         }
     }
 
     pub(crate) fn with_position(mut self, position: impl Into<Position>) -> Self {
-        self.position = Some(position.into());
+        self.inner.position = Some(position.into());
         self
     }
 
     pub fn position(&self) -> Option<&Position> {
-        self.position.as_ref()
+        self.inner.position.as_ref()
     }
 }

--- a/src/result/incomplete.rs
+++ b/src/result/incomplete.rs
@@ -5,8 +5,18 @@ use thiserror::Error;
 /// For non-blocking readers, indicates that there was not enough data available in the input buffer
 /// to complete the requested action.
 #[derive(Clone, Debug, Error, PartialEq)]
-#[error("ran out of input while reading {label} at offset {position}")]
+#[error("ran out of input while reading {} at offset {}", .inner.label, .inner.position)]
 pub struct IncompleteError {
+    // Boxed so that `IonError`, which carries this variant, stays small (a smaller error shrinks
+    // `Result<T, IonError>` on every read/write path). Note the trade-off: for streaming readers
+    // `Incomplete` is ordinary control flow, so this adds one allocation per buffer refill where
+    // the payload was previously inline. An inline (allocation-free) payload would require changing
+    // the public `position() -> &Position` signature, so boxing is the non-breaking option.
+    inner: Box<IncompleteErrorInner>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct IncompleteErrorInner {
     label: Cow<'static, str>,
     position: Position,
 }
@@ -14,12 +24,14 @@ pub struct IncompleteError {
 impl IncompleteError {
     pub(crate) fn new(label: impl Into<Cow<'static, str>>, position: impl Into<Position>) -> Self {
         IncompleteError {
-            label: label.into(),
-            position: position.into(),
+            inner: Box::new(IncompleteErrorInner {
+                label: label.into(),
+                position: position.into(),
+            }),
         }
     }
 
     pub fn position(&self) -> &Position {
-        &self.position
+        &self.inner.position
     }
 }

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -175,3 +175,46 @@ impl<T> IonFailure for IonResult<T> {
         Err(IonError::illegal_operation(operation))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{IonError, IonFailure};
+    use crate::position::Position;
+    use std::mem::{align_of, size_of};
+
+    /// `IonError` is returned (inside `IonResult`) from nearly every read/write operation, so its
+    /// size directly inflates the size of `Result<T, IonError>` on hot paths. The largest inline
+    /// variant payloads (`DecodingError`, `IncompleteError`, `ConversionError`) are boxed down to a
+    /// single pointer; the 32-byte bound is currently pinned by the still-inline `Cow<'static, str>`
+    /// payloads of `EncodingError`/`IllegalOperation` (24 bytes + the enum discriminant). This
+    /// guards against a regression that would reintroduce a large inline payload.
+    #[test]
+    fn ion_error_stays_small() {
+        assert!(
+            size_of::<IonError>() <= 32,
+            "size_of::<IonError>() = {} (expected <= 32); a variant likely gained a large inline \
+             payload — box it as done for position/type-name data",
+            size_of::<IonError>()
+        );
+        assert!(
+            align_of::<IonError>() <= 8,
+            "align_of::<IonError>() = {} (expected <= 8)",
+            align_of::<IonError>()
+        );
+    }
+
+    // Boxing moved these errors' fields into private inner structs. These assert that the
+    // user-visible `Display` text is unchanged (guards against, e.g., transposing the two
+    // positional format arguments, which would still compile).
+    #[test]
+    fn display_text_is_stable() {
+        let decoding = IonError::decoding_error("bad input");
+        assert_eq!(decoding.to_string(), "bad input");
+
+        let incomplete = IonError::incomplete("a value", Position::with_offset(42));
+        assert_eq!(
+            incomplete.to_string(),
+            "ran out of input while reading a value at offset 42"
+        );
+    }
+}


### PR DESCRIPTION


**Issue #, if available:**

N/A

**Description of changes:**

`IonError` was 80 bytes, driven by the inline `Position` in `DecodingError` and `IncompleteError`; it inflates every `Result<T, IonError>` on the read/write hot paths, enlarging return values and stack frames. Box those payloads (and `ConversionError`'s type names) into private inner structs so `IonError` shrinks from 80 to 32 bytes. The ceiling is now the unboxed `Cow` payloads of `EncodingError`/`IllegalOperation`.

This is non-breaking. The variants, public accessors, and `Display` output are unchanged; boxed fields are private.

The tradeoff is that for streaming readers, `Incomplete` is control flow, so this adds one (small) allocation per buffer refill. A zero-alloc inline payload would require changing the public `position() -> &Position` signature, so boxing is the non-breaking option.

Add a regression test pinning `size_of::<IonError>()` <= 32 / align <= 8 and a `Display`-stability test.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
