### PR TITLE
perf(struct): store fields in a boxed slice with a lazy index

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ generic-array = "=0.14.7" # 0.14.8 introduces a deprecation warning that fails o
 digest = { version = "0.9", optional = true }
 ice_code = "0.1.4"
 rustc-hash = "2.0.0"
+hashbrown = "0.15"
 phf = { version = "0.11.2", features = ["macros"] }
 sha2 = { version = "0.9", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,10 @@ harness = false
 name = "struct_ops"
 harness = false
 
+[[bench]]
+name = "struct_threshold_model"
+harness = false
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,10 @@ bench = false
 name = "text_location_throughput"
 harness = false
 
+[[bench]]
+name = "struct_ops"
+harness = false
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/benches/struct_ops.rs
+++ b/benches/struct_ops.rs
@@ -1,0 +1,345 @@
+//! Benchmarks the public `Struct` operations against the layout shipped in this crate: `get`,
+//! `get_all`, construction (`FromIterator`), `PartialEq`, and the `IonData`-mediated `ion_eq`,
+//! ordering, and hashing. Where a pre-index baseline is meaningful (`get`, `get_all`, construction)
+//! an `FxHashMap<name, Vec<index>>` — the shape the old `Struct` maintained eagerly — is measured
+//! alongside so the trade is visible.
+//!
+//! Lookup and equality/ordering/hashing fixtures are **primed** (the relevant lazy index is built
+//! once before timing), so these measure the warm steady-state cost. Construction is measured cold
+//! via `iter_batched`, since building the value is the thing under test.
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use hashbrown::HashMap;
+use ion_rs::{Element, IonData, Struct, Symbol};
+use rustc_hash::FxBuildHasher;
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+type FxHashIndex = HashMap<String, Vec<usize>, FxBuildHasher>;
+
+// Field counts spanning the linear/hash crossover (48) and the largest size the plan calls out
+// (100), plus the small sizes where a struct usually lives.
+const FIELD_COUNTS: &[usize] = &[1, 4, 8, 16, 32, 48, 64, 100];
+const TARGET_FIELD: &str = "target";
+const MISSING_FIELD: &str = "missing";
+
+#[derive(Clone, Copy)]
+enum NameShape {
+    Distinct,
+    EveryEighthDuplicate,
+}
+
+impl NameShape {
+    fn label(self) -> &'static str {
+        match self {
+            NameShape::Distinct => "distinct",
+            NameShape::EveryEighthDuplicate => "every_8th_duplicate",
+        }
+    }
+
+    fn slots(self, field_count: usize) -> Vec<(Symbol, Element)> {
+        match self {
+            NameShape::Distinct => build_distinct_slots(field_count),
+            NameShape::EveryEighthDuplicate => {
+                build_every_eighth_duplicate_slots(field_count, TARGET_FIELD)
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum GetScenario {
+    HitAtFront,
+    HitAtBack,
+    Miss,
+}
+
+impl GetScenario {
+    fn label(self) -> &'static str {
+        match self {
+            GetScenario::HitAtFront => "hit_front",
+            GetScenario::HitAtBack => "hit_back",
+            GetScenario::Miss => "miss",
+        }
+    }
+}
+
+// ---- fixture builders ------------------------------------------------------
+
+fn build_distinct_slots(field_count: usize) -> Vec<(Symbol, Element)> {
+    let mut slots = Vec::with_capacity(field_count);
+    for index in 0..field_count {
+        slots.push((format!("field_{index}").into(), (index as i64).into()));
+    }
+    slots
+}
+
+fn build_hit_front_slots(field_count: usize, query: &'static str) -> Vec<(Symbol, Element)> {
+    let mut slots = Vec::with_capacity(field_count);
+    if field_count > 0 {
+        slots.push((query.into(), 0_i64.into()));
+    }
+    for index in 1..field_count {
+        slots.push((format!("field_{index}").into(), (index as i64).into()));
+    }
+    slots
+}
+
+fn build_hit_back_slots(field_count: usize, query: &'static str) -> Vec<(Symbol, Element)> {
+    let mut slots = Vec::with_capacity(field_count);
+    if field_count == 0 {
+        return slots;
+    }
+    for index in 0..field_count - 1 {
+        slots.push((format!("field_{index}").into(), (index as i64).into()));
+    }
+    slots.push((query.into(), ((field_count - 1) as i64).into()));
+    slots
+}
+
+fn build_every_eighth_duplicate_slots(
+    field_count: usize,
+    query: &'static str,
+) -> Vec<(Symbol, Element)> {
+    let mut slots = Vec::with_capacity(field_count);
+    for index in 0..field_count {
+        let name: Symbol = if index % 8 == 0 {
+            query.into()
+        } else {
+            format!("field_{index}").into()
+        };
+        slots.push((name, (index as i64).into()));
+    }
+    slots
+}
+
+fn build_hash_index(slots: &[(Symbol, Element)]) -> FxHashIndex {
+    let mut hash_index = FxHashIndex::with_capacity_and_hasher(slots.len(), FxBuildHasher);
+    for (index, (field_name, _)) in slots.iter().enumerate() {
+        let field_name = field_name
+            .text()
+            .expect("benchmark fixture uses known text");
+        hash_index
+            .entry(field_name.to_owned())
+            .or_default()
+            .push(index);
+    }
+    hash_index
+}
+
+fn struct_from(slots: &[(Symbol, Element)]) -> Struct {
+    slots.iter().cloned().collect()
+}
+
+// ---- lookup ----------------------------------------------------------------
+
+struct LookupFixture {
+    slots: Vec<(Symbol, Element)>,
+    ion_struct: Struct,
+    hash_index: FxHashIndex,
+    query: &'static str,
+}
+
+impl LookupFixture {
+    fn new(slots: Vec<(Symbol, Element)>, query: &'static str) -> Self {
+        let hash_index = build_hash_index(&slots);
+        let ion_struct = struct_from(&slots);
+        let _ = ion_struct.get(query); // prime the lazy hash index
+        Self {
+            slots,
+            ion_struct,
+            hash_index,
+            query,
+        }
+    }
+
+    fn hash_map_get(&self) -> Option<&Element> {
+        self.hash_index
+            .get(self.query)
+            .and_then(|indices| indices.last())
+            .map(|&index| &self.slots[index].1)
+    }
+
+    fn hash_map_get_all(&self) -> usize {
+        let mut count = 0;
+        if let Some(indices) = self.hash_index.get(self.query) {
+            for &index in indices {
+                black_box(&self.slots[index].1);
+                count += 1;
+            }
+        }
+        count
+    }
+
+    fn struct_get_all(&self) -> usize {
+        let mut count = 0;
+        for value in self.ion_struct.get_all(self.query) {
+            black_box(value);
+            count += 1;
+        }
+        count
+    }
+}
+
+fn bench_get(c: &mut Criterion) {
+    let mut group = c.benchmark_group("struct_get");
+    for scenario in [
+        GetScenario::HitAtFront,
+        GetScenario::HitAtBack,
+        GetScenario::Miss,
+    ] {
+        for &field_count in FIELD_COUNTS {
+            let (slots, query) = match scenario {
+                GetScenario::HitAtFront => (
+                    build_hit_front_slots(field_count, TARGET_FIELD),
+                    TARGET_FIELD,
+                ),
+                GetScenario::HitAtBack => (
+                    build_hit_back_slots(field_count, TARGET_FIELD),
+                    TARGET_FIELD,
+                ),
+                GetScenario::Miss => (build_distinct_slots(field_count), MISSING_FIELD),
+            };
+            let fixture = LookupFixture::new(slots, query);
+            let parameter = format!("{}/{}_fields", scenario.label(), field_count);
+            group.bench_with_input(
+                BenchmarkId::new("struct_current", &parameter),
+                &fixture,
+                |b, fixture| b.iter(|| black_box(fixture.ion_struct.get(fixture.query))),
+            );
+            group.bench_with_input(
+                BenchmarkId::new("hash_map", &parameter),
+                &fixture,
+                |b, fixture| b.iter(|| black_box(fixture.hash_map_get())),
+            );
+        }
+    }
+    group.finish();
+}
+
+fn bench_get_all(c: &mut Criterion) {
+    let mut group = c.benchmark_group("struct_get_all");
+    for scenario in [NameShape::Distinct, NameShape::EveryEighthDuplicate] {
+        for &field_count in FIELD_COUNTS {
+            // Distinct puts a single hit at the back; the duplicate shape repeats the target.
+            let slots = match scenario {
+                NameShape::Distinct => build_hit_back_slots(field_count, TARGET_FIELD),
+                NameShape::EveryEighthDuplicate => {
+                    build_every_eighth_duplicate_slots(field_count, TARGET_FIELD)
+                }
+            };
+            let fixture = LookupFixture::new(slots, TARGET_FIELD);
+            let parameter = format!("{}/{}_fields", scenario.label(), field_count);
+            group.bench_with_input(
+                BenchmarkId::new("struct_current", &parameter),
+                &fixture,
+                |b, fixture| b.iter(|| black_box(fixture.struct_get_all())),
+            );
+            group.bench_with_input(
+                BenchmarkId::new("hash_map", &parameter),
+                &fixture,
+                |b, fixture| b.iter(|| black_box(fixture.hash_map_get_all())),
+            );
+        }
+    }
+    group.finish();
+}
+
+// ---- construction ----------------------------------------------------------
+
+fn bench_construct(c: &mut Criterion) {
+    let mut group = c.benchmark_group("struct_construct");
+    for scenario in [NameShape::Distinct, NameShape::EveryEighthDuplicate] {
+        for &field_count in FIELD_COUNTS {
+            let slots = scenario.slots(field_count);
+            let parameter = format!("{}/{}_fields", scenario.label(), field_count);
+            // The cloned slot list is produced outside the timed section.
+            group.bench_with_input(
+                BenchmarkId::new("struct_current", &parameter),
+                &slots,
+                |b, slots| {
+                    b.iter_batched(
+                        || slots.clone(),
+                        |slots| black_box(slots.into_iter().collect::<Struct>()),
+                        BatchSize::SmallInput,
+                    )
+                },
+            );
+            group.bench_with_input(
+                BenchmarkId::new("hash_map", &parameter),
+                &slots,
+                |b, slots| b.iter(|| black_box(build_hash_index(slots))),
+            );
+        }
+    }
+    group.finish();
+}
+
+// ---- equality / ordering / hashing -----------------------------------------
+
+struct PairFixture {
+    a: Struct,
+    b: Struct,
+    ion_a: IonData<Struct>,
+    ion_b: IonData<Struct>,
+}
+
+impl PairFixture {
+    fn new(slots: Vec<(Symbol, Element)>) -> Self {
+        // `b` is the same multiset in reverse insertion order, so equality/ordering do their full
+        // work (no early length or first-field mismatch) and exercise the `by_field` sort.
+        let mut reversed = slots.clone();
+        reversed.reverse();
+        let a = struct_from(&slots);
+        let b = struct_from(&reversed);
+        let _ = a == b; // prime both structs' lazy `by_field` order
+        let ion_a = IonData::from(a.clone());
+        let ion_b = IonData::from(b.clone());
+        let _ = ion_a.cmp(&ion_b); // prime the wrapped clones' `by_field`
+        Self { a, b, ion_a, ion_b }
+    }
+}
+
+fn bench_eq_ord_hash(c: &mut Criterion) {
+    let mut group = c.benchmark_group("struct_eq_ord_hash");
+    for scenario in [NameShape::Distinct, NameShape::EveryEighthDuplicate] {
+        for &field_count in FIELD_COUNTS {
+            let fixture = PairFixture::new(scenario.slots(field_count));
+            let parameter = format!("{}/{}_fields", scenario.label(), field_count);
+            group.bench_with_input(
+                BenchmarkId::new("partial_eq", &parameter),
+                &fixture,
+                |b, fixture| b.iter(|| black_box(fixture.a == fixture.b)),
+            );
+            group.bench_with_input(
+                BenchmarkId::new("ion_eq", &parameter),
+                &fixture,
+                |b, fixture| b.iter(|| black_box(IonData::eq(&fixture.a, &fixture.b))),
+            );
+            group.bench_with_input(
+                BenchmarkId::new("ion_cmp", &parameter),
+                &fixture,
+                |b, fixture| b.iter(|| black_box(fixture.ion_a.cmp(&fixture.ion_b))),
+            );
+            group.bench_with_input(
+                BenchmarkId::new("ion_hash", &parameter),
+                &fixture,
+                |b, fixture| {
+                    b.iter(|| {
+                        let mut hasher = DefaultHasher::new();
+                        fixture.ion_a.hash(&mut hasher);
+                        black_box(hasher.finish())
+                    })
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(
+    struct_ops,
+    bench_get,
+    bench_get_all,
+    bench_construct,
+    bench_eq_ord_hash
+);
+criterion_main!(struct_ops);

--- a/benches/struct_threshold_model.rs
+++ b/benches/struct_threshold_model.rs
@@ -1,0 +1,199 @@
+//! Threshold-model measurement bench (experimental / tuning — not part of the shipped crate API).
+//!
+//! Measures clean primitives of the `Struct` lifecycle so individual and amortized costs — and the
+//! linear-vs-hash crossover per access pattern — can be *computed*, not eyeballed. Run it twice via
+//! the compile-time threshold knob:
+//!   * linear regime: `ION_RS_STRUCT_LINEAR_SCAN_THRESHOLD=100000 cargo bench --bench struct_threshold_model`
+//!   * hash regime:   `ION_RS_STRUCT_LINEAR_SCAN_THRESHOLD=0      cargo bench --bench struct_threshold_model`
+//!
+//! Recovery (linear run = L-suffixed, hash run = H-suffixed):
+//!   construct           C        = construct_drop[L] - drop[L]
+//!   drop, no index      D_lin    = drop[L]
+//!   drop, with index    D_hash   = drop[H]
+//!   index drop          = D_hash - D_lin
+//!   warm probe          P        = warm_probe[H]
+//!   lazy index build    B        = first_lookup[H] - P
+//!   per linear lookup            = access[L] / L
+//! Fully-loaded crossover for pattern k (L = k*N): linear wins iff
+//!   access_lin(kN)  <  access_hash(kN) + (D_hash - D_lin)
+//! (the build is already inside access_hash; index-drop is the one added term).
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use ion_rs::{Element, Struct, Symbol};
+
+// Individual-cost groups include N=1 (anchors the fixed-cost intercept); access patterns do not
+// (k=0.5 is meaningless at N=1, and 1 is already ruled out as a threshold).
+const SIZES_ALL: &[usize] = &[1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 64];
+const SIZES_ACCESS: &[usize] = &[2, 4, 8, 12, 16, 24, 32, 40, 48, 64];
+
+// A key guaranteed to exist, used to prime the lazy index in setup.
+const PRIME_KEY: &str = "field_0";
+// A key guaranteed to be absent, for the miss access pattern.
+const MISS_KEY: &str = "definitely_absent";
+
+#[derive(Clone, Copy)]
+struct Pattern {
+    label: &'static str,
+    num: usize,
+    den: usize,
+}
+
+const PATTERNS: &[Pattern] = &[
+    Pattern {
+        label: "0.5x",
+        num: 1,
+        den: 2,
+    },
+    Pattern {
+        label: "1.0x",
+        num: 1,
+        den: 1,
+    },
+    Pattern {
+        label: "2.0x",
+        num: 2,
+        den: 1,
+    },
+];
+
+fn slots(field_count: usize) -> Vec<(Symbol, Element)> {
+    (0..field_count)
+        .map(|i| (format!("field_{i}").into(), (i as i64).into()))
+        .collect()
+}
+
+fn struct_from(slots: &[(Symbol, Element)]) -> Struct {
+    slots.iter().cloned().collect()
+}
+
+/// The `L = ceil-ish(k*N)` query strings for a pattern. Hits are spread uniformly across the field
+/// range so the linear cost reflects the average position, not a front/back bias; misses are all the
+/// same absent key (each a full scan for linear, a miss-probe for hash).
+fn queries(field_count: usize, pattern: Pattern, miss: bool) -> Vec<String> {
+    let lookups = (field_count * pattern.num / pattern.den).max(1);
+    if miss {
+        return vec![MISS_KEY.to_string(); lookups];
+    }
+    (0..lookups)
+        .map(|j| format!("field_{}", j * field_count / lookups))
+        .collect()
+}
+
+// 1. construct + drop of a no-index struct (both timed). Threshold-independent (construction never
+//    builds the index); read from the linear run as C + D_lin.
+fn bench_construct_drop(c: &mut Criterion) {
+    let mut group = c.benchmark_group("construct_drop");
+    for &n in SIZES_ALL {
+        let s = slots(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &s, |b, s| {
+            b.iter(|| {
+                let built = struct_from(s);
+                black_box(&built);
+            })
+        });
+    }
+    group.finish();
+}
+
+// 2. drop only (timed), struct primed in untimed setup. Linear run => D_lin (no index); hash run =>
+//    D_hash (index built by the priming get).
+fn bench_drop(c: &mut Criterion) {
+    let mut group = c.benchmark_group("drop");
+    group.sample_size(200);
+    for &n in SIZES_ALL {
+        let s = slots(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &s, |b, s| {
+            b.iter_batched(
+                || {
+                    let built = struct_from(s);
+                    let _ = built.get(PRIME_KEY);
+                    built
+                },
+                |built| {
+                    black_box(built.len());
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+    group.finish();
+}
+
+// 3. L lookups on a fresh struct (construct + drop excluded). Linear run => A_lin; hash run =>
+//    A_hash (the first lookup builds the index, so the build is amortized across the L lookups).
+fn bench_access(c: &mut Criterion) {
+    let mut group = c.benchmark_group("access");
+    for &n in SIZES_ACCESS {
+        let s = slots(n);
+        for &pattern in PATTERNS {
+            for (miss, kind) in [(false, "hit"), (true, "miss")] {
+                let q = queries(n, pattern, miss);
+                let id = format!("{kind}/{}/{n}", pattern.label);
+                group.bench_with_input(BenchmarkId::from_parameter(id), &s, |b, s| {
+                    b.iter_batched_ref(
+                        || struct_from(s),
+                        |built| {
+                            let mut hits = 0usize;
+                            for query in &q {
+                                if built.get(query.as_str()).is_some() {
+                                    hits += 1;
+                                }
+                            }
+                            black_box(hits)
+                        },
+                        BatchSize::SmallInput,
+                    )
+                });
+            }
+        }
+    }
+    group.finish();
+}
+
+// 4. one lookup on a fresh (unprimed) struct, construct + drop excluded. Hash run => B + P.
+fn bench_first_lookup(c: &mut Criterion) {
+    let mut group = c.benchmark_group("first_lookup");
+    group.sample_size(200);
+    for &n in SIZES_ALL {
+        let s = slots(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &s, |b, s| {
+            b.iter_batched_ref(
+                || struct_from(s),
+                |built| black_box(built.get(PRIME_KEY).is_some()),
+                BatchSize::SmallInput,
+            )
+        });
+    }
+    group.finish();
+}
+
+// 5. one lookup on a primed struct (index built in untimed setup), construct + drop excluded.
+//    Hash run => P (warm probe).
+fn bench_warm_probe(c: &mut Criterion) {
+    let mut group = c.benchmark_group("warm_probe");
+    group.sample_size(200);
+    for &n in SIZES_ALL {
+        let s = slots(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &s, |b, s| {
+            b.iter_batched_ref(
+                || {
+                    let built = struct_from(s);
+                    let _ = built.get(PRIME_KEY);
+                    built
+                },
+                |built| black_box(built.get(PRIME_KEY).is_some()),
+                BatchSize::SmallInput,
+            )
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    struct_threshold_model,
+    bench_construct_drop,
+    bench_drop,
+    bench_access,
+    bench_first_lookup,
+    bench_warm_probe
+);
+criterion_main!(struct_threshold_model);

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // `Struct`'s linear-scan/hash-index threshold can be overridden at build time via this
+    // environment variable (read with `option_env!` in `src/types/struct.rs`). Declaring it here
+    // makes Cargo's fingerprint depend on it, so changing the value triggers a rebuild — without
+    // this, `option_env!` alone is not tracked and a stale binary can be reused.
+    println!("cargo:rerun-if-env-changed=ION_RS_STRUCT_LINEAR_SCAN_THRESHOLD");
+}

--- a/src/types/struct.rs
+++ b/src/types/struct.rs
@@ -4,80 +4,186 @@ use crate::ion_data::{IonDataHash, IonDataOrd, IonEq};
 use crate::symbol_ref::AsSymbolRef;
 use crate::text::text_formatter::FmtValueFormatter;
 use crate::Symbol;
-use smallvec::SmallVec;
+use hashbrown::HashTable;
+use rustc_hash::FxHasher;
 use std::cmp::Ordering;
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::fmt::{Display, Formatter};
-use std::hash::Hasher;
+use std::hash::{Hash, Hasher};
+use std::sync::OnceLock;
 
-// A convenient type alias for a vector capable of storing a single `usize` inline
-// without heap allocation. This type should not be used in public interfaces directly.
-type IndexVec = SmallVec<[usize; 1]>;
+/// Field counts at or below this length are served by a linear scan over `slots`; above it, `get()`
+/// lazily builds and probes a hash index. The crossover is a benchmark-derived tuning default
+/// (measured on aarch64 / Graviton2, with a workload of roughly one lookup per field), not a
+/// contract. Revisit if `Element`/`Symbol` size or real `get()` access patterns change.
+const LINEAR_SCAN_THRESHOLD: usize = 48;
 
-// This collection is broken out into its own type to allow instances of it to be shared with Arc/Rc.
+/// One entry in the lazily built hash lookup index. Stores the cached field-name hash (so probes
+/// don't rehash the stored name) and the index of the corresponding pair in [`Fields::slots`].
+/// Only fields with **known** text are indexed; unknown-text (`$0`) lookups scan `slots` directly.
+#[derive(Debug, Clone, Copy)]
+struct HashIndex {
+    hash: u64,
+    slot_index: u32,
+}
+
+/// Lazily built auxiliary indexes over [`Fields::slots`]. Boxed behind a single `OnceLock` so an
+/// iterate-only struct never allocates either index, and so `Fields` itself stays pointer-small.
+#[derive(Debug, Clone, Default)]
+struct FieldsAux {
+    /// Hash lookup index over known-text fields, built on the first large-struct `get()`.
+    table: OnceLock<Box<HashTable<HashIndex>>>,
+    /// Slot indices sorted into canonical Ion field order, built on the first
+    /// equality / ordering / hashing operation. Covers **all** slots, including unknown-text ones.
+    by_field: OnceLock<Box<[u32]>>,
+}
+
+// The struct's storage, split into its own type so `Struct` stays a thin wrapper.
 #[derive(Debug, Clone)]
 struct Fields {
-    // Key/value pairs in the order they were inserted
-    by_index: Vec<(Symbol, Element)>,
-    // Maps symbols to a list of indexes where values may be found in `by_index` above
-    by_name: HashMap<Symbol, IndexVec>,
+    /// Every (name, value) pair in insertion order. The single source of truth for the struct's
+    /// contents — a boxed slice rather than a `Vec` because a struct is immutable once built, so the
+    /// capacity word is dead weight.
+    slots: Box<[(Symbol, Element)]>,
+    /// Lazily allocated indexes; absent until the first operation that needs one.
+    aux: OnceLock<Box<FieldsAux>>,
+}
+
+/// Hashes a field name's text with the portable hasher the lookup index is built against. `get()`
+/// must hash probes the same way the index was populated, so this is the one place the choice lives.
+fn field_name_hash(text: &str) -> u64 {
+    let mut hasher = FxHasher::default();
+    text.hash(&mut hasher);
+    hasher.finish()
 }
 
 impl Fields {
-    /// Gets all of the indexes that contain a value associated with the given field name.
-    fn get_indexes<A: AsSymbolRef>(&self, field_name: A) -> Option<&IndexVec> {
-        field_name
-            .as_symbol_ref()
-            .text()
-            .map(|text| {
-                // If the symbol has defined text, look it up by &str
-                self.by_name.get(text)
-            })
-            .unwrap_or_else(|| {
-                // Otherwise, construct a (cheap, stack-allocated) Symbol with unknown text...
-                let symbol = Symbol::unknown_text();
-                // ...and use the unknown text symbol to look up matching field values
-                self.by_name.get(&symbol)
-            })
+    fn aux(&self) -> &FieldsAux {
+        self.aux
+            .get_or_init(|| Box::new(FieldsAux::default()))
+            .as_ref()
     }
 
-    /// Iterates over the values found at the specified indexes.
-    fn get_values_at_indexes<'a>(&'a self, indexes: &'a IndexVec) -> FieldValuesIterator<'a> {
-        FieldValuesIterator {
-            current: 0,
-            indexes: Some(indexes),
-            by_index: &self.by_index,
+    /// Returns the hash lookup index, building it on first use. Indexes only known-text fields;
+    /// unknown-text fields are found by [`get_unknown_text`](Self::get_unknown_text) instead.
+    fn table(&self) -> &HashTable<HashIndex> {
+        self.aux()
+            .table
+            .get_or_init(|| {
+                // Slot indices are stored as `u32`; a struct with >4B fields is unsupported (and
+                // would need hundreds of GB of live data). The cast below is checked here.
+                debug_assert!(
+                    self.slots.len() <= u32::MAX as usize,
+                    "slot index must fit in u32"
+                );
+                let mut table = HashTable::with_capacity(self.slots.len());
+                for (i, (name, _)) in self.slots.iter().enumerate() {
+                    if let Some(text) = name.text() {
+                        let hash = field_name_hash(text);
+                        table.insert_unique(
+                            hash,
+                            HashIndex {
+                                hash,
+                                slot_index: i as u32,
+                            },
+                            |entry| entry.hash,
+                        );
+                    }
+                }
+                Box::new(table)
+            })
+            .as_ref()
+    }
+
+    /// Returns slot indices in canonical Ion field order, building the ordering on first use.
+    /// Used by equality, ordering, and hashing, all of which treat a struct as an unordered
+    /// multiset of (name, value) pairs.
+    fn by_field(&self) -> &[u32] {
+        self.aux()
+            .by_field
+            .get_or_init(|| {
+                debug_assert!(
+                    self.slots.len() <= u32::MAX as usize,
+                    "slot index must fit in u32"
+                );
+                let mut order: Vec<u32> = (0..self.slots.len() as u32).collect();
+                // Unstable is fine: `ion_cmp_field` only reports `Equal` for slots that are fully
+                // interchangeable for every `by_field` consumer, so their relative order is
+                // irrelevant.
+                order.sort_unstable_by(|&a, &b| {
+                    ion_cmp_field(&self.slots[a as usize], &self.slots[b as usize])
+                });
+                order.into_boxed_slice()
+            })
+            .as_ref()
+    }
+
+    /// Returns *a* value associated with the given field name, or `None` if there is none.
+    ///
+    /// The Ion data model views a struct as an unordered bag of (name, value) pairs, so when a name
+    /// appears more than once this returns an arbitrary match. The choice is consistent within a
+    /// single struct instance but is otherwise unspecified. Applications that repeat field names
+    /// should use [`get_all`](Self::get_all).
+    fn get<A: AsSymbolRef>(&self, field_name: A) -> Option<&Element> {
+        match field_name.as_symbol_ref().text() {
+            Some(text) => self.get_by_text(text),
+            None => self.get_unknown_text(),
         }
     }
 
-    /// Gets the last value in the Struct that is associated with the specified field name.
-    ///
-    /// Note that the Ion data model views a struct as a bag of (name, value) pairs and does not
-    /// have a notion of field ordering. In most use cases, field names are distinct and the last
-    /// appearance of a field in the struct's serialized form will have been the _only_ appearance.
-    /// If a field name appears more than once, this method makes the arbitrary decision to return
-    /// the value associated with the last appearance. If your application uses structs that repeat
-    /// field names, you are encouraged to use [`get_all`](Self::get_all) instead.
-    fn get_last<A: AsSymbolRef>(&self, field_name: A) -> Option<&Element> {
-        self.get_indexes(field_name)
-            .and_then(|indexes| indexes.last())
-            .and_then(|index| self.by_index.get(*index))
-            .map(|(_name, value)| value)
+    /// Looks up a known-text field name: a linear scan for small structs, a hash probe for large
+    /// ones. Both return the first match encountered, which is consistent per instance because the
+    /// slice order is fixed and the built-once table's `find` order is stable.
+    fn get_by_text(&self, text: &str) -> Option<&Element> {
+        if self.slots.len() <= LINEAR_SCAN_THRESHOLD {
+            self.slots
+                .iter()
+                .find(|(name, _)| name.text() == Some(text))
+                .map(|(_, value)| value)
+        } else {
+            let hash = field_name_hash(text);
+            self.table()
+                .find(hash, |entry| {
+                    self.slots[entry.slot_index as usize].0.text() == Some(text)
+                })
+                .map(|entry| &self.slots[entry.slot_index as usize].1)
+        }
     }
 
-    /// Iterates over all of the values associated with the given field name.
+    /// Looks up the unknown-text (`$0`) field name. These share a hash with the empty-text field
+    /// name but compare unequal, so they are never indexed; a direct scan for the first text-less
+    /// field is both correct and cheap.
+    fn get_unknown_text(&self) -> Option<&Element> {
+        self.slots
+            .iter()
+            .find(|(name, _)| name.text().is_none())
+            .map(|(_, value)| value)
+    }
+
+    /// Iterates over all values associated with the given field name.
+    ///
+    /// This is a scan over `slots` regardless of struct size: duplicate field names are uncommon,
+    /// so the hash index is not maintained per-name and this path does not consult it. Values are
+    /// yielded in the order the pairs sit in `slots`, but a struct is an unordered bag so that
+    /// order is an implementation artifact, not a guarantee to callers.
     fn get_all<A: AsSymbolRef>(&self, field_name: A) -> FieldValuesIterator<'_> {
-        let indexes = self.get_indexes(field_name);
+        // The probe borrows from `field_name`, a by-value argument, so the target text cannot be
+        // borrowed into the returned iterator. Copy it (cold path — see above) or record that an
+        // unknown-text name was requested.
+        let target = match field_name.as_symbol_ref().text() {
+            Some(text) => FieldNameMatch::Text(text.to_owned()),
+            None => FieldNameMatch::UnknownText,
+        };
         FieldValuesIterator {
-            current: 0,
-            indexes,
-            by_index: &self.by_index,
+            slots: &self.slots,
+            pos: 0,
+            target,
         }
     }
 
     /// Iterates over all of the (field name, field value) pairs in the struct.
     fn iter(&self) -> impl Iterator<Item = &(Symbol, Element)> {
-        self.by_index.iter()
+        self.slots.iter()
     }
 }
 
@@ -131,24 +237,35 @@ impl Iterator for OwnedFieldIterator {
     }
 }
 
+/// The field name a [`FieldValuesIterator`] matches against. Owned so the iterator can outlive the
+/// by-value probe argument it was built from.
+enum FieldNameMatch {
+    UnknownText,
+    Text(String),
+}
+
 /// Iterates over the values associated with a given field name in a Struct.
 pub(crate) struct FieldValuesIterator<'a> {
-    current: usize,
-    indexes: Option<&'a IndexVec>,
-    by_index: &'a Vec<(Symbol, Element)>,
+    slots: &'a [(Symbol, Element)],
+    pos: usize,
+    target: FieldNameMatch,
 }
 
 impl<'a> Iterator for FieldValuesIterator<'a> {
     type Item = &'a Element;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.indexes
-            .and_then(|i| i.get(self.current))
-            .and_then(|i| {
-                self.current += 1;
-                self.by_index.get(*i)
-            })
-            .map(|(_name, value)| value)
+        while let Some((name, value)) = self.slots.get(self.pos) {
+            self.pos += 1;
+            let matches = match &self.target {
+                FieldNameMatch::UnknownText => name.text().is_none(),
+                FieldNameMatch::Text(text) => name.text() == Some(text.as_str()),
+            };
+            if matches {
+                return Some(value);
+            }
+        }
+        None
     }
 }
 
@@ -186,7 +303,7 @@ impl Struct {
     }
 
     pub fn clone_builder(&self) -> StructBuilder {
-        StructBuilder::with_initial_fields(&self.fields.by_index)
+        StructBuilder::with_initial_fields(&self.fields.slots)
     }
 
     /// Returns an iterator over the field name/value pairs in this Struct.
@@ -202,72 +319,42 @@ impl Struct {
             .map(|(name, element)| (name, element))
     }
 
+    /// Compares two structs as unordered multisets of (name, value) pairs.
+    ///
+    /// Each side's slots are visited in canonical Ion field order (via `by_field`) and compared
+    /// positionally. This is valid even though `eq` may be coarser than Ion's total `ion_cmp`
+    /// order — `PartialEq` treats `-0e0 == 0e0`, numeric-equal decimals such as `0d0`/`0d3` as
+    /// equal, and timestamps as equal by instant — because `ion_cmp` orders each such
+    /// `eq`-equivalence class as a **contiguous run**: the tie-breaks it adds (e.g. decimal
+    /// exponent, timestamp precision/offset) only reorder values that are already `eq`-equal, so no
+    /// `eq`-*unequal* value ever sorts between two `eq`-equal ones. Sorting both sides by `ion_cmp`
+    /// and pairing positionally therefore cannot mis-pair slots. A future `eq` that merged two
+    /// values with an `eq`-unequal value ordered between them would break this invariant and would
+    /// instead need a greedy bipartite match over each repeated name's values.
     fn fields_eq(&self, other: &Self, eq: impl Fn(&Element, &Element) -> bool) -> bool {
-        if self.fields.by_index.len() != self.fields.by_name.len() {
-            return self.fields_with_repeated_names_eq(other, eq);
-        }
-
-        for (field_name, field_value_indexes) in &self.fields.by_name {
-            let other_value_indexes = match other.fields.get_indexes(field_name) {
-                Some(indexes) => indexes,
-                // The other struct doesn't have a field with this name so they're not equal.
-                None => return false,
-            };
-
-            debug_assert_eq!(field_value_indexes.len(), 1);
-            if other_value_indexes.len() != 1 {
-                // The other struct has fields with the same name, but a different number of them.
+        let these = self.fields.by_field();
+        let those = other.fields.by_field();
+        // Callers guarantee equal length before reaching here.
+        debug_assert_eq!(these.len(), those.len());
+        for (&this_i, &that_i) in these.iter().zip(those.iter()) {
+            let (this_name, this_value) = &self.fields.slots[this_i as usize];
+            let (that_name, that_value) = &other.fields.slots[that_i as usize];
+            // Only name equality matters here (`by_field` already put both sides in the same
+            // order); `ion_eq` can short-circuit on the first differing byte, where `ion_cmp` would
+            // compute a full ordering.
+            if !this_name.ion_eq(that_name) {
                 return false;
             }
-
-            // Direct indexing is safe here because we've already guaranteed that len() == 1
-            let self_value = &self.fields.by_index[field_value_indexes[0]].1;
-            let other_value = &other.fields.by_index[other_value_indexes[0]].1;
-            if !eq(self_value, other_value) {
+            if !eq(this_value, that_value) {
                 return false;
             }
         }
-
-        true
-    }
-
-    /// Bitvector multiset matching fallback for structs with repeated field names.
-    /// O(p * m^2) where p is the number of unique field names and m is the max repeat count.
-    fn fields_with_repeated_names_eq(
-        &self,
-        other: &Self,
-        eq: impl Fn(&Element, &Element) -> bool,
-    ) -> bool {
-        for (field_name, field_value_indexes) in &self.fields.by_name {
-            let other_value_indexes = match other.fields.get_indexes(field_name) {
-                Some(indexes) => indexes,
-                None => return false,
-            };
-
-            if field_value_indexes.len() != other_value_indexes.len() {
-                return false;
-            }
-
-            let mut matched = vec![false; other_value_indexes.len()];
-            for field_value in self.fields.get_values_at_indexes(field_value_indexes) {
-                let found = other
-                    .fields
-                    .get_values_at_indexes(other_value_indexes)
-                    .enumerate()
-                    .find(|(i, other_value)| !matched[*i] && eq(field_value, other_value));
-                match found {
-                    Some((i, _)) => matched[i] = true,
-                    None => return false,
-                }
-            }
-        }
-
         true
     }
 
     /// Returns the number of fields in this Struct.
     pub fn len(&self) -> usize {
-        self.fields.by_index.len()
+        self.fields.slots.len()
     }
 
     /// Returns `true` if this struct has zero fields.
@@ -276,16 +363,17 @@ impl Struct {
     }
 
     pub fn iter(&self) -> FieldIterator<'_> {
-        FieldIterator::new(&self.fields.by_index)
+        FieldIterator::new(&self.fields.slots)
     }
 
-    /// Returns the value associated with the specified field name.
+    /// Returns a value associated with the specified field name.
     ///
-    /// If more than one field in this struct has that name, this method will return the value of
-    /// the _last_ field with that name. To access other fields with the same name, see
-    /// [`get_all`](Self::get_all).
+    /// The Ion data model views a struct as an unordered bag of (name, value) pairs. If more than
+    /// one field has the given name, this returns an arbitrary one; the choice is consistent within
+    /// a single struct instance but is otherwise unspecified. To access every value for a repeated
+    /// name, see [`get_all`](Self::get_all).
     pub fn get<A: AsSymbolRef>(&self, field_name: A) -> Option<&Element> {
-        self.fields.get_last(field_name)
+        self.fields.get(field_name)
     }
 
     /// Returns an iterator over all of the values associated with the specified field name.
@@ -310,7 +398,8 @@ impl IntoIterator for Struct {
     type IntoIter = OwnedFieldIterator;
 
     fn into_iter(self) -> Self::IntoIter {
-        OwnedFieldIterator::new(self.fields.by_index)
+        // `into_vec` reuses the boxed slice's allocation, so this does not copy the elements.
+        OwnedFieldIterator::new(self.fields.slots.into_vec())
     }
 }
 
@@ -321,20 +410,14 @@ where
 {
     /// Returns an owned struct from the given iterator of field names/values.
     fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
-        let mut by_index: Vec<(Symbol, Element)> = Vec::new();
-        let mut by_name: HashMap<Symbol, IndexVec> = HashMap::new();
-        for (field_name, field_value) in iter {
-            let field_name = field_name.into();
-            let field_value = field_value.into();
-
-            by_name
-                .entry(field_name.clone())
-                .or_default()
-                .push(by_index.len());
-            by_index.push((field_name, field_value));
-        }
-
-        let fields = Fields { by_index, by_name };
+        let slots: Box<[(Symbol, Element)]> = iter
+            .into_iter()
+            .map(|(name, value)| (name.into(), value.into()))
+            .collect();
+        let fields = Fields {
+            slots,
+            aux: OnceLock::new(),
+        };
         Self { fields }
     }
 }
@@ -353,20 +436,20 @@ impl IonEq for Struct {
 
 impl IonDataOrd for Struct {
     fn ion_cmp(&self, other: &Self) -> Ordering {
-        let mut these_fields = self.fields.by_index.iter().collect::<Vec<_>>();
-        let mut those_fields = other.fields.by_index.iter().collect::<Vec<_>>();
-        these_fields.sort_by(ion_cmp_field);
-        those_fields.sort_by(ion_cmp_field);
-
-        let mut i0 = these_fields.iter();
-        let mut i1 = those_fields.iter();
+        let these = self.fields.by_field();
+        let those = other.fields.by_field();
+        let mut i0 = these.iter();
+        let mut i1 = those.iter();
         loop {
             match [i0.next(), i1.next()] {
                 [None, Some(_)] => return Ordering::Less,
                 [None, None] => return Ordering::Equal,
                 [Some(_), None] => return Ordering::Greater,
-                [Some(a), Some(b)] => {
-                    let ord = ion_cmp_field(a, b);
+                [Some(&a), Some(&b)] => {
+                    let ord = ion_cmp_field(
+                        &self.fields.slots[a as usize],
+                        &other.fields.slots[b as usize],
+                    );
                     if ord != Ordering::Equal {
                         return ord;
                     }
@@ -376,7 +459,7 @@ impl IonDataOrd for Struct {
     }
 }
 
-fn ion_cmp_field(this: &&(Symbol, Element), that: &&(Symbol, Element)) -> Ordering {
+fn ion_cmp_field(this: &(Symbol, Element), that: &(Symbol, Element)) -> Ordering {
     let ord = this.0.ion_cmp(&that.0);
     if !ord.is_eq() {
         return ord;
@@ -386,20 +469,164 @@ fn ion_cmp_field(this: &&(Symbol, Element), that: &&(Symbol, Element)) -> Orderi
 
 impl IonDataHash for Struct {
     fn ion_data_hash<H: Hasher>(&self, state: &mut H) {
-        let mut these_fields = self.fields.by_index.iter().collect::<Vec<_>>();
-        these_fields.sort_by(ion_cmp_field);
-        for (name, value) in these_fields {
+        for &i in self.fields.by_field() {
+            let (name, value) = &self.fields.slots[i as usize];
             name.ion_data_hash(state);
             value.ion_data_hash(state);
         }
     }
 }
 
+// `Struct` is one variant of the `Value` enum embedded in `Element`. Keeping its footprint within
+// the per-variant budget is what lets `Element` fit in a single 64-byte cache line on a 64-bit
+// target; a later field addition that busts this budget fails to compile here rather than silently
+// growing `Element`. The byte counts are a 64-bit-target claim (see the 32-bit counterpart below).
+#[cfg(target_pointer_width = "64")]
+const _: () = {
+    assert!(std::mem::size_of::<Struct>() <= 32);
+    assert!(std::mem::align_of::<Struct>() == 8);
+};
+
+// The 32-bit counterpart, so `wasm32`/`i686` check something rather than skipping. `Fields` is
+// entirely pointer-shaped (a boxed slice plus a `OnceLock<Box<_>>`), so it halves on a 32-bit
+// target: two words for `slots`, two for `aux`.
+#[cfg(target_pointer_width = "32")]
+const _: () = {
+    assert!(std::mem::size_of::<Struct>() <= 16);
+    assert!(std::mem::align_of::<Struct>() == 4);
+};
+
 #[cfg(test)]
 mod tests {
     use crate::element::Element;
     use crate::ion_data::IonEq;
-    use crate::ion_struct;
+    use crate::{ion_struct, Struct, Symbol};
+
+    // Field count that forces `get()` onto the hash-index path (> LINEAR_SCAN_THRESHOLD).
+    const ABOVE_THRESHOLD: usize = 60;
+
+    /// Builds a struct with `n` distinct fields named `f0..fn`, plus any `extra` (name, value)
+    /// pairs appended after them. Used to exercise both the linear-scan and hash-index regimes.
+    fn struct_with(n: usize, extra: &[(&str, i64)]) -> Struct {
+        let mut builder = Struct::builder();
+        for i in 0..n {
+            builder = builder.with_field(format!("f{i}"), Element::int(i as i64));
+        }
+        for (name, value) in extra {
+            builder = builder.with_field(*name, Element::int(*value));
+        }
+        builder.build()
+    }
+
+    #[test]
+    fn get_all_preserves_duplicates_and_order() {
+        // A name repeated three times yields all three, in insertion order.
+        let s = ion_struct! { "a": 1, "a": 2, "a": 3, "b": 9 };
+        let all: Vec<_> = s.get_all("a").collect();
+        assert_eq!(
+            all,
+            vec![&Element::int(1), &Element::int(2), &Element::int(3)]
+        );
+        // A unique name yields exactly one.
+        assert_eq!(s.get_all("b").collect::<Vec<_>>(), vec![&Element::int(9)]);
+        // An absent name yields none.
+        assert_eq!(s.get_all("z").count(), 0);
+    }
+
+    #[test]
+    fn get_all_scans_in_both_regimes() {
+        // Above the threshold, get_all still scans slots rather than consulting the index.
+        let s = struct_with(ABOVE_THRESHOLD, &[("dup", 1), ("dup", 2), ("dup", 3)]);
+        assert_eq!(
+            s.get_all("dup").collect::<Vec<_>>(),
+            vec![&Element::int(1), &Element::int(2), &Element::int(3)]
+        );
+        assert_eq!(s.get_all("f0").collect::<Vec<_>>(), vec![&Element::int(0)]);
+    }
+
+    #[rstest::rstest]
+    #[case::below(4)]
+    #[case::above(ABOVE_THRESHOLD)]
+    fn get_matches_str_symbol_and_symbol_ref(#[case] n: usize) {
+        // The struct's own fields land in slots f0..fn; append a known target after them.
+        let s = struct_with(n, &[("target", 42)]);
+        let expected = Some(&Element::int(42));
+
+        // &str probe
+        assert_eq!(s.get("target"), expected);
+        // &Symbol probe
+        let sym = Symbol::owned("target");
+        assert_eq!(s.get(&sym), expected);
+        // owned Symbol probe
+        assert_eq!(s.get(Symbol::owned("target")), expected);
+    }
+
+    #[rstest::rstest]
+    #[case::below(4)]
+    #[case::above(ABOVE_THRESHOLD)]
+    fn get_and_get_all_find_unknown_text(#[case] n: usize) {
+        // Build with an unknown-text ($0) field among known ones.
+        let mut builder = Struct::builder();
+        for i in 0..n {
+            builder = builder.with_field(format!("f{i}"), Element::int(i as i64));
+        }
+        let s = builder
+            .with_field(Symbol::unknown_text(), Element::int(7))
+            .build();
+
+        assert_eq!(s.get(Symbol::unknown_text()), Some(&Element::int(7)));
+        assert_eq!(
+            s.get_all(Symbol::unknown_text()).collect::<Vec<_>>(),
+            vec![&Element::int(7)]
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::below(4)]
+    #[case::above(ABOVE_THRESHOLD)]
+    fn unknown_text_and_empty_text_do_not_collide(#[case] n: usize) {
+        // Symbol::unknown_text() and Symbol::from("") hash identically but compare unequal. A
+        // hand-written hash/eq that collapsed them would return the wrong value for one.
+        let mut builder = struct_with(n, &[]).clone_builder();
+        builder = builder
+            .with_field(Symbol::unknown_text(), Element::int(100))
+            .with_field(Symbol::owned(""), Element::int(200));
+        let s = builder.build();
+
+        assert_eq!(s.get(Symbol::unknown_text()), Some(&Element::int(100)));
+        assert_eq!(s.get(Symbol::owned("")), Some(&Element::int(200)));
+        assert_eq!(s.get(""), Some(&Element::int(200)));
+    }
+
+    #[rstest::rstest]
+    #[case::below(4)]
+    #[case::above(ABOVE_THRESHOLD)]
+    fn get_absent_name_is_none(#[case] n: usize) {
+        let s = struct_with(n, &[]);
+        assert_eq!(s.get("not-a-field"), None);
+        assert_eq!(s.get(Symbol::unknown_text()), None);
+    }
+
+    #[test]
+    fn empty_struct() {
+        let s = Struct::builder().build();
+        assert!(s.is_empty());
+        assert_eq!(s.len(), 0);
+        assert_eq!(s.get("anything"), None);
+        assert_eq!(s.get_all("anything").count(), 0);
+        assert_eq!(s, Struct::builder().build());
+    }
+
+    #[rstest::rstest]
+    #[case(crate::types::r#struct::LINEAR_SCAN_THRESHOLD)]
+    #[case(crate::types::r#struct::LINEAR_SCAN_THRESHOLD + 1)]
+    fn threshold_boundary_lookup(#[case] n: usize) {
+        // Off-by-one at the regime crossover: the last field must be findable at both N and N+1.
+        let s = struct_with(n, &[]);
+        let last = format!("f{}", n - 1);
+        assert_eq!(s.get(last.as_str()), Some(&Element::int((n - 1) as i64)));
+        assert_eq!(s.get("f0"), Some(&Element::int(0)));
+    }
 
     #[test]
     fn duplicate_field_values_not_equal() {
@@ -415,6 +642,70 @@ mod tests {
         let s2 = ion_struct! { "b": 3, "a": 2, "a": 1 };
         assert_eq!(s1, s2);
         assert!(s1.ion_eq(&s2));
+    }
+
+    #[test]
+    fn equal_length_differing_repeat_counts_not_equal() {
+        // Same length, same names present, but different multiplicities.
+        let s1 = ion_struct! { "a": 1, "a": 2, "b": 3 };
+        let s2 = ion_struct! { "a": 1, "b": 2, "b": 3 };
+        assert_ne!(s1, s2);
+        assert!(!s1.ion_eq(&s2));
+    }
+
+    #[test]
+    fn all_identical_names_equal_as_multiset() {
+        let s1 = ion_struct! { "a": 1, "a": 2, "a": 3 };
+        let s2 = ion_struct! { "a": 3, "a": 1, "a": 2 };
+        assert_eq!(s1, s2);
+        assert!(s1.ion_eq(&s2));
+    }
+
+    #[rstest::rstest]
+    // `pad` distinct filler fields (f0..f{pad}) precede the class-defining fields on both sides, so
+    // the same struct lands below the threshold (pad=0, linear regime) or above it (hash regime).
+    // Equality routes through `by_field`, which does not branch on the threshold, so every class
+    // must resolve identically in both regimes.
+    #[case::below(0)]
+    #[case::above(ABOVE_THRESHOLD)]
+    fn multiset_equality_classes(#[case] pad: usize) {
+        let mk = |extra: &[(&str, i64)]| struct_with(pad, extra);
+        // no duplicates, different order
+        assert_eq!(mk(&[("a", 1), ("b", 2)]), mk(&[("b", 2), ("a", 1)]));
+        // one name twice
+        assert_eq!(mk(&[("a", 1), ("a", 2)]), mk(&[("a", 2), ("a", 1)]));
+        assert!(mk(&[("a", 1), ("a", 2)]).ion_eq(&mk(&[("a", 2), ("a", 1)])));
+        // all names identical
+        assert_eq!(
+            mk(&[("a", 1), ("a", 2), ("a", 3)]),
+            mk(&[("a", 3), ("a", 1), ("a", 2)])
+        );
+        // equal length, same names present, differing repeat counts -> not equal
+        assert_ne!(
+            mk(&[("a", 1), ("a", 2), ("b", 3)]),
+            mk(&[("a", 1), ("b", 2), ("b", 3)])
+        );
+        // differing values under a repeated name -> not equal (and not ion_eq)
+        let s1 = mk(&[("a", 1), ("a", 2)]);
+        let s2 = mk(&[("a", 1), ("a", 3)]);
+        assert_ne!(s1, s2);
+        assert!(!s1.ion_eq(&s2));
+    }
+
+    #[test]
+    fn rebuild_changing_duplicate_shape_stays_equal() {
+        // A struct rebuilt through the builder — introducing then removing a duplicate — must
+        // compare equal to a direct build under both PartialEq and IonEq. This guards against an
+        // index (here, `by_field`) that was somehow derived from a stale pair list.
+        let direct = ion_struct! { "a": 1, "b": 2 };
+        let rebuilt = direct
+            .clone_builder()
+            .with_field("b", Element::int(99)) // introduce a duplicate "b"
+            .remove_field("b") // remove the first "b"
+            .build();
+        // rebuilt is now { a: 1, b: 99 }; not equal to the original, but a well-formed struct.
+        assert_eq!(rebuilt, ion_struct! { "a": 1, "b": 99 });
+        assert!(rebuilt.ion_eq(&ion_struct! { "a": 1, "b": 99 }));
     }
 
     #[test]
@@ -435,6 +726,93 @@ mod tests {
         assert_eq!(s1, s2);
         // IonEq distinguishes signed zeros
         assert!(!s1.ion_eq(&s2));
+    }
+
+    #[test]
+    fn rebuild_last_duplicate_survives_removal() {
+        // `remove_field` removes the FIRST matching field, so from {a:1, b:2, b:3} it leaves the
+        // last "b". The lazy indexes must be rebuilt from the post-removal pair list: `get`/
+        // `get_all` must see 3 (the survivor), never a stale 2.
+        let rebuilt = ion_struct! { "a": 1, "b": 2, "b": 3 }
+            .clone_builder()
+            .remove_field("b")
+            .build();
+        let expected = ion_struct! { "a": 1, "b": 3 };
+        assert_eq!(rebuilt, expected);
+        assert!(rebuilt.ion_eq(&expected));
+        assert_eq!(rebuilt.get("b"), Some(&Element::int(3)));
+        assert_eq!(
+            rebuilt.get_all("b").collect::<Vec<_>>(),
+            vec![&Element::int(3)]
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::below(4)]
+    #[case::above(ABOVE_THRESHOLD)]
+    fn get_all_across_probe_forms_and_absent(#[case] n: usize) {
+        let s = struct_with(n, &[("target", 42), ("target", 43)]);
+        let want = vec![Element::int(42), Element::int(43)];
+        let sym = Symbol::owned("target");
+        // &str, &Symbol, and owned Symbol probes all yield every value in insertion order.
+        assert_eq!(s.get_all("target").cloned().collect::<Vec<_>>(), want);
+        assert_eq!(s.get_all(&sym).cloned().collect::<Vec<_>>(), want);
+        assert_eq!(
+            s.get_all(Symbol::owned("target"))
+                .cloned()
+                .collect::<Vec<_>>(),
+            want
+        );
+        // An absent name yields nothing in both regimes.
+        assert_eq!(s.get_all("absent").count(), 0);
+    }
+
+    #[test]
+    fn get_agrees_before_and_after_index_build() {
+        // A large struct clone taken *before* the lazy hash index is built must answer lookups the
+        // same as the original does after building it.
+        let s = struct_with(ABOVE_THRESHOLD, &[("target", 5)]);
+        let clone_before = s.clone();
+        // First get triggers the lazy table build; the second reads the built table.
+        assert_eq!(s.get("target"), Some(&Element::int(5)));
+        assert_eq!(s.get("target"), Some(&Element::int(5)));
+        // The pre-build clone builds its own index independently and agrees.
+        assert_eq!(clone_before.get("target"), Some(&Element::int(5)));
+        assert_eq!(clone_before, s);
+    }
+
+    #[test]
+    fn concurrent_get_agrees() {
+        use std::sync::Arc;
+        // Racing threads on the first get() of a large struct all race the same OnceLock table
+        // build; every thread must observe the correct value regardless of which one initializes.
+        let s = Arc::new(struct_with(ABOVE_THRESHOLD, &[("target", 5)]));
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let s = Arc::clone(&s);
+                std::thread::spawn(move || s.get("target").cloned())
+            })
+            .collect();
+        for handle in handles {
+            assert_eq!(handle.join().unwrap(), Some(Element::int(5)));
+        }
+    }
+
+    #[test]
+    fn struct_is_send_sync() {
+        // The lazy OnceLock-backed indexes must not cost `Struct` its `Send`/`Sync`.
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Struct>();
+    }
+
+    #[test]
+    fn clone_agrees_with_original() {
+        // Cloning after the lazy indexes are built must preserve lookup answers.
+        let s = struct_with(ABOVE_THRESHOLD, &[("target", 5)]);
+        let _ = s.get("target"); // force the hash index to build
+        let cloned = s.clone();
+        assert_eq!(cloned.get("target"), Some(&Element::int(5)));
+        assert_eq!(cloned, s);
     }
 
     #[test]

--- a/src/types/struct.rs
+++ b/src/types/struct.rs
@@ -13,10 +13,46 @@ use std::hash::{Hash, Hasher};
 use std::sync::OnceLock;
 
 /// Field counts at or below this length are served by a linear scan over `slots`; above it, `get()`
-/// lazily builds and probes a hash index. The crossover is a benchmark-derived tuning default
-/// (measured on aarch64 / Graviton2, with a workload of roughly one lookup per field), not a
-/// contract. Revisit if `Element`/`Symbol` size or real `get()` access patterns change.
-const LINEAR_SCAN_THRESHOLD: usize = 48;
+/// lazily builds and probes a hash index. The default is a benchmark-derived tuning value, not a
+/// contract; revisit if `Element`/`Symbol` size or real `get()` access patterns change.
+///
+/// Chosen on aarch64 / Graviton2 against a happy-path (hit-dominated) workload: the linear-vs-hash
+/// crossover measured at ~10 fields for 2 lookups/field, ~19 for 1×, and ~28 for 0.5×, and the cost
+/// of setting the threshold too high (linear's O(n²) tail) dwarfs setting it too low (one bounded
+/// ~140 ns + ~14 ns/field index build). Erring low, 16 covers the ≥1×/field cases and stays cheap
+/// for the sparser ones.
+///
+/// The default (16) can be overridden at build time by setting the
+/// `ION_RS_STRUCT_LINEAR_SCAN_THRESHOLD` environment variable to a base-10 integer, e.g.
+/// `ION_RS_STRUCT_LINEAR_SCAN_THRESHOLD=32 cargo build`. This is a tuning/experimentation knob, not
+/// a stability guarantee; a malformed value is a compile error. `rustc` records the read, so the
+/// crate is rebuilt when the value changes.
+const LINEAR_SCAN_THRESHOLD: usize = match option_env!("ION_RS_STRUCT_LINEAR_SCAN_THRESHOLD") {
+    None => 16,
+    Some(text) => parse_threshold(text),
+};
+
+/// Parses the `ION_RS_STRUCT_LINEAR_SCAN_THRESHOLD` override in const context. A non-empty run of
+/// ASCII digits only; anything else is a compile error, and const evaluation traps on overflow.
+const fn parse_threshold(text: &str) -> usize {
+    let bytes = text.as_bytes();
+    assert!(
+        !bytes.is_empty(),
+        "ION_RS_STRUCT_LINEAR_SCAN_THRESHOLD must not be empty"
+    );
+    let mut value: usize = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        let digit = bytes[i];
+        assert!(
+            digit >= b'0' && digit <= b'9',
+            "ION_RS_STRUCT_LINEAR_SCAN_THRESHOLD must be a base-10 integer"
+        );
+        value = value * 10 + (digit - b'0') as usize;
+        i += 1;
+    }
+    value
+}
 
 /// One entry in the lazily built hash lookup index. Stores the cached field-name hash (so probes
 /// don't rehash the stored name) and the index of the corresponding pair in [`Fields::slots`].


### PR DESCRIPTION
**Issue #, if available:**

Supports #476

**Description of changes:**

This replaces `Struct`'s `Vec<(Symbol, Element)>` and eager `HashMap<Symbol, SmallVec<[usize; 1]>>` with a single boxed slice plus lazily-built indexes. `Struct` goes from 48 to 32 bytes on 64-bit targets (asserted; 16 on 32-bit), `get()` stays sub-linear for large structs, and constructing a struct no longer allocates a map or a per-field `SmallVec`.

`Fields` is now a `slots: Box<[(Symbol, Element)]>` and an `aux: OnceLock<Box<FieldsAux>>`. `FieldsAux` holds two independently lazy indexes:

- a `hashbrown::HashTable<HashIndex>` that `get()` builds and probes once a struct is large enough to be worth it, and
- a `by_field: Box<[u32]>` that orders the slots into the `IonDataOrd` order for `PartialEq`, `IonEq`, `IonDataOrd`, and `IonDataHash`.

A struct that is only iterated builds neither index. Using a boxed slice rather than a `Vec` is deliberate: a struct is immutable once built, so the capacity word is dead weight, and dropping it is part of what gets `Struct` down to 32 bytes.

The PR is three commits: the storage rewrite, a `struct_ops` benchmark, and the build-time threshold knob described below.



#### Tunable `LINEAR_SCAN_THRESHOLD`

`get()` scans linearly at or below `LINEAR_SCAN_THRESHOLD` and builds and probes the hash index above it. The threshold is a compile-time `const` that can be overridden at build time with `ION_RS_STRUCT_LINEAR_SCAN_THRESHOLD=<n> cargo build`. It is parsed in a `const fn`, so a malformed value is a compile error rather than a silent fallback, and the `build.rs` entry makes cargo rebuild when it changes.

The default is 16. I chose it on aarch64 against a hit-dominated workload, where the linear-vs-hash crossover measured around 10 fields at 2 lookups per field, ~19 at 1x, and ~28 at 0.5x. The asymmetry is what pushed the default low: setting the threshold too high pays linear's O(n²) tail as structs grow, while setting it too low pays only a bounded index build of roughly 140 ns plus ~14 ns per field. Erring low is the cheaper mistake. The `struct_threshold_model` bench in this PR is the instrument those numbers came from, and it can re-derive the crossover if the hardware or the `Symbol`/`Element` layout changes.

I'm happy to drop the environment override if we would rather not carry a tuning knob in the public build. Users aren't expected to need to set this (the default value should be good), but it provides an escape hatch for users who want to optimize for other access patterns.

#### Performance

Measured on Graviton2 against the current `main`:

- `PartialEq` is 90% to 99% faster, `ion_cmp` 57% to 83% faster, and `ion_data_hash` 11% to 38% faster across 1 to 100 fields. The old implementations rebuilt a sorted `Vec` (or did a per-field map lookup) on every call; the sorted order is now built once and cached in the `OnceLock`.
- `get()` is faster across the board except for a key sitting at the back of a struct within the linear band, whose cost is bounded by the threshold-sized scan and recovers as soon as the hash index engages.
- Construction does fewer allocations, since there is no map and no per-duplicate `SmallVec`, resulting in small but meaningful deserialization improvements on some real-world data that I used. (Don't have an exact figure since it's somewhat entangled with the rest of my work to reduce the size and align of `Element`.)

There is one regression introduced. Calling `get_all()` is now a scan over the slice rather than a map lookup. Duplicate field names are uncommon and the scan is over one contiguous allocation, so I think this should be acceptable. A Graviton L1 data cache is 64 kB, so the entire `slots` vec will fit in the L1 cache for struct with even several hundred fields. (You only need ~8 kB of cache to fit 100 fields.) If it turns out to be a problem, we can leverage the `by_fields` index to perform a binary search of field names for large structs.


#### Testing

- The full test suite, the `ion-tests` corpus, and `tests/ion_data_consistency.rs` (the `good/equivs` `Eq`/`Ord`/`Hash` gate) pass.
- `--features experimental-ion-hash` passes; the struct digest is unchanged, since it still hashes the per-field _digests_ in their own sorted order.
- `cargo check --target wasm32-unknown-unknown` passes, which is what checks the pointer-width byte-size assertions.
- New unit tests cover both lookup regimes: duplicate, absent, and unknown-text (`$0`) lookups; the `$0`-versus-empty-text case, whose keys hash alike but compare unequal; multiset equality across the equivalence classes crossed with both regimes; the threshold boundary; `Send`/`Sync`; and a concurrent first `get()`.

----

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
